### PR TITLE
fix: Use backticks for status strings to handle apostrophes

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -195,7 +195,7 @@ jobs:
             const fieldId = process.env.STATUS_FIELD_ID;
             const itemId = '${{ steps.add-to-project.outputs.itemId || steps.get-item-id.outputs.itemId }}';
             const optionId = '${{ steps.determine-status.outputs.statusId || steps.determine-closed-status.outputs.statusId }}';
-            const status = '${{ steps.determine-status.outputs.status || steps.determine-closed-status.outputs.status }}';
+            const status = `${{ steps.determine-status.outputs.status || steps.determine-closed-status.outputs.status }}`;
 
             const mutation = `
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
@@ -224,8 +224,8 @@ jobs:
         with:
           script: |
             const action = context.payload.action;
-            const status = '${{ steps.determine-status.outputs.status }}';
-            const reason = '${{ steps.determine-status.outputs.reason }}';
+            const status = `${{ steps.determine-status.outputs.status }}`;
+            const reason = `${{ steps.determine-status.outputs.reason }}`;
             const addedToProject = '${{ steps.add-to-project.outputs.success }}' === 'true';
 
             const emoji = addedToProject ? '✅' : '⚠️';
@@ -322,7 +322,7 @@ jobs:
             const projectId = process.env.PROJECT_ID;
             const fieldId = process.env.STATUS_FIELD_ID;
             const optionId = '${{ steps.pr-status.outputs.statusId }}';
-            const status = '${{ steps.pr-status.outputs.status }}';
+            const status = `${{ steps.pr-status.outputs.status }}`;
 
             for (const issueNumber of issueNumbers) {
               try {


### PR DESCRIPTION
## 🐛 Bug Fix

**Problem:** JavaScript syntax error when status strings contain apostrophes (e.g., "Won't Do")

**Root Cause:** 
Using single quotes for JavaScript string literals that contain text with apostrophes:
```javascript
const status = '${{ steps.determine-closed-status.outputs.status }}';
// When status = "Won't Do", this becomes:
// const status = '🚫 Won't Do'; // ❌ Syntax error!
```

**Solution:**
Changed to template literals (backticks) to properly handle special characters:
```javascript
const status = `${{ steps.determine-closed-status.outputs.status }}`;
// Now becomes:
// const status = `🚫 Won't Do`; // ✅ Works!
```

**Files Changed:**
- `.github/workflows/project-automation-v2.yml` - Updated 4 instances

**Testing:**
This fix is required for Test Scenario #5 (Close as Not Planned → Won't Do) to pass.

**Impact:**
- ✅ Fixes: Issue closed as "not planned" status update
- ✅ Fixes: All status strings with special characters
- ✅ No breaking changes

Fixes failed test from PR #106 testing phase.