### PR TITLE
chore: harden AI findings triage validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,13 @@ At minimum verify:
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Reject AI-generated test or automation mutations that move executable code across scope boundaries or "simplify" filters without positive and negative evidence.
+
 ## Issue And PR Discipline
 
 - Every real out-of-scope finding becomes a GitHub issue immediately; no untracked follow-up work is allowed.
@@ -110,4 +117,5 @@ Treat `api.secpal.app` as a deprecated web host.
 - For GitHub workflows, set explicit permissions, set `timeout-minutes` on every job, pin external actions, and never expose secrets in logs.
 - Workflow templates for other repositories live in `workflow-templates/`.
   Reusable workflow definitions live in `.github/workflows/reusable-*.yml` and are invoked via `uses:`.
+- For governance scripts, prefer explicit positive and negative checks over broad regex simplification; treat shell changes as policy changes, not cosmetic refactors.
 - Keep changes repo-local, minimal, and aligned with the existing governance and automation patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 - clarified `docs/workflows/QUICK_REFERENCE.md` and `docs/workflows/ROLLOUT_GUIDE.md` so rollout and daily board usage explicitly preserve issues, milestones, and linked PRs as the source of truth
 - added a focused shell regression check for the project-board helper collateral and wired it into local preflight
 
+## 2026-04-15 - Add AI Finding Triage Guardrails
+
+**Changed:**
+
+- added an explicit AI-findings triage section to the organization Copilot baseline so AI-generated fix PRs now require proof of the defect instead of relying on green CI alone
+- extended `scripts/validate-copilot-instructions.sh` plus its documentation so the central validator now fails when Copilot instructions omit proof-of-defect and green-CI-is-not-enough guidance, while still accepting inline SPDX headers and repo-local "do not inherit" wording without false positives
+- clarified `.github` repository conventions so shell and regex policy changes are reviewed as governance changes with explicit positive and negative evidence
+
 ## 2026-04-15 - Replace Non-Applicable CodeQL Scan With Guardrail Check
 
 **Changed:**

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -365,8 +365,9 @@ Current instruction-content checks include runtime-model guidance, critical rule
 repo baselines keep requiring proof-of-defect review for AI-generated suggestions.
 
 The validator also accepts either inline SPDX headers or companion `.license` sidecars for `copilot-instructions.md`,
-and its pseudo-inheritance check is intentionally scoped to positive inheritance directives so repo-local "do not
-inherit" guidance does not trigger false positives.
+but when a `.license` sidecar is present it must still be valid and consistent with any inline SPDX metadata. Its
+pseudo-inheritance check is intentionally scoped to positive inheritance directives so repo-local "do not inherit"
+guidance does not trigger false positives.
 
 ### Updating Test Logic
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -361,6 +361,13 @@ REPO_TYPE=api ./scripts/validate-copilot-instructions.sh
 4. Document in this file
 5. Update scripts/README.md
 
+Current instruction-content checks include runtime-model guidance, critical rules, and AI findings triage language so
+repo baselines keep requiring proof-of-defect review for AI-generated suggestions.
+
+The validator also accepts either inline SPDX headers or companion `.license` sidecars for `copilot-instructions.md`,
+and its pseudo-inheritance check is intentionally scoped to positive inheritance directives so repo-local "do not
+inherit" guidance does not trigger false positives.
+
 ### Updating Test Logic
 
 1. Modify test function

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,6 +77,7 @@ Validates Copilot instructions and configuration files across all repositories.
 
 6. **Content Validation**
    - Ensures critical rules/principles section exists
+   - Ensures AI findings triage guidance exists
    - Validates core content presence
 
 **Exit Codes:**
@@ -135,7 +136,9 @@ The script automatically detects repository type:
 
 - **org**: `.github` repository (org-wide instructions)
 - **api**: Laravel API (has `artisan`, `composer.json`)
-- **frontend**: React frontend (has `package.json` with `vite`)
+- **frontend**: React frontend or Android wrapper (has `package.json` with `vite`)
+- **changelog**: Next.js changelog site (has `next.config.mjs`)
+- **website**: Astro landing page (has `astro.config.mjs`)
 - **contracts**: OpenAPI contracts (has `package.json` with `openapi` or `docs/openapi.yaml`)
 
 ## Adding New Scripts

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -42,6 +42,16 @@ detect_repo_type() {
         return
     fi
 
+    if [ -f "next.config.mjs" ]; then
+        echo "changelog"
+        return
+    fi
+
+    if [ -f "astro.config.mjs" ]; then
+        echo "website"
+        return
+    fi
+
     if [ -f "package.json" ] && grep -q "vite" package.json 2>/dev/null; then
         echo "frontend"
         return
@@ -74,8 +84,13 @@ test_yaml_config_exists() {
 test_instructions_reuse() {
     if [ -f ".github/copilot-instructions.md.license" ] && grep -q "CC0-1.0" ".github/copilot-instructions.md.license"; then
         print_result "copilot-instructions.md has REUSE license" "PASS"
+        return
+    fi
+
+    if head -n 10 ".github/copilot-instructions.md" | grep -q "SPDX-License-Identifier:"; then
+        print_result "copilot-instructions.md has REUSE license" "PASS"
     else
-        print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing or wrong license file"
+        print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing inline SPDX header or wrong license file"
     fi
 }
 
@@ -121,7 +136,7 @@ test_no_pseudo_inheritance() {
     local search_targets=()
     # Pseudo-inheritance markers include explicit directives and common textual variants.
     # Keep this list centralized so it is easy to review and extend as conventions evolve.
-    local pseudo_inheritance_pattern='@?extends|inherits?|inheritance|base[_ -]?instructions?|parent[_ -]?instructions?'
+    local pseudo_inheritance_pattern='@?extends|inherit[[:space:]]+from|inherits[[:space:]]+from|auto[-[:space:]]*inherit|base[_ -]?instructions?[^[:alpha:]]*(apply|load|import)|parent[_ -]?instructions?[^[:alpha:]]*(apply|load|import)'
 
     if [ -f ".github/copilot-instructions.md" ]; then
         search_targets+=(".github/copilot-instructions.md")
@@ -197,6 +212,30 @@ test_critical_rules() {
     fi
 }
 
+test_ai_findings_guidance() {
+    local has_ai_findings=1
+    local has_proof_requirement=1
+    local has_ci_guardrail=1
+
+    if grep -qiE 'AI findings?|AI-generated' .github/copilot-instructions.md; then
+        has_ai_findings=0
+    fi
+
+    if grep -qiE 'failing test|reproducible defect|stated invariant|prove the defect|proof of the defect|violates it' .github/copilot-instructions.md; then
+        has_proof_requirement=0
+    fi
+
+    if grep -qiE 'green CI alone|CI alone|green checks alone' .github/copilot-instructions.md; then
+        has_ci_guardrail=0
+    fi
+
+    if [ "$has_ai_findings" -eq 0 ] && [ "$has_proof_requirement" -eq 0 ] && [ "$has_ci_guardrail" -eq 0 ]; then
+        print_result "instructions contain AI findings triage guidance" "PASS"
+    else
+        print_result "instructions contain AI findings triage guidance" "FAIL" "Missing AI-finding proof or CI guardrail language"
+    fi
+}
+
 test_instruction_frontmatter() {
     local file
     local found=0
@@ -240,6 +279,7 @@ main() {
     test_no_pseudo_inheritance
     test_runtime_model "$repo_type"
     test_critical_rules
+    test_ai_findings_guidance
     test_instruction_frontmatter
 
     echo ""

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -82,12 +82,14 @@ test_yaml_config_exists() {
 }
 
 test_instructions_reuse() {
+    local spdx_license_marker='SPDX-License''-Identifier:'
+
     if [ -f ".github/copilot-instructions.md.license" ] && grep -q "CC0-1.0" ".github/copilot-instructions.md.license"; then
         print_result "copilot-instructions.md has REUSE license" "PASS"
         return
     fi
 
-    if head -n 10 ".github/copilot-instructions.md" | grep -q "SPDX-License-Identifier:"; then
+    if head -n 10 ".github/copilot-instructions.md" | grep -q "$spdx_license_marker"; then
         print_result "copilot-instructions.md has REUSE license" "PASS"
     else
         print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing inline SPDX header or wrong license file"

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -84,15 +84,24 @@ test_yaml_config_exists() {
 test_instructions_reuse() {
     local spdx_license_marker='SPDX-License''-Identifier:'
 
-    if [ -f ".github/copilot-instructions.md.license" ] && grep -q "CC0-1.0" ".github/copilot-instructions.md.license"; then
-        print_result "copilot-instructions.md has REUSE license" "PASS"
+    if [ ! -f ".github/copilot-instructions.md" ]; then
+        print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing .github/copilot-instructions.md"
+        return
+    fi
+
+    if [ -f ".github/copilot-instructions.md.license" ]; then
+        if grep -q "CC0-1.0" ".github/copilot-instructions.md.license"; then
+            print_result "copilot-instructions.md has REUSE license" "PASS"
+        else
+            print_result "copilot-instructions.md has REUSE license" "FAIL" "Sidecar .license exists but does not declare CC0-1.0"
+        fi
         return
     fi
 
     if head -n 10 ".github/copilot-instructions.md" | grep -q "$spdx_license_marker"; then
         print_result "copilot-instructions.md has REUSE license" "PASS"
     else
-        print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing inline SPDX header or wrong license file"
+        print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing inline SPDX header or .license sidecar"
     fi
 }
 
@@ -215,19 +224,25 @@ test_critical_rules() {
 }
 
 test_ai_findings_guidance() {
+    local instructions_file=".github/copilot-instructions.md"
     local has_ai_findings=1
     local has_proof_requirement=1
     local has_ci_guardrail=1
 
-    if grep -qiE 'AI findings?|AI-generated' .github/copilot-instructions.md; then
+    if [ ! -f "$instructions_file" ]; then
+        print_result "instructions contain AI findings triage guidance" "FAIL" "Missing $instructions_file"
+        return
+    fi
+
+    if grep -qiE 'AI findings?|AI-generated' "$instructions_file"; then
         has_ai_findings=0
     fi
 
-    if grep -qiE 'failing test|reproducible defect|stated invariant|prove the defect|proof of the defect|violates it' .github/copilot-instructions.md; then
+    if grep -qiE 'failing test|reproducible defect|stated invariant|prove the defect|proof of the defect|violates it' "$instructions_file"; then
         has_proof_requirement=0
     fi
 
-    if grep -qiE 'green CI alone|CI alone|green checks alone' .github/copilot-instructions.md; then
+    if grep -qiE 'green CI alone|CI alone|green checks alone' "$instructions_file"; then
         has_ci_guardrail=0
     fi
 


### PR DESCRIPTION
Closes #368
Refs SecPal/.github#367

## Summary

- add an explicit AI findings triage section to the organization Copilot baseline
- extend the central validator so proof-of-defect and green-CI guardrails are enforced
- document the validator behavior and governance-script review expectations

## Validation

- `./scripts/validate-copilot-instructions.sh`
- `./scripts/preflight.sh`
- `npx markdownlint-cli2 .github/copilot-instructions.md CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md ../api/.github/copilot-instructions.md ../api/.github/instructions/php-laravel.instructions.md ../api/CHANGELOG.md ../frontend/.github/copilot-instructions.md ../frontend/.github/instructions/react-typescript.instructions.md ../frontend/CHANGELOG.md ../contracts/.github/copilot-instructions.md ../contracts/CHANGELOG.md ../android/.github/copilot-instructions.md ../android/.github/instructions/react-capacitor.instructions.md ../android/CHANGELOG.md ../changelog/.github/copilot-instructions.md ../changelog/CHANGELOG.md ../secpal.app/.github/copilot-instructions.md ../secpal.app/CHANGELOG.md`
