### PR TITLE
fix(adr): Correct API endpoint patterns from /api/v1/ to /v1/

### DIFF
--- a/docs/adr/20251027-opentimestamp-for-audit-trail.md
+++ b/docs/adr/20251027-opentimestamp-for-audit-trail.md
@@ -326,7 +326,7 @@ Batch events into Merkle tree, anchor root daily.
 
 ### Phase 3: Verification & Export
 
-- [ ] Verification endpoint: `GET /api/v1/events/{id}/verify-timestamp`
+- [ ] Verification endpoint: `GET /v1/events/{id}/verify-timestamp`
 - [ ] PDF export includes OTS proof
 - [ ] Standalone verification tool for auditors
 

--- a/docs/adr/20251111-rbac-design-decisions.md
+++ b/docs/adr/20251111-rbac-design-decisions.md
@@ -168,14 +168,14 @@ model_has_permissions:
 
 ```php
 // Permanent assignment (default - most common case)
-POST /api/v1/users/{id}/roles
+POST /v1/users/{id}/roles
 {
   "role": "manager"
   // No valid_from, no valid_until = permanent
 }
 
 // Temporal assignment (optional - special cases)
-POST /api/v1/users/{id}/roles
+POST /v1/users/{id}/roles
 {
   "role": "manager",
   "valid_from": "2025-12-01T00:00:00Z",

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -1282,27 +1282,27 @@ $table->enum('type', ['permanent', 'temporary'])->default('permanent');
 
 **Customer Assignments:**
 
-- `GET /api/v1/customer-assignments` - List with filters
-- `POST /api/v1/customer-assignments` - Create assignment
-- `GET /api/v1/customer-assignments/{id}` - Show details
-- `PUT /api/v1/customer-assignments/{id}` - Update assignment
-- `DELETE /api/v1/customer-assignments/{id}` - Remove assignment
+- `GET /v1/customer-assignments` - List with filters
+- `POST /v1/customer-assignments` - Create assignment
+- `GET /v1/customer-assignments/{id}` - Show details
+- `PUT /v1/customer-assignments/{id}` - Update assignment
+- `DELETE /v1/customer-assignments/{id}` - Remove assignment
 
 **Site Assignments:**
 
-- `GET /api/v1/site-assignments` - List with filters
-- `POST /api/v1/site-assignments` - Create assignment
-- `GET /api/v1/site-assignments/{id}` - Show details
-- `PUT /api/v1/site-assignments/{id}` - Update assignment
-- `DELETE /api/v1/site-assignments/{id}` - Remove assignment
+- `GET /v1/site-assignments` - List with filters
+- `POST /v1/site-assignments` - Create assignment
+- `GET /v1/site-assignments/{id}` - Show details
+- `PUT /v1/site-assignments/{id}` - Update assignment
+- `DELETE /v1/site-assignments/{id}` - Remove assignment
 
 **Sites:**
 
-- `GET /api/v1/sites` - List with filters (customer, type, status)
-- `POST /api/v1/sites` - Create site
-- `GET /api/v1/sites/{id}` - Show site details
-- `PUT /api/v1/sites/{id}` - Update site
-- `DELETE /api/v1/sites/{id}` - Soft delete site
+- `GET /v1/sites` - List with filters (customer, type, status)
+- `POST /v1/sites` - Create site
+- `GET /v1/sites/{id}` - Show site details
+- `PUT /v1/sites/{id}` - Update site
+- `DELETE /v1/sites/{id}` - Soft delete site
 
 **Plus:** Customers, Contacts, Attachments endpoints (22 total endpoints)
 

--- a/docs/adr/20251221-activity-logging-audit-trail-strategy.md
+++ b/docs/adr/20251221-activity-logging-audit-trail-strategy.md
@@ -1258,7 +1258,7 @@ test('hash chain detects injection attacks', function () {
 **Approach:**
 
 ```
-GET /api/public/activity-logs/{id}/verify
+GET /public/activity-logs/{id}/verify
 → Returns: event_hash, merkle_proof, ots_proof
 → Auditor can verify independently
 ```


### PR DESCRIPTION
## Summary

This PR corrects the API endpoint patterns across all ADRs from `/api/v1/` to `/v1/` to match the actual Laravel route implementation.

## Changes

Fixed endpoint patterns in 4 ADRs:
- ADR-005 (RBAC Design): `POST /v1/users/{id}/roles`
- ADR-007 (Organizational Structure): Customer/Site/Assignment endpoints
- ADR-010 (Activity Logging): `GET /public/activity-logs/{id}/verify`
- ADR (OpenTimestamp): `GET /v1/events/{id}/verify-timestamp`

## Rationale

Laravel routes are defined under `Route::prefix('v1')` in `api/routes/api.php`, which results in URLs like `/v1/...` not `/api/v1/...`. The documentation incorrectly used the latter pattern.

## Type

**Documentation Fix** - No functional changes, only documentation alignment with actual implementation.

---

**Related:** ADR consistency improvement