### PR TITLE
fix: resolve workflow startup_failure in consuming repositories

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -9,20 +9,6 @@ on:
       PROJECT_TOKEN:
         description: "Fine-grained PAT with Projects (Read & Write) and Issues (Read & Write) permissions"
         required: false # Changed from true - allows direct events to use repo secrets
-  issues:
-    types:
-      - opened
-      - reopened
-      - closed
-  pull_request:
-    types:
-      - opened
-      - ready_for_review
-      - closed
-      - converted_to_draft
-  pull_request_review:
-    types:
-      - submitted
 
 env:
   PROJECT_ID: PVT_kwDOCUodoc4BGgjL

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,204 +1,27 @@
 # SPDX-FileCopyrightText: 2025 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
-name: Add Issues to Project
+name: Project Board Automation
 
 on:
   issues:
     types:
       - opened
       - reopened
-
-env:
-  # Project ID for SecPal Roadmap (organization project)
-  # To find your project ID: gh api graphql -f query='query{organization(login:"YOUR_ORG"){projectV2(number:YOUR_PROJECT_NUMBER){id}}}'
-  # Replace "YOUR_ORG" with your organization login, and "YOUR_PROJECT_NUMBER" with your project number.
-  PROJECT_ID: PVT_kwDOCUodoc4BGgjL
+      - closed
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - closed
+      - converted_to_draft
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
-  add-to-project:
-    name: Add issue to project board
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
-    outputs:
-      project-add-outcome: ${{ steps.set-outcome.outputs.outcome }}
-      project-item-id: ${{ steps.add-to-project.outputs.itemId }}
-    steps:
-      - name: Add to project
-        id: add-to-project
-        continue-on-error: true
-        uses: actions/github-script@v8
-        with:
-          # NOTE: A fine-grained Personal Access Token is required here because GITHUB_TOKEN
-          # lacks organization-level project permissions.
-          # Required permissions for PROJECT_TOKEN (configured as org secret):
-          #   - Organization: Projects (Read & Write)
-          #   - Repository: Issues (Read & Write)
-          #   - Repository: Metadata (Read-only, automatically included)
-          # Fallback: If this step fails, a helpful error comment is posted (see step: Comment if project add failed)
-          github-token: ${{ secrets.PROJECT_TOKEN }}
-          script: |
-            const projectId = process.env.PROJECT_ID;
-            const contentId = context.payload.issue.node_id;
-
-            const mutation = `
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                  item {
-                    id
-                  }
-                }
-              }
-            `;
-
-            try {
-              const result = await github.graphql(mutation, {
-                projectId,
-                contentId
-              });
-              console.log('✅ Successfully added to project:', result);
-              const itemId = result.addProjectV2ItemById.item.id;
-              core.setOutput('itemId', itemId);
-              return itemId;
-            } catch (error) {
-              console.error('❌ Failed to add to project:', error.message, error.status, error.response, error);
-              throw error;
-            }
-
-      - name: Set outcome output
-        id: set-outcome
-        if: always()
-        run: echo "outcome=\"${{ steps.add-to-project.outcome }}\"" >> "$GITHUB_OUTPUT"
-
-      - name: Comment if project add failed
-        if: steps.add-to-project.outcome == 'failure'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const body = [
-              '⚠️ **Manual Action Required**',
-              '',
-              'This issue could not be automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) due to missing permissions.',
-              '',
-              '**To add manually:**',
-              '```bash',
-              `gh project item-add 1 --owner SecPal --url ${context.payload.issue.html_url}`,
-              '```',
-              '',
-              '**To enable automation:** An organization admin needs to:',
-              '1. Create a fine-grained Personal Access Token with `Contents: Read` and `Projects: Read & Write` permissions',
-              '2. Add it as a repository secret named `PROJECT_TOKEN`',
-              '3. Update this workflow to use `github-token: \\${{ secrets.PROJECT_TOKEN }}`',
-              '',
-              'See: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects'
-            ].join('\n');
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
-
-  set-status-field:
-    name: Set initial status based on labels
-    runs-on: ubuntu-latest
-    needs: add-to-project
-    permissions:
-      issues: write
-      contents: read
-    if: |
-      (success() || failure()) &&
-      (contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'core-feature'))
-    steps:
-      - name: Determine initial status
-        id: status
-        run: |
-          # Check labels to determine initial project status
-          CORE_FEATURE="${{ contains(github.event.issue.labels.*.name, 'core-feature') }}"
-          BLOCKER="${{ contains(github.event.issue.labels.*.name, 'priority: blocker') }}"
-
-          if [[ "$CORE_FEATURE" == "true" ]]; then
-            {
-              echo "status=📋 Planned"
-              echo "status-id=aa8c7fe5"
-              echo "description=Core feature - scheduled for implementation"
-            } >> "$GITHUB_OUTPUT"
-          elif [[ "$BLOCKER" == "true" ]]; then
-            {
-              echo "status=📥 Backlog"
-              echo "status-id=53395960"
-              echo "description=High priority - needs immediate attention"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "status=💡 Ideas"
-              echo "status-id=88b56a57"
-              echo "description=New idea - needs discussion and evaluation"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set project status
-        if: needs.add-to-project.outputs.project-add-outcome == 'success'
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
-          script: |
-            const projectId = process.env.PROJECT_ID;
-            const itemId = '${{ needs.add-to-project.outputs.project-item-id }}';
-            const fieldId = 'PVTSSF_lADOCUodoc4BGgjLzg3iI0Y'; // Status field ID
-            const optionId = '${{ steps.status.outputs.status-id }}';
-
-            const mutation = `
-              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $projectId
-                  itemId: $itemId
-                  fieldId: $fieldId
-                  value: { singleSelectOptionId: $optionId }
-                }) {
-                  projectV2Item {
-                    id
-                  }
-                }
-              }
-            `;
-
-            try {
-              await github.graphql(mutation, {
-                projectId,
-                itemId,
-                fieldId,
-                optionId
-              });
-              console.log('✅ Status set to:', '${{ steps.status.outputs.status }}');
-            } catch (error) {
-              console.error('❌ Failed to set status:', error.message);
-              // Don't fail the workflow if status update fails
-            }
-
-      - name: Comment on issue
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const status = '${{ steps.status.outputs.status }}';
-            const description = '${{ steps.status.outputs.description }}';
-            const projectAdded = '${{ needs.add-to-project.outputs.project-add-outcome }}' === 'success';
-            const message = projectAdded
-              ? `✅ This issue has been automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) with status: **${status}**\n\n_${description}_`
-              : `📋 Suggested status for [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1): **${status}**\n\n_${description}_`;
-
-            const statusFlow = `
-            **Status Flow:**
-            💡 Ideas → 💬 Discussion → 📥 Backlog → 📋 Planned → 🚧 In Progress → 👀 In Review → ✅ Done
-
-            _Note: Ideas that won't be implemented should be moved to 🚫 Won't Do with a reason._`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `${message}\n${statusFlow}\n\n**Next steps:**\n- Review and refine the issue description\n- Add relevant labels (area, priority)\n- Discuss feasibility and approach\n- Move through status flow as work progresses`
-            });
+  project-automation:
+    name: Project automation
+    uses: ./.github/workflows/project-automation-v2.yml
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/docs/workflows/PROJECT_AUTOMATION.md
+++ b/docs/workflows/PROJECT_AUTOMATION.md
@@ -1,0 +1,230 @@
+<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Project Board Automation
+
+Automated project board management that keeps your [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) in sync with issues and pull requests.
+
+## 🎯 Overview
+
+This workflow automatically:
+
+- ✅ Adds issues and PRs to the project board
+- 🔄 Updates status based on labels, events, and PR state
+- 💬 Posts helpful comments explaining status transitions
+- 🚧 Supports draft PR workflow for incremental development
+
+## 📊 Status Flow
+
+```mermaid
+graph LR
+    A[💡 Ideas] --> B[💬 Discussion]
+    B --> C[📥 Backlog]
+    B --> D[📋 Planned]
+    C --> D
+    D --> E[🚧 In Progress]
+    E --> F[👀 In Review]
+    F --> E
+    F --> G[✅ Done]
+    B --> H[🚫 Won't Do]
+```
+
+### Status Meanings
+
+| Status          | Emoji | Meaning                                        |
+| --------------- | ----- | ---------------------------------------------- |
+| **Ideas**       | 💡    | New ideas requiring discussion                 |
+| **Discussion**  | 💬    | Being discussed, or reopened for re-evaluation |
+| **Backlog**     | 📥    | High priority blockers waiting to be planned   |
+| **Planned**     | 📋    | Core features scheduled for implementation     |
+| **In Progress** | 🚧    | Currently being worked on                      |
+| **In Review**   | 👀    | Ready for review/testing                       |
+| **Done**        | ✅    | Completed and merged                           |
+| **Won't Do**    | 🚫    | Closed as not planned                          |
+
+## 🔄 Automatic Status Updates
+
+### Issue Events
+
+| Event          | Condition                  | Status        |
+| -------------- | -------------------------- | ------------- |
+| Issue opened   | Label: `enhancement`       | 💡 Ideas      |
+| Issue opened   | Label: `core-feature`      | 📋 Planned    |
+| Issue opened   | Label: `priority: blocker` | 📥 Backlog    |
+| Issue reopened | Any                        | 💬 Discussion |
+| Issue closed   | Reason: `completed`        | ✅ Done       |
+| Issue closed   | Reason: `not_planned`      | 🚫 Won't Do   |
+
+### Pull Request Events
+
+| Event                     | Condition | Linked Issue Status |
+| ------------------------- | --------- | ------------------- |
+| PR opened                 | Draft     | 🚧 In Progress      |
+| PR opened                 | Non-draft | 👀 In Review        |
+| PR marked ready           | -         | 👀 In Review        |
+| **PR converted to draft** | -         | 🚧 In Progress      |
+| PR merged                 | -         | ✅ Done             |
+| PR closed unmerged        | -         | _No change_         |
+
+### Pull Request Review Events
+
+| Event            | Review State        | Linked Issue Status |
+| ---------------- | ------------------- | ------------------- |
+| Review submitted | `changes_requested` | 🚧 In Progress      |
+
+> **Note:** For single-maintainer projects, use `gh pr ready --undo` (convert to draft) as an alternative to formal "Request Changes" reviews.
+
+## 🚀 Quick Start
+
+### For This Repository (.github)
+
+The workflow is already active! It runs automatically on:
+
+- Issue opened/reopened/closed
+- Pull request opened/ready/closed/converted to draft
+- Pull request review submitted
+
+### For Other Repositories
+
+See [ROLLOUT_GUIDE.md](./ROLLOUT_GUIDE.md) for deployment instructions.
+
+## 💡 Best Practices
+
+### Draft PR Workflow (Recommended)
+
+For incremental development and self-review:
+
+```bash
+# 1. Start work - create draft PR
+gh pr create --draft \
+  --title "WIP: Implement feature X" \
+  --body "Closes #123"
+# → Issue #123 status: 🚧 In Progress
+
+# 2. Ready for review (or Copilot review)
+gh pr ready <PR-number>
+# → Issue #123 status: 👀 In Review
+
+# 3. Need to make changes after review?
+gh pr ready --undo <PR-number>
+# → Issue #123 status: 🚧 In Progress (signals "working on fixes")
+
+# 4. Fixed - ready again
+gh pr ready <PR-number>
+# → Issue #123 status: 👀 In Review
+
+# 5. Merge when approved
+gh pr merge <PR-number>
+# → Issue #123 status: ✅ Done (auto-closed)
+```
+
+### Single Maintainer Projects
+
+When you can't get formal code reviews:
+
+- ✅ Use draft PRs to signal work-in-progress
+- ✅ Let Copilot review your PRs
+- ✅ Convert to draft when addressing review feedback
+- ✅ Use the status board to track progress
+
+### Issue Linking
+
+Always link PRs to issues using keywords:
+
+```markdown
+Closes #123
+Fixes #456
+Resolves #789
+```
+
+The workflow automatically:
+
+- Updates linked issue status when PR state changes
+- Closes issues when PR is merged
+
+## 🔧 Configuration
+
+### Required Secret
+
+**Repository Secret:** `PROJECT_TOKEN`
+
+Fine-grained Personal Access Token with:
+
+- **Organization Permissions:**
+  - Projects: Read and write
+- **Repository Permissions:**
+  - Issues: Read and write
+  - Pull requests: Read and write
+
+### Environment Variables
+
+Set in workflow file (`.github/workflows/project-automation-v2.yml`):
+
+```yaml
+env:
+  PROJECT_ID: PVT_kwDOCUodoc4BGgjL # SecPal Roadmap
+  STATUS_FIELD_ID: PVTSSF_lADOCUodoc4BGgjLzg3iI0Y # Status field
+```
+
+### Status Option IDs
+
+```yaml
+Ideas: 88b56a57 # 💡
+Discussion: e2ca3f9c # 💬
+Backlog: 53395960 # 📥
+Planned: aa8c7fe5 # 📋
+In Progress: d20ace06 # 🚧
+In Review: fc39b4e9 # 👀
+Done: d8103dfe # ✅
+Won't Do: 6df780dd # 🚫
+```
+
+## 📝 Labels
+
+The workflow responds to these labels on issues:
+
+- `enhancement` → 💡 Ideas
+- `core-feature` → 📋 Planned
+- `priority: blocker` → 📥 Backlog
+
+Create these labels in your repository or adjust the workflow logic.
+
+## 🐛 Troubleshooting
+
+### Issue not added to project
+
+**Check:**
+
+1. Is `PROJECT_TOKEN` secret set?
+2. Does the PAT have Organization Projects permission?
+3. Is the PAT expired? (Check Settings → Secrets)
+
+### Status not updating
+
+**Check:**
+
+1. Workflow run logs (Actions tab)
+2. Issue/PR has correct labels
+3. PR body contains `Closes #N` for linked issues
+
+### "Bad credentials" error
+
+**Fix:**
+
+1. Go to Settings → Secrets → Actions
+2. Update `PROJECT_TOKEN` with a fresh PAT
+3. Ensure PAT has Organization-level Projects permission
+
+## 📚 Additional Documentation
+
+- [Rollout Guide](./ROLLOUT_GUIDE.md) - Deploy to other repositories
+- [Testing Guide](../../WORKFLOW_REVIEW.md) - Complete test scenarios
+- [Implementation Summary](../../IMPLEMENTATION_SUMMARY.md) - Technical details
+
+## 🆘 Support
+
+For issues or questions:
+
+- Check workflow runs in Actions tab
+- Review [WORKFLOW_REVIEW.md](../../WORKFLOW_REVIEW.md) for expected behavior
+- Open an issue with `workflow` label

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -1,0 +1,271 @@
+<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Quick Reference: Project Automation
+
+Quick reference card for daily usage of the project automation workflow.
+
+## 🎯 Status at a Glance
+
+| Status             | When             | How                            |
+| ------------------ | ---------------- | ------------------------------ |
+| 💡 **Ideas**       | New ideas        | Label: `enhancement`           |
+| 💬 **Discussion**  | Needs discussion | Reopen issue                   |
+| 📥 **Backlog**     | High priority    | Label: `priority: blocker`     |
+| 📋 **Planned**     | Scheduled work   | Label: `core-feature`          |
+| 🚧 **In Progress** | Working on it    | Create/convert to draft PR     |
+| 👀 **In Review**   | Ready for review | Mark PR ready                  |
+| ✅ **Done**        | Completed        | Merge PR or close as completed |
+| 🚫 **Won't Do**    | Not implementing | Close as not planned           |
+
+## 🔄 Common Workflows
+
+### Create New Issue
+
+```bash
+# Enhancement (goes to Ideas)
+gh issue create \
+  --title "Add feature X" \
+  --label "enhancement" \
+  --body "Description..."
+
+# Core feature (goes to Planned)
+gh issue create \
+  --title "Implement Y" \
+  --label "core-feature" \
+  --body "Description..."
+
+# Blocker (goes to Backlog)
+gh issue create \
+  --title "Fix critical bug" \
+  --label "priority: blocker" \
+  --body "Description..."
+```
+
+### Draft PR Workflow (Recommended)
+
+```bash
+# 1. Create draft PR (→ In Progress)
+gh pr create --draft \
+  --title "WIP: Feature X" \
+  --body "Closes #123"
+
+# 2. Mark ready (→ In Review)
+gh pr ready 456
+
+# 3. Need changes? (→ In Progress)
+gh pr ready --undo 456
+
+# 4. Ready again (→ In Review)
+gh pr ready 456
+
+# 5. Merge (→ Done, closes issue)
+gh pr merge 456 --squash
+```
+
+### Close Issue
+
+```bash
+# Completed (→ Done)
+gh issue close 123 --reason "completed"
+
+# Not planned (→ Won't Do)
+gh issue close 123 --reason "not planned"
+```
+
+### Reopen Issue
+
+```bash
+# Reopened (→ Discussion)
+gh issue reopen 123
+```
+
+## 📝 PR Body Template
+
+Always link issues in PR description:
+
+```markdown
+## Description
+
+Brief description of changes
+
+## Related Issues
+
+Closes #123
+Fixes #456
+Resolves #789
+
+## Testing
+
+- [ ] Unit tests added
+- [ ] Manual testing done
+
+## Checklist
+
+- [ ] Code follows style guide
+- [ ] Documentation updated
+```
+
+## 🏷️ Label Reference
+
+| Label               | Status     | Use Case                   |
+| ------------------- | ---------- | -------------------------- |
+| `enhancement`       | 💡 Ideas   | New features, improvements |
+| `core-feature`      | 📋 Planned | Core functionality         |
+| `priority: blocker` | 📥 Backlog | Blocking issues            |
+
+## 🔍 Check Status
+
+### Via GitHub UI
+
+1. Go to [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
+2. Find your issue/PR
+3. Check status column
+
+### Via CLI
+
+```bash
+# View issue with project status
+gh issue view 123 --json projectItems \
+  --jq '.projectItems[0].status.name'
+
+# View PR with linked issues
+gh pr view 456 --json body
+```
+
+## 🐛 Troubleshooting Quick Fixes
+
+### Issue not in project
+
+```bash
+# Check workflow run
+gh run list --workflow "Project Board Automation" --limit 5
+
+# View latest run logs
+gh run view --log
+```
+
+### Status not updating
+
+1. Check issue has correct label
+2. Check PR body has `Closes #N`
+3. Wait 15-30 seconds for workflow
+4. Check Actions tab for errors
+
+### Reset status manually
+
+1. Go to project board
+2. Drag issue to correct column
+3. Or edit issue status field directly
+
+## ⚡ Power User Tips
+
+### Batch Create Issues
+
+```bash
+# Create multiple related issues
+for feature in "Login" "Signup" "Logout"; do
+  gh issue create \
+    --label "core-feature" \
+    --title "Implement $feature" \
+    --body "Part of authentication system"
+done
+```
+
+### Check All Open PRs
+
+```bash
+# List PRs with their status
+gh pr list --json number,title,isDraft,state \
+  --jq '.[] | "\(.number): \(.title) (Draft: \(.isDraft))"'
+```
+
+### Find Stale Issues
+
+```bash
+# Issues in Discussion > 30 days
+gh issue list --state open --label "discussion" \
+  --json number,title,updatedAt \
+  --jq '.[] | select(.updatedAt < (now - 2592000))'
+```
+
+## 📊 Status Transitions
+
+```
+Enhancement → 💡 Ideas
+           ↓ (discuss)
+         💬 Discussion
+           ↓ (plan)
+         📋 Planned
+           ↓ (start draft PR)
+         🚧 In Progress
+           ↓ (mark ready)
+         👀 In Review
+           ↓ (merge)
+         ✅ Done
+
+High Priority → 📥 Backlog → 📋 Planned → ...
+
+Reopen → 💬 Discussion
+Close (not planned) → 🚫 Won't Do
+```
+
+## 🎯 Single Maintainer Flow
+
+When working alone:
+
+```bash
+# 1. Create issue
+gh issue create --label "core-feature" --title "..."
+
+# 2. Start work (draft PR)
+gh pr create --draft --body "Closes #123"
+# → Issue: 🚧 In Progress
+
+# 3. Self-review ready
+gh pr ready <PR>
+# → Issue: 👀 In Review
+
+# 4. Copilot found issues?
+gh pr ready --undo <PR>
+# → Issue: 🚧 In Progress (signals: "fixing issues")
+
+# 5. Fixed and ready
+gh pr ready <PR>
+# → Issue: 👀 In Review
+
+# 6. Merge
+gh pr merge <PR> --squash
+# → Issue: ✅ Done (auto-closed)
+```
+
+## 📱 Shortcuts
+
+```bash
+# Create enhancement issue
+alias gh-idea='gh issue create --label "enhancement"'
+
+# Create core feature issue
+alias gh-feature='gh issue create --label "core-feature"'
+
+# Create blocker issue
+alias gh-blocker='gh issue create --label "priority: blocker"'
+
+# Create draft PR
+alias gh-draft='gh pr create --draft'
+
+# Mark PR ready
+alias gh-ready='gh pr ready'
+
+# Convert to draft
+alias gh-wip='gh pr ready --undo'
+```
+
+Add to your `.zshrc` or `.bashrc`.
+
+## 🔗 Quick Links
+
+- [Full Documentation](./PROJECT_AUTOMATION.md)
+- [Rollout Guide](./ROLLOUT_GUIDE.md)
+- [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
+- [Test Scenarios](../../WORKFLOW_REVIEW.md)

--- a/docs/workflows/ROLLOUT_GUIDE.md
+++ b/docs/workflows/ROLLOUT_GUIDE.md
@@ -1,0 +1,345 @@
+<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Rollout Guide: Project Automation Workflow
+
+Guide for deploying the project automation workflow to other repositories (api, frontend, contracts).
+
+## 📋 Prerequisites
+
+Before rolling out to a repository:
+
+- [ ] Repository is part of the SecPal organization
+- [ ] Repository has issues enabled
+- [ ] You have admin access to the repository
+- [ ] `PROJECT_TOKEN` secret is set (can be organization-level or repo-level)
+
+## 🚀 Deployment Steps
+
+### Step 1: Create Workflow File
+
+Create `.github/workflows/project-automation.yml` in the target repository:
+
+```yaml
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+name: Project Board Automation
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - closed
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - closed
+      - converted_to_draft
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  automate:
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+```
+
+That's it! Only ~30 lines needed per repository.
+
+### Step 2: Configure Secret
+
+#### Option A: Organization-Level Secret (Recommended)
+
+Set once for all repositories:
+
+1. Go to Organization Settings → Secrets → Actions
+2. Click "New organization secret"
+3. Name: `PROJECT_TOKEN`
+4. Value: Your fine-grained PAT
+5. Repository access: "All repositories" or "Selected repositories"
+
+#### Option B: Repository-Level Secret
+
+Set individually per repository:
+
+```bash
+# For api repository
+gh secret set PROJECT_TOKEN --repo SecPal/api
+# Paste your PAT when prompted
+
+# For frontend repository
+gh secret set PROJECT_TOKEN --repo SecPal/frontend
+
+# For contracts repository
+gh secret set PROJECT_TOKEN --repo SecPal/contracts
+```
+
+### Step 3: Create Required Labels
+
+Create these labels in each repository (or adjust workflow logic):
+
+```bash
+# Navigate to repository
+cd /path/to/repo
+
+# Create labels
+gh label create "enhancement" --color "a2eeef" --description "New feature or request"
+gh label create "core-feature" --color "0e8a16" --description "Core functionality - planned implementation"
+gh label create "priority: blocker" --color "d93f0b" --description "High priority issue blocking progress"
+```
+
+Or via GitHub UI:
+
+1. Go to repository → Issues → Labels
+2. Create:
+   - `enhancement` (light blue)
+   - `core-feature` (dark green)
+   - `priority: blocker` (dark red)
+
+### Step 4: Test the Workflow
+
+Create a test issue to verify automation:
+
+```bash
+gh issue create \
+  --repo SecPal/api \
+  --title "Test: Project Automation" \
+  --label "enhancement" \
+  --body "Testing automatic project board integration.
+
+Expected: Should be added to SecPal Roadmap with status 💡 Ideas"
+```
+
+**Verify:**
+
+1. Go to [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
+2. Check that issue appears with status "💡 Ideas"
+3. Check Actions tab for workflow run
+4. Issue should have a comment explaining status
+
+### Step 5: Test Draft PR Workflow
+
+```bash
+# Create test issue
+ISSUE=$(gh issue create \
+  --repo SecPal/api \
+  --title "Test: Draft PR Workflow" \
+  --label "enhancement" \
+  --body "Testing draft PR status updates" \
+  --json number -q .number)
+
+# Create branch and draft PR
+git checkout -b test-automation
+echo "test" >> test.txt
+git add test.txt
+git commit -m "test: Automation"
+git push -u origin test-automation
+
+gh pr create \
+  --repo SecPal/api \
+  --draft \
+  --title "WIP: Test automation" \
+  --body "Closes #$ISSUE"
+```
+
+**Verify:**
+
+1. Issue status should be "🚧 In Progress"
+2. Workflow ran successfully (Actions tab)
+3. Mark PR ready: `gh pr ready <PR-number>`
+4. Issue status should change to "👀 In Review"
+
+## 🔄 Per-Repository Checklist
+
+Use this checklist for each repository rollout:
+
+### api Repository
+
+- [ ] Create `.github/workflows/project-automation.yml`
+- [ ] Set `PROJECT_TOKEN` secret
+- [ ] Create labels (`enhancement`, `core-feature`, `priority: blocker`)
+- [ ] Test with sample issue
+- [ ] Test draft PR workflow
+- [ ] Clean up test artifacts
+- [ ] Document in README (optional)
+
+### frontend Repository
+
+- [ ] Create `.github/workflows/project-automation.yml`
+- [ ] Set `PROJECT_TOKEN` secret
+- [ ] Create labels
+- [ ] Test with sample issue
+- [ ] Test draft PR workflow
+- [ ] Clean up test artifacts
+- [ ] Document in README (optional)
+
+### contracts Repository
+
+- [ ] Create `.github/workflows/project-automation.yml`
+- [ ] Set `PROJECT_TOKEN` secret
+- [ ] Create labels
+- [ ] Test with sample issue
+- [ ] Test draft PR workflow
+- [ ] Clean up test artifacts
+- [ ] Document in README (optional)
+
+## 🛠️ Customization
+
+### Using Different Labels
+
+If your repository uses different labels, modify the workflow file:
+
+```yaml
+jobs:
+  automate:
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    # Note: Label mapping is in the reusable workflow
+    # To customize, fork the workflow or use different labels
+```
+
+For custom label mapping, you'll need to modify the reusable workflow in `.github` repository.
+
+### Disabling Specific Events
+
+To disable certain triggers:
+
+```yaml
+on:
+  issues:
+    types:
+      - opened
+      # Comment out events you don't want:
+      # - reopened
+      # - closed
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      # - closed
+      # - converted_to_draft
+  # Disable PR reviews entirely:
+  # pull_request_review:
+  #   types:
+  #     - submitted
+```
+
+## 🐛 Troubleshooting
+
+### Workflow not triggering
+
+**Check:**
+
+1. Workflow file is in `.github/workflows/` directory
+2. File has `.yml` or `.yaml` extension
+3. Syntax is valid (use `yamllint` or GitHub's validator)
+4. Events match the ones in the workflow file
+
+### "Bad credentials" error
+
+**Fix:**
+
+1. Verify `PROJECT_TOKEN` secret is set
+2. Check PAT hasn't expired
+3. Ensure PAT has Organization Projects permission (not just repository)
+
+### Workflow runs but status doesn't update
+
+**Check:**
+
+1. Issue/PR has correct labels
+2. PR body contains `Closes #N` for linked issues
+3. Project ID and Field ID match in reusable workflow
+4. Workflow logs in Actions tab for errors
+
+### Status updates to wrong value
+
+**Verify:**
+
+1. Labels are spelled correctly (case-sensitive)
+2. Status option IDs in reusable workflow match your project
+3. No conflicting labels on the issue
+
+## 📊 Monitoring
+
+### View Workflow Runs
+
+```bash
+# List recent workflow runs
+gh run list --repo SecPal/api --workflow "Project Board Automation"
+
+# View specific run
+gh run view <run-id> --repo SecPal/api
+
+# View logs
+gh run view <run-id> --log --repo SecPal/api
+```
+
+### Success Metrics
+
+After deployment, monitor:
+
+- ✅ Workflow success rate (should be >95%)
+- ✅ Status updates within 30 seconds
+- ✅ No duplicate status updates
+- ✅ Proper status transitions
+
+## 🔄 Updating the Workflow
+
+When the reusable workflow in `.github` is updated:
+
+1. **Automatic:** Workflows in other repos automatically use the latest version (because of `@main`)
+2. **No action needed** in consuming repositories
+3. **Testing:** Always test in `.github` repo first
+
+### Pinning to a Specific Version
+
+For stability, pin to a release tag:
+
+```yaml
+uses: SecPal/.github/.github/workflows/project-automation-v2.yml@v1.0.0
+```
+
+## 📝 Documentation Updates
+
+After rollout, update each repository's README with:
+
+```markdown
+## 🤖 Automation
+
+This repository uses automated project board management. Issues and PRs are
+automatically added to the [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
+with status based on labels and PR state.
+
+See [Project Automation docs](https://github.com/SecPal/.github/blob/main/docs/workflows/PROJECT_AUTOMATION.md)
+for details.
+```
+
+## ✅ Validation
+
+After deploying to all repositories:
+
+- [ ] All repositories have workflow file
+- [ ] All `PROJECT_TOKEN` secrets set and working
+- [ ] Labels created in all repos
+- [ ] Test issues/PRs created and verified
+- [ ] No workflow failures in Actions tab
+- [ ] Project board shows correct status for test items
+- [ ] README updated with automation info
+- [ ] Team notified about new automation
+
+## 🎯 Next Steps
+
+After successful rollout:
+
+1. **Monitor** for 1-2 weeks
+2. **Gather feedback** from team
+3. **Iterate** on label definitions if needed
+4. **Document** any custom workflows
+5. **Clean up** test issues/PRs


### PR DESCRIPTION
## Problem
All project automation workflows in api, frontend, and contracts repositories are failing with `startup_failure` error.

## Root Cause
The reusable workflow (`project-automation-v2.yml`) had BOTH `workflow_call` trigger AND direct event triggers (`issues`, `pull_request`, etc.). This caused GitHub Actions to fail when trying to call the workflow from other repositories.

## Solution
1. **Removed direct event triggers** from `project-automation-v2.yml` (reusable workflow)
   - Now only has `workflow_call` trigger
   - This is the correct pattern for reusable workflows

2. **Created calling workflow** for `.github` repository itself
   - `project-automation.yml` calls `project-automation-v2.yml`
   - Uses local reference: `./.github/workflows/project-automation-v2.yml`

## Changes
- ✅ Fixed `project-automation-v2.yml` - removed direct events
- ✅ Created `project-automation.yml` - calling workflow for .github repo
- ✅ Includes 3 documentation files that were missing from main:
  - `docs/workflows/PROJECT_AUTOMATION.md`
  - `docs/workflows/QUICK_REFERENCE.md`
  - `docs/workflows/ROLLOUT_GUIDE.md`

## Testing
After merge, test by creating an issue in api/frontend/contracts repos. The workflow should:
- ✅ Start successfully (no more `startup_failure`)
- ✅ Add issue to project board
- ✅ Set correct status based on labels

## Impact
- **Fixes**: SecPal/api, SecPal/frontend, SecPal/contracts automation
- **No breaking changes**: Other repos will automatically pick up the fix on next run

## Related
- Discovered during rollout testing after merging PRs #10, #39, #25