### PR TITLE
fix: Prevent duplicate workflow runs on labeled events

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,7 +8,6 @@ on:
     types:
       - opened
       - reopened
-      - labeled
 
 env:
   # Project ID for SecPal Roadmap (organization project)


### PR DESCRIPTION
## Problem

When creating issues with labels (e.g., `gh issue create --label "enhancement"`), the workflow runs **twice**:

1. **`opened` event** - Issue created ✅
2. **`labeled` event** - Label added during creation ✅

This causes **duplicate status comments** (see Issue #100).

## Root Cause

The `labeled` trigger is unnecessary because:
- Labels added during issue creation are already present when `opened` fires
- The workflow checks for labels in conditions anyway
- We don't need to re-add issues to the project when labels change later

## Solution

Remove `labeled` from triggers. Only use:
- `opened` - New issues
- `reopened` - Reopened issues

## Testing

Issue #100 received two identical comments. After this fix, new issues should only get one comment.

## Changes

```diff
 on:
   issues:
     types:
       - opened
       - reopened
-      - labeled
```