### PR TITLE
chore(deps): bump test-dependency from 1.2.3 to 1.2.4

### DIFF
--- a/.test-dependency-version
+++ b/.test-dependency-version
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+# This is a test dependency file for testing the Dependabot auto-merge workflow
+# Version: 1.2.4
+TEST_DEPENDENCY_VERSION=1.2.4


### PR DESCRIPTION
## 🧪 Test PR: Dependabot Auto-Merge Workflow Simulation

**⚠️ This is a TEST PR** to simulate a Dependabot PATCH update.

### Purpose

Test the auto-merge workflow logic with a simulated Dependabot PR.

### Simulated update

```
test-dependency from 1.2.3 to 1.2.4 (PATCH)
```

### Expected behavior

❌ **Will NOT auto-merge** because `github.actor != 'dependabot[bot]'`

But the workflow should:
1. Detect update type correctly (PATCH)
2. Parse version numbers (1.2.3 → 1.2.4)
3. Skip auto-merge with informative comment

### Manual testing

After #41 is merged, this PR can be used to test the workflow's decision logic.

---

**Note:** This PR can be closed immediately after testing or merged if you want to keep the test file.