### PR TITLE
chore(ci): replace hosted cla status

### DIFF
--- a/.github/workflows/license-cla.yml
+++ b/.github/workflows/license-cla.yml
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+name: CLA Status
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: cla-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync-cla-status:
+    name: Synchronize CLA Status
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Synchronize signature state and commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLA_BRANCH: cla-signatures
+          CLA_CONTEXT: license/cla
+          CLA_DOCUMENT_URL: https://github.com/SecPal/.github/blob/main/CLA.md
+          CLA_FILE: signatures/version1/cla.json
+          CLA_RECHECK_COMMENT: recheck cla
+          CLA_SIGN_COMMENT: I have read the CLA and I hereby sign it.
+          CLA_STATUS_MARKER: <!-- secpal-cla-status -->
+          CLA_VERSION: 2026-04-03
+          EXEMPT_LOGINS: dependabot[bot],renovate[bot],github-actions[bot],copilot-pull-request-reviewer
+        run: |
+          set -euo pipefail
+
+          api() {
+            gh api -H "X-GitHub-Api-Version: 2022-11-28" "$@"
+          }
+
+          is_exempt_login() {
+            local login="$1"
+            local pattern
+
+            IFS=',' read -r -a exempt_patterns <<< "$EXEMPT_LOGINS"
+            for pattern in "${exempt_patterns[@]}"; do
+              if [[ -n "$pattern" && "$login" == "$pattern" ]]; then
+                return 0
+              fi
+            done
+
+            return 1
+          }
+
+          update_status() {
+            local state="$1"
+            local description="$2"
+
+            api -X POST "repos/$repository/statuses/$head_sha" \
+              -f state="$state" \
+              -f context="$CLA_CONTEXT" \
+              -f description="$description" \
+              -f target_url="$CLA_DOCUMENT_URL" >/dev/null
+          }
+
+          ensure_signature_branch() {
+            if api "repos/$repository/git/ref/heads/$CLA_BRANCH" >/dev/null 2>&1; then
+              return 0
+            fi
+
+            local default_head_sha
+            default_head_sha="$(api "repos/$repository/git/ref/heads/$default_branch" --jq '.object.sha')"
+
+            api -X POST "repos/$repository/git/refs" \
+              -f ref="refs/heads/$CLA_BRANCH" \
+              -f sha="$default_head_sha" >/dev/null
+          }
+
+          load_signatures() {
+            signature_file_sha=""
+
+            if api "repos/$repository/contents/$CLA_FILE?ref=$CLA_BRANCH" >"$signature_response" 2>/dev/null; then
+              signature_file_sha="$(jq -r '.sha' "$signature_response")"
+              jq -r '.content' "$signature_response" | tr -d '\n' | base64 --decode >"$signature_json"
+            else
+              printf '%s\n' '{"document_version":"","document_url":"","signatures":[]}' >"$signature_json"
+            fi
+          }
+
+          save_signatures() {
+            local commit_message="$1"
+            local payload_file
+            local encoded_content
+
+            ensure_signature_branch
+            payload_file="$(mktemp)"
+            encoded_content="$(base64 -w 0 <"$signature_json")"
+
+            if [[ -n "$signature_file_sha" ]]; then
+              jq -n \
+                --arg message "$commit_message" \
+                --arg branch "$CLA_BRANCH" \
+                --arg content "$encoded_content" \
+                --arg sha "$signature_file_sha" \
+                '{message:$message, branch:$branch, content:$content, sha:$sha}' >"$payload_file"
+            else
+              jq -n \
+                --arg message "$commit_message" \
+                --arg branch "$CLA_BRANCH" \
+                --arg content "$encoded_content" \
+                '{message:$message, branch:$branch, content:$content}' >"$payload_file"
+            fi
+
+            api -X PUT "repos/$repository/contents/$CLA_FILE" --input "$payload_file" >"$signature_update_response"
+            signature_file_sha="$(jq -r '.content.sha' "$signature_update_response")"
+          }
+
+          upsert_pr_comment() {
+            local body="$1"
+            local existing_comment_id
+            local payload_file
+
+            existing_comment_id="$({
+              api --paginate "repos/$repository/issues/$pr_number/comments?per_page=100" \
+                --jq ".[] | select((.body // \"\") | contains(\"$CLA_STATUS_MARKER\")) | .id"
+            } | tail -n 1)"
+
+            payload_file="$(mktemp)"
+            jq -n --arg body "$body" '{body:$body}' >"$payload_file"
+
+            if [[ -n "$existing_comment_id" ]]; then
+              api -X PATCH "repos/$repository/issues/comments/$existing_comment_id" --input "$payload_file" >/dev/null
+            else
+              api -X POST "repos/$repository/issues/$pr_number/comments" --input "$payload_file" >/dev/null
+            fi
+          }
+
+          normalize_comment() {
+            tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//'
+          }
+
+          repository="$GITHUB_REPOSITORY"
+          event_path="$GITHUB_EVENT_PATH"
+          event_name="$GITHUB_EVENT_NAME"
+          default_branch="$(jq -r '.repository.default_branch' "$event_path")"
+
+          pr_response="$(mktemp)"
+          signature_response="$(mktemp)"
+          signature_update_response="$(mktemp)"
+          signature_json="$(mktemp)"
+          trap 'rm -f "$pr_response" "$signature_response" "$signature_update_response" "$signature_json"' EXIT
+
+          if [[ "$event_name" == "issue_comment" ]]; then
+            pr_number="$(jq -r '.issue.number' "$event_path")"
+            if ! api "repos/$repository/pulls/$pr_number" >"$pr_response" 2>/dev/null; then
+              echo "Issue comment is not attached to a pull request."
+              exit 0
+            fi
+
+            comment_author="$(jq -r '.comment.user.login // ""' "$event_path")"
+            normalized_comment="$(jq -r '.comment.body // ""' "$event_path" | normalize_comment)"
+
+            if [[ "$normalized_comment" != "$CLA_SIGN_COMMENT" && "$normalized_comment" != "$CLA_RECHECK_COMMENT" ]]; then
+              echo "Ignoring unrelated pull request comment."
+              exit 0
+            fi
+          else
+            pr_number="$(jq -r '.pull_request.number' "$event_path")"
+            api "repos/$repository/pulls/$pr_number" >"$pr_response"
+            comment_author=""
+            normalized_comment=""
+          fi
+
+          head_sha="$(jq -r '.head.sha' "$pr_response")"
+          pr_author="$(jq -r '.user.login' "$pr_response")"
+
+          update_status pending "Checking contributor signatures"
+
+          contributor_logins="$({
+            printf '%s\n' "$pr_author"
+            api --paginate "repos/$repository/pulls/$pr_number/commits?per_page=100" --jq '.[].author.login // empty'
+            api --paginate "repos/$repository/pulls/$pr_number/commits?per_page=100" --jq '.[].committer.login // empty'
+          } | awk 'NF' | sort -u)"
+
+          unresolved_authors="$({
+            api --paginate "repos/$repository/pulls/$pr_number/commits?per_page=100" \
+              --jq '.[ ] | select(.author == null) | "\(.commit.author.name // "unknown") <\(.commit.author.email // "unknown")>"'
+          } | awk 'NF' | sort -u)"
+
+          required_contributors=()
+          exempt_contributors=()
+
+          while IFS= read -r contributor_login; do
+            [[ -z "$contributor_login" ]] && continue
+            if is_exempt_login "$contributor_login"; then
+              exempt_contributors+=("$contributor_login")
+            else
+              required_contributors+=("$contributor_login")
+            fi
+          done <<< "$contributor_logins"
+
+          load_signatures
+
+          if [[ "$normalized_comment" == "$CLA_SIGN_COMMENT" ]]; then
+            signer_is_required=0
+            for contributor_login in "${required_contributors[@]}"; do
+              if [[ "$comment_author" == "$contributor_login" ]]; then
+                signer_is_required=1
+                break
+              fi
+            done
+
+            if [[ "$signer_is_required" -eq 1 ]]; then
+              tmp_signature_json="$(mktemp)"
+              jq \
+                --arg version "$CLA_VERSION" \
+                --arg document_url "$CLA_DOCUMENT_URL" \
+                --arg login "$comment_author" \
+                --arg repository_name "$repository" \
+                --arg signed_at "$(date -u +%FT%TZ)" \
+                --argjson pull_request_number "$pr_number" \
+                ".document_version = \$version
+                | .document_url = \$document_url
+                | .signatures = (
+                    (.signatures // [])
+                    | map(select(.login != \$login or .version != \$version))
+                    + [{
+                        login: \$login,
+                        version: \$version,
+                        document_url: \$document_url,
+                        repository: \$repository_name,
+                        pull_request: \$pull_request_number,
+                        signed_at: \$signed_at,
+                        source: \"pull_request_comment\"
+                      }]
+                  )" "$signature_json" >"$tmp_signature_json"
+              mv "$tmp_signature_json" "$signature_json"
+              save_signatures "chore(cla): record signature for $comment_author"
+            else
+              echo "Comment author is not a missing contributor for this pull request."
+            fi
+          fi
+
+          signed_contributors="$({
+            jq -r --arg version "$CLA_VERSION" ".signatures[]? | select(.version == \$version) | .login" "$signature_json"
+          } | awk 'NF' | sort -u)"
+
+          missing_contributors=()
+          for contributor_login in "${required_contributors[@]}"; do
+            if ! grep -Fxq "$contributor_login" <<< "$signed_contributors"; then
+              missing_contributors+=("$contributor_login")
+            fi
+          done
+
+          if [[ -n "$unresolved_authors" ]]; then
+            unresolved_list="$(printf '%s\n' "$unresolved_authors" | sed 's/^/- /')"
+            missing_block=""
+            if [[ "${#missing_contributors[@]}" -gt 0 ]]; then
+              missing_list="$(printf '%s\n' "${missing_contributors[@]}" | sed 's/^/- @/')"
+              missing_block="$(printf "The following linked contributors still need to sign the CLA for version \`%s\`:\n\n%s\n\n" "$CLA_VERSION" "$missing_list")"
+            fi
+            update_status failure "Maintainer action required for unlinked commit authors"
+            comment_body="$(printf '%s\n' \
+              "${CLA_STATUS_MARKER}" \
+              "## CLA Status" \
+              "" \
+              "This pull request cannot pass the CLA gate yet." \
+              "" \
+              "Unlinked commit authors require maintainer review before SecPal can record a signature for them:" \
+              "" \
+              "${unresolved_list}" \
+              "" \
+              "${missing_block}Document: ${CLA_DOCUMENT_URL}" \
+              "" \
+              "To sign, a missing contributor must add this exact pull request comment:" \
+              "" \
+              "> ${CLA_SIGN_COMMENT}" \
+              "" \
+              "If the status does not refresh after signing, comment:" \
+              "" \
+              "> ${CLA_RECHECK_COMMENT}" \
+              "" \
+              "Signature records are stored on branch \`${CLA_BRANCH}\` in \`${CLA_FILE}\`." \
+            )"
+            upsert_pr_comment "$comment_body"
+            exit 1
+          fi
+
+          if [[ "${#missing_contributors[@]}" -eq 0 ]]; then
+            exempt_block=""
+            if [[ "${#exempt_contributors[@]}" -gt 0 ]]; then
+              exempt_block="Exempt contributors: $(printf '@%s ' "${exempt_contributors[@]}" | sed 's/ $//')."
+            fi
+            update_status success "All contributors signed CLA version $CLA_VERSION"
+            comment_body="$(printf '%s\n' \
+              "${CLA_STATUS_MARKER}" \
+              "## CLA Status" \
+              "" \
+              "All non-exempt contributors have signed CLA version \`${CLA_VERSION}\`." \
+              "" \
+              "Document: ${CLA_DOCUMENT_URL}" \
+              "${exempt_block}" \
+              "" \
+              "Signature records are stored on branch \`${CLA_BRANCH}\` in \`${CLA_FILE}\`." \
+            )"
+            upsert_pr_comment "$comment_body"
+            exit 0
+          fi
+
+          missing_list="$(printf '%s\n' "${missing_contributors[@]}" | sed 's/^/- @/')"
+          update_status failure "${#missing_contributors[@]} contributor(s) still need to sign the CLA"
+          comment_body="$(printf '%s\n' \
+            "${CLA_STATUS_MARKER}" \
+            "## CLA Status" \
+            "" \
+            "This pull request is blocked until every non-exempt contributor signs CLA version \`${CLA_VERSION}\`." \
+            "" \
+            "Missing contributors:" \
+            "" \
+            "${missing_list}" \
+            "" \
+            "Document: ${CLA_DOCUMENT_URL}" \
+            "" \
+            "To sign, a missing contributor must add this exact pull request comment:" \
+            "" \
+            "> ${CLA_SIGN_COMMENT}" \
+            "" \
+            "If the status does not refresh after signing, comment:" \
+            "" \
+            "> ${CLA_RECHECK_COMMENT}" \
+            "" \
+            "Signature records are stored on branch \`${CLA_BRANCH}\` in \`${CLA_FILE}\`." \
+          )"
+          upsert_pr_comment "$comment_body"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Chronological log of notable changes to SecPal organization defaults.
 
 ---
 
+## 2026-04-03 - Replace Flaky Hosted CLA Status With Repo-Local Workflow
+
+**Changed:**
+
+- replaced the previously unreliable hosted `CLA Assistant` dependency for the `license/cla` status with a repo-local GitHub Actions workflow design that owns the commit status directly, stores signature metadata on a dedicated `cla-signatures` branch, and documents the exact pull-request comment contributors must use to sign
+- added `scripts/enable-cla-required-checks.sh` so maintainers can re-enable `license/cla` as a required branch-protection check across all SecPal repositories only after the workflow exists on each default branch
+- updated the central CLA, licensing, and workflow-template documentation to describe the new deterministic signing flow instead of the old external webhook model
+
 ## 2026-04-03 - Document Local actionlint Remediation For Preflight Warnings
 
 **Changed:**

--- a/CLA.md
+++ b/CLA.md
@@ -148,18 +148,17 @@ You agree to notify SecPal of any facts or circumstances of which you become awa
 
 ### Automated Signing (Recommended)
 
-We use **[CLA Assistant](https://cla-assistant.io/)** to manage CLA signatures. When you submit your first pull request, the CLA Assistant will automatically comment on your PR with instructions.
+SecPal uses a repo-local `license/cla` workflow to manage CLA signatures. When you open or update a pull request, the workflow checks every non-exempt contributor and posts instructions directly on the pull request when a signature is missing.
 
 **Steps:**
 
 1. **Submit your pull request**
-2. **Wait for CLA Assistant** to comment on your PR
-3. **Click the link** in the comment to review the CLA
-4. **Sign in with GitHub** (OAuth authentication)
-5. **Click "I agree"** to sign the CLA
-6. **The PR status will update** automatically once signed
+2. **Open the CLA document** linked by the workflow comment
+3. **Add this exact pull request comment** from each missing contributor account: `I have read the CLA and I hereby sign it.`
+4. **Wait for the `license/cla` status** to update automatically
+5. **Comment `recheck cla`** if the status needs to be recalculated manually
 
-The signature is stored securely in a database hosted in the Azure Europe region ("West Europe" - Netherlands) and is GDPR-compliant.
+Each repository stores its own signature metadata on the `cla-signatures` branch in `signatures/version1/cla.json`.
 
 ### Manual Signing (Alternative)
 

--- a/README.md
+++ b/README.md
@@ -359,14 +359,14 @@ By contributing to SecPal projects, you agree to our [Contributor License Agreem
 
 **CLA Signing Process:**
 
-When you submit your first pull request, [CLA Assistant](https://cla-assistant.io/) will automatically comment with instructions. Simply:
+When you submit or update a pull request, SecPal's repo-local `license/cla` workflow checks every non-exempt contributor and posts instructions directly on the pull request when a signature is still missing.
 
-1. Click the link in the comment
-2. Sign in with GitHub (OAuth)
-3. Click "I agree" to sign the CLA
-4. Your PR status will update automatically
+1. Open the CLA document linked by the workflow comment
+2. Add this exact pull request comment from each missing contributor account: `I have read the CLA and I hereby sign it.`
+3. Wait for the `license/cla` status to turn green
+4. If the status does not refresh automatically, add `recheck cla`
 
-All signatures are stored securely in a GDPR-compliant database hosted in Europe.
+Each repository stores its own signature metadata on the `cla-signatures` branch in `signatures/version1/cla.json`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
@@ -374,17 +374,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ### For Repository Maintainers
 
-To enable CLA checks in your SecPal repository:
+To enable CLA checks in a SecPal repository:
 
-1. Go to [CLA Assistant](https://cla-assistant.io/) and sign in with GitHub
-2. Click "Configure CLA"
-3. Select your repository from the dropdown
-4. Link it to the SecPal CLA Gist (ask an organization admin for the Gist URL)
-5. Done! CLA Assistant will automatically monitor all pull requests
+1. Commit `.github/workflows/license-cla.yml` to the repository's default branch
+2. Run `.github/scripts/enable-cla-required-checks.sh` from this repository after rollout
+3. Verify that `license/cla` appears in branch protection and on new pull requests
 
-**Unlike the previous GitHub Action approach, no workflow files are needed** – CLA Assistant uses GitHub webhooks directly.
-
-All CLA signatures are stored centrally in a secure database (Azure Europe, GDPR-compliant).
+This workflow replaces the previously flaky hosted `CLA Assistant` status with a repo-local GitHub Actions flow that owns the `license/cla` commit status directly.
 
 ---
 

--- a/scripts/enable-cla-required-checks.sh
+++ b/scripts/enable-cla-required-checks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+repos=(
+  "SecPal/.github"
+  "SecPal/api"
+  "SecPal/frontend"
+  "SecPal/contracts"
+  "SecPal/android"
+  "SecPal/secpal.app"
+)
+
+for repo in "${repos[@]}"; do
+  echo "==> ${repo}"
+
+  if ! gh api "repos/${repo}/contents/.github/workflows/license-cla.yml?ref=main" >/dev/null 2>&1; then
+    echo "  skip: .github/workflows/license-cla.yml is not on main yet"
+    continue
+  fi
+
+  protection_json="$(mktemp)"
+  payload_json="$(mktemp)"
+  trap 'rm -f "$protection_json" "$payload_json"' RETURN
+
+  gh api "repos/${repo}/branches/main/protection" >"$protection_json"
+
+  jq '
+    {
+      strict: .required_status_checks.strict,
+      checks: (
+        .required_status_checks.checks
+        + if any(.required_status_checks.checks[]?; .context == "license/cla")
+          then []
+          else [{context: "license/cla", app_id: null}]
+          end
+      )
+    }
+  ' "$protection_json" >"$payload_json"
+
+  gh api -X PATCH "repos/${repo}/branches/main/protection/required_status_checks" --input "$payload_json" >/dev/null
+  echo "  ok: ensured required status check license/cla"
+
+  rm -f "$protection_json" "$payload_json"
+  trap - RETURN
+done

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -10,38 +10,35 @@ This directory contains reusable GitHub Actions workflow templates for SecPal re
 
 ## CLA Assistant
 
-**Note:** SecPal uses the hosted [CLA Assistant service](https://cla-assistant.io/) for CLA management. This is configured organization-wide and does **not** require workflow files in individual repositories.
+**Note:** SecPal uses a repo-local GitHub Actions workflow for CLA management. Every protected repository should carry `.github/workflows/license-cla.yml` on its default branch.
 
-### How CLA Assistant Works
+### How The CLA Workflow Works
 
-1. **Automatic PR Comments**: When a contributor opens a pull request, CLA Assistant automatically posts a comment
-2. **Click-Through Signing**: Contributors click the link to sign the CLA on [cla-assistant.io](https://cla-assistant.io/)
-3. **OAuth Authentication**: GitHub OAuth ensures secure identity verification
-4. **Status Updates**: PR status is automatically updated when all contributors have signed
-5. **Centralized Management**: All signatures are stored in a database (Azure Europe, GDPR-compliant)
+1. **Automatic PR Checks**: The repo-local workflow evaluates every non-exempt contributor on pull request events
+2. **Comment-Based Signing**: Missing contributors sign by adding the exact pull request comment `I have read the CLA and I hereby sign it.`
+3. **Deterministic Status**: The workflow updates the `license/cla` commit status directly instead of depending on an external webhook
+4. **Repo-Local Storage**: Signature metadata is written to `signatures/version1/cla.json` on the `cla-signatures` branch
 
 ### For Repository Maintainers
 
-**No setup required!** CLA Assistant is configured at the organization level:
+Every protected repository should:
 
-- CLA document: Stored as a GitHub Gist and linked on [cla-assistant.io](https://cla-assistant.io/)
-- All repositories automatically protected
-- Contributors sign via <https://cla-assistant.io/>
-- Signatures are centrally managed
+- carry `.github/workflows/license-cla.yml` on the default branch
+- keep the shared CLA document link pointing to `SecPal/.github`
+- add `license/cla` to required status checks after the workflow is live on `main`
+- allow the workflow to manage the `cla-signatures` branch
 
 ### Adding CLA to a New Repository
 
-1. Go to [cla-assistant.io](https://cla-assistant.io/) (sign in with GitHub)
-2. Select your new repository
-3. Link it to the organization's CLA Gist
-4. Done! CLA Assistant will now monitor all pull requests
+1. Copy `.github/workflows/license-cla.yml` into the repository
+2. Merge it to the default branch
+3. Run `.github/scripts/enable-cla-required-checks.sh` from this repository
+4. Verify that `license/cla` appears on new pull requests
 
-**No workflow files needed** - CLA Assistant uses GitHub webhooks directly.
+The old hosted `CLA Assistant` integration is intentionally no longer used for required status enforcement.
 
 ## For More Information
 
 - [CLA Document](../CLA.md)
-- [CLA Assistant Service](https://cla-assistant.io/)
-- [CLA Assistant Documentation](https://github.com/cla-assistant/cla-assistant)
 - [Dual-Licensing Documentation](../README.md#licensing)
 - [Contributing Guidelines](../CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- replace the flaky hosted CLA status with a repo-local workflow that publishes the license/cla check
- update the CLA and maintainer docs for the new comment-based signing flow
- add the guarded helper script to re-enable license/cla as a required check after rollout

## Validation
- pre-commit hooks
- actionlint .github/workflows/license-cla.yml
