### PR TITLE
fix: Replace actions/add-to-project with direct GraphQL mutation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   # Project ID for SecPal Roadmap (organization project)
-  # To find your project ID: gh api graphql -f query='query{organization(login:"SecPal"){projectV2(number:1){id}}}'
+  # To find your project ID: gh api graphql -f query='query{organization(login:"YOUR_ORG"){projectV2(number:YOUR_PROJECT_NUMBER){id}}}'
+  # Replace "YOUR_ORG" with your organization login, and "YOUR_PROJECT_NUMBER" with your project number.
   PROJECT_ID: PVT_kwDOCUodoc4BGgjL
 
 jobs:
@@ -59,7 +60,7 @@ jobs:
               });
               console.log('✅ Successfully added to project:', result);
             } catch (error) {
-              console.error('❌ Failed to add to project:', error.message);
+              console.error('❌ Failed to add to project:', error.message, error.status, error.response, error);
               throw error;
             }
 


### PR DESCRIPTION
## Problem

The `actions/add-to-project@v1.0.2` action consistently fails with "Bad credentials" error, even when using valid fine-grained Personal Access Tokens that work perfectly when tested manually via the GraphQL API.

## Root Cause

After extensive debugging (issues #88, #90-95), we determined:
- ✅ Fine-grained PAT is **valid** (manual GraphQL tests succeed)
- ✅ PAT has correct permissions (Organization Projects: Read & Write, Repository Issues: Read & Write)
- ✅ User is Organization Owner
- ❌ The `actions/add-to-project` action fails to authenticate despite all of the above

## Solution

Replace the problematic third-party action with **direct GraphQL mutation** using `actions/github-script@v7`.

This approach:
- ✅ Uses the same PROJECT_TOKEN secret
- ✅ Provides full control over authentication
- ✅ Better error messages for debugging
- ✅ Same functionality without wrapper complications

## Changes

- Replaced `actions/add-to-project@v1.0.2` with `actions/github-script@v7`
- Direct GraphQL `addProjectV2ItemById` mutation
- Maintains graceful error handling with `continue-on-error: true`
- Preserves all existing workflow logic (status comments, etc.)

## Testing

- Manual GraphQL test with PROJECT_TOKEN: ✅ Success
- Fine-grained PAT authentication: ✅ Verified
- Project read access: ✅ Confirmed

Next step: Test with a new issue after this PR is merged.