### PR TITLE
fix: add changelog accuracy PR guardrail

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 ## ⚠️ Important: Open as Draft PR First
@@ -46,6 +46,7 @@ Closes #
 
 - [ ] Code follows project style guidelines
 - [ ] Self-review completed
+- [ ] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
 - [ ] Comments added for complex logic
 - [ ] Documentation updated (if needed)
 - [ ] No new warnings introduced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-15 - Add Changelog Accuracy PR Guardrail
+
+**Changed:**
+
+- added an explicit PR checklist guardrail requiring `CHANGELOG.md` edits to be checked against the actual implementation, tests, schema, or config touched by the PR and to avoid overstating behavior the code does not yet enforce
+- added a focused regression test plus local preflight enforcement so the changelog-accuracy checklist item stays present in the shared pull request template
+
 ## 2026-04-15 - Adopt Issue-First Planning Governance
 
 **Changed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -111,7 +111,7 @@ if [ -f tests/pull-request-template.sh ]; then
   bash tests/pull-request-template.sh || {
     echo "" >&2
     echo "❌ Pull request template regression test failed!" >&2
-    echo "Restore the required changelog verification checklist item before continuing." >&2
+    echo "Review the test output above and restore any required pull request template content, including the changelog verification checklist item and the no-overstatement reminder, before continuing." >&2
     exit 1
   }
 fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -107,6 +107,15 @@ if [ -f tests/audit-closed-epics.sh ]; then
   }
 fi
 
+if [ -f tests/pull-request-template.sh ]; then
+  bash tests/pull-request-template.sh || {
+    echo "" >&2
+    echo "❌ Pull request template regression test failed!" >&2
+    echo "Restore the required changelog verification checklist item before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/tests/pull-request-template.sh
+++ b/tests/pull-request-template.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "Expected file '.github/pull_request_template.md' was not found." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR' "$TEMPLATE"; then
+  echo "PR template is missing the changelog verification checklist item." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'and avoids claims that the code does not actually enforce yet' "$TEMPLATE"; then
+  echo "PR template is missing the no-overstatement reminder for changelog entries." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a shared PR checklist guardrail for factual CHANGELOG verification
- add a regression test plus preflight enforcement so the checklist item cannot silently disappear
- update the org changelog for the new governance rule

## Testing

- bash tests/pull-request-template.sh
- ./scripts/preflight.sh

## Related Issues

Closes #355
