### PR TITLE
fix: make PROJECT_TOKEN optional in core workflow

### DIFF
--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -17,7 +17,7 @@ on:
     secrets:
       PROJECT_TOKEN:
         description: "Fine-grained PAT with Projects (Read & Write) and Issues (Read & Write) permissions"
-        required: true
+        required: false
 
 env:
   PROJECT_ID: PVT_kwDOCUodoc4BGgjL


### PR DESCRIPTION
## Quick Fix

After deploying the refactored architecture (#133), workflows are failing because `PROJECT_TOKEN` is marked as `required: true` in the core workflow.

When workflows call other workflows locally (same repo) using `./.github/workflows/...`, required secrets can cause issues.

**Change**: `required: true` → `required: false`

This matches the original working configuration and allows both local and cross-repo calls to work correctly.

Will test immediately after merge!