### PR TITLE
fix: keep setup-hooks running across repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-08 - Fix setup-hooks Success Counter Abort
+
+**Fixed:**
+
+- replaced the `((SUCCESS_COUNT++))` arithmetic post-increments in `setup-hooks.sh` with `set -e` safe assignment increments so the workspace hook bootstrap no longer aborts after the first successful repository
+- added a focused shell regression test that exercises the happy-path multi-repository bootstrap and verifies the final success summary is reported
+
 ## 2026-04-06 - Adopt apk.secpal.app Android Distribution Governance
 
 **Changed:**

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -41,7 +41,7 @@ for repo in "${REPOS[@]}"; do
 	if [ -f "scripts/setup-pre-push.sh" ]; then
 		if ./scripts/setup-pre-push.sh; then
 			echo "  ✓ Pre-push hook installed"
-			((SUCCESS_COUNT++))
+			SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
 		else
 			echo "  ✗ Pre-push hook installation failed"
 			FAILED_REPOS+=("$repo (pre-push)")
@@ -55,7 +55,7 @@ for repo in "${REPOS[@]}"; do
         if [ -f "scripts/setup-pre-commit.sh" ]; then
                 if ./scripts/setup-pre-commit.sh; then
                         echo "  ✓ Pre-commit hook installed"
-                        ((SUCCESS_COUNT++))
+				SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
                 else
                         echo "  ✗ Pre-commit hook installation failed"
                         FAILED_REPOS+=("$repo (pre-commit)")

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -55,7 +55,7 @@ for repo in "${REPOS[@]}"; do
         if [ -f "scripts/setup-pre-commit.sh" ]; then
                 if ./scripts/setup-pre-commit.sh; then
                         echo "  ✓ Pre-commit hook installed"
-				SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+                        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
                 else
                         echo "  ✗ Pre-commit hook installation failed"
                         FAILED_REPOS+=("$repo (pre-commit)")

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-workspace="$(mktemp -d)"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/setup-hooks.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/.github"

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+workspace="$(mktemp -d)"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/.github"
+cp "$REPO_ROOT/setup-hooks.sh" "$workspace/.github/setup-hooks.sh"
+
+mkdir -p "$workspace/bin"
+cat >"$workspace/bin/pre-commit" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$workspace/bin/pre-commit"
+
+create_repo() {
+  local repo="$1"
+
+  mkdir -p "$workspace/$repo/scripts"
+
+  cat >"$workspace/$repo/scripts/setup-pre-push.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  cat >"$workspace/$repo/scripts/setup-pre-commit.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  chmod +x "$workspace/$repo/scripts/setup-pre-push.sh" "$workspace/$repo/scripts/setup-pre-commit.sh"
+}
+
+for repo in api frontend contracts android secpal.app .github; do
+  create_repo "$repo"
+done
+
+output_file="$workspace/output.txt"
+
+if ! PATH="$workspace/bin:$PATH" bash "$workspace/.github/setup-hooks.sh" >"$output_file" 2>&1; then
+  cat "$output_file"
+  echo "setup-hooks.sh unexpectedly failed" >&2
+  exit 1
+fi
+
+grep -q 'Successfully installed: 12 hooks' "$output_file"
+grep -q 'All Git hooks have been successfully installed' "$output_file"


### PR DESCRIPTION
## Summary
- keep `setup-hooks.sh` running after each successful hook install under `set -e`
- add a shell regression test that exercises the all-repositories happy path
- document the fix in the changelog

## Testing
- bash tests/setup-hooks.sh
- ./scripts/preflight.sh

Closes #325
