### PR TITLE
docs: update CLA enforcement details in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -186,7 +186,7 @@ All contributors must sign the [CLA](../CLA.md) to:
 - Retain copyright ownership of contributions
 - Enable dual-licensing business model
 
-CLA signing is **automated** via CLA Assistant bot on pull requests.
+**CLA Enforcement:** Automated via [CLA Assistant](https://cla-assistant.io) **hosted service** (NOT a GitHub Action workflow). OAuth click-through signing (§ 126b BGB compliant), GDPR-compliant storage (Azure West Europe). GitHub status check: `license/cla`. See [CLA.md](../CLA.md) for signing instructions.
 
 ## Repository Visibility
 


### PR DESCRIPTION
## Summary

Updates the Copilot Instructions to reflect the recent migration from GitHub Actions to the hosted CLA Assistant service (completed in #48).

## Changes

- Changed description from "CLA Assistant bot" to "CLA Assistant hosted service"
- **Added clarification:** NOT a GitHub Action workflow (prevents future AI confusion)
- Specified OAuth click-through signing (§ 126b BGB compliant)
- Added GDPR-compliant storage location (Azure West Europe)
- Documented correct status check name: `license/cla`
- Added reference link to CLA.md for signing instructions

## Rationale

The previous description was **outdated and misleading** after PR #48:
- Said "CLA Assistant bot" instead of "hosted service"
- Didn't mention it's NOT a workflow (AI might search for `.github/workflows/cla.yml`)
- Missing legal compliance details (§ 126b BGB, GDPR)
- Missing correct check name for branch protection configuration

## Validation

- ✅ All preflight checks pass
- ✅ REUSE compliant
- ✅ Formatting validated
- ✅ No linting errors (markdownlint false positive on external URL)
- ✅ 410 lines total (within <450 lines target)

## Related

- Follows: #48 (CLA migration to hosted service)