### PR TITLE
fix(dependabot): support flexible version formats in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -66,19 +66,20 @@ jobs:
           #   "Bump package from 1.2.3 to 1.2.4"
           #   "Update dependency from 1.2.3 to 1.2.4"
           #   "chore(deps): bump package from 1.2.3 to 1.2.4"
+          #   "Bump action from 5 to 6" (GitHub Actions often use single-digit versions)
           #
           # Note: Pre-release versions (1.2.3-beta) and build metadata (1.2.3+build)
           # are NOT supported. Such PRs will fall back to 'unparseable' status and
           # require manual review, which is the safer approach for non-stable versions.
 
-          # Extract "from X.Y.Z to A.B.C" pattern
-          if [[ "${PR_TITLE}" =~ from[[:space:]]+([0-9]+)\.([0-9]+)\.([0-9]+)[[:space:]]+to[[:space:]]+([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          # Extract "from X[.Y[.Z]] to A[.B[.C]]" pattern (flexible version format)
+          if [[ "${PR_TITLE}" =~ from[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?[[:space:]]+to[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))? ]]; then
             OLD_MAJOR="${BASH_REMATCH[1]}"
-            OLD_MINOR="${BASH_REMATCH[2]}"
-            OLD_PATCH="${BASH_REMATCH[3]}"
-            NEW_MAJOR="${BASH_REMATCH[4]}"
-            NEW_MINOR="${BASH_REMATCH[5]}"
-            NEW_PATCH="${BASH_REMATCH[6]}"
+            OLD_MINOR="${BASH_REMATCH[3]:-0}"  # Default to 0 if not present
+            OLD_PATCH="${BASH_REMATCH[5]:-0}"  # Default to 0 if not present
+            NEW_MAJOR="${BASH_REMATCH[6]}"
+            NEW_MINOR="${BASH_REMATCH[8]:-0}"  # Default to 0 if not present
+            NEW_PATCH="${BASH_REMATCH[10]:-0}" # Default to 0 if not present
 
             echo "Old version: ${OLD_MAJOR}.${OLD_MINOR}.${OLD_PATCH}"
             echo "New version: ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes the Dependabot auto-merge workflow to correctly parse version numbers in different formats.

### Problem

The workflow's regex pattern only supported full semantic versions (`X.Y.Z`), causing GitHub Actions updates like `from 5 to 6` to be marked as "unparseable" instead of correctly identifying them as MAJOR updates.

**Example from PR #70:**
```
Title: chore(deps): Bump fsfe/reuse-action from 5 to 6
Expected: MAJOR update (5.0.0 → 6.0.0)
Actual: ❓ unparseable
```

### Solution

Updated the regex pattern to support flexible version formats:
- `5` → normalized to `5.0.0`
- `1.2` → normalized to `1.2.0`  
- `1.2.3` → stays `1.2.3`

Missing MINOR/PATCH components default to `0`, following semantic versioning conventions.

### Changes

- 📝 Updated regex in `.github/workflows/dependabot-auto-merge.yml`
- ✨ Support for single-digit versions (common in GitHub Actions)
- ✨ Support for partial versions (e.g., `1.2`)
- 📚 Enhanced documentation with GitHub Actions example

### Testing

This fix will be validated against PR #70 which should now be correctly identified as a MAJOR update requiring manual review.

### Related Issues

- Resolves parsing issue mentioned in PR #70
- Improves Dependabot automation reliability

---

**Auto-merge:** This is a bug fix (PATCH), eligible for auto-merge once CI passes ✅