### PR TITLE
🔒 Fix shell injection vulnerability in PR size workflow

### DIFF
--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -31,9 +31,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MAX_LINES: ${{ inputs.max-lines }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Check if PR has 'large-pr-approved' label
-          PR_NUMBER="${{ github.event.pull_request.number }}"
           LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
 
           if echo "$LABELS" | grep -q "large-pr-approved"; then
@@ -43,10 +44,10 @@ jobs:
           fi
 
           # Fetch base branch
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin "$BASE_REF"
 
           # Calculate merge base
-          MERGE_BASE=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
 
           # Get raw diff output
           RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD)


### PR DESCRIPTION
## 🔒 Security Fix

This PR fixes a **High Severity** shell injection vulnerability in the GitHub Actions workflow for PR size checking.

## 🐛 Vulnerability Details

**File:** `.github/workflows/reusable-pr-size.yml`  
**Rule:** `yaml.github-actions.security.run-shell-injection`  
**Severity:** 🔴 **High**  
**Found by:** Semgrep static analysis

### Issue

Direct interpolation of `github.event.*` context variables in shell commands allows potential command injection:

```yaml
# ❌ VULNERABLE
run: |
  PR_NUMBER="${{ github.event.pull_request.number }}"
  git fetch origin ${{ github.base_ref }}
```

An attacker could craft malicious PR data to inject shell commands that would execute in the GitHub Actions runner.

## ✅ Fix Applied

Move GitHub context variables to environment variables:

```yaml
# ✅ SECURE
env:
  PR_NUMBER: ${{ github.event.pull_request.number }}
  BASE_REF: ${{ github.base_ref }}
run: |
  LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
  git fetch origin "$BASE_REF"
```

### Changes
- ✅ `github.event.pull_request.number` → Environment variable `PR_NUMBER`
- ✅ `github.base_ref` → Environment variable `BASE_REF`
- ✅ Added quotes around all variable references (`"$VAR"`)
- ✅ Eliminated direct `${{ }}` interpolation in `run:` scripts

## 🎯 Impact

- **Before:** Malicious PR could potentially inject shell commands
- **After:** Input is sanitized through environment variables
- **Risk Level:** High → **None**

## 🔍 Testing

- [x] Pre-push hooks passed (yamllint, REUSE)
- [x] Semgrep re-scan shows 0 findings
- [x] Workflow syntax validated
- [x] No functional changes to workflow behavior

## 📚 References

- Semgrep Rule: https://sg.run/pkzk
- GitHub Security Best Practices: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
- Full scan report: Issue #68

## ⚡ Priority

**URGENT** - Security vulnerability fix should be merged ASAP

---

**Related:** Issue #68 (Semgrep Security Scan Report)