### PR TITLE
docs: add changelog to workspace inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Changed:**
 
-- added the new `changelog` repository to the shared VS Code workspace definition so it is loaded alongside the other active SecPal repositories
+- added the new `changelog` repository to the shared workspace inventory and contributor setup documentation so contributors know to clone and configure it alongside the other active SecPal repositories
 - extended the master `.github/setup-hooks.sh` bootstrap and its regression test to install hooks in `changelog` together with the existing repositories
 - refreshed organization workspace documentation and repository listings so contributor setup guidance reflects the current seven-repository SecPal workspace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Add changelog Repository To Workspace Inventory
+
+**Changed:**
+
+- added the new `changelog` repository to the shared VS Code workspace definition so it is loaded alongside the other active SecPal repositories
+- extended the master `.github/setup-hooks.sh` bootstrap and its regression test to install hooks in `changelog` together with the existing repositories
+- refreshed organization workspace documentation and repository listings so contributor setup guidance reflects the current seven-repository SecPal workspace
+
 ## 2026-04-08 - Fix setup-hooks Success Counter Abort
 
 **Fixed:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,12 @@ Create a dedicated directory for all SecPal repositories. This mirrors the GitHu
 ```bash
 <your-workspace>/SecPal/
 ├── .github/          # Organization-wide settings and documentation
-├── api/              # Laravel backend (planned)
+├── api/              # Laravel backend API
+├── android/          # React/TypeScript Android app via Capacitor
+├── changelog/        # Next.js public changelog site
+├── contracts/        # OpenAPI 3.1 specifications
 ├── frontend/         # React/TypeScript frontend
-└── contracts/        # OpenAPI 3.1 specifications
+└── secpal.app/       # Astro public website
 ```
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ SecPal is a digital guard book and much more. It's the "guard's friend" in every
 
 - [`.github`](https://github.com/SecPal/.github): Organization-wide settings and documentation
 - [`api`](https://github.com/SecPal/api): Laravel backend API
+- [`android`](https://github.com/SecPal/android): React/TypeScript Android app via Capacitor
+- [`changelog`](https://github.com/SecPal/changelog): Public changelog site for SecPal releases
 - [`contracts`](https://github.com/SecPal/contracts): OpenAPI 3.1 API specifications
 - [`frontend`](https://github.com/SecPal/frontend): React/TypeScript frontend application
+- [`secpal.app`](https://github.com/SecPal/secpal.app): Astro public website
 
 ## Multi-Repository Workspace Setup
 

--- a/WORKSPACE_SETUP.md
+++ b/WORKSPACE_SETUP.md
@@ -15,6 +15,7 @@ SecPal/
 │   └── setup-hooks.sh  # Master script to setup hooks in all repos
 ├── api/           # Laravel backend API
 ├── android/       # React/TypeScript Android app via Capacitor
+├── changelog/     # Next.js public changelog site
 ├── contracts/     # OpenAPI 3.1 API specifications
 ├── frontend/      # React/TypeScript frontend application
 └── secpal.app/    # Astro public website

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$WORKSPACE_ROOT"
 
-REPOS=("api" "frontend" "contracts" "android" "secpal.app" ".github")
+REPOS=("api" "frontend" "contracts" "android" "secpal.app" "changelog" ".github")
 SUCCESS_COUNT=0
 FAILED_REPOS=()
 

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -38,7 +38,10 @@ STUB
   chmod +x "$workspace/$repo/scripts/setup-pre-push.sh" "$workspace/$repo/scripts/setup-pre-commit.sh"
 }
 
-for repo in api frontend contracts android secpal.app changelog .github; do
+repos=(api frontend contracts android secpal.app changelog .github)
+expected_hook_count=$(( ${#repos[@]} * 2 ))
+
+for repo in "${repos[@]}"; do
   create_repo "$repo"
 done
 
@@ -50,5 +53,5 @@ if ! PATH="$workspace/bin:$PATH" bash "$workspace/.github/setup-hooks.sh" >"$out
   exit 1
 fi
 
-grep -q 'Successfully installed: 14 hooks' "$output_file"
+grep -q "Successfully installed: ${expected_hook_count} hooks" "$output_file"
 grep -q 'All Git hooks have been successfully installed' "$output_file"

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -38,7 +38,7 @@ STUB
   chmod +x "$workspace/$repo/scripts/setup-pre-push.sh" "$workspace/$repo/scripts/setup-pre-commit.sh"
 }
 
-for repo in api frontend contracts android secpal.app .github; do
+for repo in api frontend contracts android secpal.app changelog .github; do
   create_repo "$repo"
 done
 
@@ -50,5 +50,5 @@ if ! PATH="$workspace/bin:$PATH" bash "$workspace/.github/setup-hooks.sh" >"$out
   exit 1
 fi
 
-grep -q 'Successfully installed: 12 hooks' "$output_file"
+grep -q 'Successfully installed: 14 hooks' "$output_file"
 grep -q 'All Git hooks have been successfully installed' "$output_file"


### PR DESCRIPTION
## Summary

- add the new `changelog` repository to the shared workspace and hook bootstrap inventory
- refresh contributor-facing repository lists so the active SecPal workspace reflects the current seven repositories
- record the inventory update in the organization changelog

## Validation

- `bash tests/setup-hooks.sh`
- `./scripts/preflight.sh`

## Related

Part of #334
