### PR TITLE
docs: enhance copilot review protocol with GraphQL resolution and bot PR validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,7 +151,7 @@ When changes span multiple repositories:
 
 5. **Repeat 1-4** until step 1 returns empty array
 
-**LEARNED LESSON:** Bot-created PRs (e.g., copilot/sub-pr-\*) = noise. Close immediately if redundant/irrelevant to current project scope (e.g., Rust lockfiles when no Rust used). Copilot may auto-create PRs from review suggestions - validate necessity before accepting.
+**See Lesson #11 below for bot PR validation protocol.**
 
 ### Pre-Push Hook Override (Large PRs Only):
 
@@ -910,6 +910,8 @@ git status  # MUST output: "nothing to commit, working tree clean"
 ### 11. Bot PR Validation (CRITICAL)
 
 **WHAT:** GitHub bots (Copilot, Dependabot) may auto-create PRs. MUST validate before merge.
+
+**VALIDATION SCOPE:** MUST validate against tech stack and existing fixes. Bot PRs must be checked to ensure they are relevant to the project's technology stack and do not duplicate fixes already present in main or merged PRs.
 
 **WHY:** Bot PRs may be redundant (duplicate fix already merged), irrelevant (suggest tech not used in project), or conflict with project scope.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Chronological log of notable changes to SecPal organization defaults.
 
 ## 2025-10-31 - Copilot Review Protocol Enhancement
 
-**copilot-instructions.md - Added bot PR validation + GraphQL review resolution:**
+**`copilot-instructions.md` - Added bot PR validation + GraphQL review resolution:**
 
 - **GraphQL Review Resolution:** Clarified review threads MUST be resolved via GraphQL mutation (`resolveReviewThread`), NEVER via regular PR comments
 - **Bot PR Validation (Lesson #11):** Added critical validation protocol for bot-created PRs (Copilot, Dependabot)


### PR DESCRIPTION
## Summary

Enhances Copilot review protocol based on learned lessons from bot-created PRs #155 and #45.

## Changes

### 1. GraphQL Review Resolution (Critical)

**Clarified:** Review threads MUST be resolved via GraphQL mutation, NEVER via regular PR comments.

```bash
# Correct method:
gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"THREAD_ID"}){thread{id isResolved}}}'

# Incorrect: Regular PR comment (ineffective)
```

**Why:** Regular comments don't update thread resolution state in GitHub's review system.

### 2. Bot PR Validation Protocol (Lesson #11)

**Added:** Mandatory validation checklist for bot-created PRs (Copilot, Dependabot).

**Triggers:** Branch pattern `copilot/sub-pr-*` = auto-created from review suggestion

**Validation steps:**

1. Check PR branch name → identify bot origin
2. Validate against current tech stack (e.g., `find . -name "Cargo.toml"` for Rust)
3. Compare with merged PRs (check for redundancy)
4. Reject if: redundant, irrelevant, out-of-scope
5. Full review checklist if valid

**Context:** Copilot auto-created PRs after review comments mentioned Cargo.lock (future-proofing), despite SecPal using **no Rust**.

**Examples rejected:**

- `.github#155` - Duplicate lockfile exclude (already merged in #154)
- `api#45` - JS/TS config for PHP-only repository

## Testing

- [x] Instructions remain KI-optimized (terse, constraint-based)
- [x] No human-readable fluff added
- [x] Markdown formatting valid
- [x] CHANGELOG.md updated with context
- [x] All checks pass locally

## Related

Part of systematic quality improvement from lessons learned during PR reviews.