### PR TITLE
fix: inline node setup in reusable workflows to restore cross-repo CI

### DIFF
--- a/.github/workflows/reusable-openapi-lint.yml
+++ b/.github/workflows/reusable-openapi-lint.yml
@@ -36,12 +36,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js and dependencies
-        uses: SecPal/.github/.github/actions/setup-node-with-deps@main
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
-          global-package: "@redocly/cli"
-          require-lockfile: ${{ inputs.require-lockfile }}
+
+      - name: Install dependencies
+        env:
+          REQUIRE_LOCKFILE: ${{ inputs.require-lockfile }}
+        run: |
+          set -euo pipefail
+          if [ -f "package.json" ]; then
+            if ! command -v jq >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y jq
+            fi
+            if [ -f "package-lock.json" ]; then
+              npm ci
+            elif [ "$REQUIRE_LOCKFILE" = "true" ]; then
+              echo "::error::package-lock.json not found. Commit a lock file or disable require-lockfile." >&2
+              exit 1
+            else
+              echo "::warning::No package-lock.json found. Using npm install instead of npm ci." >&2
+              echo "::warning::Consider committing package-lock.json for reproducible builds." >&2
+              npm install
+            fi
+          else
+            npm install -g @redocly/cli
+          fi
 
       - name: Validate OpenAPI specification
         env:

--- a/.github/workflows/reusable-prettier.yml
+++ b/.github/workflows/reusable-prettier.yml
@@ -36,12 +36,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js and dependencies
-        uses: SecPal/.github/.github/actions/setup-node-with-deps@main
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
-          global-package: "prettier"
-          require-lockfile: ${{ inputs.require-lockfile }}
+
+      - name: Install dependencies
+        env:
+          REQUIRE_LOCKFILE: ${{ inputs.require-lockfile }}
+        run: |
+          set -euo pipefail
+          if [ -f "package.json" ]; then
+            if ! command -v jq >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y jq
+            fi
+            if [ -f "package-lock.json" ]; then
+              npm ci
+            elif [ "$REQUIRE_LOCKFILE" = "true" ]; then
+              echo "::error::package-lock.json not found. Commit a lock file or disable require-lockfile." >&2
+              exit 1
+            else
+              echo "::warning::No package-lock.json found. Using npm install instead of npm ci." >&2
+              echo "::warning::Consider committing package-lock.json for reproducible builds." >&2
+              npm install
+            fi
+          else
+            npm install -g prettier
+          fi
 
       - name: Run Prettier Check
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Chronological log of notable changes to SecPal organization defaults.
 
 ---
 
+## 2026-04-01 - Fix Cross-Repo Composite Action Resolution In Reusable Workflows
+
+**Fixed:**
+
+- inlined the Node.js setup and dependency-install steps back into `reusable-prettier.yml` and `reusable-openapi-lint.yml` to restore cross-repo compatibility; GitHub Actions cannot resolve composite actions stored under `.github/actions/` in an external repository when referenced from a step inside a reusable `workflow_call` workflow, causing all callers (`frontend`, `secpal.app`) to fail with "Can't find action.yml"
+- the composite action `setup-node-with-deps` is retained for potential future use once a supported path layout is confirmed
+
 ## 2026-04-01 - Refactor Reusable Node Workflow Setup
 
 **Changed:**


### PR DESCRIPTION
## Problem

GitHub Actions cannot resolve composite actions stored under `.github/actions/` of an external repository when referenced from a step inside a reusable `workflow_call` workflow. Since PR #291 merged, all callers of `reusable-prettier.yml` via `SecPal/.github/.github/workflows/reusable-prettier.yml@main` fail at job setup with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action
'SecPal/.github/.github/actions/setup-node-with-deps@main'.
```

**Affected:** `frontend` (PR #691 blocked), `secpal.app`.

The same issue affects `reusable-openapi-lint.yml` (preemptive fix).

## Root Cause

PR #291 refactored the Node.js + dependency-install steps into a shared composite action at `.github/actions/setup-node-with-deps/`. While GitHub can serve reusable **workflows** from `.github/workflows/` cross-repo, it cannot resolve composite **actions** from `.github/actions/` when referenced via `owner/repo/.github/actions/path@ref` inside a `workflow_call`-triggered workflow. The action file exists but the runner fails to locate it during job setup.

## Fix

Inline the Node.js setup and dependency-install steps directly into both affected reusable workflows, restoring the behaviour that existed before PR #291. The `setup-node-with-deps` composite action is left in place — it remains useful for callers within the same repository or once a supported cross-repo path layout is identified.

## Validation Checklist

- [ ] pre-commit hooks passed (reuse, prettier, yamllint, actionlint)
- [ ] CHANGELOG updated
- [ ] GPG-signed commit
- [ ] local 4-pass review complete