### PR TITLE
debug: add step to verify PROJECT_TOKEN availability

### DIFF
--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -37,11 +37,11 @@ jobs:
     steps:
       - name: Debug - Check if PROJECT_TOKEN is available
         run: |
-          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+          if [ -z "$PROJECT_TOKEN" ]; then
             echo "❌ PROJECT_TOKEN is EMPTY or not available"
             echo "This indicates the secret was not passed to the reusable workflow"
           else
-            echo "✅ PROJECT_TOKEN is available (length: ${#PROJECT_TOKEN})"
+            echo "✅ PROJECT_TOKEN is available (length: $(echo -n "$PROJECT_TOKEN" | wc -c))"
           fi
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Debug

Adding a debug step to check if `PROJECT_TOKEN` is actually available in the reusable workflow.

This will help us understand if the secret is being passed correctly via `secrets: inherit` in cross-repo calls.

## Testing

After merge, we can create a test issue in api repo and check the workflow logs to see if the token is available.