### PR TITLE
docs: document Copilot CLA allowlist exception

### DIFF
--- a/.github/CLA_SETUP.md
+++ b/.github/CLA_SETUP.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 
 SPDX-License-Identifier: CC0-1.0
 -->
@@ -36,8 +36,9 @@ When you link an organization with CLA Assistant:
    - Save configuration
 
 4. **Allowlist Configuration**
-   - Add bot users to allowlist: `bot*`, `dependabot[bot]`, `dependabot-preview[bot]`
+   - Add bot users to allowlist: `bot*`, `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`
    - This allows automated PRs without CLA signature
+   - Copilot-created pull requests in SecPal currently appear as author `copilot-swe-agent`; keep that exact account in the allowlist alongside Dependabot
 
 ### How It Works
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-06 - Document Copilot CLA Allowlist Exception
+
+**Changed:**
+
+- documented that Copilot-created pull requests currently use the author account `copilot-swe-agent` and must be allowlisted in CLA Assistant alongside the existing Dependabot bot exceptions so the organization-wide `cla/check` status does not block automated PRs
+
 ## 2026-04-04 - Clarify Clean Main Start And Post-Merge Readiness
 
 **Changed:**

--- a/README.md
+++ b/README.md
@@ -380,7 +380,8 @@ To enable CLA checks in your SecPal repository:
 2. Click "Configure CLA"
 3. Select your repository from the dropdown
 4. Link it to the SecPal CLA Gist (ask an organization admin for the Gist URL)
-5. Done! CLA Assistant will automatically monitor all pull requests
+5. Add automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` to the CLA Assistant allowlist
+6. Done! CLA Assistant will automatically monitor all pull requests
 
 **Unlike the previous GitHub Action approach, no workflow files are needed** – CLA Assistant uses GitHub webhooks directly.
 

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 
 SPDX-License-Identifier: CC0-1.0
 -->
@@ -28,6 +28,7 @@ This directory contains reusable GitHub Actions workflow templates for SecPal re
 - All repositories automatically protected
 - Contributors sign via <https://cla-assistant.io/>
 - Signatures are centrally managed
+- Allowlist automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` directly in CLA Assistant
 
 ### Adding CLA to a New Repository
 


### PR DESCRIPTION
## Description

Document the existing org-wide CLA Assistant setup so Copilot-authored pull requests are handled the same way as Dependabot PRs. This keeps the guidance aligned with the actual automated PR author currently used by Copilot: `copilot-swe-agent`.

## Type of Change

- [x] 📝 Documentation update

## Related Issues

Closes #

## Changes Made

- added `copilot-swe-agent` to the documented CLA Assistant allowlist alongside the existing Dependabot entries
- clarified in the central CLA setup guide that Copilot-created PRs currently appear under that exact author and should remain allowlisted
- updated the maintainer README, workflow-template README, and changelog so the org-wide guidance is consistent

## Testing

- [x] Preflight checks pass locally (`./scripts/preflight.sh`)
- [ ] All existing tests pass
- [ ] New tests added (if applicable)
- [x] Manual testing performed

**Test Configuration:**

- `git diff --check`
- pre-commit hooks during signed commit
- pre-push validation, including Prettier, markdownlint, REUSE, domain-policy, and conflict-marker checks

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] All commits are signed (`git commit -S`)
- [x] REUSE compliance is maintained (all files have SPDX headers)
- [x] PR size is reasonable (< 600 lines changed)
- [x] **This PR addresses exactly ONE topic** (no mixing of unrelated changes)

## Additional Notes

The functional exception itself is applied in CLA Assistant organization settings, not in repository workflows. Because the SecPal CLA Assistant setup is organization-wide, the documented allowlist entry applies across existing and future SecPal repositories once configured there.