### PR TITLE
governance: centralize epic closure evidence

### DIFF
--- a/.github/CLA_SETUP.md
+++ b/.github/CLA_SETUP.md
@@ -48,6 +48,18 @@ When you link an organization with CLA Assistant:
 - **Re-signing**: Contributors must re-sign if the CLA document changes
 - **Organization-Wide**: One signature applies to all SecPal repositories
 
+### Required Verification
+
+Changing the allowlist in documentation is not enough. Because CLA Assistant is an external service with live organization settings, verify the active configuration after setup changes.
+
+Use this checklist:
+
+1. Confirm the allowlist includes `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent`
+2. Confirm the organization or repository link still points to the current SecPal CLA document
+3. Confirm the expected required status check is `cla/check`
+4. Verify a recent automated PR shows `cla/check` passing instead of blocking on signature
+5. If the live config does not match the documented setup, track that drift as a `.github` issue before closing the related repository-specific issue
+
 ### Required Branch Protection
 
 Add the following status check to branch protection rules for each repository:

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -25,7 +25,7 @@ body:
         4. Each PR closes its sub-issue: `Fixes #<sub-issue-number>`
         5. Only the LAST PR closes this epic: `Closes #<epic-number>`
 
-        📚 Full documentation: See `SecPal/.github/docs/EPIC_WORKFLOW.md`
+        📚 Full documentation: See [docs/EPIC_WORKFLOW.md](https://github.com/SecPal/.github/blob/main/docs/EPIC_WORKFLOW.md)
 
   - type: textarea
     id: goal

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: 🗺️ Epic (Multi-PR Feature)
@@ -25,7 +25,7 @@ body:
         4. Each PR closes its sub-issue: `Fixes #<sub-issue-number>`
         5. Only the LAST PR closes this epic: `Closes #<epic-number>`
 
-        📚 Full documentation: See `docs/EPIC_WORKFLOW.md` in the api repository
+        📚 Full documentation: See `SecPal/.github/docs/EPIC_WORKFLOW.md`
 
   - type: textarea
     id: goal
@@ -84,6 +84,20 @@ body:
       required: true
 
   - type: textarea
+    id: closure_checklist
+    attributes:
+      label: 🔒 Closure Checklist
+      description: What must be verified before this parent epic may actually be closed?
+      value: |
+        - [ ] Each acceptance criterion is mapped to exact child issues and merged PRs
+        - [ ] Cross-repo work was checked repo by repo where applicable
+        - [ ] Any discovered acceptance gap was reopened or re-filed before closure
+        - [ ] Deferred but still relevant work is linked as dedicated follow-up issues
+        - [ ] A closure comment will be posted with the final acceptance mapping
+    validations:
+      required: true
+
+  - type: textarea
     id: non_goals
     attributes:
       label: 🚫 Non-Goals
@@ -116,6 +130,19 @@ body:
         2. **Update This Epic**: Edit the "Sub-Issues & Work Plan" section with actual issue numbers
         3. **Start Work**: Begin with the first sub-issue
         4. **PR Linking**: Each PR should reference its sub-issue (`Fixes #<sub-issue>`), not this epic
-        5. **Close Epic**: Only the LAST PR should close this epic (`Closes #<epic-number>`)
+        5. **Close Epic**: Only the LAST PR should close this epic (`Closes #<epic-number>`) and only after the closure checklist is satisfied
+
+        **Required closure comment template:**
+
+        ```markdown
+        ## Epic Closure Evidence
+
+        ### Acceptance Criteria Mapping
+        - Criterion: <acceptance slice>
+          Delivered by: <child issue>, <PR>, <repo>
+
+        ### Deferred Follow-Up
+        - <issue link> — <why it remains out of scope>
+        ```
 
         **Example:** See Issue #50 in the api repository for a real-world example.

--- a/.github/ISSUE_TEMPLATE/sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/sub-issue.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: 📦 Sub-Issue (Part of Epic)
@@ -24,7 +24,7 @@ body:
         3. Your PR should reference the epic: `Part of: #<epic-number>`
         4. Do NOT use `Fixes #<epic-number>` unless this is the LAST sub-issue
 
-        📚 Full documentation: See `docs/EPIC_WORKFLOW.md` in the api repository
+        📚 Full documentation: See `SecPal/.github/docs/EPIC_WORKFLOW.md`
 
   - type: input
     id: parent_epic
@@ -124,4 +124,5 @@ body:
         **⚠️ Important:**
         - Do NOT use `Fixes #<epic-number>` unless this is the LAST sub-issue
         - The epic should only close when ALL sub-issues are complete
+        - If you discover remaining in-scope gaps, reopen or file follow-up issues before asking to close the parent epic
         - If you're unsure, ask in the epic discussion thread

--- a/.github/ISSUE_TEMPLATE/sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/sub-issue.yml
@@ -24,7 +24,7 @@ body:
         3. Your PR should reference the epic: `Part of: #<epic-number>`
         4. Do NOT use `Fixes #<epic-number>` unless this is the LAST sub-issue
 
-        📚 Full documentation: See `SecPal/.github/docs/EPIC_WORKFLOW.md`
+        📚 Full documentation: See [docs/EPIC_WORKFLOW.md](https://github.com/SecPal/.github/blob/main/docs/EPIC_WORKFLOW.md)
 
   - type: input
     id: parent_epic

--- a/.github/copilot-config.yaml
+++ b/.github/copilot-config.yaml
@@ -413,6 +413,14 @@ issue_management:
         why: "Prevents premature epic closure, maintains granular tracking"
         example: "PR description: 'Fixes #52' (sub-issue), NOT 'Fixes #50' (epic)"
 
+      closure_verification:
+        rule: "A parent epic closes only after every acceptance slice is mapped to exact child issues and merged PRs"
+        required_steps:
+          - "Verify acceptance coverage repo by repo for every touched repository"
+          - "Post a closure comment mapping acceptance criteria to child issues and PRs"
+          - "Re-open or re-file any discovered acceptance gap before closure"
+          - "Link deferred but still relevant follow-up issues before closure"
+
     commands:
       create_epic: 'gh issue create --template epic.yml --title "[EPIC] Feature name"'
       create_sub_issue: 'gh issue create --template sub-issue.yml --title "PR-X: Step name"'
@@ -441,10 +449,10 @@ issue_management:
 
       - step: 6
         action: "Last sub-issue PR closes the epic"
-        validation: "PR description: 'Fixes #<last-sub-issue> and closes #<epic>'"
+        validation: "PR description uses 'Fixes #<last-sub-issue> and closes #<epic>' only after epic closure evidence is prepared"
 
     documentation_reference:
-      detailed_guide: "api/docs/EPIC_WORKFLOW.md"
+      detailed_guide: "docs/EPIC_WORKFLOW.md"
       real_world_example: "Issue #50 with 7 sub-issues (#52, #53, #55, #60, #64, #65, #67)"
 
   ai_protocol:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,6 +61,9 @@ At minimum verify:
 
 - Every real out-of-scope finding becomes a GitHub issue immediately; no untracked follow-up work is allowed.
 - Complex work uses EPIC plus sub-issues before implementation. PRs should close sub-issues, not the epic, until the final linked step.
+- Before closing a parent epic, verify each acceptance slice against the exact child issues and merged PRs across every touched repository.
+- Parent epic closure comments must list the child issues and PRs that satisfied each acceptance slice, and any remaining gap must be reopened or re-filed before closure.
+- Deferred but still relevant follow-up work must be linked as dedicated issues before a parent epic is closed.
 - When local review finds zero issues, commit and push the finished branch before opening any PR.
 - The first PR state must be draft. Do not open a normal PR first.
 - Mark a draft PR ready only after the final self-review in the PR view still finds zero issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,7 +440,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
   - Pre-commit checklist item: "Issue Creation Protocol" validates all findings documented as GitHub issues
   - AI Execution Protocol updated with prominent reminder: "Found bug → CREATE GITHUB ISSUE NOW"
   - Forbidden patterns: "TODO: fix later" without issue reference, "we should fix X" without creating issue
-  - Cross-reference to `api/docs/EPIC_WORKFLOW.md` for detailed EPIC/sub-issue guidance
+  - Cross-reference to `api/docs/EPIC_WORKFLOW.md` for detailed EPIC/sub-issue guidance (superseded by `docs/EPIC_WORKFLOW.md` in this repository)
 
 - **Issue Management section in Markdown** - Clear, concise rules added before Critical Rules section
   - Immediate issue creation protocol: 8 scenarios requiring immediate action (bugs, tech debt, coverage gaps, etc.)
@@ -471,7 +471,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 - Complete AI workflows: Discovery workflow (assess → create issue) and Feature planning workflow (assess complexity → EPIC or simple issue)
 - Examples: Security bug during docs work, test coverage gap during feature implementation, duplication refactoring
 - EPIC workflow: 6-step process from epic creation to final PR closing epic
-- Cross-references: `api/docs/EPIC_WORKFLOW.md` for detailed guide with Issue #50 real-world example
+- Cross-references: `api/docs/EPIC_WORKFLOW.md` for detailed guide with Issue #50 real-world example (superseded by `docs/EPIC_WORKFLOW.md` in this repository)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Centralize Epic Closure Evidence And CLA Ops Verification
+
+**Changed:**
+
+- added a central `docs/EPIC_WORKFLOW.md` guide in the `.github` repository so epic and sub-issue governance no longer depends on the `api` repository as the documentation source of truth
+- strengthened the organization issue templates, markdown Copilot baseline, and machine-readable Copilot config to require explicit parent-epic closure evidence, repo-by-repo acceptance verification, and pre-closure tracking of reopened or deferred follow-up work
+- extended CLA setup guidance and maintainer-facing docs to require live verification of the external CLA Assistant allowlist and `cla/check` behavior for automated authors such as `copilot-swe-agent`, reducing the chance of future bot PR blockage being treated as fixed based on documentation alone
+
 ## 2026-04-08 - Fix setup-hooks Success Counter Abort
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -381,7 +381,9 @@ To enable CLA checks in your SecPal repository:
 3. Select your repository from the dropdown
 4. Link it to the SecPal CLA Gist (ask an organization admin for the Gist URL)
 5. Add automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` to the CLA Assistant allowlist
-6. Done! CLA Assistant will automatically monitor all pull requests
+6. Verify that `cla/check` passes on a recent automated PR instead of blocking on signature
+7. If the live CLA Assistant state does not match the documented setup, track that drift in `SecPal/.github` before closing the repository-local symptom issue
+8. Done! CLA Assistant will automatically monitor all pull requests
 
 **Unlike the previous GitHub Action approach, no workflow files are needed** – CLA Assistant uses GitHub webhooks directly.
 

--- a/docs/EPIC_WORKFLOW.md
+++ b/docs/EPIC_WORKFLOW.md
@@ -1,0 +1,139 @@
+<!-- SPDX-FileCopyrightText: 2026 SecPal -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Epic And Sub-Issue Workflow
+
+## Why This Exists
+
+Large SecPal work often spans multiple repositories, multiple PRs, or both. When that happens, a parent epic can look complete before all acceptance criteria are actually satisfied.
+
+This guide defines the minimum structure and closure evidence required so an epic reflects reality instead of just merged PR count.
+
+## When To Use An Epic
+
+Create an epic before implementation when work:
+
+- needs more than one PR or probably will
+- spans multiple repositories
+- has distinct implementation phases or milestones
+- cannot be reviewed safely as one topic-sized change
+
+For single-PR work, use a regular issue instead.
+
+## Required Structure
+
+### 1. Create The Parent Epic First
+
+Use the organization issue template: `🗺️ Epic (Multi-PR Feature)`.
+
+The epic must define:
+
+- a clear goal
+- acceptance criteria
+- non-goals
+- a sub-issue work plan
+
+### 2. Split Work Into Sub-Issues
+
+Use one sub-issue per PR-sized slice of work.
+
+Each sub-issue must:
+
+- link back to the parent epic
+- stay focused on one logical change
+- carry its own acceptance criteria
+- note dependencies when order matters
+
+### 3. Link PRs To Sub-Issues, Not The Epic
+
+Every PR should close its sub-issue, not the parent epic.
+
+Use:
+
+```markdown
+Fixes #<sub-issue-number>
+Part of: #<epic-number>
+```
+
+Only the final PR may close the epic, and only when the epic closure checklist below is satisfied.
+
+## Parent Epic Closure Checklist
+
+Do not close a parent epic until all of the following are true:
+
+- every linked acceptance criterion is satisfied by merged work, not just planned work
+- the exact child issues and PRs that satisfy each acceptance slice are identified
+- any discovered acceptance gap was reopened or re-filed before closure
+- deferred but still relevant work was linked as dedicated follow-up issues before closure
+- the sub-issue tasklist reflects reality across all touched repositories
+
+If any item above is still unclear, the epic stays open.
+
+## Cross-Repo Verification
+
+Before closing a cross-repository epic, review the linked work repo by repo.
+
+For each repository involved:
+
+- identify the merged PRs that delivered the intended scope
+- verify the corresponding sub-issues are actually closed or explicitly superseded
+- check whether any promised acceptance slice was only partially implemented
+- check whether follow-up issues were created for deferred scope discovered during delivery
+
+This verification is required even if project board automation already moved issues to a done-like state.
+
+## Required Closure Comment
+
+When an epic is closed, add a closure comment that maps acceptance criteria to the exact child issues and PRs.
+
+Use this structure:
+
+```markdown
+## Epic Closure Evidence
+
+### Acceptance Criteria Mapping
+
+- Criterion: <acceptance slice>
+  Delivered by: <child issue>, <PR>, <repo>
+- Criterion: <acceptance slice>
+  Delivered by: <child issue>, <PR>, <repo>
+
+### Deferred Follow-Up
+
+- <issue link> — <why it remains out of scope>
+
+### Notes
+
+- <optional clarification about superseded or reopened work>
+```
+
+The comment should make it possible to audit why the epic was closed without reconstructing the full history from scratch.
+
+## What To Do When You Find A Gap Late
+
+If epic closure review finds that something was assumed complete but is not actually complete:
+
+1. Reopen the relevant issue if the original scope still applies.
+2. Create a new follow-up issue if the remaining work is distinct.
+3. Link that issue from the parent epic before closing it.
+4. Keep the epic open until the remaining scope is either done or explicitly tracked as deferred.
+
+Do not close the epic first and clean up the tracking later.
+
+## CLA And Other External Services
+
+If a workflow depends on repository settings or external services, merged code alone is not enough evidence. Verify the live configuration separately and track any missing operational step as its own issue.
+
+## Quick Reference
+
+- Each PR closes one sub-issue.
+- The parent epic stays open until closure evidence exists.
+- Cross-repo acceptance checks must happen before epic closure.
+- Deferred work must be linked before, not after, closure.
+
+## Related Guidance
+
+- [README.md](../README.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [.github/ISSUE_TEMPLATE/epic.yml](../.github/ISSUE_TEMPLATE/epic.yml)
+- [.github/ISSUE_TEMPLATE/sub-issue.yml](../.github/ISSUE_TEMPLATE/sub-issue.yml)

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -29,6 +29,8 @@ This directory contains reusable GitHub Actions workflow templates for SecPal re
 - Contributors sign via <https://cla-assistant.io/>
 - Signatures are centrally managed
 - Allowlist automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` directly in CLA Assistant
+- Verify the live `cla/check` status on a recent automated PR after changing CLA Assistant settings; documentation alone does not prove the external service is in sync
+- Track any live CLA Assistant config drift in `SecPal/.github` before treating a repository-specific CLA blockage as resolved
 
 ### Adding CLA to a New Repository
 


### PR DESCRIPTION
## Summary

- centralize epic and sub-issue workflow guidance in the `.github` repository instead of pointing back to `api/docs/EPIC_WORKFLOW.md`
- require explicit parent-epic closure evidence in the issue templates and organization-wide Copilot governance
- strengthen CLA Assistant guidance so external allowlist changes are treated as live configuration that must be verified, not just documented

## Problem

Cross-repo epic closure discipline was already partially documented, but the source of truth was fragmented and still depended on the `api` repository for the detailed workflow. That made the rule easy to miss and weakened the closure standard described in `.github#323`.

The CLA symptom tracked in `SecPal/frontend#760` also showed a second process gap: documentation updates about CLA Assistant are not enough when the actual enforcement lives in an external service.

## Changes

- add a central `docs/EPIC_WORKFLOW.md` guide in this repository
- update the epic and sub-issue issue templates with an explicit closure checklist and closure-evidence comment structure
- update `.github/copilot-instructions.md` and `.github/copilot-config.yaml` so parent epic closure now requires repo-by-repo acceptance verification and tracked follow-up issues before closure
- update CLA Assistant setup guidance in `.github/CLA_SETUP.md`, `README.md`, and `workflow-templates/README.md` to require live `cla/check` verification for automated authors such as `copilot-swe-agent`
- record the governance change in `CHANGELOG.md`

## Validation

- `./scripts/preflight.sh`

## Related

Fixes #323
Context: SecPal/frontend#760 was closed separately after verifying it was an external CLA Assistant configuration symptom rather than a remaining frontend repository code issue.
