### PR TITLE
fix: replace non-applicable CodeQL scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: "CodeQL Advanced Security"
+name: "CodeQL Applicability Guardrail"
 
 on:
   push:
@@ -13,81 +13,25 @@ on:
     - cron: "0 2 * * *"
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
-  check-languages:
-    name: Check for Code to Analyze
-    runs-on: ubuntu-latest
-    outputs:
-      has-javascript: ${{ steps.check.outputs.has-javascript }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Check for JavaScript/TypeScript files
-        id: check
-        run: |
-          # Check if any JS/TS files exist (excluding node_modules and .git)
-          if find . -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" -o -name "*.mjs" -o -name "*.cjs" \) \
-             -not -path "*/node_modules/*" -not -path "*/.git/*" | grep -q .; then
-            echo "has-javascript=true" >> $GITHUB_OUTPUT
-            echo "✅ Found JavaScript/TypeScript files to analyze"
-          else
-            echo "has-javascript=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ No JavaScript/TypeScript files found - CodeQL analysis will be skipped"
-          fi
-
-  analyze:
-    name: Analyze Code
-    runs-on: ubuntu-latest
-    needs: check-languages
-    # Only run if we have code to analyze
-    if: needs.check-languages.outputs.has-javascript == 'true'
-    timeout-minutes: 360
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # CodeQL supports: 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Note: PHP is not supported by CodeQL
-        language: ["javascript-typescript"]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: ${{ matrix.language }}
-          # Run all queries (default + security-extended + security-and-quality)
-          queries: +security-extended,security-and-quality
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
-        with:
-          category: "/language:${{ matrix.language }}"
-
-  # Summary job to provide consistent "CodeQL" check status for branch protection
-  # This job always runs and reports success whether analysis ran or was skipped
-  codeql-summary:
+  codeql:
     name: CodeQL
     runs-on: ubuntu-latest
-    needs: [check-languages, analyze]
-    if: always()
+    timeout-minutes: 5
     steps:
-      - name: Check CodeQL Status
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Verify CodeQL applicability
         run: |
-          if [ "${{ needs.analyze.result }}" == "success" ] || [ "${{ needs.analyze.result }}" == "skipped" ]; then
-            echo "✅ CodeQL check passed (analysis: ${{ needs.analyze.result }})"
-            exit 0
-          else
-            echo "❌ CodeQL analysis failed"
+          # This repository no longer contains any tracked CodeQL-supported source files.
+          # Keep a stable branch-protection check and fail fast if JS/TS code returns.
+          if git ls-files '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' | grep -q .; then
+            echo "Tracked JavaScript/TypeScript files were detected." >&2
+            echo "Restore a real CodeQL workflow before merging supported source files into this repository." >&2
             exit 1
           fi
+
+          echo "No tracked CodeQL-supported source files detected. CodeQL is not applicable to this repository."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,11 @@ jobs:
 
       - name: Verify CodeQL applicability
         run: |
-          # This repository no longer contains any tracked CodeQL-supported source files.
-          # Keep a stable branch-protection check and fail fast if JS/TS code returns.
-          if git ls-files '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' | grep -q .; then
+          # Delegate detection to the test script so the glob list stays in one place.
+          if tests/codeql-applicability.sh; then
+            echo "No tracked CodeQL-supported source files detected. CodeQL is not applicable to this repository."
+          else
             echo "Tracked JavaScript/TypeScript files were detected." >&2
             echo "Restore a real CodeQL workflow before merging supported source files into this repository." >&2
             exit 1
           fi
-
-          echo "No tracked CodeQL-supported source files detected. CodeQL is not applicable to this repository."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Verify CodeQL applicability
         run: |
           # Delegate detection to the test script so the glob list stays in one place.
-          if tests/codeql-applicability.sh; then
+          if bash tests/codeql-applicability.sh; then
             echo "No tracked CodeQL-supported source files detected. CodeQL is not applicable to this repository."
           else
             echo "Tracked JavaScript/TypeScript files were detected." >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 - clarified `docs/workflows/QUICK_REFERENCE.md` and `docs/workflows/ROLLOUT_GUIDE.md` so rollout and daily board usage explicitly preserve issues, milestones, and linked PRs as the source of truth
 - added a focused shell regression check for the project-board helper collateral and wired it into local preflight
 
+## 2026-04-15 - Replace Non-Applicable CodeQL Scan With Guardrail Check
+
+**Changed:**
+
+- replaced the `.github` repository's stale CodeQL workflow with a lightweight applicability guardrail because the repository no longer contains any tracked CodeQL-supported JS/TS source files, which had left Code Scanning stuck on a November 2025 analysis record
+- added a focused regression test plus local preflight enforcement so future changes must keep the workflow aligned with whether this repository actually contains tracked CodeQL-supported files
+
 ## 2026-04-15 - Add Changelog Accuracy PR Guardrail
 
 **Changed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -98,6 +98,15 @@ if [ -f tests/reusable-workflow-timeouts.sh ]; then
   }
 fi
 
+if [ -f tests/codeql-applicability.sh ]; then
+  bash tests/codeql-applicability.sh || {
+    echo "" >&2
+    echo "❌ CodeQL applicability regression test failed!" >&2
+    echo "Match the CodeQL workflow to the repository's tracked supported-language files before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/audit-closed-epics.sh ]; then
   bash tests/audit-closed-epics.sh || {
     echo "" >&2

--- a/tests/codeql-applicability.sh
+++ b/tests/codeql-applicability.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+workflow_path=".github/workflows/codeql.yml"
+
+if [ ! -f "$workflow_path" ]; then
+  echo "Expected workflow '$workflow_path' was not found." >&2
+  exit 1
+fi
+
+has_supported_files=0
+if git ls-files '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' | grep -q .; then
+  has_supported_files=1
+fi
+
+if [ "$has_supported_files" -eq 0 ] && grep -q 'github/codeql-action/' "$workflow_path"; then
+  echo "CodeQL workflow still invokes github/codeql-action even though this repository has no tracked JS/TS files." >&2
+  echo "Remove the CodeQL action usage or restore supported source files before keeping CodeQL enabled." >&2
+  exit 1
+fi
+
+if [ "$has_supported_files" -eq 1 ] && ! grep -q 'github/codeql-action/' "$workflow_path"; then
+  echo "Tracked JS/TS files were found, but the CodeQL workflow no longer invokes github/codeql-action." >&2
+  echo "Restore a real CodeQL scan before merging supported source files into this repository." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- replace the stale non-applicable CodeQL workflow with a lightweight guardrail that keeps the branch-protection check stable for this repository
- add a focused regression test plus local preflight enforcement so future changes must keep the workflow aligned with tracked supported-language files
- record the governance and workflow change in CHANGELOG.md

## Validation
- bash tests/codeql-applicability.sh
- ./scripts/preflight.sh
