### PR TITLE
fix: add missing PR size check workflow

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+name: PR Size Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-size:
+    name: Check PR Size
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
+    with:
+      max-lines: 600

--- a/.github/workflows/pr-size.yml.license
+++ b/.github/workflows/pr-size.yml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 SecPal
+SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
## Problem

PR #65 with 5,489 lines was merged without PR size validation because the `.github` repository was missing the `pr-size.yml` workflow.

## Solution

- ✅ Add separate `pr-size.yml` workflow (consistent with other repos)
- ✅ Uses reusable workflow from `SecPal/.github`
- ✅ 600 lines limit with `.preflight-exclude` support
- ✅ REUSE-compliant with license file

## Impact

This ensures all SecPal repositories have consistent PR size protection.

## Verification

All other repositories (`api`, `frontend`, `contracts`) already have this workflow in place.

## Next Steps

After merge, branch protection rules will be updated via GitHub API to require the "Check PR Size" status check.