### PR TITLE
hotfix: fix workflow path to use external reference

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -22,6 +22,6 @@ on:
 jobs:
   project-automation:
     name: Project automation
-    uses: ./.github/workflows/project-automation-v2.yml
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Problem
The local workflow path `./.github/workflows/project-automation-v2.yml` causes `startup_failure` in the .github repository.

## Root Cause  
Local reusable workflow calls with relative paths don't work reliably. The path resolution fails because:
- Repository is named `.github`
- Workflows are in `.github/workflows/` within that repo
- Local path `./.github/workflows/...` creates ambiguity

## Solution
Use the **same external reference** as all other repositories:
```yaml
uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
```

## Benefits
- ✅ **Consistency**: All repos (api, frontend, contracts, .github) use identical pattern
- ✅ **Reliability**: External references work everywhere
- ✅ **Simplicity**: One pattern to maintain

## Impact
This fixes the `startup_failure` errors in the .github repository itself. After merge, test issues #123 and #124 should be processed successfully.

## Testing
After merge:
1. Create new test issue in .github repo
2. Verify workflow runs without startup_failure
3. Verify issue is added to project board

## Related
- Follow-up to PR #122
- Addresses ongoing startup_failure in .github repo