### PR TITLE
fix: add converted_to_draft to pull_request event triggers

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -19,6 +19,7 @@ on:
       - opened
       - ready_for_review
       - closed
+      - converted_to_draft
   pull_request_review:
     types:
       - submitted


### PR DESCRIPTION
## Problem
After merging PR #130, testing revealed that PRs being converted to draft wouldn't trigger the workflow because `converted_to_draft` was missing from the event triggers.

We added the logic to handle `converted_to_draft` in the Copilot review fixes, but forgot to add it to the `on.pull_request.types` array.

## Solution
Add `converted_to_draft` to the pull_request event triggers.

## Impact
- ✅ Enables draft PR workflow (convert to draft → status changes to "🚧 In Progress")
- ✅ Completes the single-maintainer workflow pattern
- ✅ Matches the event types in calling workflows (api, frontend, contracts)

## Note
This is a small but critical fix that should be merged quickly to enable proper testing of the draft PR workflow.