### PR TITLE
docs: add cross-references for large-pr-approved label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,16 @@ Keep PRs **≤ 600 changed lines** for maintainability. If larger, split into se
 2. Core implementation
 3. Tests and documentation
 
+**Exceptions:**
+
+Large PRs (> 600 lines) are acceptable for:
+
+- **Dependency updates** (e.g., `package-lock.json`, `Cargo.lock`)
+- **Generated code** (e.g., OpenAPI clients, database migrations)
+- **Boilerplate/templates** that cannot be reasonably split
+
+In these cases, add the `large-pr-approved` label to bypass the size check. See [Organization Label Standards](https://github.com/SecPal/.github/blob/main/docs/labels.md) for details.
+
 ## Branch Naming Convention
 
 Use the following prefixes for your branch names:

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -98,7 +98,7 @@ Labels: bug, security, priority: high
 **Optional:**
 
 - `breaking-change` if backward incompatible
-- `large-pr-approved` if > 600 lines and legitimate
+- `large-pr-approved` if > 600 lines and legitimate (see [CONTRIBUTING.md](../CONTRIBUTING.md#pr-size-limit))
 - `dependencies` (usually auto-added by Dependabot)
 
 **Example:**


### PR DESCRIPTION
## Changes

- Add **Exceptions** section to CONTRIBUTING.md PR Size Limit
- Document when large PRs (>600 lines) are acceptable:
  - Dependency updates (package-lock.json, Cargo.lock)
  - Generated code (OpenAPI clients, migrations)  
  - Boilerplate/templates that cannot be split
- Add cross-reference from CONTRIBUTING.md to docs/labels.md
- Add cross-reference from docs/labels.md to CONTRIBUTING.md
- Use absolute GitHub URLs for better discoverability

## Why

The `large-pr-approved` label exists in:
- scripts/sync-labels.sh ✅
- docs/labels.md ✅
- Workflow checks ✅

But the mechanism to bypass the 600-line limit was not documented in CONTRIBUTING.md.

## Impact

All repos using symlinked CONTRIBUTING.md (contracts, frontend) automatically get this documentation update.