### PR TITLE
feat: Add converted_to_draft event support for single-maintainer workflow

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -19,6 +19,7 @@ on:
       - opened
       - ready_for_review
       - closed
+      - converted_to_draft
   pull_request_review:
     types:
       - submitted
@@ -305,6 +306,14 @@ jobs:
               echo "status=👀 In Review"
               echo "statusId=fc39b4e9"
               echo "reason=Pull request ready for review"
+              echo "shouldUpdate=true"
+            } >> "$GITHUB_OUTPUT"
+          elif [[ "$ACTION" == "converted_to_draft" ]]; then
+            # PR converted back to draft → In Progress (needs more work)
+            {
+              echo "status=🚧 In Progress"
+              echo "statusId=d20ace06"
+              echo "reason=Converted to draft - changes in progress"
               echo "shouldUpdate=true"
             } >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## 🎯 Enhancement: Single-Maintainer Workflow Support

### Problem

Test scenario #10 ("PR review requests changes → In Progress") cannot be tested in single-maintainer projects because:
- You cannot review your own PRs
- Copilot reviews don't trigger `pull_request_review` events
- No other maintainer available to request changes

### Solution

Add support for `converted_to_draft` event as an **alternative signal** that changes are needed.

### Workflow for Single Maintainers

```bash
# 1. Create draft PR
gh pr create --draft --title "WIP: Feature" --body "Closes #123"
# → Issue status: 🚧 In Progress ✅

# 2. Mark ready for review
gh pr ready <PR>
# → Issue status: 👀 In Review ✅

# 3. Copilot finds issues / you want to make changes
gh pr ready --undo <PR>
# → Issue status: 🚧 In Progress ✅ (NEW!)

# 4. Push fixes, mark ready again
gh pr ready <PR>
# → Issue status: 👀 In Review ✅

# 5. Merge
gh pr merge <PR>
# → Issue status: ✅ Done ✅
```

### Changes

**File:** `.github/workflows/project-automation-v2.yml`

1. Added `converted_to_draft` to `pull_request.types`
2. Added logic to set status to "In Progress" when PR converted to draft

### Benefits

✅ **Semantic correctness** - Draft = Work in Progress  
✅ **Visual feedback** - Project board shows correct state  
✅ **No workarounds needed** - Uses GitHub's native draft feature  
✅ **Single maintainer friendly** - No second account required  

### Testing

Will test with existing PR #116:
1. Convert to draft → Check status updates to In Progress
2. Mark ready → Check status updates back to In Review

### Related

- Addresses test scenario #10 from PR #106
- Alternative to formal "Request Changes" review workflow
- Complements existing draft PR workflow from PR #106