### PR TITLE
fix: Correct dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,5 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     target-branch: "main"
-    allow:
-      - dependency-type: "all"
-    insecure-external-code-execution: "deny"
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
This PR fixes the dependabot configuration by removing unsupported keys ('reviewers', 'assignees', 'allow', 'insecure-external-code-execution').