### PR TITLE
fix: Make PROJECT_TOKEN optional for direct event triggers

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -8,7 +8,7 @@ on:
     secrets:
       PROJECT_TOKEN:
         description: "Fine-grained PAT with Projects (Read & Write) and Issues (Read & Write) permissions"
-        required: true
+        required: false # Changed from true - allows direct events to use repo secrets
   issues:
     types:
       - opened


### PR DESCRIPTION
## 🐛 Bug Fix: PROJECT_TOKEN Not Available in Direct Event Mode

### Problem

Workflow failed with "Bad credentials" error when triggered by direct events (issues, pull_request) in the `.github` repository itself.

**Root Cause:**
```yaml
workflow_call:
  secrets:
    PROJECT_TOKEN:
      required: true  # ❌ Blocks direct event triggers
```

When `required: true`, the workflow expects PROJECT_TOKEN to be **passed as parameter**. But direct events don't have a caller to pass it - they use repository secrets directly.

### Error Log

```
❌ Failed to update issue #115: Bad credentials
```

### Solution

Changed to `required: false`:

```yaml
workflow_call:
  secrets:
    PROJECT_TOKEN:
      required: false  # ✅ Allows both modes
```

### How It Works Now

**Mode 1: Direct Events** (`.github` repo)
```yaml
# Triggered by: issues, pull_request, pull_request_review
# Token source: Repository secrets (secrets.PROJECT_TOKEN)
# Use case: Testing and self-management
```

**Mode 2: Workflow Call** (other repos)
```yaml
# api/.github/workflows/project-automation.yml
uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
secrets:
  PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}  # Explicitly passed
```

### Testing

This fix enables Test #10 (converted_to_draft) to work properly in the `.github` repository.

Will test by converting PR #116 to/from draft after merge.

### Impact

✅ No breaking changes for other repos  
✅ Enables `.github` repo self-automation  
✅ Both modes work correctly with same syntax