### PR TITLE
docs: align board helper collateral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-15 - Align Project Board Helper Collateral With Issue-First Planning
+
+**Changed:**
+
+- updated `scripts/setup-project-board.sh` so its status-label guidance and setup messaging no longer depend on `feature-requirements.md` and instead describe the project board as an optional mirror of issue and PR state
+- clarified `docs/workflows/QUICK_REFERENCE.md` and `docs/workflows/ROLLOUT_GUIDE.md` so rollout and daily board usage explicitly preserve issues, milestones, and linked PRs as the source of truth
+- added a focused shell regression check for the project-board helper collateral and wired it into local preflight
+
 ## 2026-04-15 - Add Changelog Accuracy PR Guardrail
 
 **Changed:**

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -5,6 +5,8 @@
 
 Quick reference card for daily usage of the project automation workflow.
 
+Issues, milestones, and linked PRs remain the source of truth. The project board is an optional mirrored view.
+
 ## 🎯 Status at a Glance
 
 | Status             | When             | How                            |
@@ -118,6 +120,8 @@ Resolves #789
 
 ### Via GitHub UI
 
+If the project board is enabled:
+
 1. Go to [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
 2. Find your issue/PR
 3. Check status column
@@ -157,6 +161,8 @@ gh run view --log
 1. Go to project board
 2. Drag issue to correct column
 3. Or edit issue status field directly
+
+Use manual board edits only to correct the mirror after checking the underlying issue or PR state first.
 
 ## ⚡ Power User Tips
 

--- a/docs/workflows/ROLLOUT_GUIDE.md
+++ b/docs/workflows/ROLLOUT_GUIDE.md
@@ -1,9 +1,11 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Rollout Guide: Project Automation Workflow
 
 Guide for deploying the project automation workflow to other repositories (api, frontend, contracts).
+
+Issues, milestones, and linked PRs remain the source of truth. The project board is an optional mirrored view for cross-repository status.
 
 ## 📋 Prerequisites
 
@@ -121,6 +123,8 @@ Expected: Should be added to SecPal Roadmap with status 💡 Ideas"
 2. Check that issue appears with status "💡 Ideas"
 3. Check Actions tab for workflow run
 4. Issue should have a comment explaining status
+
+This verifies board mirroring only. The issue itself remains the authoritative work record.
 
 ### Step 5: Test Draft PR Workflow
 
@@ -313,9 +317,10 @@ After rollout, update each repository's README with:
 ```markdown
 ## 🤖 Automation
 
-This repository uses automated project board management. Issues and PRs are
-automatically added to the [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)
-with status based on labels and PR state.
+This repository uses automated project board mirroring. Issues and PRs remain
+the source of truth and are automatically mirrored to the
+[SecPal Roadmap](https://github.com/orgs/SecPal/projects/1) with status based
+on labels and PR state.
 
 See [Project Automation docs](https://github.com/SecPal/.github/blob/main/docs/workflows/PROJECT_AUTOMATION.md)
 for details.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -116,6 +116,15 @@ if [ -f tests/pull-request-template.sh ]; then
   }
 fi
 
+if [ -f tests/setup-project-board.sh ]; then
+  bash tests/setup-project-board.sh || {
+    echo "" >&2
+    echo "❌ Project board helper regression test failed!" >&2
+    echo "Fix project board helper collateral before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/scripts/setup-project-board.sh
+++ b/scripts/setup-project-board.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 set -euo pipefail
 
-echo "🚀 Setting up GitHub Project Board Integration for SecPal"
-echo "=========================================================="
+echo "🚀 Setting up the optional GitHub Project Board mirror for SecPal"
+echo "================================================================"
 echo ""
 
 # Colors
@@ -65,8 +65,8 @@ echo "📋 Step 2: Creating status labels..."
 echo ""
 
 status_labels=(
-    "status: backlog|FBCA04|In Ideas Backlog"
-    "status: specified|0075CA|Specified in feature-requirements.md"
+    "status: backlog|FBCA04|Waiting for issue triage or planning"
+    "status: discussion|BFD4F2|Needs decision before implementation"
     "status: ready|0E8A16|Ready for Implementation"
     "core-feature|7057FF|Core platform feature (not small enhancement)"
 )
@@ -87,10 +87,10 @@ echo "✅ All labels created successfully!"
 echo ""
 
 # Step 3: Instructions for Project setup
-echo "📊 Step 3: GitHub Project Setup"
-echo "================================"
+echo "📊 Step 3: Optional GitHub Project Setup"
+echo "========================================"
 echo ""
-echo "Next, you need to create a GitHub Project Board:"
+echo "If you want the optional visual board mirror, create a GitHub Project:"
 echo ""
 echo "1. Go to: https://github.com/orgs/SecPal/projects"
 echo "2. Click 'New project'"
@@ -111,6 +111,9 @@ echo "7. Update .github/workflows/project-automation.yml:"
 echo "   Replace 'project-url: https://github.com/orgs/SecPal/projects/1'"
 echo "   with your actual project number"
 echo ""
+echo "Issues, milestones, and linked PRs remain the source of truth."
+echo "The board is only a mirrored status view."
+echo ""
 
 # Optional: Ask if user wants to create a test issue
 echo ""
@@ -123,28 +126,30 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     gh issue create \
         --repo SecPal/.github \
         --title "[Test] Project Board Integration Test" \
-        --body "This is a test issue to verify the project board automation.
+        --body "This is a test issue to verify the optional project board mirror.
 
 **Feature Area:** Infrastructure
 **Priority:** P3 (Low)
 **Status:** Testing
+
+Issues and linked PRs remain the source of truth.
 
 This issue can be closed after verifying it appears on the project board." \
         --label "core-feature,area: infrastructure,priority: low"
 
     echo ""
     echo -e "${GREEN}✅ Test issue created!${NC}"
-    echo "Check your project board to see if it was added automatically."
+    echo "Check your project board to see if it was added automatically as a mirror of issue state."
 fi
 
 echo ""
 echo "🎉 Setup complete!"
 echo ""
 echo "Next steps:"
-echo "1. Create your GitHub Project Board (see instructions above)"
+echo "1. Create the optional GitHub Project Board (see instructions above)"
 echo "2. Update project-automation.yml with the project number"
 echo "3. Commit and push the new templates and workflow"
-echo "4. Start creating feature issues using the templates!"
+echo "4. Track active work through issues and linked PRs; let the board mirror progress"
 echo ""
 echo "Documentation: docs/project-board-integration.md"
 echo ""

--- a/tests/setup-project-board.sh
+++ b/tests/setup-project-board.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fq "$expected" "$path"; then
+    echo "Expected to find '$expected' in $path" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local path="$1"
+  local unexpected="$2"
+
+  if grep -Fq "$unexpected" "$path"; then
+    echo "Did not expect to find '$unexpected' in $path" >&2
+    exit 1
+  fi
+}
+
+assert_contains "$REPO_ROOT/scripts/setup-project-board.sh" "optional GitHub Project Board mirror"
+assert_contains "$REPO_ROOT/scripts/setup-project-board.sh" "Issues, milestones, and linked PRs remain the source of truth."
+assert_contains "$REPO_ROOT/scripts/setup-project-board.sh" "status: discussion|BFD4F2|Needs decision before implementation"
+assert_not_contains "$REPO_ROOT/scripts/setup-project-board.sh" "Specified in feature-requirements.md"
+
+assert_contains "$REPO_ROOT/docs/workflows/QUICK_REFERENCE.md" "Issues, milestones, and linked PRs remain the source of truth."
+assert_contains "$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md" "The project board is an optional mirrored view"


### PR DESCRIPTION
## Summary

- align setup-project-board.sh with the issue-first planning model so it no longer references feature-requirements.md as an active planning step
- clarify the board quick reference and rollout guide so the project board is described as an optional mirror of issue and PR state
- add a focused shell regression test for board helper collateral and run it through local preflight

## Validation

- bash tests/setup-project-board.sh
- ./scripts/preflight.sh

## Notes

- Issue #360 remains blocked by draft PR #361 because it continues work in the same planning archive files that are not on main yet

Closes #359
