### PR TITLE
Add closed epic audit helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-11 - Add Closed Epic Audit Helper
+
+**Changed:**
+
+- added `scripts/audit-closed-epics.sh` to audit closed Epic issues for stale checklist state, unresolved child issues, and false positives caused by PR references in issue bodies
+- added a focused shell regression test and wired it into local preflight so future changes keep the audit helper correctly distinguishing issue links from PR links
+- documented the retrospective audit command in the shared Epic workflow guide and scripts reference so maintainers can re-check closed epics before trusting their closure state
+
 ## 2026-04-11 - Add Timeouts To Inline Workflow Jobs
 
 **Changed:**

--- a/docs/EPIC_WORKFLOW.md
+++ b/docs/EPIC_WORKFLOW.md
@@ -120,6 +120,25 @@ If epic closure review finds that something was assumed complete but is not actu
 
 Do not close the epic first and clean up the tracking later.
 
+## Retrospective Audit Helper
+
+When you need to verify already-closed epics, use the audit helper in this
+repository:
+
+```bash
+bash scripts/audit-closed-epics.sh
+```
+
+You can scope it to specific repositories when investigating a narrower set of
+epics:
+
+```bash
+bash scripts/audit-closed-epics.sh --org SecPal --repo .github --repo api
+```
+
+This catches stale checklist state, open child issues, and checked items that do
+not resolve to closed issues.
+
 ## CLA And Other External Services
 
 If a workflow depends on repository settings or external services, merged code alone is not enough evidence. Verify the live configuration separately and track any missing operational step as its own issue.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,38 @@ This directory contains utility scripts for SecPal development.
 
 ## Validation Scripts
 
+### `audit-closed-epics.sh`
+
+Audits closed Epic issues and reports checklist drift, such as child issues that
+are still open or already closed while the parent epic checklist remains
+unchecked.
+
+**Usage:**
+
+```bash
+# Audit the full SecPal workspace set
+bash scripts/audit-closed-epics.sh
+
+# Audit a smaller scope
+bash scripts/audit-closed-epics.sh --org SecPal --repo .github --repo api
+```
+
+**What It Checks:**
+
+1. Searches for closed Epic issues by label and title
+2. Parses checklist-linked child issues from each epic body
+3. Ignores PR references so merged PR numbers are not mistaken for issues
+4. Reports:
+   - open child issues in closed epics
+   - checked items that point to non-closed issues
+   - stale unchecked checklist items whose child issues are already closed
+
+**Exit Codes:**
+
+- `0`: No checklist issues found
+- `1`: One or more checklist issues found
+- `2`: Usage or dependency error
+
 ### `validate-copilot-instructions.sh`
 
 Validates Copilot instructions and configuration files across all repositories.

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+org="SecPal"
+repos=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --org)
+      org="$2"
+      shift 2
+      ;;
+    --repo)
+      repos+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: bash scripts/audit-closed-epics.sh [--org ORG] [--repo REPO]...
+
+Audit closed Epic issues by checking checklist-linked child issues.
+
+Options:
+  --org ORG    GitHub organization or owner to inspect (default: SecPal)
+  --repo REPO  Repository name to inspect. Repeat to scope the audit.
+
+If no repositories are provided, the script audits the active SecPal workspace
+repositories: api, changelog, frontend, contracts, android, secpal.app, .github.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ${#repos[@]} -eq 0 ]; then
+  repos=(api changelog frontend contracts android secpal.app .github)
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required to audit closed epics." >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to audit closed epics." >&2
+  exit 2
+fi
+
+export EPIC_AUDIT_ORG="$org"
+epic_audit_repos="$(printf '%s\n' "${repos[@]}")"
+export EPIC_AUDIT_REPOS="$epic_audit_repos"
+
+python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+
+org = os.environ["EPIC_AUDIT_ORG"]
+repos = [repo for repo in os.environ["EPIC_AUDIT_REPOS"].splitlines() if repo]
+
+explicit_ref = re.compile(rf"{re.escape(org)}/([A-Za-z0-9_.-]+)#(\d+)")
+issue_url_ref = re.compile(rf"https://github\.com/{re.escape(org)}/([A-Za-z0-9_.-]+)/issues/(\d+)")
+relative_ref = re.compile(r"(?<![\w/])#(\d+)")
+markdown_link = re.compile(r"\[[^\]]*\]\([^)]*\)")
+pr_ref = re.compile(r"\bPR\s+#\d+", re.IGNORECASE)
+checklist_line = re.compile(r"^- \[[ xX]\]")
+
+
+def gh_json(*args):
+    output = subprocess.check_output(
+        ["gh", "api", *args],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+    return json.loads(output)
+
+
+def search_epics(owner: str, repo: str):
+    queries = [
+        f"repo:{owner}/{repo} is:issue label:epic is:closed",
+        f"repo:{owner}/{repo} is:issue in:title epic is:closed",
+    ]
+    results = []
+    for query in queries:
+        payload = gh_json(
+            "/search/issues",
+            "-X",
+            "GET",
+            "-f",
+            f"q={query}",
+            "-f",
+            "per_page=100",
+        )
+        results.extend(payload.get("items", []))
+    unique = {}
+    for item in results:
+        key = (item["repository_url"], item["number"])
+        unique[key] = item
+    return list(unique.values())
+
+
+issue_state_cache = {}
+
+
+def fetch_issue_state(owner_repo: str, number: int):
+    cache_key = (owner_repo, number)
+    if cache_key in issue_state_cache:
+        return issue_state_cache[cache_key]
+
+    try:
+        payload = gh_json(f"/repos/{owner_repo}/issues/{number}")
+        state = {
+            "state": payload.get("state", "unknown"),
+            "title": payload.get("title", ""),
+        }
+    except subprocess.CalledProcessError:
+        state = {"state": "missing", "title": ""}
+
+    issue_state_cache[cache_key] = state
+    return state
+
+
+def parse_issue_refs(line: str, epic_repo: str):
+    refs = []
+    for repo_name, number in explicit_ref.findall(line):
+        refs.append((f"{org}/{repo_name}", int(number)))
+
+    for repo_name, number in issue_url_ref.findall(line):
+        refs.append((f"{org}/{repo_name}", int(number)))
+
+    scrubbed = issue_url_ref.sub("", line)
+    scrubbed = markdown_link.sub("", scrubbed)
+    scrubbed = pr_ref.sub("", scrubbed)
+    scrubbed = explicit_ref.sub("", scrubbed)
+    for number in relative_ref.findall(scrubbed):
+        refs.append((epic_repo, int(number)))
+
+    deduped = []
+    seen = set()
+    for ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        deduped.append(ref)
+    return deduped
+
+
+epics = []
+for repo in repos:
+    epics.extend(search_epics(org, repo))
+
+unique_epics = {}
+for item in epics:
+    key = (item["repository_url"], item["number"])
+    unique_epics[key] = item
+
+findings = []
+for item in sorted(unique_epics.values(), key=lambda epic: (epic["repository_url"], epic["number"])):
+    epic_repo = item["repository_url"].split("/repos/", 1)[1]
+    epic_number = item["number"]
+    epic_title = item["title"]
+    body = item.get("body") or ""
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not checklist_line.match(stripped):
+            continue
+
+        marked_checked = stripped.startswith("- [x]") or stripped.startswith("- [X]")
+        refs = parse_issue_refs(stripped, epic_repo)
+        for ref_repo, ref_number in refs:
+            if (ref_repo, ref_number) == (epic_repo, epic_number):
+                continue
+
+            state = fetch_issue_state(ref_repo, ref_number)["state"]
+            if state == "missing":
+                findings.append(
+                    {
+                        "kind": "missing-child",
+                        "epic_repo": epic_repo,
+                        "epic_number": epic_number,
+                        "epic_title": epic_title,
+                        "child_repo": ref_repo,
+                        "child_number": ref_number,
+                        "line": stripped,
+                    }
+                )
+            elif marked_checked and state != "closed":
+                findings.append(
+                    {
+                        "kind": "checked-open-child",
+                        "epic_repo": epic_repo,
+                        "epic_number": epic_number,
+                        "epic_title": epic_title,
+                        "child_repo": ref_repo,
+                        "child_number": ref_number,
+                        "line": stripped,
+                    }
+                )
+            elif not marked_checked and state == "closed":
+                findings.append(
+                    {
+                        "kind": "stale-unchecked-child",
+                        "epic_repo": epic_repo,
+                        "epic_number": epic_number,
+                        "epic_title": epic_title,
+                        "child_repo": ref_repo,
+                        "child_number": ref_number,
+                        "line": stripped,
+                    }
+                )
+            elif not marked_checked and state != "closed":
+                findings.append(
+                    {
+                        "kind": "open-child",
+                        "epic_repo": epic_repo,
+                        "epic_number": epic_number,
+                        "epic_title": epic_title,
+                        "child_repo": ref_repo,
+                        "child_number": ref_number,
+                        "line": stripped,
+                    }
+                )
+
+if not findings:
+    print(f"No closed epic checklist issues found across {len(unique_epics)} epic(s).")
+    sys.exit(0)
+
+deduped_findings = []
+seen_findings = set()
+for finding in findings:
+    key = (
+        finding["kind"],
+        finding["epic_repo"],
+        finding["epic_number"],
+        finding["child_repo"],
+        finding["child_number"],
+    )
+    if key in seen_findings:
+        continue
+    seen_findings.add(key)
+    deduped_findings.append(finding)
+
+print(f"Closed epic checklist issues found: {len(deduped_findings)} across {len(unique_epics)} epic(s).")
+for finding in deduped_findings:
+    epic_prefix = f"{finding['epic_repo']}#{finding['epic_number']}"
+    child_prefix = f"{finding['child_repo']}#{finding['child_number']}"
+    if finding["kind"] == "stale-unchecked-child":
+        message = f"{child_prefix} is closed but still unchecked"
+    elif finding["kind"] == "open-child":
+        message = f"{child_prefix} is still open"
+    elif finding["kind"] == "checked-open-child":
+        message = f"{child_prefix} is not closed but is marked done"
+    else:
+        message = f"{child_prefix} could not be resolved from the checklist reference"
+    print(f"- {epic_prefix} \"{finding['epic_title']}\": {message}")
+
+sys.exit(1)
+PY

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -76,12 +76,19 @@ checklist_line = re.compile(r"^- \[[ xX]\]")
 
 
 def gh_json(*args):
-    output = subprocess.check_output(
-        ["gh", "api", *args],
-        text=True,
-        stderr=subprocess.DEVNULL,
-    )
-    return json.loads(output)
+    try:
+        output = subprocess.check_output(
+            ["gh", "api", *args],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+        return json.loads(output)
+    except subprocess.CalledProcessError as exc:
+        first_line = (exc.stderr or "").strip().splitlines()[:1]
+        raise RuntimeError(
+            f"gh api {args[0] if args else ''} failed: "
+            f"{first_line[0] if first_line else exc.returncode}"
+        ) from exc
 
 
 def search_epics(owner: str, repo: str):
@@ -91,16 +98,24 @@ def search_epics(owner: str, repo: str):
     ]
     results = []
     for query in queries:
-        payload = gh_json(
-            "/search/issues",
-            "-X",
-            "GET",
-            "-f",
-            f"q={query}",
-            "-f",
-            "per_page=100",
-        )
-        results.extend(payload.get("items", []))
+        page = 1
+        while True:
+            payload = gh_json(
+                "/search/issues",
+                "-X",
+                "GET",
+                "-f",
+                f"q={query}",
+                "-f",
+                "per_page=100",
+                "-f",
+                f"page={page}",
+            )
+            items = payload.get("items", [])
+            results.extend(items)
+            if len(items) < 100:
+                break
+            page += 1
     unique = {}
     for item in results:
         key = (item["repository_url"], item["number"])
@@ -122,7 +137,7 @@ def fetch_issue_state(owner_repo: str, number: int):
             "state": payload.get("state", "unknown"),
             "title": payload.get("title", ""),
         }
-    except subprocess.CalledProcessError:
+    except RuntimeError:
         state = {"state": "missing", "title": ""}
 
     issue_state_cache[cache_key] = state
@@ -154,115 +169,119 @@ def parse_issue_refs(line: str, epic_repo: str):
     return deduped
 
 
-epics = []
-for repo in repos:
-    epics.extend(search_epics(org, repo))
+try:
+    epics = []
+    for repo in repos:
+        epics.extend(search_epics(org, repo))
 
-unique_epics = {}
-for item in epics:
-    key = (item["repository_url"], item["number"])
-    unique_epics[key] = item
+    unique_epics = {}
+    for item in epics:
+        key = (item["repository_url"], item["number"])
+        unique_epics[key] = item
 
-findings = []
-for item in sorted(unique_epics.values(), key=lambda epic: (epic["repository_url"], epic["number"])):
-    epic_repo = item["repository_url"].split("/repos/", 1)[1]
-    epic_number = item["number"]
-    epic_title = item["title"]
-    body = item.get("body") or ""
+    findings = []
+    for item in sorted(unique_epics.values(), key=lambda epic: (epic["repository_url"], epic["number"])):
+        epic_repo = item["repository_url"].split("/repos/", 1)[1]
+        epic_number = item["number"]
+        epic_title = item["title"]
+        body = item.get("body") or ""
 
-    for line in body.splitlines():
-        stripped = line.strip()
-        if not checklist_line.match(stripped):
-            continue
-
-        marked_checked = stripped.startswith("- [x]") or stripped.startswith("- [X]")
-        refs = parse_issue_refs(stripped, epic_repo)
-        for ref_repo, ref_number in refs:
-            if (ref_repo, ref_number) == (epic_repo, epic_number):
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not checklist_line.match(stripped):
                 continue
 
-            state = fetch_issue_state(ref_repo, ref_number)["state"]
-            if state == "missing":
-                findings.append(
-                    {
-                        "kind": "missing-child",
-                        "epic_repo": epic_repo,
-                        "epic_number": epic_number,
-                        "epic_title": epic_title,
-                        "child_repo": ref_repo,
-                        "child_number": ref_number,
-                        "line": stripped,
-                    }
-                )
-            elif marked_checked and state != "closed":
-                findings.append(
-                    {
-                        "kind": "checked-open-child",
-                        "epic_repo": epic_repo,
-                        "epic_number": epic_number,
-                        "epic_title": epic_title,
-                        "child_repo": ref_repo,
-                        "child_number": ref_number,
-                        "line": stripped,
-                    }
-                )
-            elif not marked_checked and state == "closed":
-                findings.append(
-                    {
-                        "kind": "stale-unchecked-child",
-                        "epic_repo": epic_repo,
-                        "epic_number": epic_number,
-                        "epic_title": epic_title,
-                        "child_repo": ref_repo,
-                        "child_number": ref_number,
-                        "line": stripped,
-                    }
-                )
-            elif not marked_checked and state != "closed":
-                findings.append(
-                    {
-                        "kind": "open-child",
-                        "epic_repo": epic_repo,
-                        "epic_number": epic_number,
-                        "epic_title": epic_title,
-                        "child_repo": ref_repo,
-                        "child_number": ref_number,
-                        "line": stripped,
-                    }
-                )
+            marked_checked = stripped.startswith("- [x]") or stripped.startswith("- [X]")
+            refs = parse_issue_refs(stripped, epic_repo)
+            for ref_repo, ref_number in refs:
+                if (ref_repo, ref_number) == (epic_repo, epic_number):
+                    continue
 
-if not findings:
-    print(f"No closed epic checklist issues found across {len(unique_epics)} epic(s).")
-    sys.exit(0)
+                state = fetch_issue_state(ref_repo, ref_number)["state"]
+                if state == "missing":
+                    findings.append(
+                        {
+                            "kind": "missing-child",
+                            "epic_repo": epic_repo,
+                            "epic_number": epic_number,
+                            "epic_title": epic_title,
+                            "child_repo": ref_repo,
+                            "child_number": ref_number,
+                            "line": stripped,
+                        }
+                    )
+                elif marked_checked and state != "closed":
+                    findings.append(
+                        {
+                            "kind": "checked-open-child",
+                            "epic_repo": epic_repo,
+                            "epic_number": epic_number,
+                            "epic_title": epic_title,
+                            "child_repo": ref_repo,
+                            "child_number": ref_number,
+                            "line": stripped,
+                        }
+                    )
+                elif not marked_checked and state == "closed":
+                    findings.append(
+                        {
+                            "kind": "stale-unchecked-child",
+                            "epic_repo": epic_repo,
+                            "epic_number": epic_number,
+                            "epic_title": epic_title,
+                            "child_repo": ref_repo,
+                            "child_number": ref_number,
+                            "line": stripped,
+                        }
+                    )
+                elif not marked_checked and state != "closed":
+                    findings.append(
+                        {
+                            "kind": "open-child",
+                            "epic_repo": epic_repo,
+                            "epic_number": epic_number,
+                            "epic_title": epic_title,
+                            "child_repo": ref_repo,
+                            "child_number": ref_number,
+                            "line": stripped,
+                        }
+                    )
 
-deduped_findings = []
-seen_findings = set()
-for finding in findings:
-    key = (
-        finding["kind"],
-        finding["epic_repo"],
-        finding["epic_number"],
-        finding["child_repo"],
-        finding["child_number"],
-    )
-    if key in seen_findings:
-        continue
-    seen_findings.add(key)
-    deduped_findings.append(finding)
+    if not findings:
+        print(f"No closed epic checklist issues found across {len(unique_epics)} epic(s).")
+        sys.exit(0)
 
-print(f"Closed epic checklist issues found: {len(deduped_findings)} across {len(unique_epics)} epic(s).")
-for finding in deduped_findings:
-    epic_prefix = f"{finding['epic_repo']}#{finding['epic_number']}"
-    child_prefix = f"{finding['child_repo']}#{finding['child_number']}"
-    if finding["kind"] == "stale-unchecked-child":
-        message = f"{child_prefix} is closed but still unchecked"
-    elif finding["kind"] == "open-child":
-        message = f"{child_prefix} is still open"
-    elif finding["kind"] == "checked-open-child":
-        message = f"{child_prefix} is not closed but is marked done"
-    else:
-        message = f"{child_prefix} could not be resolved from the checklist reference"
-    print(f"- {epic_prefix} \"{finding['epic_title']}\": {message}")
+    deduped_findings = []
+    seen_findings = set()
+    for finding in findings:
+        key = (
+            finding["kind"],
+            finding["epic_repo"],
+            finding["epic_number"],
+            finding["child_repo"],
+            finding["child_number"],
+        )
+        if key in seen_findings:
+            continue
+        seen_findings.add(key)
+        deduped_findings.append(finding)
 
-sys.exit(1)
+    print(f"Closed epic checklist issues found: {len(deduped_findings)} across {len(unique_epics)} epic(s).")
+    for finding in deduped_findings:
+        epic_prefix = f"{finding['epic_repo']}#{finding['epic_number']}"
+        child_prefix = f"{finding['child_repo']}#{finding['child_number']}"
+        if finding["kind"] == "stale-unchecked-child":
+            message = f"{child_prefix} is closed but still unchecked"
+        elif finding["kind"] == "open-child":
+            message = f"{child_prefix} is still open"
+        elif finding["kind"] == "checked-open-child":
+            message = f"{child_prefix} is not closed but is marked done"
+        else:
+            message = f"{child_prefix} could not be resolved from the checklist reference"
+        print(f"- {epic_prefix} \"{finding['epic_title']}\": {message}")
+
+    sys.exit(1)
+except RuntimeError as exc:
+    print(f"Error: {exc}", file=sys.stderr)
+    sys.exit(2)
 PY

--- a/scripts/audit-closed-epics.sh.license
+++ b/scripts/audit-closed-epics.sh.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: MIT

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -98,6 +98,15 @@ if [ -f tests/reusable-workflow-timeouts.sh ]; then
   }
 fi
 
+if [ -f tests/audit-closed-epics.sh ]; then
+  bash tests/audit-closed-epics.sh || {
+    echo "" >&2
+    echo "❌ Closed epic audit regression test failed!" >&2
+    echo "Fix scripts/audit-closed-epics.sh before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/tests/audit-closed-epics.sh
+++ b/tests/audit-closed-epics.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/audit-closed-epics.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/bin" "$workspace/fixtures"
+
+cat >"$workspace/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture_dir="${EPIC_AUDIT_FIXTURE_DIR:?}"
+
+if [ "$1" != "api" ]; then
+  echo "unexpected gh command: $*" >&2
+  exit 1
+fi
+
+shift
+
+if [ "$1" = "/search/issues" ]; then
+  cat "$fixture_dir/search.json"
+  exit 0
+fi
+
+case "$1" in
+  /repos/SecPal/api/issues/10)
+    cat "$fixture_dir/api-10.json"
+    ;;
+  /repos/SecPal/frontend/issues/30)
+    cat "$fixture_dir/frontend-30.json"
+    ;;
+  /repos/SecPal/.github/issues/40)
+    cat "$fixture_dir/github-40.json"
+    ;;
+  *)
+    echo "unexpected gh api endpoint: $1" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$workspace/bin/gh"
+
+cat >"$workspace/fixtures/search.json" <<'JSON'
+{
+  "total_count": 1,
+  "incomplete_results": false,
+  "items": [
+    {
+      "number": 500,
+      "title": "[EPIC] Demo epic",
+      "body": "- [x] SecPal/api#10 -> [PR #20](https://github.com/SecPal/api/pull/20)\n- [ ] SecPal/frontend#30 - stale checklist item\n- [ ] #40 - still open child issue",
+      "repository_url": "https://api.github.com/repos/SecPal/.github"
+    }
+  ]
+}
+JSON
+
+cat >"$workspace/fixtures/api-10.json" <<'JSON'
+{
+  "state": "closed",
+  "title": "Closed child"
+}
+JSON
+
+cat >"$workspace/fixtures/frontend-30.json" <<'JSON'
+{
+  "state": "closed",
+  "title": "Closed child with stale epic checklist"
+}
+JSON
+
+cat >"$workspace/fixtures/github-40.json" <<'JSON'
+{
+  "state": "open",
+  "title": "Open child issue"
+}
+JSON
+
+output_file="$workspace/output.txt"
+
+set +e
+PATH="$workspace/bin:$PATH" \
+EPIC_AUDIT_FIXTURE_DIR="$workspace/fixtures" \
+bash "$REPO_ROOT/scripts/audit-closed-epics.sh" --org SecPal --repo .github >"$output_file" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+  cat "$output_file"
+  echo "audit-closed-epics.sh unexpectedly passed" >&2
+  exit 1
+fi
+
+grep -q 'SecPal/frontend#30 is closed but still unchecked' "$output_file"
+grep -q 'SecPal/.github#40 is still open' "$output_file"
+
+if grep -q '#20' "$output_file"; then
+  cat "$output_file"
+  echo "audit-closed-epics.sh incorrectly treated a PR reference as an issue" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/audit-closed-epics.sh` to audit closed Epic checklist drift without confusing PR references for issue links
- add a focused regression test and wire it into local preflight so the audit helper stays reliable
- document the retrospective audit workflow in the shared Epic governance docs and scripts reference

## Validation
- `bash tests/audit-closed-epics.sh`
- `./scripts/preflight.sh`

## Follow-Up
- Refs #350 for the historical backfill of already-closed Epic issues with stale checklist state

Closes #323
