### PR TITLE
🚨 SECURITY: Fix token leak in error comment

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -58,7 +58,7 @@ jobs:
               '**To enable automation:** An organization admin needs to:',
               '1. Create a fine-grained Personal Access Token with `Contents: Read` and `Projects: Read & Write` permissions',
               '2. Add it as a repository secret named `PROJECT_TOKEN`',
-              '3. Update this workflow to use `github-token: ${{ secrets.PROJECT_TOKEN }}`',
+              '3. Update this workflow to use `github-token: \\${{ secrets.PROJECT_TOKEN }}`',
               '',
               'See: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects'
             ].join('\n');


### PR DESCRIPTION
## 🚨 CRITICAL SECURITY FIX 🚨

### Problem

The error comment in the workflow was using `${{ secrets.PROJECT_TOKEN }}` in a template literal, which caused GitHub Actions to **expand the secret value** and include it in public issue comments!

**Exposed Token:**
- Token: `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`
- Exposed in: Issue #88, Comment ID 3453881177 (now deleted)
- Visibility: **PUBLIC** (anyone could have seen it)

### Fix

Escaped the template literal: `\\${{ secrets.PROJECT_TOKEN }}` to prevent expansion.

### Required Actions

⚠️ **IMMEDIATE:**
1. ✅ Leaked comment deleted
2. ❌ **REVOKE the leaked token** at https://github.com/settings/tokens
3. ❌ **Create new PROJECT_TOKEN** with same permissions
4. ❌ **Update organization secret** with new token

### Token Permissions (for replacement)

- Projects: Read & Write (org-level)
- Contents: Read  
- Issues: Read & Write

## Merge Priority

**URGENT** - Merge immediately to prevent future token leaks.