### PR TITLE
fix: add required permissions to project automation caller workflow

### DIFF
--- a/.github/workflows/project-automation-v2.yml
+++ b/.github/workflows/project-automation-v2.yml
@@ -25,6 +25,11 @@ on:
     types:
       - submitted
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   project-automation:
     name: Project automation


### PR DESCRIPTION
## Problem

The project automation workflow was experiencing `startup_failure` with the error:

```
Error calling workflow 'SecPal/.github/.github/workflows/project-automation-core.yml@main'. 
The nested job 'handle-issue' is requesting 'issues: write', but is only allowed 'issues: none'.
```

## Root Cause

**Caller workflows must explicitly grant permissions that reusable workflows request.** 

When a workflow calls a reusable workflow using `uses:`, GitHub Actions requires the caller to declare the permissions that the reusable workflow needs. Without this, the nested jobs are denied all permissions by default.

## Solution

Added `permissions:` block to `project-automation-v2.yml`:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

This grants the core reusable workflow the permissions it needs to:
- Read repository contents
- Create/update/close issues
- Update pull request status and labels

## Pattern Match

This follows the same pattern as other working caller workflows in the organization (e.g., `pr-size.yml`).

## Testing

After this is merged, the same fix needs to be applied to:
- [ ] api repo (`api/.github/workflows/project-automation.yml`)
- [ ] frontend repo (`frontend/.github/workflows/project-automation.yml`)
- [ ] contracts repo (`contracts/.github/workflows/project-automation.yml`)

## Related

This completes the architectural refactor started in #133 to separate the core reusable workflow from caller workflows.