### PR TITLE
docs(.github): replace DDEV runtime guidance

### DIFF
--- a/.github/copilot-config.yaml
+++ b/.github/copilot-config.yaml
@@ -28,7 +28,7 @@ multi_repo:
         extends: ".github/copilot-config.yaml"
         override_allowed: true
         specific_rules:
-          - "DDEV-specific commands (ddev exec)"
+          - "Native PHP shell commands in local or remote SSH environments"
           - "Pest testing framework (never PHPUnit directly)"
           - "Data protection (GDPR encryption patterns)"
 
@@ -585,8 +585,8 @@ stack:
     framework: Laravel
     framework_version: "13.x"
     testing: Pest # EXCLUSIVE: Only Pest, never PHPUnit directly
-    test_runner: "ddev exec php artisan test"
-    development_environment: DDEV
+    test_runner: "php artisan test"
+    development_environment: "Native PHP shell (local or remote over SSH)"
     database: PostgreSQL 16
 
   frontend:
@@ -609,7 +609,7 @@ stack:
 testing:
   backend:
     framework: Pest
-    runner: "ddev exec php artisan test"
+    runner: "php artisan test"
     coverage_minimum: 80
     coverage_critical: 100
     patterns:
@@ -653,7 +653,7 @@ validation:
     actionlint: "actionlint"
 
   tests:
-    backend: "ddev exec php artisan test"
+    backend: "php artisan test"
     backend_local: "php artisan test"
     frontend: "npm test"
 
@@ -662,12 +662,12 @@ validation:
     frontend: "npm run lint"
 
   development:
-    start: "ddev start"
-    stop: "ddev stop"
-    exec: "ddev exec <command>"
-    ssh: "ddev ssh"
-    logs: "ddev logs"
-    mailpit: "http://localhost:8026 (DDEV Mailpit UI)"
+    start: "Use the repo-native dev entrypoint, for example composer run dev"
+    stop: "Stop the active dev server or relevant service manager process"
+    exec: "Run commands directly in the active shell"
+    ssh: "ssh <user>@<host>"
+    logs: "tail -f storage/logs/laravel.log or the relevant service logs"
+    mail_testing: "Use the mail sink configured for the active environment; do not assume Mailpit is present"
 
 # Data Protection (GDPR/DSGVO)
 data_protection:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ See `copilot-config.yaml:multi_repo` for complete structure and repository mappi
 ```text
 SecPal Organization:
 ├── .github/     - Organization-wide settings (base rules)
-├── api/         - Laravel backend (keeps repo-local copies of org rules + DDEV/Pest rules)
+├── api/         - Laravel backend (keeps repo-local copies of org rules + native PHP/Pest runtime rules)
 ├── frontend/    - React/TypeScript frontend (keeps repo-local copies of org rules + PWA rules)
 └── contracts/   - OpenAPI 3.1 specifications (keeps repo-local copies of org rules + contract-first rules)
 ```
@@ -226,13 +226,13 @@ If bypass REQUIRED (production down):
 
 See `copilot-config.yaml:stack` for complete technology details.
 
-**Backend:** PHP 8.4, Laravel 13, DDEV (use `ddev exec`), Pest testing (NEVER PHPUnit directly), PostgreSQL 16
+**Backend:** PHP 8.4, Laravel 13, native PHP shell usage (local or remote over SSH), Pest testing (NEVER PHPUnit directly), PostgreSQL 16
 
 **Frontend:** Node 22.x, React, TypeScript (strict), Vite, Vitest + React Testing Library
 
 **API:** OpenAPI 3.1, REST, JSON, Bearer tokens, URL versioning (`/api/v1/`, `/api/v2/`)
 
-**Database:** PostgreSQL 16 (via DDEV), Laravel migrations (MUST be reversible)
+**Database:** PostgreSQL 16, Laravel migrations (MUST be reversible)
 
 ### Data Protection (GDPR/DSGVO)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Chronological log of notable changes to SecPal organization defaults.
 
 ---
 
+## 2026-03-20 - Replace DDEV Runtime Assumptions In Copilot Guidance
+
+**Changed:**
+
+- Updated organization-level Copilot instructions and YAML guidance to describe the API backend as a native PHP runtime instead of a DDEV-only environment
+- Replaced DDEV-specific command examples in the machine-readable backend guidance with direct shell, SSH, and log access guidance that fits the current VPS workflow
+
+**Why:**
+
+SecPal API development now runs directly on the VPS in a full server environment. Organization guidance should not keep telling agents to use container wrappers that are no longer part of the active workflow.
+
+**Impact:**
+
+- Cross-repo AI guidance now matches the real backend runtime and command surface
+- Agents are less likely to suggest `ddev exec`, `ddev ssh`, or DDEV-only tooling when operating on the API repository remotely
+
 ## 2026-03-19 - Align Laravel Version References With Current Runtime
 
 **Changed:**


### PR DESCRIPTION
## Summary
- replace DDEV-specific backend runtime guidance in the organization Copilot instructions with native PHP shell guidance
- align the machine-readable YAML examples with direct shell and SSH-based operation on the VPS
- document the governance update in `CHANGELOG.md`

## Self-review
- Reviewed the isolated diff before commit
- Tightened the YAML wording to avoid over-specifying a single dev start command
- No further findings remained in the final diff

## Validation
- `git diff --check`
- `./scripts/preflight.sh`
- editor diagnostics for changed files
- repo hooks on signed commit passed

## Follow-up
- Remaining DDEV references outside the active instruction files are tracked in #255