### PR TITLE
ci: add workflow job timeouts

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,7 @@ jobs:
   actionlint:
     name: Lint GitHub Actions Workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/draft-pr-reminder.yml
+++ b/.github/workflows/draft-pr-reminder.yml
@@ -17,6 +17,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.action == 'opened'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/license-compatibility.yml
+++ b/.github/workflows/license-compatibility.yml
@@ -18,6 +18,7 @@ jobs:
   license-check:
     name: Check License Compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -34,6 +34,7 @@ jobs:
     name: Handle issue lifecycle events
     if: github.event.issue != null
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       issues: write
       contents: read
@@ -303,6 +304,7 @@ jobs:
     # Skip for bot-created PRs (Dependabot, etc.) - they don't have access to secrets
     if: github.event.pull_request != null && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       pull-requests: read
       issues: write
@@ -478,6 +480,7 @@ jobs:
     name: Handle pull request review events
     if: github.event.review != null && github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       pull-requests: read
       issues: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,6 +25,7 @@ jobs:
   reuse:
     name: Check REUSE Compliance
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -35,6 +36,7 @@ jobs:
   license-compatibility:
     name: Check License Compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -53,6 +55,7 @@ jobs:
   prettier:
     name: Check Code Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -71,6 +74,7 @@ jobs:
   markdown-lint:
     name: Lint Markdown Files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,6 +18,7 @@ jobs:
   reuse:
     name: Check REUSE Compliance
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -10,6 +10,7 @@ jobs:
   test-job:
     name: Minimal test job
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Echo test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Add Timeouts To Inline Workflow Jobs
+
+**Changed:**
+
+- added explicit `timeout-minutes` values to the remaining inline `.github` workflow jobs so organization automation no longer falls back to GitHub Actions' six-hour default for actionlint, draft PR reminders, license checks, project automation, quality checks, REUSE, and the inline workflow test harness job
+
 ## 2026-04-11 - Add OFL-1.1 To License Compatibility Allowlist
 
 **Changed:**


### PR DESCRIPTION
## Summary

- add explicit `timeout-minutes` values to the remaining inline GitHub workflow jobs
- keep reusable-workflow caller jobs unchanged so the workflow schema stays valid
- document the automation hardening in the organization changelog

## Validation

- `./scripts/preflight.sh`

Fixes #338
