### PR TITLE
fix: add OFL-1.1 to license compatibility allowlist

### DIFF
--- a/.github/workflows/license-compatibility.yml
+++ b/.github/workflows/license-compatibility.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: License Compatibility
@@ -48,6 +48,8 @@ jobs:
           # - LGPL-3.0-or-later (can be upgraded to AGPL)
           # - MIT, BSD, Apache-2.0 (permissive licenses)
           # - CC0-1.0 (public domain)
+          # - OFL-1.1 (SIL Open Font License: permits embedding in software/websites;
+          #   font files remain under OFL but their use in AGPL projects is allowed)
 
           compatible_licenses=(
             "AGPL-3.0-or-later"
@@ -59,6 +61,7 @@ jobs:
             "Apache-2.0"
             "CC0-1.0"
             "ISC"
+            "OFL-1.1"
           )
 
           incompatible_found=0

--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -47,6 +47,8 @@ jobs:
           # - LGPL-3.0-or-later (can be upgraded to AGPL)
           # - MIT, BSD, Apache-2.0 (permissive licenses)
           # - CC0-1.0 (public domain)
+          # - OFL-1.1 (SIL Open Font License: permits embedding in software/websites;
+          #   font files remain under OFL but their use in AGPL projects is allowed)
           # - LicenseRef-TailwindPlus (Catalyst UI Kit: explicitly permits use in open source
           #   projects, components remain under original license but usage is allowed)
 
@@ -60,6 +62,7 @@ jobs:
             "Apache-2.0"
             "CC0-1.0"
             "ISC"
+            "OFL-1.1"
             "LicenseRef-TailwindPlus"
           )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Changed:**
 
-- added OFL-1.1 (SIL Open Font License 1.1) to the compatible licenses list in the reusable
-  license-compatibility workflow; OFL-1.1 fonts are embeddable in AGPL-3.0-or-later projects
-  without conflict
-
----
+- added OFL-1.1 (SIL Open Font License 1.1) to the compatible licenses list in both the
+  reusable and standalone license-compatibility workflows; OFL-1.1 fonts are embeddable in
+  AGPL-3.0-or-later projects without conflict
 
 ## 2026-04-11 - Add Job Timeouts To Reusable Workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Add OFL-1.1 To License Compatibility Allowlist
+
+**Changed:**
+
+- added OFL-1.1 (SIL Open Font License 1.1) to the compatible licenses list in the reusable
+  license-compatibility workflow; OFL-1.1 fonts are embeddable in AGPL-3.0-or-later projects
+  without conflict
+
+---
+
 ## 2026-04-11 - Add Job Timeouts To Reusable Workflows
 
 **Changed:**


### PR DESCRIPTION
fix: add OFL-1.1 to license compatibility allowlist

## Summary
- add OFL-1.1 (SIL Open Font License 1.1) to the compatible_licenses list
  in the reusable license-compatibility workflow
- OFL-1.1 allows embedding fonts in software/websites including AGPL-3.0-or-later
  projects without license conflict

## Validation
- reuse lint (pre-commit hook)
- prettier (pre-commit hook)
- markdownlint (pre-commit hook)
- yamllint (pre-commit hook)

Required by: SecPal/changelog#27
