### PR TITLE
docs: Add ADR-008 User-Based Tenant Resolution

### DIFF
--- a/docs/adr/20251219-user-based-tenant-resolution.md
+++ b/docs/adr/20251219-user-based-tenant-resolution.md
@@ -143,6 +143,7 @@ public function users(): HasMany
 
 ```php
 $table->unsignedBigInteger('tenant_id')->nullable()->after('id');
+$table->index('tenant_id');
 $table->foreign('tenant_id')->references('id')->on('tenant_keys');
 ```
 
@@ -394,10 +395,10 @@ $request->session()->put('active_tenant_id', $selectedTenantId);
 
 ## Related Documentation
 
-- [Multi-Tenant Deployment Guide](/api/docs/guides/multi-tenant-deployment.md)
-- [Tenant Provisioning Guide](/api/docs/guides/tenant-provisioning.md)
-- [Migration Guide: Single → Multi-Tenant](/api/docs/migration-guides/single-to-multi-tenant.md)
-- [RBAC Architecture (Tenant Context)](/api/docs/rbac-architecture.md)
+- [Multi-Tenant Deployment Guide](https://github.com/SecPal/api/blob/main/docs/guides/multi-tenant-deployment.md)
+- [Tenant Provisioning Guide](https://github.com/SecPal/api/blob/main/docs/guides/tenant-provisioning.md)
+- [Migration Guide: Single → Multi-Tenant](https://github.com/SecPal/api/blob/main/docs/migration-guides/single-to-multi-tenant.md)
+- [RBAC Architecture (Tenant Context)](https://github.com/SecPal/api/blob/main/docs/rbac-architecture.md)
 - [Epic #357: Production-Ready Multi-Tenant Architecture](https://github.com/SecPal/api/issues/357)
 
 ## ADR History


### PR DESCRIPTION
## Summary

Documents architectural decision for Epic #357 multi-tenant implementation.

## What Changed

Added ADR-008: User-Based Tenant Resolution
- Documents why `users.tenant_id` was chosen
- Evaluates alternatives (subdomain, JWT, session-based)
- Details integration with Spatie Permission
- Security considerations and InjectTenantId middleware

## Why

Epic #357 Phase 1 requires:
> "Documentation complete (ADR, deployment guide, provisioning guide, migration guide)"

This ADR documents the core architectural decision that enables the multi-tenant implementation.

## Related Issues

- Part of Epic #357 documentation deliverables
- References Issues #358, #359, #360, #361
- Related to PR #356 (InjectTenantId middleware)
- Companion to api repository documentation PR

## Checklist

- [x] ✅ REUSE compliance (117/117 files)
- [x] ✅ Markdown lint (0 errors)
- [x] ✅ Prettier formatting passed
- [x] ✅ Domain policy check passed