### PR TITLE
chore: add changelog.secpal.app to org domain policy

### DIFF
--- a/.github/copilot-config.yaml
+++ b/.github/copilot-config.yaml
@@ -1352,6 +1352,7 @@ workflows:
 domain_policy:
   critical: true
   homepage_domain: "secpal.app"
+  changelog_domain: "changelog.secpal.app"
   android_artifact_domain: "apk.secpal.app"
   api_domain: "api.secpal.dev"
   frontend_domain: "app.secpal.dev"
@@ -1366,6 +1367,9 @@ domain_policy:
       - "Public homepage and website content"
       - "Official contact information"
       - "Real email addresses"
+    changelog_secpal_app:
+      - "Public changelog site"
+      - "Changelog entries and release notes"
     apk_secpal_app:
       - "Canonical Android artifact host"
       - "Stable APK, checksum, and release metadata downloads"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,6 +82,7 @@ When all passes are clean, commit and push before creating the draft PR.
 Use only these domains and identifiers:
 
 - `secpal.app` for the public homepage and real email addresses
+- `changelog.secpal.app` for the public changelog site
 - `apk.secpal.app` for the canonical Android artifact and download host
 - `api.secpal.dev` for the live API host
 - `app.secpal.dev` for the live PWA/frontend host

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,7 +16,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
+echo "Public changelog site: changelog.secpal.app"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Human-facing Android landing page: secpal.app/android"
@@ -52,7 +53,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api.secpal.app is temporarily tolerated (deprecated web host, flagged separately).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -107,6 +108,7 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
+    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact/download host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"


### PR DESCRIPTION
Add `changelog.secpal.app` to the org-wide domain policy list in `.github/copilot-instructions.md`.

`changelog.secpal.app` is now the live public changelog site for SecPal released as part of EPIC SecPal/.github#334. Without this entry, any repo's domain check or Copilot context would treat the domain as unlisted.

## Changes

- `.github/copilot-instructions.md`: added `changelog.secpal.app — public changelog site` bullet to the Domain Policy list

## Checklist

- [x] Single topic
- [x] No tests required (doc/policy change only)
- [x] Pre-commit hooks passed
- [x] CHANGELOG not required (governance-only change)
- [x] GPG-signed commit
- [x] REUSE not affected
- [x] 4-pass review: clean

Closes SecPal/changelog#11 (partial — only .github scope)