### PR TITLE
hotfix: fix event context checks in reusable workflow

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -20,7 +20,7 @@ jobs:
   # ============================================================================
   handle-issue:
     name: Handle issue lifecycle events
-    if: github.event_name == 'issues'
+    if: github.event.issue != null
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -240,7 +240,7 @@ jobs:
   # ============================================================================
   handle-pull-request:
     name: Handle pull request lifecycle events
-    if: github.event_name == 'pull_request'
+    if: github.event.pull_request != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -385,7 +385,7 @@ jobs:
   # ============================================================================
   handle-pr-review:
     name: Handle pull request review events
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested'
+    if: github.event.review != null && github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## 🐛 Critical Fix: startup_failure in ALL repositories

### Root Cause
The reusable workflow used `github.event_name` to filter jobs:
```yaml
if: github.event_name == 'issues'  # ❌ DOES NOT WORK in reusable workflows!
```

**In reusable workflows, `github.event_name` is NOT propagated from the calling workflow!** This caused all jobs to be skipped immediately, resulting in `startup_failure` in:
- ❌ SecPal/.github
- ❌ SecPal/api  
- ❌ SecPal/frontend
- ❌ SecPal/contracts

### Solution
Replace `event_name` checks with actual event object checks:

```yaml
# Before (broken):
if: github.event_name == 'issues'
if: github.event_name == 'pull_request'
if: github.event_name == 'pull_request_review'

# After (working):
if: github.event.issue != null
if: github.event.pull_request != null
if: github.event.review != null
```

### Changes
- `handle-issue` job: Check for `github.event.issue` existence
- `handle-pull-request` job: Check for `github.event.pull_request` existence
- `handle-pr-review` job: Check for `github.event.review` existence

### Impact
**Fixes automation in ALL 4 repositories!** After merge:
- ✅ Workflows will start successfully
- ✅ Issues automatically added to project board
- ✅ PRs tracked through lifecycle
- ✅ Status updates work correctly

### Testing
After merge, retry test issues:
- .github #126
- api #13

Both should be automatically added to project board with correct status.

### References
- GitHub Actions docs: Event context in reusable workflows
- Related: PRs #122, #125