### PR TITLE
fix(workflows): respect local configs in reusable workflows

### DIFF
--- a/.github/workflows/reusable-openapi-lint.yml
+++ b/.github/workflows/reusable-openapi-lint.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           if [ -f "package.json" ]; then
             npm ci || npm install
+            # Install jq for JSON parsing if not available
+            if ! command -v jq &> /dev/null; then
+              sudo apt-get update && sudo apt-get install -y jq
+            fi
           else
             npm install -g @redocly/cli
           fi
@@ -42,10 +46,26 @@ jobs:
         env:
           OPENAPI_FILE: ${{ inputs.openapi-file }}
         run: |
-          if [ -f "package.json" ] && grep -q "\"lint\"" package.json; then
-            npm run lint
-          elif [ -f ".redocly.yaml" ] || [ -f ".redocly.yml" ]; then
-            npx redocly lint "$OPENAPI_FILE" --config .redocly.yaml 2>/dev/null || npx redocly lint "$OPENAPI_FILE" --config .redocly.yml || redocly lint "$OPENAPI_FILE"
+          # Check if package.json has a lint script that we can use
+          # Only use it if OPENAPI_FILE matches the default to avoid ignoring custom file paths
+          if [ -f "package.json" ] && command -v jq &> /dev/null && jq -e '.scripts.lint' package.json > /dev/null 2>&1; then
+            if [ "$OPENAPI_FILE" = "openapi.yaml" ] || [ "$OPENAPI_FILE" = "docs/openapi.yaml" ]; then
+              npm run lint
+            else
+              echo "Warning: Skipping 'npm run lint' because OPENAPI_FILE ($OPENAPI_FILE) doesn't match default paths."
+              echo "Falling back to direct redocly invocation."
+              if [ -f ".redocly.yaml" ]; then
+                npx redocly lint "$OPENAPI_FILE" --config .redocly.yaml
+              elif [ -f ".redocly.yml" ]; then
+                npx redocly lint "$OPENAPI_FILE" --config .redocly.yml
+              else
+                npx redocly lint "$OPENAPI_FILE"
+              fi
+            fi
+          elif [ -f ".redocly.yaml" ]; then
+            npx redocly lint "$OPENAPI_FILE" --config .redocly.yaml
+          elif [ -f ".redocly.yml" ]; then
+            npx redocly lint "$OPENAPI_FILE" --config .redocly.yml
           else
-            npx redocly lint "$OPENAPI_FILE" || redocly lint "$OPENAPI_FILE"
+            npx redocly lint "$OPENAPI_FILE"
           fi

--- a/.github/workflows/reusable-prettier.yml
+++ b/.github/workflows/reusable-prettier.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           if [ -f "package.json" ]; then
             npm ci || npm install
+            # Install jq for JSON parsing if not available
+            if ! command -v jq &> /dev/null; then
+              sudo apt-get update && sudo apt-get install -y jq
+            fi
           else
             npm install -g prettier
           fi
@@ -42,8 +46,16 @@ jobs:
         env:
           FILES: ${{ inputs.files }}
         run: |
-          if [ -f "package.json" ] && grep -q "\"format:check\"" package.json; then
-            npm run format:check
+          # Check if package.json has a format:check script that we can use
+          # Only use it if FILES matches the default to avoid ignoring custom file patterns
+          if [ -f "package.json" ] && command -v jq &> /dev/null && jq -e '.scripts["format:check"]' package.json > /dev/null 2>&1; then
+            if [ "$FILES" = "**/*.{md,yml,yaml,json}" ]; then
+              npm run format:check
+            else
+              echo "Warning: Skipping 'npm run format:check' because FILES ($FILES) doesn't match default pattern."
+              echo "Falling back to direct prettier invocation."
+              npx prettier --check "$FILES"
+            fi
           else
-            npx prettier --check "$FILES" || prettier --check "$FILES"
+            npx prettier --check "$FILES"
           fi


### PR DESCRIPTION
## Summary

Fix reusable workflows to respect local configurations by detecting and using project-specific npm scripts and config files.

## Problem

Reusable workflows (`reusable-openapi-lint.yml`, `reusable-prettier.yml`) call global tools without respecting local configuration files:

- `redocly lint` without `--config .redocly.yaml` → rejects custom rules like `struct: off`
- `prettier --check` without respecting `.prettierignore` → checks `node_modules`

This causes **CI failures in contracts PR #85** and potentially other projects with custom configurations.

## Solution

### Enhanced Workflow Logic

Both workflows now follow a smart detection pattern:

1. **Use npm script if available** (e.g., `npm run lint`, `npm run format:check`)
   - Only when input parameters match defaults (respects custom parameters)
   - Uses project's exact command with all their flags
2. **Detect local config files** (`.redocly.yaml`, `.redocly.yml`)
   - Pass config to CLI tools: `redocly lint --config .redocly.yaml`
3. **Fall back to npx** (uses local node_modules first)
   - `npx prettier --check` respects `.prettierignore` automatically

### Key Improvements

#### Initial Fixes (commit 093ed4d)
- ✅ Detect and use npm scripts when available
- ✅ Detect and use local config files
- ✅ Backward compatible with projects without configs

#### Copilot Review Improvements (commit f78366f)
1. ✅ **Robust JSON parsing** - Use `jq` instead of `grep` for reliable package.json script detection
2. ✅ **Respect input parameters** - Only use npm scripts when parameters match defaults (OPENAPI_FILE="openapi.yaml", FILES='**/*.{md,yml,yaml,json}')
3. ✅ **Clear error messages** - Remove `2>/dev/null` suppression for better debugging
4. ✅ **Fail-fast behavior** - Remove silent fallbacks that mask configuration issues
5. ✅ **Clean conditional logic** - Use if/elif chains instead of try-catch patterns
6. ✅ **Auto-install jq** - Automatically install when package.json exists
7. ✅ **Parameter consistency** - Warn users when custom parameters provided

**Not implemented** (tracked in #232):
- Extract shared dependency logic to composite action
- Stricter npm ci behavior without fallback

## Testing

### Local Testing
```bash
# Test with npm scripts
npm run lint                 # ✅ Uses project's script
npm run format:check         # ✅ Uses project's script

# Test with direct CLI
redocly lint --config .redocly.yaml  # ✅ Respects config
prettier --check **/*.md              # ✅ Respects .prettierignore
```

### Preflight Checks
- ✅ Prettier: All files formatted
- ✅ markdownlint: 0 errors
- ✅ REUSE: 120/120 files compliant
- ✅ Domain policy: secpal.app/secpal.dev only
- ✅ No conflict markers

## Impact

### Fixes
- ✅ **Unblocks contracts PR #85** - OpenAPI Lint & Prettier will pass
- ✅ **Prevents future CI failures** - All projects with local configs work correctly
- ✅ **Better debugging** - Clear error messages when configs missing
- ✅ **Consistent behavior** - Same logic across all reusable workflows

### Backward Compatibility
- ✅ Projects **without** configs: Still work (uses npx with defaults)
- ✅ Projects **with** configs: Now correctly detected and used
- ✅ Projects **with custom parameters**: Falls back to direct tool invocation with parameters

## Related

- **Blocked PR**: SecPal/contracts#85 (CI fails without these fixes)
- **Follow-up**: #232 (Extract shared logic, stricter npm ci)
- **Original Issue**: Identified during OpenAPI documentation for SecPal/api#394

---

## ⚠️ Priority: HIGH

**This PR blocks contracts PR #85** which is waiting for these workflow fixes to pass CI checks. Once merged, contracts CI will automatically re-run and should pass.