### PR TITLE
fix: align Copilot instruction validator with runtime model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The validator still enforced the old pseudo-inheritance approach even though the
 **Impact:**
 
 - Local and CI validation now match the actual Copilot instruction architecture
-- False negatives from outdated `@EXTENDS` and org-reminder checks are removed
+- False positives from outdated `@EXTENDS` and org-reminder checks are removed
 
 ## 2026-03-08 - Harden Copilot Instructions for Multi-Repo Workspace
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -191,7 +191,7 @@ Similar to api, detects via `package.json` with `vite`
 
 ### contracts Repository (OpenAPI)
 
-Similar to api, detects via `package.json` with `openapi`
+Similar to api, detects via `package.json` with `openapi` or `docs/openapi.yaml`
 
 ## Integration Points
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,7 +104,7 @@ The script automatically detects repository type:
 - **org**: `.github` repository (org-wide instructions)
 - **api**: Laravel API (has `artisan`, `composer.json`)
 - **frontend**: React frontend (has `package.json` with `vite`)
-- **contracts**: OpenAPI contracts (has `package.json` with `openapi`)
+- **contracts**: OpenAPI contracts (has `package.json` with `openapi` or `docs/openapi.yaml`)
 
 ## Adding New Scripts
 

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -21,14 +21,14 @@ print_result() {
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
 
     if [ "$status" = "PASS" ]; then
-        echo -e "${GREEN}✓${NC} $test_name"
+        printf '%b✓%b %s\n' "$GREEN" "$NC" "$test_name"
         PASSED_TESTS=$((PASSED_TESTS + 1))
         return
     fi
 
-    echo -e "${RED}✗${NC} $test_name"
+    printf '%b✗%b %s\n' "$RED" "$NC" "$test_name"
     if [ -n "$message" ]; then
-        echo -e "  ${YELLOW}→${NC} $message"
+        printf '  %b→%b %s\n' "$YELLOW" "$NC" "$message"
     fi
     FAILED_TESTS=$((FAILED_TESTS + 1))
 }
@@ -44,7 +44,7 @@ detect_repo_type() {
         return
     fi
 
-    if [ -f "docs/openapi.yaml" ]; then
+    if [ -f "docs/openapi.yaml" ] || { [ -f "package.json" ] && grep -q "openapi" package.json 2>/dev/null; }; then
         echo "contracts"
         return
     fi
@@ -160,22 +160,25 @@ test_critical_rules() {
 }
 
 test_instruction_frontmatter() {
-    local files
+    local file
+    local found=0
+    local message
 
-    files=$(find .github/instructions -type f -name '*.instructions.md' 2>/dev/null || true)
-    if [ -z "$files" ]; then
-        print_result "instruction files expose frontmatter" "PASS" "Skipped (no file-based instructions present)"
+    while IFS= read -r -d '' file; do
+        found=1
+        if ! head -n 10 "$file" | grep -q '^applyTo:' || ! head -n 10 "$file" | grep -q '^name:'; then
+            printf -v message 'Missing name/applyTo in %s' "$file"
+            print_result "instruction files include required frontmatter" "FAIL" "$message"
+            return
+        fi
+    done < <(find .github/instructions -type f -name '*.instructions.md' -print0 2>/dev/null)
+
+    if [ "$found" -eq 0 ]; then
+        print_result "instruction files include required frontmatter" "PASS" "Skipped (no file-based instructions present)"
         return
     fi
 
-    while IFS= read -r file; do
-        if ! head -n 10 "$file" | grep -q '^applyTo:' || ! head -n 10 "$file" | grep -q '^name:'; then
-            print_result "instruction files expose frontmatter" "FAIL" "Missing name/applyTo in $file"
-            return
-        fi
-    done <<< "$files"
-
-    print_result "instruction files expose frontmatter" "PASS"
+    print_result "instruction files include required frontmatter" "PASS"
 }
 
 main() {
@@ -211,11 +214,11 @@ main() {
     echo ""
 
     if [ "$FAILED_TESTS" -eq 0 ]; then
-        echo -e "${GREEN}✓ All tests passed!${NC}"
+            printf '%b✓ All tests passed!%b\n' "$GREEN" "$NC"
         exit 0
     fi
 
-    echo -e "${RED}✗ Some tests failed${NC}"
+        printf '%b✗ Some tests failed%b\n' "$RED" "$NC"
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- replace outdated validator assumptions around `@EXTENDS` and org-reminder blocks
- validate the current self-contained runtime instruction model instead
- add checks for runtime-model wording and `.instructions.md` frontmatter

## Validation
- ./scripts/validate-copilot-instructions.sh passed
- ./scripts/preflight.sh passed