### PR TITLE
docs: remove stale DDEV assumptions for issue 255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Chronological log of notable changes to SecPal organization defaults.
 
 ---
 
+## 2026-03-22 - Remove Stale DDEV Assumptions From Governance Docs
+
+**Changed:**
+
+- Replaced DDEV-specific API coverage commands in `CONTRIBUTING.md` with direct `php artisan test` examples
+- Updated the system requirements guide and helper script to describe the API runtime as native PHP, remove DDEV as a requirement, and add SSH-friendly guidance for remote execution
+
+**Why:**
+
+Issue #255 correctly identified that organization-level docs and helper scripts were still steering contributors toward a DDEV workflow that no longer matches the active API runtime.
+
+**Impact:**
+
+- Contributors and agents now see API setup guidance that matches the direct shell and SSH-based workflow used by the current Laravel runtime
+- The system requirements script no longer reports DDEV as a mandatory API dependency
+- Coverage and troubleshooting examples no longer suggest DDEV-only commands
+
 ## 2026-03-22 - Enforce Branch Hygiene Before Local Work Starts
 
 **Changed:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -290,10 +290,10 @@ SecPal uses [Codecov](https://codecov.io) for automated code coverage tracking a
 
 ```bash
 # Run tests with coverage
-ddev exec php artisan test --coverage-clover coverage.xml
+php artisan test --coverage-clover coverage.xml
 
 # View HTML report
-ddev exec php artisan test --coverage-html coverage-html/
+php artisan test --coverage-html coverage-html/
 open coverage-html/index.html
 ```
 

--- a/docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md
+++ b/docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -48,22 +48,22 @@ The `check-system-requirements.sh` script validates that all required tools and 
 - Git user.email - critical
 - GPG commit signing - recommended
 
-### 2. API Repository (Laravel + PHP + DDEV)
+### 2. API Repository (Laravel + Native PHP Runtime)
 
 **PHP & Composer:**
 
 - PHP 8.4+ - critical
 - Composer 2.x - critical
 
-**DDEV (Development Environment):**
+**Runtime Access:**
 
-- DDEV installed - critical for API development
-- DDEV running - warning if not started
+- Native PHP runtime available locally or on the target VPS over SSH
+- Direct `php artisan` and `composer` commands preferred
 
 **PostgreSQL:**
 
-- Provided via DDEV
-- No local PostgreSQL installation needed
+- Provided by the target environment or remote service
+- No local PostgreSQL installation needed when using the VPS workflow
 
 **Local Dependencies (api/vendor):**
 
@@ -102,8 +102,7 @@ The `check-system-requirements.sh` script validates that all required tools and 
 
 - GitHub CLI (`gh`)
 - pre-commit framework
-- Docker (for DDEV)
-- Docker Compose (for DDEV)
+- OpenSSH client (`ssh`) for remote API runtime access
 
 ## Exit Codes
 
@@ -133,7 +132,7 @@ For a completely new system:
 # 2. Install missing tools (follow hints from script)
 
 # 3. Install repository-specific dependencies
-cd ../api && composer install && ddev start
+cd ../api && composer install
 cd ../frontend && npm install
 cd ../contracts && npm install
 
@@ -152,13 +151,14 @@ The script can be used in CI pipelines:
 
 ## Special Considerations
 
-### DDEV in API Repository
+### Native API Runtime
 
-The API repository uses **DDEV** as development environment. This is an important distinction:
+The API repository uses a **native PHP runtime**. Workflows should be compatible with local shells and the VPS runtime over SSH:
 
-- DDEV manages PHP, PostgreSQL and other services
-- All Laravel commands must be executed via `ddev exec`
-- Example: `ddev exec php artisan test`
+- Run Laravel commands directly with `php artisan`
+- Run dependency management directly with `composer`
+- Use an SSH session when the active runtime is hosted remotely
+- Example: `php artisan test`
 
 ### Multi-Repo Structure
 
@@ -178,8 +178,6 @@ Each repository has its own dependencies and quality gates.
 ```bash
 cd ../api
 composer install
-# or with DDEV:
-ddev composer install
 ```
 
 ### "node_modules/ directory not found"
@@ -189,11 +187,12 @@ cd ../frontend  # or ../contracts
 npm install
 ```
 
-### "DDEV is installed but not running"
+### "API runtime is remote"
 
 ```bash
-cd ../api
-ddev start
+ssh <user>@<host>
+cd /path/to/api
+php artisan test
 ```
 
 ### "GPG commit signing not configured"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 # ============================================================================
@@ -178,11 +178,11 @@ else
 fi
 
 # ============================================================================
-# 2. API Repository Requirements (Laravel + PHP + DDEV)
+# 2. API Repository Requirements (Laravel + Native PHP Runtime)
 # ============================================================================
 
 if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "api" ]; then
-  print_header "2. API Repository (Laravel + PHP + DDEV)"
+  print_header "2. API Repository (Laravel + Native PHP Runtime)"
 
   print_section "PHP & Composer"
 
@@ -206,40 +206,13 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "api" ]; then
 
   check_command "composer" "Composer" "critical" "Install: https://getcomposer.org/download/"
 
-  print_section "DDEV (Development Environment)"
+  print_section "Runtime Access"
+  echo -e "${BLUE}ℹ${NC} API workflows use direct php artisan/composer commands"
+  echo -e "${BLUE}ℹ${NC} Use a local shell or an SSH session for the target VPS runtime"
 
-  # Check DDEV
-  if command -v ddev >/dev/null 2>&1; then
-    ddev_version=$(ddev version | head -n 1)
-    echo -e "${GREEN}✓${NC} DDEV: $ddev_version"
-    OK_COUNT=$((OK_COUNT + 1))
-
-    # Check if DDEV is running (only in api directory)
-    if [ -f "../api/.ddev/config.yaml" ]; then
-      if pushd "../api" >/dev/null 2>&1; then
-        if ddev describe >/dev/null 2>&1; then
-          echo -e "${GREEN}✓${NC} DDEV is running"
-          OK_COUNT=$((OK_COUNT + 1))
-        else
-          echo -e "${YELLOW}⚠${NC} DDEV is installed but not running"
-          echo -e "  ${YELLOW}→${NC} Run: cd api && ddev start"
-          WARNING_COUNT=$((WARNING_COUNT + 1))
-        fi
-        popd >/dev/null 2>&1
-      else
-        echo -e "${YELLOW}⚠${NC} Cannot access ../api directory"
-        WARNING_COUNT=$((WARNING_COUNT + 1))
-      fi
-    fi
-  else
-    echo -e "${RED}✗${NC} DDEV ${RED}(REQUIRED for API development)${NC}"
-    echo -e "  ${YELLOW}→${NC} Install: https://ddev.readthedocs.io/en/stable/"
-    CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
-  fi
-
-  print_section "PostgreSQL (via DDEV)"
-  echo -e "${BLUE}ℹ${NC} PostgreSQL is provided by DDEV"
-  echo -e "${BLUE}ℹ${NC} No local PostgreSQL installation needed"
+  print_section "PostgreSQL Access"
+  echo -e "${BLUE}ℹ${NC} PostgreSQL is provided by the target environment or remote service"
+  echo -e "${BLUE}ℹ${NC} No local PostgreSQL installation needed when using the VPS workflow"
 
   # Check API local dependencies
   if [ -d "../api" ]; then
@@ -443,8 +416,7 @@ print_header "5. Optional but Recommended Tools"
 
 check_command "gh" "GitHub CLI" "optional" "Install: https://cli.github.com/"
 check_command "pre-commit" "pre-commit framework" "optional" "Install: pip3 install pre-commit"
-check_command "docker" "Docker" "optional" "Required if using DDEV (auto-managed)"
-check_command "docker-compose" "Docker Compose" "optional" "Required if using DDEV (auto-managed)"
+check_command "ssh" "OpenSSH client" "optional" "Needed for remote API runtime access"
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
## Summary
- replace stale DDEV-specific API coverage commands in the org contributing guide with direct `php artisan test` examples
- update the system requirements guide and helper script to describe the API runtime as native PHP with SSH-friendly guidance for remote execution
- remove DDEV from the API requirements baseline and replace the optional tool hint with `ssh`

## Validation
- ./scripts/preflight.sh

## Issue
- Fixes #255