### PR TITLE
fix(scripts): prevent jq injection in label sync

### DIFF
--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -91,7 +91,7 @@ for label_spec in "${LABELS[@]}"; do
   IFS='|' read -r name color description <<< "$label_spec"
 
   # Check if label exists (using cached data)
-  LABEL_DATA=$(echo "$EXISTING_LABELS" | jq -r ".[] | select(.name==\"$name\")")
+  LABEL_DATA=$(echo "$EXISTING_LABELS" | jq -r --arg name "$name" '.[] | select(.name==$name)')
 
   if [ -n "$LABEL_DATA" ]; then
     # Label exists, check if update needed


### PR DESCRIPTION
## Fix

Prevent potential jq injection vulnerability in label sync script by using `--arg` for safe variable interpolation.

### Problem

The previous implementation used string interpolation:
```bash
jq -r ".[] | select(.name==\"$name\")"
```

This would **fail** (or worse) if label names contain special characters like:
- Quotes: `"`, `'`
- Backslashes: `\`
- Dollar signs: `$`

### Solution

Use jq's `--arg` parameter for safe variable passing:
```bash
jq -r --arg name "$name" '.[] | select(.name==$name)'
```

### Impact

- ✅ **Security:** Prevents potential code injection
- ✅ **Robustness:** Handles any valid label name
- ✅ **Best Practice:** Standard jq pattern for variables

### Testing

Tested with edge cases:
```bash
# These would fail before, work now:
test"label
test\label
test$label
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking)
- [x] 🔒 Security fix

## References

- Addresses Copilot review comment #2462924280
- Related to PR #50