### PR TITLE
docs: fix Codecov documentation inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Chronological log of notable changes to SecPal organization defaults.
   - Backend flag (`api/`) and Frontend flag (`frontend/`)
   - Comprehensive ignore patterns for tests, configs, build artifacts
   - PR comments enabled with coverage diff and tree view
-  - Strict CI enforcement: `fail_ci_if_error: true`
+  - Strict CI enforcement: `if_ci_failed: error`
 
 **Changed:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,10 +287,10 @@ SecPal uses [Codecov](https://codecov.io) for automated code coverage tracking a
 
 ```bash
 # Run tests with coverage
-php artisan test --coverage-clover coverage.xml
+ddev exec php artisan test --coverage-clover coverage.xml
 
 # View HTML report
-php artisan test --coverage-html coverage-html/
+ddev exec php artisan test --coverage-html coverage-html/
 open coverage-html/index.html
 ```
 


### PR DESCRIPTION
## Description

This PR fixes two documentation inconsistencies identified during Copilot review of PR #191:

1. **CHANGELOG.md:** Updates the Codecov configuration reference from `fail_ci_if_error: true` to `if_ci_failed: error` to match the actual `.codecov.yml` configuration.

2. **CONTRIBUTING.md:** Adds the `ddev exec` prefix to backend coverage commands to align with our documented DDEV development environment setup.

## Changes

- ✅ Updated CHANGELOG.md: Changed "Strict CI enforcement: `fail_ci_if_error: true`" to "`if_ci_failed: error`"
- ✅ Updated CONTRIBUTING.md: Prefixed backend coverage commands with `ddev exec`

## Context

These inconsistencies were identified by GitHub Copilot during review of the initial Codecov integration PR. The actual implementations were correct; only the documentation needed updates.

## Testing

- [x] All preflight checks passed (formatting, linting, REUSE compliance)
- [x] Documentation reviewed for accuracy

## Related Issues

Fixes #192
Fixes #193

Part of Epic #189: Implement Code Coverage Tracking with Codecov