### PR TITLE
docs: update org PROFILE/README.md to canonical product description

### DIFF
--- a/PROFILE/README.md
+++ b/PROFILE/README.md
@@ -5,7 +5,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Hi there 👋
 
-SecPal is a digital guard book and much more. It's the "guard's friend" in every respect. The target group is private, German security services.
+SecPal is the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works.
+
+_SecPal – A guard's best friend._
 
 - 🌐 Main Domain: [secpal.app](https://secpal.app)
 - 🛠️ Development/Demo Domain: [secpal.dev](https://secpal.dev)


### PR DESCRIPTION
## Summary

Replace informal "digital guard book and much more" description in the GitHub organization profile with the canonical SecPal product description and tagline.

Closes #344.

## Changes

- `PROFILE/README.md`: Replace informal guard book framing with canonical two-sentence description plus tagline

## Checklist

- [x] One topic, one branch, one PR
- [x] Prettier passes
- [x] markdownlint passes
- [x] REUSE compliant
- [x] Domain policy check passed
- [x] Preflight OK
- [x] GPG-signed commit