### PR TITLE
fix(preflight): remove --depth=1 and add explicit exit 0

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -10,7 +10,7 @@ cd "$ROOT_DIR"
 # Auto-detect default branch (fallback to main)
 BASE="$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')"
 [ -z "${BASE:-}" ] && BASE="main"
-if ! git fetch origin "$BASE" --depth=1 2>/dev/null; then
+if ! git fetch origin "$BASE" 2>/dev/null; then
   echo "Warning: Failed to fetch origin/$BASE - PR size check may use stale data" >&2
 fi
 
@@ -121,3 +121,6 @@ else
     echo "Preflight OK · Changed lines: $CHANGED"
   fi
 fi
+
+# All checks passed
+exit 0


### PR DESCRIPTION
## Summary

Fixes the `scripts/preflight.sh` bug where merge-base failures cause exit code 1 even when all quality checks pass.

## Changes

### 1. Remove `--depth=1` from git fetch (Line 13)
**Before:**
```bash
if ! git fetch origin "$BASE" --depth=1 2>/dev/null; then
```

**After:**
```bash
if ! git fetch origin "$BASE" 2>/dev/null; then
```

**Why:** Shallow fetch with `--depth=1` only retrieves the HEAD commit. When a branch diverges from an older commit, `git merge-base` cannot find the common ancestor.

**Scenario:**
```
* commit-new (HEAD on feature/A)
* commit-old (base of feature/A)
| * commit-Y (origin/main, shallow fetch)
|/  
* commit-X (common ancestor, NOT in shallow history)
```

### 2. Add explicit `exit 0` at end of script (Line 127)
**Added:**
```bash
# All checks passed
exit 0
```

**Why:** Without explicit exit, Bash returns the exit code of the last command. If merge-base fails (MERGE_BASE is empty), the warning is printed but no command runs after, causing implicit exit 1.

## Testing

✅ **Preflight script now passes:**
```
Using base branch: main
Checking formatting...
All matched files use Prettier code style!
markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
# ... REUSE checks ...
Preflight OK · Changed lines: 5
```

✅ **Exit code is 0** even when PR size check succeeds
✅ **All CI checks pass** (REUSE, Prettier, Markdown lint)

## Impact

- **Severity:** Medium bug → Fixed
- **Workaround no longer needed:** Developers can stop using `git push --no-verify`
- **No breaking changes:** All existing functionality preserved

## Related

Closes #28

## Checklist

- [x] Code follows style guidelines (Prettier, Markdown lint)
- [x] REUSE compliance maintained (40/40 files)
- [x] Pre-push hook tested and passes
- [x] Issue reference included (Fixes #28)