### PR TITLE
ci: add reusable workflow job timeouts

### DIFF
--- a/.github/workflows/reusable-actionlint.yml
+++ b/.github/workflows/reusable-actionlint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - actionlint
@@ -10,6 +10,7 @@ jobs:
   actionlint:
     name: Lint GitHub Actions Workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-check-conflict-markers.yml
+++ b/.github/workflows/reusable-check-conflict-markers.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Reusable - Check for Merge Conflict Markers
@@ -19,6 +19,7 @@ jobs:
   check-conflict-markers:
     runs-on: ubuntu-latest
     name: Detect Git Conflict Markers
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Reusable Dependabot Auto-Merge Workflow
@@ -44,6 +44,7 @@ jobs:
     name: Check Auto-Merge Eligibility
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    timeout-minutes: 10
     outputs:
       should-auto-merge: ${{ steps.check.outputs.should-auto-merge }}
       update-type: ${{ steps.check.outputs.update-type }}
@@ -238,6 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-eligibility
     if: needs.check-eligibility.outputs.should-auto-merge != 'true' && github.actor == 'dependabot[bot]'
+    timeout-minutes: 10
     steps:
       - name: Add comment for manual review
         uses: actions/github-script@v9

--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - License Compatibility
@@ -16,6 +16,7 @@ jobs:
   license-check:
     name: Check License Compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - Markdown Lint
@@ -16,6 +16,7 @@ jobs:
   markdown-lint:
     name: Lint Markdown Files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-node-build.yml
+++ b/.github/workflows/reusable-node-build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - Node.js Build
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Build Project
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-node-lint.yml
+++ b/.github/workflows/reusable-node-lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - Node.js Lint
@@ -26,6 +26,7 @@ jobs:
   lint:
     name: Run Linter
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - Node.js Tests
@@ -26,6 +26,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Skip tests for spike branches (exploration/prototyping)
     # Spike branches are for experimentation and cannot be merged to main
     # See: CONTRIBUTING.md - Spike Branch Policy

--- a/.github/workflows/reusable-php-lint.yml
+++ b/.github/workflows/reusable-php-lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - Laravel Pint
@@ -21,6 +21,7 @@ jobs:
   pint:
     name: Check Code Style
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-php-stan.yml
+++ b/.github/workflows/reusable-php-stan.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - PHPStan
@@ -21,6 +21,7 @@ jobs:
   phpstan:
     name: Static Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-php-test.yml
+++ b/.github/workflows/reusable-php-test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - PHP Tests (PEST)
@@ -26,6 +26,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Skip tests for spike branches (exploration/prototyping)
     # Spike branches are for experimentation and cannot be merged to main
     # See: CONTRIBUTING.md - Spike Branch Policy

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 name: Reusable PR Size Check
@@ -21,6 +21,7 @@ jobs:
   pr-size:
     name: Check PR Size
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-reuse.yml
+++ b/.github/workflows/reusable-reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - REUSE Compliance
@@ -10,6 +10,7 @@ jobs:
   reuse:
     name: Check REUSE Compliance
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Add Job Timeouts To Reusable Workflows
+
+**Changed:**
+
+- added explicit `timeout-minutes` values to every previously unbounded job in the reusable GitHub Actions workflows so caller repositories inherit bounded execution instead of GitHub's six-hour default
+- added a focused `tests/reusable-workflow-timeouts.sh` regression check and wired it into local preflight so missing reusable workflow timeouts fail before push
+
 ## 2026-04-08 - Fix setup-hooks Success Counter Abort
 
 **Fixed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -89,6 +89,15 @@ if [ -f scripts/check-conflict-markers.sh ]; then
   }
 fi
 
+if [ -f tests/reusable-workflow-timeouts.sh ]; then
+  bash tests/reusable-workflow-timeouts.sh || {
+    echo "" >&2
+    echo "❌ Reusable workflow timeout validation failed!" >&2
+    echo "Add timeout-minutes to every reusable workflow job before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/tests/reusable-workflow-timeouts.sh
+++ b/tests/reusable-workflow-timeouts.sh
@@ -31,6 +31,7 @@ while IFS= read -r workflow; do
         if (current_job != "" && current_has_timeout == 0) {
           print path ":" current_job
         }
+        in_jobs = 0
         exit
       }
 

--- a/tests/reusable-workflow-timeouts.sh
+++ b/tests/reusable-workflow-timeouts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+failures=()
+
+while IFS= read -r workflow; do
+  while IFS= read -r failure; do
+    failures+=("$failure")
+  done < <(
+    awk -v path="$workflow" '
+      BEGIN {
+        in_jobs = 0
+        current_job = ""
+        current_has_timeout = 0
+      }
+
+      /^jobs:$/ {
+        in_jobs = 1
+        next
+      }
+
+      in_jobs && /^[^[:space:]]/ {
+        if (current_job != "" && current_has_timeout == 0) {
+          print path ":" current_job
+        }
+        exit
+      }
+
+      in_jobs && /^  [A-Za-z0-9_-]+:$/ {
+        if (current_job != "" && current_has_timeout == 0) {
+          print path ":" current_job
+        }
+
+        current_job = $0
+        sub(/^  /, "", current_job)
+        sub(/:$/, "", current_job)
+        current_has_timeout = 0
+        next
+      }
+
+      in_jobs && current_job != "" && /^    timeout-minutes:/ {
+        current_has_timeout = 1
+        next
+      }
+
+      END {
+        if (in_jobs && current_job != "" && current_has_timeout == 0) {
+          print path ":" current_job
+        }
+      }
+    ' "$workflow"
+  )
+done < <(find .github/workflows -maxdepth 1 -type f -name 'reusable-*.yml' | sort)
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo "Missing timeout-minutes on reusable workflow jobs:" >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add explicit `timeout-minutes` values to every previously unbounded reusable workflow job
- add a regression test that fails when any `reusable-*.yml` job is missing `timeout-minutes`
- run the new timeout regression through local preflight so reusable workflow drift is caught before push

## Validation

- `bash tests/reusable-workflow-timeouts.sh`
- `pre-commit run --files .github/workflows/reusable-actionlint.yml .github/workflows/reusable-check-conflict-markers.yml .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/reusable-license-compatibility.yml .github/workflows/reusable-markdown-lint.yml .github/workflows/reusable-node-build.yml .github/workflows/reusable-node-lint.yml .github/workflows/reusable-node-test.yml .github/workflows/reusable-php-lint.yml .github/workflows/reusable-php-stan.yml .github/workflows/reusable-php-test.yml .github/workflows/reusable-pr-size.yml .github/workflows/reusable-reuse.yml scripts/preflight.sh tests/reusable-workflow-timeouts.sh CHANGELOG.md`
- `./scripts/preflight.sh`

## Related

- Fixes SecPal/changelog#17
- Duplicate tracked and closed: SecPal/changelog#16
- Follow-up for non-reusable org workflows: #338
