### PR TITLE
fix(workflow): resolve self-wait deadlock in Dependabot auto-merge

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -154,7 +154,7 @@ jobs:
           running-workflow-name: "auto-merge / Enable Auto-Merge"
           allowed-conclusions: success,skipped,neutral
           # Also ignore by explicit check name as backup
-          ignore-checks: "Dependabot Auto-Merge,auto-merge / Enable Auto-Merge,auto-merge / Check Eligibility"
+          ignore-checks: "Dependabot Auto-Merge,auto-merge / Enable Auto-Merge,auto-merge / Check Auto-Merge Eligibility"
         continue-on-error: true
 
       - name: Log wait result


### PR DESCRIPTION
## Problem

The Dependabot auto-merge workflow was failing with "Wait for CI checks - Process completed with exit code 1". 

**Root Cause:** The `lewagon/wait-on-check-action` was waiting for itself to complete, creating a deadlock. For reusable workflows, the check name format is `"caller_job / callee_job"` (e.g., `"auto-merge / Enable Auto-Merge"`), not just the job name.

## Solution

1. **Fixed `running-workflow-name`**: Updated to correct format for reusable workflows: `"auto-merge / Enable Auto-Merge"`
2. **Added `ignore-checks` parameter**: As backup, explicitly ignoring:
   - `Dependabot Auto-Merge` (workflow name)
   - `auto-merge / Enable Auto-Merge` (this job)
   - `auto-merge / Check Eligibility` (other job in workflow)
3. **Added logging step**: Diagnose wait result outcome for debugging
4. **Kept `continue-on-error: true`**: For repos without other CI checks

## Testing

After merging, re-run any failing Dependabot PR workflows to verify the fix.

## Related

- Fixes failing auto-merge in SecPal/frontend, SecPal/api, SecPal/contracts
- Based on [lewagon/wait-on-check-action documentation](https://github.com/lewagon/wait-on-check-action#running-workflow-name)