### PR TITLE
fix(scripts): skip Markdown files to prevent false positives in conflict marker detection

### DIFF
--- a/scripts/check-conflict-markers.sh
+++ b/scripts/check-conflict-markers.sh
@@ -42,14 +42,14 @@ echo ""
 while IFS= read -r -d '' file; do
   # Skip binary files and non-text files
   if file "$file" | grep -q "text"; then
-    CHECKED_FILES=$((CHECKED_FILES + 1))
-
     # Skip Markdown files to avoid false positives from code examples
     # Note: This means real conflicts in Markdown will not be detected.
     # This is an acceptable trade-off for documentation files.
     if [[ "$file" =~ \.md$ ]]; then
       continue
     fi
+
+    CHECKED_FILES=$((CHECKED_FILES + 1))
 
     # Check each conflict marker pattern
     for marker in "${MARKERS[@]}"; do


### PR DESCRIPTION
## Problem

The conflict marker detection script was flagging documentation files that contain example conflict markers in code blocks, causing false positives.

Example: `docs/scripts/CHECK_CONFLICT_MARKERS.md` contains:
```markdown
```bash
<<<<<<< HEAD
code from current branch
```
```

This legitimate documentation was being detected as a real conflict marker.

## Solution

Add skip logic for Markdown files (`.md`):
```bash
# Skip Markdown files to avoid false positives from code examples
# Note: This means real conflicts in Markdown will not be detected.
# This is an acceptable trade-off for documentation files.
if [[ "$file" =~ \.md$ ]]; then
  continue
fi
```

## Impact

- ✅ Unblocks Dependabot PR #55 in contracts (security update for js-yaml)
- ✅ Prevents future false positives in documentation files
- ✅ Consistent with skip logic already present in individual repo scripts
- ⚠️ Trade-off: Real conflicts in Markdown files won't be detected (acceptable for docs)

## Related

- Fixes false positive in SecPal/contracts#55
- Follows pattern from contracts/scripts/check-conflict-markers.sh
- Part of Issue #176 implementation refinement