### PR TITLE
fix: Remove 'opened' trigger from Copilot Review Check to prevent race condition

### DIFF
--- a/.github/workflows/copilot-review-check.yml
+++ b/.github/workflows/copilot-review-check.yml
@@ -6,6 +6,8 @@ name: Copilot Review Check
 on:
   pull_request:
     types: [synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
 
 # Prevent duplicate runs
 concurrency:


### PR DESCRIPTION
## Problem

The `copilot-review-check.yml` workflow had a race condition with the `opened` trigger causing immediate failures on new PRs.

## Root Cause

Timeline of the issue:
1. PR opened → `opened` trigger fires immediately (e.g., 23:00:38Z)
2. Workflow runs and checks for Copilot review → **none exists yet** → fails
3. Copilot reviews a few seconds later (e.g., 23:00:43Z)
4. Check remains failed (no re-run triggered)

The `opened` trigger is fundamentally flawed because:
- Reviews naturally come AFTER code is pushed
- The workflow runs before Copilot can possibly review
- This causes guaranteed failures on every new PR

## Solution

Remove the `opened` trigger. The correct configuration is:

```yaml
on:
  pull_request:
    types: [synchronize, reopened]  # ← 'opened' removed
  pull_request_review:
    types: [submitted]  # ← ESSENTIAL - makes check pass after review
```

**Why this works:**
1. New PR opened → No check runs (avoiding race condition)
2. Copilot reviews → `pull_request_review` event fires
3. Workflow runs → finds review → ✅ check passes
4. New commit pushed → `synchronize` event fires
5. Workflow checks if review is still fresh → passes/fails accordingly

**The `pull_request_review` trigger is NOT redundant** - it's essential to make the check pass after a review!

## Evidence

Before fix (with `opened` trigger):
- PR #10: Check ran before review → failed
- PR #12 (this PR): First run failed at 23:00:38Z, review came at 23:00:43Z

After fix (without `opened` trigger):
- 23:07:50Z: `pull_request` event → ✅ SUCCESS
- 23:08:40Z: `pull_request_review` event → ✅ SUCCESS

## Impact

- ✅ Eliminates race condition on new PRs
- ✅ Check passes automatically after Copilot reviews
- ✅ Still validates review freshness on new commits
- ✅ Cleaner, more reliable workflow behavior

Fixes the issues mentioned in PR #10.