### PR TITLE
docs: adopt issue-first planning governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
-## 2026-04-14 - Harden Copilot Instructions And Workflow Timeout Validations
-
 ## 2026-04-15 - Adopt Issue-First Planning Governance
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ## 2026-04-14 - Harden Copilot Instructions And Workflow Timeout Validations
 
+## 2026-04-15 - Adopt Issue-First Planning Governance
+
+**Changed:**
+
+- accepted ADR-013 to establish GitHub Issues, milestones, ADRs, and linked PRs as the canonical planning model, with the organization project board retained only as an optional mirrored view
+- rewrote `docs/planning.md` as the canonical contributor planning guide and reframed `docs/project-board-integration.md` as optional board operations guidance
+- archived `docs/feature-requirements.md` for active planning, clarified the non-canonical role of `docs/ideas-backlog.md`, and updated `README.md` plus `docs/workflows/PROJECT_AUTOMATION.md` to match the issue-first process
+- updated the ADR index with the new planning-governance decision
+
+## 2026-04-14 - Harden Copilot Instructions And Workflow Timeout Validations
+
 **Changed:**
 
 - updated SPDX copyright headers in `docs/workflows/PROJECT_AUTOMATION.md` and `docs/workflows/QUICK_REFERENCE.md` to `2025-2026`

--- a/README.md
+++ b/README.md
@@ -32,35 +32,35 @@ For setting up a local development environment with all repositories, see [WORKS
 
 ### Feature Management & Project Tracking
 
-SecPal uses a structured approach to feature planning and tracking:
+SecPal uses an issue-first planning model:
 
-- **📝 Documentation**: Features start in `docs/ideas-backlog.md` and mature to `docs/feature-requirements.md`
-- **🎫 Issue Templates**: Use structured templates (`core_feature.yml`, `feature_request.yml`) for consistency
-- **📊 Project Board**: Kanban-style tracking with automatic issue assignment
-- **🏷️ Labels**: Organized by area (`area: RBAC`, `area: employee-mgmt`), priority (`P0-P3`), and status
+- **🎫 GitHub Issues**: Canonical source of truth for active work and deferred follow-up
+- **🏷️ Labels and Milestones**: Priority, type, component, and release grouping
+- **🧭 ADRs**: Durable records for planning and architecture decisions
+- **📊 Project Board**: Optional mirrored view for cross-repository status tracking
 
 **Quick Start:**
 
 ```bash
-# Set up project board integration and labels
-./scripts/setup-project-board.sh
+# Read the canonical planning guide
+cat docs/planning.md
 
-# Read the full workflow guide
+# Optional: read the board mirror guide
 cat docs/project-board-integration.md
 ```
 
 **Workflow:**
 
-1. **New Idea** → Add to `docs/ideas-backlog.md`
-2. **Ready to Specify** → Detail in `docs/feature-requirements.md`
-3. **Ready to Build** → Create issue via template → Auto-added to Project Board
-4. **Track Progress** → Move through Kanban columns: Ideas → Backlog → Ready → In Progress → Done
+1. **Open or refine an issue** in the repository that owns the work
+2. **Add labels and milestone** to make priority and delivery intent explicit
+3. **Split multi-PR work** into an epic plus sub-issues before implementation
+4. **Open a draft PR** linked to the issue; board automation mirrors progress only when enabled
 
-See [docs/project-board-integration.md](docs/project-board-integration.md) for detailed instructions.
+See [docs/planning.md](docs/planning.md) for the canonical process and [docs/project-board-integration.md](docs/project-board-integration.md) for the optional board layer.
 
 ### 🤖 Automated Project Board Management
 
-SecPal uses automated workflows to manage the [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) project board. Issues and pull requests are automatically added and their status is updated based on labels, PR state, and review activity.
+SecPal uses automated workflows to manage the optional [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) project board. Issues and pull requests are automatically added and their status is updated based on labels, PR state, and review activity, but the board remains a mirrored view rather than the planning source of truth.
 
 **Status Flow:**
 
@@ -110,7 +110,7 @@ gh pr merge <PR> --squash                   # → Done (auto-closes issue)
 - [📋 Quick Reference](docs/workflows/QUICK_REFERENCE.md) - Daily usage commands
 - [🚀 Rollout Guide](docs/workflows/ROLLOUT_GUIDE.md) - Deployment to repositories
 
-See [docs/project-board-integration.md](docs/project-board-integration.md) for detailed instructions.
+See [docs/project-board-integration.md](docs/project-board-integration.md) for board-specific guidance and [docs/planning.md](docs/planning.md) for the canonical planning model.
 
 ### Pre-commit Hooks
 

--- a/docs/adr/20260415-issue-first-planning-governance-adr013.md
+++ b/docs/adr/20260415-issue-first-planning-governance-adr013.md
@@ -1,0 +1,89 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# ADR-013: Issue-First Planning Governance And Optional Project Board Mirror
+
+## Status
+
+**Accepted** (Issue #354)
+
+## Date
+
+2026-04-15
+
+## Deciders
+
+@aroviqen
+
+## Context
+
+SecPal planning drifted across several artifacts:
+
+- `docs/feature-requirements.md` accumulated large historical specifications
+- `docs/planning.md` and `docs/project-board-integration.md` described a project-board-heavy flow
+- active work increasingly happened in GitHub Issues and pull requests instead
+- the public roadmap direction in `SecPal/secpal.app#61` needs a stable internal source-of-truth model
+
+This left contributors without a single canonical planning process and made it too easy for planning status to diverge between documents, issues, and the project board.
+
+## Decision
+
+SecPal adopts an issue-first planning model.
+
+- GitHub Issues are the canonical source of truth for active planning and deferred follow-up work.
+- Milestones group roadmap and release intent.
+- Labels capture classification such as priority, type, and component.
+- ADRs record durable planning and architecture decisions when rationale matters beyond one issue.
+- GitHub Projects may be used as an optional visual mirror for cross-repository tracking, but never as the canonical source of scope, acceptance criteria, or delivery evidence.
+- The public roadmap must be derived from a curated, public-safe subset of issues and milestones rather than from board-only metadata.
+
+The documentation action plan attached to this decision is:
+
+- `docs/planning.md` becomes the canonical contributor-facing planning guide
+- `docs/project-board-integration.md` remains as an optional board-operations guide only
+- `docs/feature-requirements.md` is archived for active planning and kept only as historical context until remaining useful content is migrated into issues or ADRs
+
+## Consequences
+
+### Positive
+
+- Planning status has one canonical home.
+- Cross-repository work becomes easier to audit because issues and linked PRs already carry durable history.
+- The public roadmap can be built from curated issue data without depending on internal-only board hygiene.
+- Project-board automation remains useful without being a governance dependency.
+
+### Negative
+
+- Historical long-form planning content still needs cleanup and migration.
+- Existing board collateral and helper scripts may need follow-up alignment with the new governance wording.
+- Contributors used to document-first planning must change habits.
+
+## Repo-Local Follow-Up Impact
+
+- `.github` must track remaining migration of actionable content out of `docs/feature-requirements.md`.
+- `.github` must align any remaining project-board helper collateral that still assumes `feature-requirements.md` is active planning.
+- `SecPal/secpal.app#61` remains the public roadmap implementation track and must consume only public-safe planning data.
+
+## Alternatives Considered
+
+1. **GitHub Issues plus actively maintained Project Board as dual canonical sources**
+   - Pro: strong visual planning workflow
+   - Contra: creates two places where status can drift and increases maintenance cost
+
+2. **Project Board as primary planning source**
+   - Pro: easy visual triage
+   - Contra: weak auditability, poor durability for acceptance criteria, and unsuitable as a public roadmap source
+
+3. **Keep long-form planning docs as the main source**
+   - Pro: rich narrative context in one place
+   - Contra: hard to keep current, weak repo ownership, and not PR-sized or issue-driven
+
+## Related
+
+- [Issue #354](https://github.com/SecPal/.github/issues/354)
+- [SecPal/secpal.app#61](https://github.com/SecPal/secpal.app/issues/61)
+- [docs/planning.md](../planning.md)
+- [docs/project-board-integration.md](../project-board-integration.md)
+- [docs/EPIC_WORKFLOW.md](../EPIC_WORKFLOW.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -79,6 +79,7 @@ Examples:
 
 ### Accepted
 
+- [ADR-013: Issue-First Planning Governance And Optional Project Board Mirror](20260415-issue-first-planning-governance-adr013.md) - 2026-04-15
 - [ADR-012: Single-App Android Distribution and Private Provisioning QR Architecture](20260406-single-app-android-distribution-and-private-provisioning-adr012.md) - 2026-04-06
 - [ADR-011: Simplify Management Level from Model to Integer Field](20251227-simplify-management-level-to-integer-field-adr011.md) - 2025-12-27
 - [ADR-010: Activity Logging & Audit Trail Strategy](20251221-activity-logging-audit-trail-strategy.md) - 2025-12-24

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -1,15 +1,17 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
 # Feature Requirements & Business Logic
 
-**Purpose:** Document business requirements and feature specifications for SecPal.
+**Purpose:** Historical business-context archive from SecPal's early planning phase.
 
-**Status:** Living document - Features move to GitHub Issues when prioritized
+**Status:** Archived for active planning as of 2026-04-15. Do not add new planning content here. Active planning lives in GitHub Issues, milestones, and ADRs as defined in `docs/planning.md` and ADR-013.
 
-**Last Updated:** 2025-11-26
+**Preserved For:** Historical context, legacy references, and extracting deferred follow-up issues into repository-local trackers.
+
+**Last Updated:** 2026-04-15
 
 ---
 

--- a/docs/ideas-backlog.md
+++ b/docs/ideas-backlog.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC0-1.0
 
 **Last Updated:** 2026-04-11
 
-> **Note:** Core features (RBAC, Employee Management, Shift Planning) have been moved to `feature-requirements.md` for detailed specification. This document focuses on long-term/experimental ideas.
+> **Note:** This document is non-canonical idea parking only. Active planning lives in GitHub Issues and milestones. Historical detailed specifications remain in `feature-requirements.md`, which is archived for active planning.
 
 ---
 

--- a/docs/ideas-backlog.md
+++ b/docs/ideas-backlog.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC0-1.0
 
 **Status:** Living document - Add ideas freely, review quarterly
 
-**Last Updated:** 2026-04-11
+**Last Updated:** 2026-04-15
 
 > **Note:** This document is non-canonical idea parking only. Active planning lives in GitHub Issues and milestones. Historical detailed specifications remain in `feature-requirements.md`, which is archived for active planning.
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -1,347 +1,100 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
-# Project Planning & Organization
+# Project Planning Governance
 
-This document explains how SecPal organizes work, tracks progress, and plans features.
+This document is the canonical planning guide for SecPal contributors.
 
-## 📊 GitHub Projects
+## Governance Decision
 
-We use **GitHub Projects** (organization-level) for cross-repository planning:
+SecPal uses an issue-first planning model.
 
-### SecPal Roadmap Project
+- GitHub Issues are the single source of truth for active work, decisions, and deferred follow-up.
+- Milestones group issues into release horizons or roadmap buckets.
+- Labels classify priority, type, and component.
+- ADRs capture planning or architecture decisions that need durable rationale.
+- GitHub Projects may be used as an optional visual layer, but they are never the canonical record of scope, acceptance criteria, priority, or delivery evidence.
 
-**URL:** `https://github.com/orgs/SecPal/projects/1` _(to be created)_
+The decision rationale is recorded in ADR-013: `docs/adr/20260415-issue-first-planning-governance-adr013.md`.
 
-**Views:**
+## What Counts As Canonical
 
-1. **📋 Kanban Board:**
-   - Backlog (Ideas, not yet prioritized)
-   - Discussion Needed (Requires decision before work)
-   - Planned (Prioritized, ready for implementation)
-   - In Progress (Active work)
-   - In Review (PR open, awaiting review)
-   - Done (Merged/Completed)
+### Active Planning
 
-2. **🗓️ Roadmap View:**
-   - Timeline view with milestones
-   - Target dates for releases
-   - Dependencies visualization
+- GitHub Issues in the correct repository
+- linked PRs and review state
+- milestones and labels
+- epic plus sub-issue structure for multi-PR work
 
-3. **📊 Table View:**
-   - All issues with custom fields
-   - Sortable, filterable
+### Supporting But Non-Canonical
 
-**Custom Fields:**
+- GitHub Project board views
+- `docs/ideas-backlog.md` for long-horizon or non-actionable notes
+- historical specifications kept only for context
 
-| Field            | Type          | Values                                                    |
-| ---------------- | ------------- | --------------------------------------------------------- |
-| Priority         | Single select | P0 (Blocker), P1 (High), P2 (Medium), P3 (Low)            |
-| Component        | Single select | API, Frontend, Contracts, Infrastructure, Legal, Security |
-| Type             | Single select | Feature, Bug, Documentation, Research, Decision           |
-| Effort           | Single select | S (1-2 days), M (3-5 days), L (1-2 weeks), XL (2+ weeks)  |
-| Target Milestone | Milestone     | 0.1.0, 0.2.0, 1.0.0, Future                               |
-| Status           | Status        | Auto-synced with Kanban columns                           |
+If planning data exists only on a board card or in a long-form doc, it is not governed well enough.
 
-## 📁 Repository Organization
+## Public Roadmap Relationship
 
-### Where to Create Issues
+The public roadmap must be derived from a curated, public-safe subset of issues and milestones.
 
-| Topic                    | Repository  | Examples                                |
-| ------------------------ | ----------- | --------------------------------------- |
-| Backend/API features     | `api`       | "Implement guard shift endpoints"       |
-| Frontend features        | `frontend`  | "Add shift calendar view"               |
-| API contract changes     | `contracts` | "Add pagination to shift list endpoint" |
-| Cross-repo features      | `.github`   | "Digital guard book MVP"                |
-| Infrastructure/CI/CD     | `.github`   | "Add performance testing workflow"      |
-| Legal/licensing          | `.github`   | "Legal review of CLA"                   |
-| Documentation (org-wide) | `.github`   | "Architecture Decision Records"         |
-| Security/GHAS            | `.github`   | "Enable secret scanning for all repos"  |
+- internal planning stays issue-first inside GitHub
+- the public roadmap must not expose internal-only issue details, board metadata, or sensitive discussions
+- the board may inform internal prioritization, but it is not the public roadmap source of truth
 
-### Label Strategy
+Implementation planning for the public roadmap is tracked in `SecPal/secpal.app#61`.
 
-**Priority Labels** (all repos):
+## Repository Routing
 
-- `priority: blocker` 🔴 (Blocks release/development)
-- `priority: high` 🟠 (Important, should be done soon)
-- `priority: medium` 🟡 (Normal priority)
-- `priority: low` 🟢 (Nice to have, low urgency)
+Create work in the repository that owns the change.
 
-**Type Labels** (all repos):
+| Topic                    | Repository   | Examples                                |
+| ------------------------ | ------------ | --------------------------------------- |
+| Backend/API features     | `api`        | "Implement guard shift endpoints"       |
+| Frontend features        | `frontend`   | "Add shift calendar view"               |
+| API contract changes     | `contracts`  | "Add pagination to shift list endpoint" |
+| Android app work         | `android`    | "Add Device Owner enrollment bridge"    |
+| Public website / roadmap | `secpal.app` | "Implement public roadmap page"         |
+| Cross-repo features      | `.github`    | "Digital guard book MVP"                |
+| Infrastructure/CI/CD     | `.github`    | "Add performance testing workflow"      |
+| Legal/licensing          | `.github`    | "Legal review of CLA"                   |
+| Documentation (org-wide) | `.github`    | "Planning governance ADR"               |
+| Security/GHAS            | `.github`    | "Enable secret scanning for all repos"  |
 
-- `type: bug` 🐛 (Something broken)
-- `type: feature` ✨ (New functionality)
-- `type: documentation` 📝 (Docs only)
-- `type: enhancement` 💡 (Improvement to existing feature)
-- `type: research` 🔬 (Investigation/spike)
-- `type: security` 🔐 (Security-related)
+## Minimal Contributor Workflow
 
-**Status Labels** (all repos):
+1. Open or refine a GitHub Issue in the correct repository.
+2. Add the smallest useful labels and milestone.
+3. If the work needs more than one PR, create an epic first and split it into sub-issues.
+4. If the issue needs durable rationale, write an ADR.
+5. Implement from a dedicated topic branch and open a draft PR linked to the issue.
+6. Let board automation mirror progress only if the project board is enabled.
 
-- `status: discussion` 💬 (Needs decision/consensus)
-- `status: blocked` 🚧 (Can't proceed, waiting on something)
-- `status: ready` ✅ (Ready for implementation)
-- `status: wip` 🚧 (Work in progress)
+## Documentation Roles
 
-**Component Labels** (repo-specific):
+| Document                            | Role                                          | Status                       |
+| ----------------------------------- | --------------------------------------------- | ---------------------------- |
+| `docs/planning.md`                  | Canonical planning and contributor onboarding | Active                       |
+| `docs/project-board-integration.md` | Optional board setup and usage guide          | Active, non-canonical        |
+| `docs/feature-requirements.md`      | Historical specification archive              | Archived for active planning |
 
-- API: `component: database`, `component: auth`, `component: api`
-- Frontend: `component: ui`, `component: routing`, `component: state`
-- All: `component: ci/cd`, `component: tests`
+## Board Usage Rules
 
-**Effort Labels** (all repos):
+When the SecPal Roadmap board is enabled:
 
-- `effort: S` (1-2 days)
-- `effort: M` (3-5 days)
-- `effort: L` (1-2 weeks)
-- `effort: XL` (2+ weeks, consider splitting)
+- use it for status visualization, cross-repo triage, and work-in-progress awareness
+- do not store acceptance criteria only on project items
+- do not treat board fields as authoritative when they disagree with issues, milestones, or linked PRs
+- do not use the board as the public roadmap feed without a separate public-safe curation step
 
-**Special Labels**:
+If the board is unavailable or out of date, planning continues through issues, labels, milestones, and PRs without process loss.
 
-- `good first issue` 👋 (For new contributors)
-- `help wanted` 🙏 (Community contributions welcome)
-- `breaking change` ⚠️ (Requires major version bump)
-- `legal` ⚖️ (Requires legal review)
+## Related Guidance
 
-## 🎯 Milestones
-
-### Version Strategy
-
-SecPal follows **Semantic Versioning** (semver):
-
-- `0.x.x` - Pre-1.0 development (breaking changes allowed)
-- `1.0.0` - First production release
-- `1.x.x` - Backward-compatible features
-- `2.0.0+` - Breaking changes
-
-### Current Milestones
-
-**0.1.0 - Foundation** _(Target: TBD)_
-
-- Basic API structure
-- Database schema
-- OpenAPI contracts
-- CI/CD pipelines
-- Development environment (DDEV)
-
-**0.2.0 - Guard Book MVP** _(Target: TBD)_
-
-- Event sourcing implementation
-- Basic guard shift endpoints
-- Guard book entry CRUD
-- Simple frontend prototype
-
-**0.3.0 - Authentication & Authorization** _(Target: TBD)_
-
-- User management
-- Role-based access control (RBAC)
-- JWT authentication
-- API key management
-
-**1.0.0 - Production Ready** _(Target: TBD)_
-
-- Complete guard book functionality
-- Legal review completed
-- Security audit passed
-- Performance tested
-- Documentation complete
-- Production deployment
-
-## 📝 Issue Templates
-
-Located in `.github/ISSUE_TEMPLATE/` (to be created):
-
-1. **Feature Request** (`feature_request.yml`)
-2. **Bug Report** (`bug_report.yml`)
-3. **Architecture Decision** (`architecture_decision.yml`)
-4. **Research/Spike** (`research.yml`)
-5. **Security Vulnerability** (private security advisories)
-
-## 🔄 Workflow
-
-### 1. Idea → Issue
-
-1. Check if idea is in `docs/ideas-backlog.md`
-2. If actionable, create GitHub Issue in appropriate repo
-3. Add to GitHub Project
-4. Label with priority, type, component, effort
-
-### 2. Issue → Planning
-
-1. Discuss in issue comments or team meeting
-2. If architecture decision needed → Create ADR
-3. Move to "Planned" column when ready
-4. Assign to milestone
-
-### 3. Implementation
-
-1. Create branch: `feature/short-description` or `fix/short-description`
-2. Move issue to "In Progress"
-3. Implement with TDD (tests first!)
-4. Follow conventional commits
-5. Update CHANGELOG.md
-
-### 4. Review → Merge
-
-1. Open PR, link to issue (`Closes #123`)
-2. Move to "In Review"
-3. Wait for CI checks + code review
-4. Merge with squash commit
-5. Move to "Done"
-
-### 5. Release
-
-1. Tag release: `v0.1.0`
-2. Generate release notes from CHANGELOG
-3. Deploy to staging
-4. Smoke test
-5. Deploy to production
-
-## 📚 Documentation Hierarchy
-
-```
-SecPal Documentation
-├── README.md (per repo)           # Overview, quick start
-├── CONTRIBUTING.md (per repo)     # How to contribute
-├── SECURITY.md (per repo)         # Security policies
-├── CODE_OF_CONDUCT.md (per repo)  # Community standards
-├── CHANGELOG.md (per repo)        # Version history
-│
-├── .github/docs/                  # Organization-wide docs
-│   ├── adr/                       # Architecture Decision Records
-│   │   ├── README.md
-│   │   └── YYYYMMDD-title.md
-│   ├── ideas-backlog.md           # Future ideas
-│   ├── planning.md                # This file
-│   ├── openapi.md                 # API conventions
-│   ├── labels.md                  # Label definitions
-│   └── ghas-setup.md              # GitHub Advanced Security
-│
-├── contracts/docs/                # API specifications
-│   └── openapi.yaml
-│
-└── api/docs/ (future)             # API-specific docs
-    └── deployment.md
-```
-
-## 🤝 Decision Making (Single Maintainer)
-
-As a single-maintainer project, you (kevalyq) make all decisions. However:
-
-**Best Practices:**
-
-1. **Sleep on big decisions** - Don't rush architecture choices
-2. **Write ADRs** - Document reasoning for future you (or future contributors)
-3. **Use issues for self-accountability** - Track what you decided and why
-4. **Review backlog quarterly** - Are priorities still correct?
-5. **Be open to feedback** - Even without contributors, community feedback is valuable
-
-**When to involve others:**
-
-- Legal decisions → Lawyer
-- Security architecture → Security review
-- Major license changes → Community consultation
-- Breaking API changes → Document thoroughly, communicate early
-
-## 🔮 Future: Growing Beyond Single Maintainer
-
-**When external contributors join:**
-
-1. **Update CONTRIBUTING.md** with:
-   - How to claim issues
-   - Review process
-   - Commit rights process
-
-2. **Add CODEOWNERS:**
-
-   ```
-   # SPDX-FileCopyrightText: 2025 SecPal
-   # SPDX-License-Identifier: CC0-1.0
-   # Example CODEOWNERS file
-   *                @kevalyq
-   /api/database/*  @kevalyq @future-db-expert
-   ```
-
-3. **Enable Discussions:**
-   - For questions (instead of issues)
-   - For RFCs (Request for Comments)
-   - For show-and-tell
-
-4. **Regular syncs:**
-   - Monthly contributor calls
-   - Async updates in Discussions
-
-## 📊 Metrics to Track (Future)
-
-Once the project grows:
-
-- Issue close rate
-- PR merge time
-- Test coverage
-- Documentation coverage
-- Dependency update lag
-- Security vulnerability response time
-
-## 🛠️ Tools in Use
-
-| Purpose               | Tool                     | Notes                               |
-| --------------------- | ------------------------ | ----------------------------------- |
-| Planning              | GitHub Projects          | Organization-level                  |
-| Issue tracking        | GitHub Issues            | Per repository                      |
-| Code review           | GitHub PRs               | Required before merge               |
-| CI/CD                 | GitHub Actions           | Workflows in `.github/workflows/`   |
-| API docs              | OpenAPI 3.1              | In `contracts/docs/openapi.yaml`    |
-| Dependency updates    | Dependabot               | Daily at 04:00 Europe/Berlin        |
-| Security scanning     | GitHub Advanced Security | CodeQL, secret scanning, Dependabot |
-| License compliance    | REUSE 3.3                | `reuse lint` in quality workflow    |
-| Code style (API)      | Laravel Pint (PSR-12)    | Auto-fixes on pre-commit            |
-| Code style (Frontend) | Prettier + ESLint        | Auto-fixes on pre-commit            |
-| Testing (API)         | PEST                     | `composer test`                     |
-| Testing (Frontend)    | Vitest                   | `npm test`                          |
-| Static analysis (API) | PHPStan Level Max        | `composer analyse`                  |
-
-## 🚀 Quick Reference
-
-**Create a new feature:**
-
-```bash
-# 1. Create issue on GitHub
-# 2. Assign to milestone
-# 3. Add to Project
-# 4. Create branch
-git checkout -b feature/short-description
-
-# 5. Implement with tests
-# 6. Commit with conventional commits
-git commit -m "feat: add guard shift start endpoint"
-
-# 7. Push and open PR
-git push -u origin feature/short-description
-```
-
-**Weekly planning (suggested):**
-
-1. Review GitHub Project Kanban
-2. Move issues between columns
-3. Check if any issues are blocked
-4. Adjust priorities
-5. Update milestone target dates
-
-**Monthly review (suggested):**
-
-1. Review `docs/ideas-backlog.md`
-2. Move actionable ideas to issues
-3. Archive completed milestones
-4. Create next milestone
-5. Update roadmap dates
-
----
-
-**Next Steps:**
-
-1. Create GitHub Project: "SecPal Roadmap"
-2. Add issue templates to `.github/ISSUE_TEMPLATE/`
-3. Create first issues from ideas
-4. Set up labels across all repos
+- `docs/EPIC_WORKFLOW.md`
+- `docs/labels.md`
+- `docs/project-board-integration.md`
+- `docs/workflows/PROJECT_AUTOMATION.md`
+- `docs/adr/20260415-issue-first-planning-governance-adr013.md`

--- a/docs/project-board-integration.md
+++ b/docs/project-board-integration.md
@@ -1,353 +1,87 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
 # GitHub Project Board Integration
 
-**Purpose:** This document explains how SecPal's feature management workflow integrates with GitHub Projects for Kanban-style tracking.
+This document explains how the optional SecPal GitHub Project board mirrors issue and pull request progress.
 
-**Last Updated:** 2025-10-27
+## Position In The Planning Model
 
----
+The project board is a convenience layer, not the planning source of truth.
 
-## 🎯 Overview
+- canonical planning lives in GitHub Issues, labels, milestones, ADRs, and linked PRs
+- the board gives a cross-repository visual view when it is enabled
+- board fields and status columns must never be the only place where scope or acceptance criteria exist
 
-SecPal uses a **three-tier system** for feature management:
+See `docs/planning.md` for the canonical governance rules.
 
-1. **Documentation Layer** (`ideas-backlog.md` + `feature-requirements.md`)
-2. **Issue Tracking** (GitHub Issues with structured templates)
-3. **Visual Management** (GitHub Project Board)
+## What The Board Is For
 
-```
-┌────────────────────────────────────────────────────────────────┐
-│                   SecPal Feature Workflow                      │
-└────────────────────────────────────────────────────────────────┘
+Use the board for:
 
- 💡 New Idea
-     │
-     ├──► docs/ideas-backlog.md (Quick Capture)
-     │
-     ▼
- 📋 Specification Phase
-     │
-     ├──► docs/feature-requirements.md (Detailed Spec)
-     │
-     ▼
- 🎫 Issue Creation
-     │
-     ├──► GitHub Issue (via core_feature.yml template)
-     │    ↓
-     │    Automatically added to Project Board
-     │
-     ▼
- 📊 Project Board Tracking
-     │
-     └──► Kanban Board: Ideas → Backlog → Ready → In Progress → Done
-```
+- visualizing cross-repository throughput
+- weekly or release triage
+- seeing which issues are in discussion, planned, in progress, or under review
+- following draft PR workflows in a single-maintainer setup
 
----
+Do not use the board for:
 
-## 📊 Project Board Structure
+- storing the only copy of requirements
+- replacing issues, milestones, or ADRs
+- publishing the public roadmap directly
 
-### Recommended Columns
+## Recommended Status Flow
 
-| Column             | Status              | Description                                                  |
-| ------------------ | ------------------- | ------------------------------------------------------------ |
-| 💡 **Ideas**       | `status: backlog`   | Raw ideas from `ideas-backlog.md`, not yet specified         |
-| 📋 **Backlog**     | `status: specified` | Specified in `feature-requirements.md`, ready for refinement |
-| 🎯 **Ready**       | `status: ready`     | Ready for development, acceptance criteria defined           |
-| 🚧 **In Progress** | In development      | Active work, assigned to developer                           |
-| 👀 **In Review**   | PR open             | Code review in progress                                      |
-| ✅ **Done**        | Closed              | Merged and deployed                                          |
-
-### Custom Fields (Optional)
-
-Add these fields to your GitHub Project for better tracking:
-
-- **Priority**: `P0`, `P1`, `P2`, `P3` (auto-populated from labels)
-- **Feature Area**: `RBAC`, `Employee Mgmt`, `Shift Planning`, etc.
-- **Size**: `XS`, `S`, `M`, `L`, `XL`, `XXL`
-- **Target Phase**: `Phase 1`, `Phase 2`, `Phase 3`, `Phase 4`
-- **Estimated Effort**: Number field (story points or days)
-
----
-
-## 🔄 Workflow: From Idea to Implementation
-
-### Step 1: Capture the Idea
-
-**When:** You have a new feature idea (e.g., "Sub-Contractor Management", "BWR Integration")
-
-**Action:**
-
-```bash
-# Edit ideas-backlog.md
-vim docs/ideas-backlog.md
-
-# Add new section under appropriate category
-## 🏢 Sub-Contractor Management
-**Context:** ...
-**Concept:** ...
-**When to revisit:** ...
-**Complexity:** High
-**Priority:** Later
+```mermaid
+graph LR
+  A[💡 Ideas] --> B[💬 Discussion]
+  B --> C[📥 Backlog]
+  B --> D[📋 Planned]
+  C --> D
+  D --> E[🚧 In Progress]
+  E --> F[👀 In Review]
+  F --> E
+  F --> G[✅ Done]
+  B --> H[🚫 Won't Do]
 ```
 
-**No GitHub Issue yet!** Ideas stay in the backlog until they're ready for specification.
+These statuses reflect issue and PR state. They do not replace issue metadata.
 
----
+## Recommended Workflow
 
-### Step 2: Specify the Feature
+1. Create or refine an issue in the correct repository.
+2. Add labels, milestone, and any epic/sub-issue links.
+3. Let automation add or update the board item when available.
+4. Open a draft PR linked to the issue.
+5. Let PR state changes mirror progress on the board.
 
-**When:** Idea has been validated and is ready for detailed planning
+If the board is unavailable, skip step 3 and continue with the issue-first workflow.
 
-**Action:**
+## Automation Contract
 
-```bash
-# Move to feature-requirements.md
-vim docs/feature-requirements.md
+The board automation should only mirror durable GitHub state:
 
-# Add detailed specification
-## Sub-Contractor Management
-### Business Requirements
-...
-### Data Model
-...
-### API Design
-...
-```
+- issue opened, reopened, closed
+- linked PR opened, converted to draft, marked ready, merged
+- review state that sends a linked issue back to in-progress work
 
-**Still no Issue!** Features are specified first, then broken into Issues.
+The automation must not invent planning decisions that are missing from issues or milestones.
 
----
+Operational details for the current automation live in `docs/workflows/PROJECT_AUTOMATION.md`.
 
-### Step 3: Create GitHub Issue(s)
+## Public Roadmap Boundary
 
-**When:** Feature is specified and ready to be implemented (or next phase)
+The public roadmap is a curated public artifact.
 
-**Action:**
+- it should be derived from selected public-safe issues and milestones
+- it must not depend on private board-only notes or hidden internal fields
+- it is tracked separately in `SecPal/secpal.app#61`
 
-1. Go to: <https://github.com/SecPal/.github/issues/new/choose>
-2. Choose: **🎯 Core Feature Implementation**
-3. Fill out the template:
-   - **Feature Reference**: "Employee Management - BWR Integration (see feature-requirements.md)"
-   - **User Stories**: "As a HR manager, I want to..."
-   - **Acceptance Criteria**: Clear, testable criteria
-   - **Priority**: Select P0-P3
-   - **Feature Area**: Select category
-   - **Affected Repos**: `api`, `frontend`, `contracts`
+## Related Documents
 
-4. Issue is **automatically added** to Project Board (via GitHub Actions)
-
----
-
-### Step 4: Manage on Project Board
-
-**Automation (via `.github/workflows/project-automation.yml`):**
-
-- ✅ New issues → Automatically added to Project
-- ✅ Labels determine initial column:
-  - `core-feature` → 📋 Backlog
-  - `priority: blocker` → 🎯 Ready
-  - Default → 💡 Ideas
-
-**Manual Actions:**
-
-- **Refine:** Add labels, link dependencies, update description
-- **Prioritize:** Move between columns based on roadmap
-- **Assign:** Set developer when work starts
-- **Track:** Update status as work progresses
-
----
-
-## 🏷️ Label Strategy
-
-### Priority Labels
-
-- `priority: blocker` → P0 (Must have for MVP)
-- `priority: high` → P1 (Should have for Phase 1-2)
-- `priority: medium` → P2 (Nice to have for Phase 3)
-- `priority: low` → P3 (Future consideration)
-
-### Area Labels
-
-Create labels for each feature area (run these commands):
-
-```bash
-gh label create "area: RBAC" --color "0E8A16" --description "Role-Based Access Control" --repo SecPal/.github
-gh label create "area: employee-mgmt" --color "0E8A16" --description "Employee Management" --repo SecPal/.github
-gh label create "area: qualifications" --color "0E8A16" --description "Qualifications & Certifications" --repo SecPal/.github
-gh label create "area: shift-planning" --color "0E8A16" --description "Shift Planning & Scheduling" --repo SecPal/.github
-gh label create "area: compliance" --color "D93F0B" --description "Legal & Compliance (BWR, DSGVO)" --repo SecPal/.github
-gh label create "area: guard-book" --color "0E8A16" --description "Guard Book & Incidents" --repo SecPal/.github
-gh label create "area: signatures" --color "0E8A16" --description "Digital Signatures" --repo SecPal/.github
-gh label create "area: works-council" --color "0E8A16" --description "Works Council Management" --repo SecPal/.github
-```
-
-### Status Labels
-
-- `status: backlog` → In ideas-backlog.md
-- `status: specified` → In feature-requirements.md
-- `status: ready` → Ready for implementation
-- `core-feature` → Core platform feature (not a small enhancement)
-
----
-
-## 📈 Example: BWR Integration Journey
-
-### Phase 1: Idea Capture (Today)
-
-```markdown
-# docs/ideas-backlog.md
-
-## 🆔 BWR Integration
-
-**Context:** Manual BWR checking is error-prone
-**Concept:** Store BWR-ID in employee record, track status
-**Priority:** Soon
-**Complexity:** Medium
-```
-
-### Phase 2: Specification (Next Week)
-
-```markdown
-# docs/feature-requirements.md
-
-## BWR Integration
-
-### Overview
-
-...
-
-### Data Model
-
-- employee.bwr_id (string, unique)
-- employee.bwr_status (enum: active, suspended, expired)
-- employee.bwr_expiry_date (date)
-  ...
-```
-
-### Phase 3: Issue Creation (Sprint Planning)
-
-Create Issue using **Core Feature Template**:
-
-**Title:** `[Feature]: BWR Integration in Employee Management`
-
-**Labels:** `core-feature`, `area: employee-mgmt`, `area: compliance`, `priority: high`
-
-**Auto-added to Project Board** → Column: **📋 Backlog**
-
-### Phase 4: Development
-
-1. Move to **🎯 Ready** column
-2. Assign to developer
-3. Create branch: `feature/bwr-integration`
-4. Move to **🚧 In Progress**
-5. Open PR → Move to **👀 In Review**
-6. Merge → Automatically closes issue → Move to **✅ Done**
-
----
-
-## 🔧 Setup Instructions
-
-### 1. Create GitHub Project
-
-1. Go to: <https://github.com/orgs/SecPal/projects>
-2. Click **New project**
-3. Choose **Board** layout
-4. Name: `SecPal Feature Roadmap`
-5. Create columns:
-   - 💡 Ideas
-   - 📋 Backlog
-   - 🎯 Ready
-   - 🚧 In Progress
-   - 👀 In Review
-   - ✅ Done
-
-### 2. Update Automation Workflow
-
-The workflow is already configured for Project #1:
-
-```yaml
-project-url: https://github.com/orgs/SecPal/projects/1
-```
-
-If you create a different project number, edit `.github/workflows/project-automation.yml` and update the URL accordingly.
-
-### 3. Create Area Labels
-
-Run the label creation commands from the "Label Strategy" section above.
-
-### 4. Test the Workflow
-
-1. Create a test issue using the **Core Feature Template**
-2. Verify it appears on the Project Board
-3. Move it between columns to test the flow
-4. Close the test issue
-
----
-
-## 💡 Best Practices
-
-### Do's
-
-✅ **Keep docs and issues in sync**
-
-- Update `feature-requirements.md` when significant changes occur
-- Reference docs in issue descriptions
-
-✅ **Use templates consistently**
-
-- Use **Core Feature Template** for planned features
-- Use **Feature Request Template** for new ideas from users
-
-✅ **Break down large features**
-
-- If a feature is >2 weeks effort, split into multiple issues
-- Use "Depends on" to link related issues
-
-✅ **Review backlog regularly**
-
-- Monthly: Review `ideas-backlog.md` → promote to `feature-requirements.md`
-- Sprint Planning: Review `feature-requirements.md` → create Issues
-
-### Don'ts
-
-❌ **Don't create issues for every idea**
-
-- Ideas go in `ideas-backlog.md` first
-- Only create issues when you're ready to specify/implement
-
-❌ **Don't skip specification**
-
-- Features need clear acceptance criteria
-- Use `feature-requirements.md` to think through design
-
-❌ **Don't leave issues unassigned in "Ready"**
-
-- If it's ready, assign it or move back to Backlog
-- "Ready" means someone can start work immediately
-
----
-
-## 🔗 Related Resources
-
-- [Issue #67: Convert feature-requirements.md to GitHub Issues](https://github.com/SecPal/.github/issues/67)
-- [docs/ideas-backlog.md](./ideas-backlog.md) - Feature idea parking lot
-- [docs/feature-requirements.md](./feature-requirements.md) - Detailed specifications
-- [GitHub Projects Documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects)
-- [GitHub Project Automation](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project)
-
----
-
-## 📞 Questions?
-
-If you're unsure where something belongs:
-
-- **"I have a vague idea"** → `ideas-backlog.md`
-- **"I want to design this properly"** → `feature-requirements.md`
-- **"I'm ready to build this"** → Create GitHub Issue
-- **"I want to track progress visually"** → Check Project Board
-
-**When in doubt, start with the docs!** It's easier to promote an idea from docs to an Issue than to clean up premature Issues.
+- `docs/planning.md`
+- `docs/EPIC_WORKFLOW.md`
+- `docs/labels.md`
+- `docs/workflows/PROJECT_AUTOMATION.md`

--- a/docs/workflows/PROJECT_AUTOMATION.md
+++ b/docs/workflows/PROJECT_AUTOMATION.md
@@ -3,7 +3,7 @@
 
 # Project Board Automation
 
-Automated project board management that keeps your [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) in sync with issues and pull requests.
+Automated project board management that keeps the optional [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) board in sync with issues and pull requests.
 
 ## 🎯 Overview
 
@@ -13,6 +13,8 @@ This workflow automatically:
 - 🔄 Updates status based on labels, events, and PR state
 - 💬 Posts helpful comments explaining status transitions
 - 🚧 Supports draft PR workflow for incremental development
+
+Issues, milestones, ADRs, and linked PRs remain the source of truth. The board is only a mirrored view.
 
 ## 📊 Status Flow
 


### PR DESCRIPTION
## Summary

- accept ADR-013 to make GitHub Issues, milestones, ADRs, and linked PRs the canonical planning model
- rewrite planning guidance around an issue-first workflow and keep the project board as an optional mirrored view
- archive feature-requirements.md for active planning and refresh README, changelog, and project automation wording accordingly
- create follow-up issues #359 and #360 for deferred migration and helper-collateral alignment

## Validation

- ./scripts/preflight.sh

## Follow-up

- #359
- #360

Closes #354
