### PR TITLE
fix(ci): use local script in reusable conflict marker workflow

### DIFF
--- a/.github/workflows/reusable-check-conflict-markers.yml
+++ b/.github/workflows/reusable-check-conflict-markers.yml
@@ -26,10 +26,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
 
-      - name: Download conflict marker check script
-        run: |
-          curl -sSL https://raw.githubusercontent.com/SecPal/.github/main/scripts/check-conflict-markers.sh -o check-conflict-markers.sh
-          chmod +x check-conflict-markers.sh
-
       - name: Run conflict marker check
-        run: ./check-conflict-markers.sh
+        run: |
+          chmod +x scripts/check-conflict-markers.sh
+          ./scripts/check-conflict-markers.sh


### PR DESCRIPTION
## Problem

The reusable conflict marker workflow (PR #195) attempted to download the script via `curl` from the main branch, which caused failures in PRs #172, #139, and #54:
- Network dependency could fail
- Downloaded script wasn't executed from the correct location
- Circular dependency: workflow needs main branch, but PRs can't merge until workflow passes

## Solution

Use the **local copy** of `scripts/check-conflict-markers.sh` that already exists in each repository:
- ✅ No network dependency
- ✅ Works offline/in restricted environments
- ✅ Script version matches the repository being tested
- ✅ Simpler and more reliable

## Changes

```diff
- - name: Download conflict marker check script
-   run: |
-     curl -sSL https://raw.githubusercontent.com/SecPal/.github/main/scripts/check-conflict-markers.sh -o check-conflict-markers.sh
-     chmod +x check-conflict-markers.sh
-
- - name: Run conflict marker check
-   run: ./check-conflict-markers.sh
+ - name: Run conflict marker check
+   run: |
+     chmod +x scripts/check-conflict-markers.sh
+     ./scripts/check-conflict-markers.sh
```

## Testing

- [x] Preflight checks passed
- [x] Local conflict marker detection works
- [ ] Will test on failing PRs after merge

## Impact

This fix will unblock:
- SecPal/api#172
- SecPal/frontend#139
- SecPal/contracts#54

## Related

- Fixes workflow failures from #195
- Part of #176