### PR TITLE
fix: harden epic checklist audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added a focused regression test plus local preflight enforcement for the validator so reusable-workflow and repo-specific AI-risk checks cannot silently regress
 - updated the validation-system documentation to describe the new reusable workflow and automatic multi-repository enforcement path
 
+## 2026-04-17 - Audit Closure-Ready Epic Checklist Drift
+
+**Changed:**
+
+- extended `scripts/audit-closed-epics.sh` so it now audits open epics too and flags stale unchecked child-issue entries when the linked work is already closed
+- strengthened `tests/audit-closed-epics.sh` with a regression case for open-but-complete epics whose checklist state drifted from the actual child-issue status
+- clarified `scripts/README.md` and `docs/EPIC_WORKFLOW.md` so the audit helper's broader checklist-drift coverage is documented
+
 ## 2026-04-15 - Align Project Board Helper Collateral With Issue-First Planning
 
 **Changed:**

--- a/docs/EPIC_WORKFLOW.md
+++ b/docs/EPIC_WORKFLOW.md
@@ -137,7 +137,9 @@ bash scripts/audit-closed-epics.sh --org SecPal --repo .github --repo api
 ```
 
 This catches stale checklist state, open child issues, and checked items that do
-not resolve to closed issues.
+not resolve to closed issues. It also catches open epics whose child issues are
+already closed but whose checklist was never updated, so closure-ready epics do
+not silently drift.
 
 ## CLA And Other External Services
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -11,9 +11,9 @@ This directory contains utility scripts for SecPal development.
 
 ### `audit-closed-epics.sh`
 
-Audits closed Epic issues and reports checklist drift, such as child issues that
-are still open or already closed while the parent epic checklist remains
-unchecked.
+Audits Epic issues and reports checklist drift, such as closed child issues
+that remain unchecked in open or closed epics, or child issues that are still
+open even though the parent epic is already closed.
 
 **Usage:**
 
@@ -27,7 +27,7 @@ bash scripts/audit-closed-epics.sh --org SecPal --repo .github --repo api
 
 **What It Checks:**
 
-1. Searches for closed Epic issues by label and title
+1. Searches for open and closed Epic issues by label and title
 2. Parses checklist-linked child issues from each epic body
 3. Ignores PR references so merged PR numbers are not mistaken for issues
 4. Reports:

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -44,12 +44,12 @@ if [ ${#repos[@]} -eq 0 ]; then
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-    echo "gh is required to audit epic checklists." >&2
+  echo "gh is required to audit epic checklists." >&2
   exit 2
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-    echo "python3 is required to audit epic checklists." >&2
+  echo "python3 is required to audit epic checklists." >&2
   exit 2
 fi
 
@@ -205,7 +205,6 @@ try:
                     findings.append(
                         {
                             "kind": "missing-child",
-                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -218,7 +217,6 @@ try:
                     findings.append(
                         {
                             "kind": "checked-open-child",
-                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -231,7 +229,6 @@ try:
                     findings.append(
                         {
                             "kind": "stale-unchecked-child",
-                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -244,7 +241,6 @@ try:
                     findings.append(
                         {
                             "kind": "open-child",
-                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -21,7 +21,7 @@ while [ $# -gt 0 ]; do
       cat <<'EOF'
 Usage: bash scripts/audit-closed-epics.sh [--org ORG] [--repo REPO]...
 
-Audit closed Epic issues by checking checklist-linked child issues.
+Audit Epic issues for checklist drift by checking checklist-linked child issues.
 
 Options:
   --org ORG    GitHub organization or owner to inspect (default: SecPal)
@@ -44,12 +44,12 @@ if [ ${#repos[@]} -eq 0 ]; then
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-  echo "gh is required to audit closed epics." >&2
+    echo "gh is required to audit epic checklists." >&2
   exit 2
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required to audit closed epics." >&2
+    echo "python3 is required to audit epic checklists." >&2
   exit 2
 fi
 
@@ -94,7 +94,9 @@ def gh_json(*args):
 def search_epics(owner: str, repo: str):
     queries = [
         f"repo:{owner}/{repo} is:issue label:epic is:closed",
+        f"repo:{owner}/{repo} is:issue label:epic is:open",
         f"repo:{owner}/{repo} is:issue in:title epic is:closed",
+        f"repo:{owner}/{repo} is:issue in:title epic is:open",
     ]
     results = []
     for query in queries:
@@ -184,6 +186,7 @@ try:
         epic_repo = item["repository_url"].split("/repos/", 1)[1]
         epic_number = item["number"]
         epic_title = item["title"]
+        epic_state = item.get("state", "open")
         body = item.get("body") or ""
 
         for line in body.splitlines():
@@ -202,6 +205,7 @@ try:
                     findings.append(
                         {
                             "kind": "missing-child",
+                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -214,6 +218,7 @@ try:
                     findings.append(
                         {
                             "kind": "checked-open-child",
+                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -226,6 +231,7 @@ try:
                     findings.append(
                         {
                             "kind": "stale-unchecked-child",
+                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -234,10 +240,11 @@ try:
                             "line": stripped,
                         }
                     )
-                elif not marked_checked and state != "closed":
+                elif epic_state == "closed" and not marked_checked and state != "closed":
                     findings.append(
                         {
                             "kind": "open-child",
+                            "epic_state": epic_state,
                             "epic_repo": epic_repo,
                             "epic_number": epic_number,
                             "epic_title": epic_title,
@@ -248,7 +255,7 @@ try:
                     )
 
     if not findings:
-        print(f"No closed epic checklist issues found across {len(unique_epics)} epic(s).")
+        print(f"No epic checklist issues found across {len(unique_epics)} epic(s).")
         sys.exit(0)
 
     deduped_findings = []
@@ -266,7 +273,7 @@ try:
         seen_findings.add(key)
         deduped_findings.append(finding)
 
-    print(f"Closed epic checklist issues found: {len(deduped_findings)} across {len(unique_epics)} epic(s).")
+    print(f"Epic checklist issues found: {len(deduped_findings)} across {len(unique_epics)} epic(s).")
     for finding in deduped_findings:
         epic_prefix = f"{finding['epic_repo']}#{finding['epic_number']}"
         child_prefix = f"{finding['child_repo']}#{finding['child_number']}"

--- a/tests/audit-closed-epics.sh
+++ b/tests/audit-closed-epics.sh
@@ -26,13 +26,46 @@ fi
 shift
 
 if [ "$1" = "/search/issues" ]; then
-  cat "$fixture_dir/search.json"
+  shift
+
+  query=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "-f" ] && [ $# -gt 1 ]; then
+      case "$2" in
+        q=*)
+          query="${2#q=}"
+          ;;
+      esac
+      shift 2
+      continue
+    fi
+    shift
+  done
+
+  case "$query" in
+    *"is:closed"*)
+      cat "$fixture_dir/search-closed.json"
+      ;;
+    *"is:open"*)
+      cat "$fixture_dir/search-open.json"
+      ;;
+    *)
+      echo "unexpected gh query: $query" >&2
+      exit 1
+      ;;
+  esac
   exit 0
 fi
 
 case "$1" in
   /repos/SecPal/api/issues/10)
     cat "$fixture_dir/api-10.json"
+    ;;
+  /repos/SecPal/contracts/issues/50)
+    cat "$fixture_dir/contracts-50.json"
+    ;;
+  /repos/SecPal/android/issues/60)
+    cat "$fixture_dir/android-60.json"
     ;;
   /repos/SecPal/frontend/issues/30)
     cat "$fixture_dir/frontend-30.json"
@@ -48,7 +81,7 @@ esac
 STUB
 chmod +x "$workspace/bin/gh"
 
-cat >"$workspace/fixtures/search.json" <<'JSON'
+cat >"$workspace/fixtures/search-closed.json" <<'JSON'
 {
   "total_count": 1,
   "incomplete_results": false,
@@ -57,7 +90,24 @@ cat >"$workspace/fixtures/search.json" <<'JSON'
       "number": 500,
       "title": "[EPIC] Demo epic",
       "body": "- [x] SecPal/api#10 -> [PR #20](https://github.com/SecPal/api/pull/20)\n- [ ] SecPal/frontend#30 - stale checklist item\n- [ ] #40 - still open child issue",
-      "repository_url": "https://api.github.com/repos/SecPal/.github"
+      "repository_url": "https://api.github.com/repos/SecPal/.github",
+      "state": "closed"
+    }
+  ]
+}
+JSON
+
+cat >"$workspace/fixtures/search-open.json" <<'JSON'
+{
+  "total_count": 1,
+  "incomplete_results": false,
+  "items": [
+    {
+      "number": 501,
+      "title": "[EPIC] Open but done epic",
+      "body": "- [ ] SecPal/contracts#50 - child already closed\n- [ ] SecPal/android#60 - child already closed",
+      "repository_url": "https://api.github.com/repos/SecPal/.github",
+      "state": "open"
     }
   ]
 }
@@ -67,6 +117,20 @@ cat >"$workspace/fixtures/api-10.json" <<'JSON'
 {
   "state": "closed",
   "title": "Closed child"
+}
+JSON
+
+cat >"$workspace/fixtures/contracts-50.json" <<'JSON'
+{
+  "state": "closed",
+  "title": "Closed child in open epic"
+}
+JSON
+
+cat >"$workspace/fixtures/android-60.json" <<'JSON'
+{
+  "state": "closed",
+  "title": "Another closed child in open epic"
 }
 JSON
 
@@ -101,6 +165,8 @@ fi
 
 grep -q 'SecPal/frontend#30 is closed but still unchecked' "$output_file"
 grep -q 'SecPal/.github#40 is still open' "$output_file"
+grep -q 'SecPal/contracts#50 is closed but still unchecked' "$output_file"
+grep -q 'SecPal/android#60 is closed but still unchecked' "$output_file"
 
 # SecPal/api#10 is a valid checked and closed checklist item and must not be reported.
 if grep -q 'SecPal/api#10' "$output_file"; then


### PR DESCRIPTION
Refs #371

## Summary

- extend `scripts/audit-closed-epics.sh` so it also audits open epics for stale unchecked child entries whose linked issues are already closed, while still only flagging open child issues when the parent epic is already closed
- add regression coverage for the open-but-complete epic drift case and document the broadened audit behavior in the scripts docs, epic workflow guide, and changelog
- reconcile the `.github` epic drift surfaced by the updated helper so the current `.github` audit now returns clean

## Validation

- `bash tests/audit-closed-epics.sh`
- `./scripts/preflight.sh`
- `./scripts/audit-closed-epics.sh --org SecPal --repo .github`
