### PR TITLE
fix: use PROJECT_GH_TOKEN instead of reserved GH_TOKEN

### DIFF
--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -35,7 +35,7 @@ jobs:
       issues: write
       contents: read
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Setup Node.js for Octokit
         uses: actions/setup-node@v4
@@ -61,7 +61,7 @@ jobs:
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
@@ -69,10 +69,10 @@ jobs:
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
 
-            // DEBUG: Check if GH_TOKEN is available
-            console.log('DEBUG: GH_TOKEN length:', process.env.GH_TOKEN ? process.env.GH_TOKEN.length : 'UNDEFINED');
+            // DEBUG: Check if PROJECT_GH_TOKEN is available
+            console.log('DEBUG: PROJECT_GH_TOKEN length:', process.env.PROJECT_GH_TOKEN ? process.env.PROJECT_GH_TOKEN.length : 'UNDEFINED');
 
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const projectId = process.env.PROJECT_ID;
             const contentId = context.payload.issue.node_id;
@@ -171,14 +171,14 @@ jobs:
         if: github.event.action == 'closed'
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const issueNodeId = context.payload.issue.node_id;
             const projectId = process.env.PROJECT_ID;
@@ -224,14 +224,14 @@ jobs:
           (steps.get-item-id.outputs.found == 'true' && steps.determine-closed-status.outputs.statusId)
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const projectId = process.env.PROJECT_ID;
             const fieldId = process.env.STATUS_FIELD_ID;
@@ -264,14 +264,14 @@ jobs:
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const action = context.payload.action;
             const status = '${{ steps.determine-status.outputs.status }}';
@@ -310,7 +310,7 @@ jobs:
       issues: write
       contents: read
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Setup Node.js for Octokit
         uses: actions/setup-node@v4
@@ -324,14 +324,14 @@ jobs:
         id: linked-issues
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const body = context.payload.pull_request.body || '';
 
@@ -392,14 +392,14 @@ jobs:
         if: steps.linked-issues.outputs.count != '0' && steps.pr-status.outputs.shouldUpdate == 'true'
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const issueNumbers = JSON.parse('${{ steps.linked-issues.outputs.issues }}');
             const projectId = process.env.PROJECT_ID;
@@ -480,7 +480,7 @@ jobs:
       issues: write
       contents: read
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Setup Node.js for Octokit
         uses: actions/setup-node@v4
@@ -494,14 +494,14 @@ jobs:
         id: linked-issues
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const body = context.payload.pull_request.body || '';
             const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
@@ -515,14 +515,14 @@ jobs:
         if: steps.linked-issues.outputs.count != '0'
         uses: actions/github-script@v8
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          PROJECT_GH_TOKEN: ${{ env.PROJECT_GH_TOKEN }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
         with:
           script: |
             // Use token from environment variable
             const { Octokit } = require("@octokit/core");
-            const octokitWithToken = new Octokit({ auth: process.env.GH_TOKEN });
+            const octokitWithToken = new Octokit({ auth: process.env.PROJECT_GH_TOKEN });
 
             const issueNumbers = JSON.parse('${{ steps.linked-issues.outputs.issues }}');
             const projectId = process.env.PROJECT_ID;


### PR DESCRIPTION
## Problem

`GH_TOKEN` is a **reserved environment variable** in GitHub Actions. GitHub automatically overwrites it with the default `GITHUB_TOKEN`, even when we explicitly set it to `secrets.PROJECT_TOKEN`.

## Evidence

From issue #30 logs:
```
DEBUG: GH_TOKEN length: 93
❌ Failed to add to project: Bad credentials
```

The token has 93 characters (correct for our PAT), but it's actually the default GitHub Actions token with insufficient permissions for Projects v2 API.

## Solution

Renamed all occurrences:
- `GH_TOKEN` → `PROJECT_GH_TOKEN`
- `process.env.GH_TOKEN` → `process.env.PROJECT_GH_TOKEN`

This avoids the reserved variable name and ensures our custom PAT is used.

## Testing

After merge:
1. Create test issue in api repo
2. Verify DEBUG shows: `PROJECT_GH_TOKEN length: 93`
3. Verify issue is added to project board
4. **THIS SHOULD FINALLY WORK!** 🤞