### PR TITLE
debug: add GH_TOKEN availability logging

### DIFF
--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -71,7 +71,6 @@ jobs:
 
             // DEBUG: Check if GH_TOKEN is available
             console.log('DEBUG: GH_TOKEN length:', process.env.GH_TOKEN ? process.env.GH_TOKEN.length : 'UNDEFINED');
-            console.log('DEBUG: GH_TOKEN first 10 chars:', process.env.GH_TOKEN ? process.env.GH_TOKEN.substring(0, 10) : 'N/A');
 
             const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
 


### PR DESCRIPTION
## Purpose

Add debug logging to verify that `GH_TOKEN` environment variable is available in github-script context.

## What This Does

Logs:
- Length of GH_TOKEN (should be 93)
- First 10 characters (should start with "github_pat")

## Why

After all fixes (#140, #141), cross-repo calls still fail with "Bad credentials". This will help us see if the env variable is actually reaching the github-script runtime.

## Next Steps

1. Merge this
2. Create test issue in api repo
3. Check logs for DEBUG output
4. If GH_TOKEN is UNDEFINED → different approach needed
5. If GH_TOKEN is available → investigate Octokit initialization