### PR TITLE
fix: Fix workflow syntax error and permissions

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -31,17 +31,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const body = [
+              '⚠️ **Manual Action Required**',
+              '',
+              'This issue could not be automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) due to missing permissions.',
+              '',
+              '**To add manually:**',
+              '```bash',
+              `gh project item-add 1 --owner SecPal --url ${context.payload.issue.html_url}`,
+              '```',
+              '',
+              '**To enable automation:** An organization admin needs to:',
+              '1. Create a fine-grained Personal Access Token with `Contents: Read` and `Projects: Read & Write` permissions',
+              '2. Add it as a repository secret named `PROJECT_TOKEN`',
+              '3. Update this workflow to use `github-token: ${{ secrets.PROJECT_TOKEN }}`',
+              '',
+              'See: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects'
+            ].join('\n');
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `⚠️ **Manual Action Required**\n\nThis issue could not be automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) due to missing permissions.\n\n**To add manually:**\n\`\`\`bash\ngh project item-add 1 --owner SecPal --url ${context.payload.issue.html_url}\n\`\`\`\n\n**To enable automation:** An organization admin needs to:\n1. Create a fine-grained Personal Access Token with \`Contents: Read\` and \`Projects: Read & Write\` permissions\n2. Add it as a repository secret named \`PROJECT_TOKEN\`\n3. Update this workflow to use \`github-token: \${{ secrets.PROJECT_TOKEN }}\`\n\nSee: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects`
+              body: body
             });
 
   set-status-field:
     name: Set initial status based on labels
     runs-on: ubuntu-latest
     needs: add-to-project
+    permissions:
+      issues: write
+      contents: read
     if: |
       (success() || failure()) &&
       (contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'core-feature'))


### PR DESCRIPTION
## Problem

The project automation workflow was failing with two critical issues:

1. **JavaScript Syntax Error**: Nested backticks in the error comment template literal caused a syntax error when the workflow tried to post comments
2. **Missing Permissions**: The `set-status-field` job didn't have explicit `issues: write` permission

## Solution

- Refactored the comment body to use `array.join()` instead of template literals, avoiding backtick escaping issues
- Added explicit permissions to the `set-status-field` job
- Both jobs now have `issues: write` and `contents: read` permissions

## Testing

This will be tested with issue #81. The workflow should now:
- Fail gracefully when adding to project (expected with GITHUB_TOKEN)
- Successfully post an error comment with manual instructions
- Successfully post a status suggestion comment

## Related

- Fixes workflow failures discovered in #81
- Follow-up to PR #80