### PR TITLE
chore: automate Copilot AI validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,7 @@ At minimum verify:
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or automation mutations that move executable code across scope boundaries or "simplify" filters without positive and negative evidence.
+- Reject AI-generated governance cleanups that relax validator coverage, reusable workflow enforcement, or repo-specific guardrails without focused regression tests plus positive and negative fixtures.
 
 ## Issue And PR Discipline
 

--- a/.github/workflows/reusable-copilot-instructions.yml
+++ b/.github/workflows/reusable-copilot-instructions.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Reusable - Validate Copilot Instructions
+
+on:
+  workflow_call:
+    inputs:
+      governance-ref:
+        description: "Ref of SecPal/.github to use when validating sibling repositories"
+        required: false
+        type: string
+        default: "main"
+      node-version:
+        description: "Node.js version used for markdownlint-cli2"
+        required: false
+        type: string
+        default: "22"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Copilot Instructions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v6
+
+      - name: Checkout governance repository
+        if: ${{ github.repository != 'SecPal/.github' }}
+        uses: actions/checkout@v6
+        with:
+          repository: SecPal/.github
+          ref: ${{ inputs.governance-ref }}
+          path: .secpal-governance
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Select validator path
+        id: validator
+        run: |
+          if [ "${{ github.repository }}" = "SecPal/.github" ]; then
+            echo "path=./scripts/validate-copilot-instructions.sh" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=./.secpal-governance/scripts/validate-copilot-instructions.sh" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run validation script
+        env:
+          VALIDATOR_PATH: ${{ steps.validator.outputs.path }}
+        run: "$VALIDATOR_PATH"

--- a/.github/workflows/validate-copilot-instructions.yml
+++ b/.github/workflows/validate-copilot-instructions.yml
@@ -21,6 +21,9 @@ on:
       - "scripts/validate-copilot-instructions.sh"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Copilot Instructions

--- a/.github/workflows/validate-copilot-instructions.yml
+++ b/.github/workflows/validate-copilot-instructions.yml
@@ -24,33 +24,4 @@ on:
 jobs:
   validate:
     name: Validate Copilot Instructions
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
-
-      - name: Run validation script
-        id: validation
-        run: ./scripts/validate-copilot-instructions.sh
-
-      - name: Summary
-        if: always()
-        run: |
-          if [ "${{ steps.validation.outcome }}" = "success" ]; then
-            echo "✅ All Copilot instructions validation tests passed"
-          else
-            echo "❌ Some Copilot instructions validation tests failed"
-            exit 1
-          fi
+    uses: ./.github/workflows/reusable-copilot-instructions.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-17 - Enforce Automatic Copilot AI Risk Validation Across Repositories
+
+**Changed:**
+
+- added `.github/.github/workflows/reusable-copilot-instructions.yml` so sibling repositories can run the central Copilot-instructions validator automatically from their `quality.yml` workflows
+- extended `scripts/validate-copilot-instructions.sh` to distinguish Android from generic frontend repos, enforce repository-specific known-risk AI guardrails, and ignore negative "do not inherit" wording instead of treating it as pseudo-inheritance
+- added a focused regression test plus local preflight enforcement for the validator so reusable-workflow and repo-specific AI-risk checks cannot silently regress
+- updated the validation-system documentation to describe the new reusable workflow and automatic multi-repository enforcement path
+
 ## 2026-04-15 - Align Project Board Helper Collateral With Issue-First Planning
 
 **Changed:**

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -7,7 +7,10 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Overview
 
-The Validation System ensures that Copilot instructions and configuration files maintain quality and consistency across all SecPal repositories (.github, api, frontend, contracts).
+The validation system ensures that Copilot instructions maintain quality,
+consistency, and repository-specific AI-risk guidance across all SecPal
+repositories: `.github`, `api`, `frontend`, `contracts`, `android`,
+`secpal.app`, and `changelog`.
 
 ## Architecture
 
@@ -18,10 +21,13 @@ The Validation System ensures that Copilot instructions and configuration files 
 ├── scripts/
 │   ├── validate-copilot-instructions.sh  # Main validation script
 │   └── README.md                          # Script documentation
+├── tests/
+│   └── validate-copilot-instructions.sh   # Validator regression coverage
 ├── .github/
 │   ├── copilot-instructions.md            # Markdown instructions (authoritative)
 │   └── workflows/
-│       └── validate-copilot-instructions.yml  # CI workflow
+│       ├── reusable-copilot-instructions.yml  # Shared CI workflow
+│       └── validate-copilot-instructions.yml  # .github repo caller workflow
 └── docs/
     └── VALIDATION_SYSTEM.md               # This document
 
@@ -33,36 +39,42 @@ The Validation System ensures that Copilot instructions and configuration files 
 
 **Location:** `scripts/validate-copilot-instructions.sh`
 
-**Purpose:** Automated testing of Copilot instructions quality
+**Purpose:** Automated testing of Copilot instructions quality and required AI-risk guidance
 
 **Features:**
 
-- Repository-aware (detects .github, api, frontend, contracts)
-- 8 comprehensive test cases
+- Repository-aware (detects `.github`, `api`, `frontend`, `contracts`, `android`, `secpal.app`, and `changelog`)
+- generic AI triage validation plus repository-specific known-risk checks
+- regression coverage for validator guardrails and repo detection
 - Color-coded output
 - Exit codes for CI integration
 - Optional dependency handling
 
 ### CI Workflow
 
-**Location:** `.github/workflows/validate-copilot-instructions.yml`
+**Locations:** `.github/workflows/reusable-copilot-instructions.yml` and `.github/workflows/validate-copilot-instructions.yml`
 
 **Triggers:**
 
-- Push to `main` (when instruction files change)
-- Pull requests (when instruction files change)
+- Push to `main` (org repo caller, when instruction files change)
+- Pull requests (org repo caller, when instruction files change)
 - Manual dispatch
+- Reusable workflow calls from sibling-repository `quality.yml` workflows
 
 **Steps:**
 
-1. Checkout repository
-2. Setup Node.js 22
-3. Install markdownlint-cli2
-4. Run YAML syntax validation via Ruby stdlib
-5. Run validation script
-6. Report summary
+1. Checkout the caller repository
+2. Checkout `SecPal/.github` when the caller is a sibling repository
+3. Setup Node.js 22 and install `markdownlint-cli2`
+4. Run `scripts/validate-copilot-instructions.sh`
+5. Fail the caller workflow when required guidance is missing
 
 ## Test Cases
+
+The validator enforces file presence, REUSE compliance, markdown quality,
+runtime-model guidance, generic AI-triage guardrails, repository-specific
+known-risk patterns, and required frontmatter for file-based instruction
+overlays.
 
 ### 1. File Existence
 
@@ -91,7 +103,7 @@ always skips.
 **Files Checked:**
 
 - `.github/copilot-instructions.md.license`
-- License identifier: `CC0-1.0`
+- Allowed license identifiers: `CC0-1.0` or `AGPL-3.0-or-later`
 
 **Failure Impact:** CRITICAL - REUSE compliance required
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -134,6 +134,15 @@ if [ -f tests/setup-project-board.sh ]; then
   }
 fi
 
+if [ -f tests/validate-copilot-instructions.sh ]; then
+  bash tests/validate-copilot-instructions.sh || {
+    echo "" >&2
+    echo "❌ Copilot-instructions validator regression test failed!" >&2
+    echo "Fix scripts/validate-copilot-instructions.sh and reusable-copilot-instructions.yml before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -138,7 +138,7 @@ if [ -f tests/validate-copilot-instructions.sh ]; then
   bash tests/validate-copilot-instructions.sh || {
     echo "" >&2
     echo "❌ Copilot-instructions validator regression test failed!" >&2
-    echo "Fix scripts/validate-copilot-instructions.sh and reusable-copilot-instructions.yml before continuing." >&2
+    echo "Fix scripts/validate-copilot-instructions.sh and .github/workflows/reusable-copilot-instructions.yml before continuing." >&2
     exit 1
   }
 fi

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -37,6 +37,11 @@ print_result() {
 }
 
 detect_repo_type() {
+    if [ -n "${REPO_TYPE:-}" ]; then
+        echo "$REPO_TYPE"
+        return
+    fi
+
     if [ -f "artisan" ] || [ -f "composer.json" ]; then
         echo "api"
         return
@@ -44,6 +49,11 @@ detect_repo_type() {
 
     if [ -f "next.config.mjs" ]; then
         echo "changelog"
+        return
+    fi
+
+    if [ -f "capacitor.config.ts" ] || [ -d "android/app/src" ]; then
+        echo "android"
         return
     fi
 
@@ -83,6 +93,7 @@ test_yaml_config_exists() {
 
 test_instructions_reuse() {
     local spdx_license_marker='SPDX-License''-Identifier:'
+    local sidecar_license_pattern='SPDX-License''-Identifier:[[:space:]]+(CC0-1.0|AGPL-3.0-or-later)'
 
     if [ ! -f ".github/copilot-instructions.md" ]; then
         print_result "copilot-instructions.md has REUSE license" "FAIL" "Missing .github/copilot-instructions.md"
@@ -90,10 +101,10 @@ test_instructions_reuse() {
     fi
 
     if [ -f ".github/copilot-instructions.md.license" ]; then
-        if grep -q "CC0-1.0" ".github/copilot-instructions.md.license"; then
+        if grep -qE "$sidecar_license_pattern" ".github/copilot-instructions.md.license"; then
             print_result "copilot-instructions.md has REUSE license" "PASS"
         else
-            print_result "copilot-instructions.md has REUSE license" "FAIL" "Sidecar .license exists but does not declare CC0-1.0"
+            print_result "copilot-instructions.md has REUSE license" "FAIL" "Sidecar .license exists but does not declare an allowed license (CC0-1.0 or AGPL-3.0-or-later)"
         fi
         return
     fi
@@ -162,11 +173,16 @@ test_no_pseudo_inheritance() {
         return
     fi
 
-    if grep -RInEi "$pseudo_inheritance_pattern" "${search_targets[@]}" >/dev/null 2>&1; then
+    while IFS= read -r match; do
+        if printf '%s\n' "$match" | grep -qiE 'do not[^[:alpha:]]+.*(inherit|auto[-[:space:]]*inherit)|does not[^[:alpha:]]+.*(inherit|auto[-[:space:]]*inherit)|not[^[:alpha:]]+automatically[^[:alpha:]]+.*inherit'; then
+            continue
+        fi
+
         print_result "instructions avoid pseudo-inheritance markers" "FAIL" "Found pseudo-inheritance markers in active instructions"
-    else
-        print_result "instructions avoid pseudo-inheritance markers" "PASS"
-    fi
+        return
+    done < <(grep -RInEi "$pseudo_inheritance_pattern" "${search_targets[@]}" 2>/dev/null || true)
+
+    print_result "instructions avoid pseudo-inheritance markers" "PASS"
 }
 
 test_runtime_model() {
@@ -253,6 +269,67 @@ test_ai_findings_guidance() {
     fi
 }
 
+test_repo_specific_ai_risk_guidance() {
+    local repo_type="$1"
+    local instructions_file=".github/copilot-instructions.md"
+    local first_pattern=''
+    local second_pattern=''
+    local message=''
+
+    if [ ! -f "$instructions_file" ]; then
+        print_result "instructions contain repo-specific AI risk guidance" "FAIL" "Missing $instructions_file"
+        return
+    fi
+
+    case "$repo_type" in
+        api)
+            first_pattern='resource|serializer|presentation code|runs once per request'
+            second_pattern='mutable display name|stable key|stable identifier|tenant-scoped|tenant scoping|composite unique|unique constraint'
+            message='Missing API AI guardrails for resource purity or stable tenant-scoped identifiers'
+            ;;
+        frontend)
+            first_pattern='locale|language|tenant|user-derived|auth transition|session change'
+            second_pattern='memoization|dependency|stale|cache'
+            message='Missing frontend AI guardrails for stale locale or session-derived state'
+            ;;
+        contracts)
+            first_pattern='allowlist|regex|discovery pattern'
+            second_pattern='required field|enum|security scheme|positive and negative example|validation evidence'
+            message='Missing contracts AI guardrails for allowlist drift or unproven contract widening'
+            ;;
+        android)
+            first_pattern='listener-handle|listener handle|teardown|bridge'
+            second_pattern='WebView history|back behavior|back-navigation|managed-mode|owner-state'
+            message='Missing android AI guardrails for bridge teardown or managed/back-navigation behavior'
+            ;;
+        website)
+            first_pattern='static|client-only|route|build'
+            second_pattern='accessib|semantic'
+            message='Missing website AI guardrails for static rendering or accessibility regressions'
+            ;;
+        changelog)
+            first_pattern='MDX|markup|label|feed'
+            second_pattern='static build|build output|exported page|metadata'
+            message='Missing changelog AI guardrails for MDX or static export regressions'
+            ;;
+        org)
+            first_pattern='validator|reusable workflow|repo-specific guardrail'
+            second_pattern='positive and negative fixture|positive and negative evidence|regression test'
+            message='Missing org AI guardrails for validator or reusable workflow regressions'
+            ;;
+        *)
+            print_result "instructions contain repo-specific AI risk guidance" "PASS" "Skipped (no repo-specific pattern defined for $repo_type)"
+            return
+            ;;
+    esac
+
+    if grep -qiE "$first_pattern" "$instructions_file" && grep -qiE "$second_pattern" "$instructions_file"; then
+        print_result "instructions contain repo-specific AI risk guidance" "PASS"
+    else
+        print_result "instructions contain repo-specific AI risk guidance" "FAIL" "$message"
+    fi
+}
+
 test_instruction_frontmatter() {
     local file
     local found=0
@@ -297,6 +374,7 @@ main() {
     test_runtime_model "$repo_type"
     test_critical_rules
     test_ai_findings_guidance
+    test_repo_specific_ai_risk_guidance "$repo_type"
     test_instruction_frontmatter
 
     echo ""

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/validate-copilot-instructions.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/bin"
+
+cat >"$workspace/bin/npx" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$workspace/bin/npx"
+
+cat >"$workspace/bin/ruby" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$workspace/bin/ruby"
+
+write_common_instruction_file() {
+    local target_dir="$1"
+    local extra_ai_lines="$2"
+
+    mkdir -p "$target_dir/.github/instructions"
+
+    cat >"$target_dir/.github/copilot-instructions.md" <<EOF
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Test Instructions
+
+These instructions are self-contained for this repository at runtime.
+Do not automatically inherit from sibling repositories.
+
+## Always-On Rules
+
+- Quality first.
+
+## Required Validation
+
+- run the relevant checks
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes.
+$extra_ai_lines
+EOF
+
+    cat >"$target_dir/.github/instructions/example.instructions.md" <<'EOF'
+---
+name: Example
+applyTo: "**"
+---
+
+# Example Instruction
+
+- Do not automatically inherit from sibling repositories.
+EOF
+}
+
+run_validator() {
+    local repo_type="$1"
+    local output_file="$2"
+
+    set +e
+    PATH="$workspace/bin:$PATH" REPO_TYPE="$repo_type" \
+        bash "$REPO_ROOT/scripts/validate-copilot-instructions.sh" >"$output_file" 2>&1
+    local exit_code=$?
+    set -e
+
+    return "$exit_code"
+}
+
+valid_api_repo="$workspace/valid-api"
+mkdir -p "$valid_api_repo"
+touch "$valid_api_repo/composer.json"
+write_common_instruction_file "$valid_api_repo" '- Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
+- Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.'
+
+valid_output="$workspace/valid-output.txt"
+(
+    cd "$valid_api_repo"
+    run_validator api "$valid_output"
+)
+
+missing_generic_repo="$workspace/missing-generic"
+mkdir -p "$missing_generic_repo/.github"
+touch "$missing_generic_repo/composer.json"
+cat >"$missing_generic_repo/.github/copilot-instructions.md" <<'EOF'
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Broken Instructions
+
+These instructions are self-contained for this repository at runtime.
+
+## Always-On Rules
+
+- Quality first.
+
+## Required Validation
+
+- run the relevant checks
+EOF
+
+missing_generic_output="$workspace/missing-generic-output.txt"
+set +e
+(
+    cd "$missing_generic_repo"
+    run_validator api "$missing_generic_output"
+)
+missing_generic_exit=$?
+set -e
+if [ "$missing_generic_exit" -eq 0 ]; then
+    cat "$missing_generic_output"
+    echo "validator unexpectedly passed without generic AI findings guidance" >&2
+    exit 1
+fi
+grep -q 'instructions contain AI findings triage guidance' "$missing_generic_output"
+
+missing_api_specific_repo="$workspace/missing-api-specific"
+mkdir -p "$missing_api_specific_repo"
+touch "$missing_api_specific_repo/composer.json"
+write_common_instruction_file "$missing_api_specific_repo" '- Reject AI-generated helper mutations that move executable code across Pest scope boundaries.'
+
+missing_api_specific_output="$workspace/missing-api-specific-output.txt"
+set +e
+(
+    cd "$missing_api_specific_repo"
+    run_validator api "$missing_api_specific_output"
+)
+missing_api_specific_exit=$?
+set -e
+if [ "$missing_api_specific_exit" -eq 0 ]; then
+    cat "$missing_api_specific_output"
+    echo "validator unexpectedly passed without API-specific AI risk guidance" >&2
+    exit 1
+fi
+grep -q 'instructions contain repo-specific AI risk guidance' "$missing_api_specific_output"
+
+wrong_license_repo="$workspace/wrong-license"
+mkdir -p "$wrong_license_repo"
+touch "$wrong_license_repo/composer.json"
+write_common_instruction_file "$wrong_license_repo" '- Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
+- Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.'
+cat >"$wrong_license_repo/.github/copilot-instructions.md.license" <<'EOF'
+SPDX-License-Identifier: MIT
+EOF
+
+wrong_license_output="$workspace/wrong-license-output.txt"
+set +e
+(
+    cd "$wrong_license_repo"
+    run_validator api "$wrong_license_output"
+)
+wrong_license_exit=$?
+set -e
+if [ "$wrong_license_exit" -eq 0 ]; then
+    cat "$wrong_license_output"
+    echo "validator unexpectedly accepted wrong copilot-instructions sidecar license" >&2
+    exit 1
+fi
+grep -q 'Sidecar .license exists but does not declare an allowed license' "$wrong_license_output"
+
+android_repo="$workspace/android-repo"
+mkdir -p "$android_repo"
+touch "$android_repo/capacitor.config.ts"
+write_common_instruction_file "$android_repo" '- Reject AI-generated bridge changes that alter listener handles or teardown ordering without focused tests.
+- Reject AI-generated back-navigation or managed-mode changes that do not prove WebView history and owner-state invariants.'
+
+android_output="$workspace/android-output.txt"
+set +e
+(
+    cd "$android_repo"
+    PATH="$workspace/bin:$PATH" bash "$REPO_ROOT/scripts/validate-copilot-instructions.sh" >"$android_output" 2>&1
+)
+android_exit=$?
+set -e
+if [ "$android_exit" -ne 0 ]; then
+    cat "$android_output"
+    echo "validator failed for valid android fixture" >&2
+    exit 1
+fi
+grep -q 'Repository Type: android' "$android_output"


### PR DESCRIPTION
## Summary

- add a reusable Copilot-instructions validation workflow for sibling repositories
- extend the central validator with repo-specific AI-risk checks and regression coverage
- wire validator regression coverage into preflight and document the automatic enforcement path

## Testing

- bash tests/validate-copilot-instructions.sh
- ./scripts/preflight.sh
- for repo in /home/holger/code/SecPal/api /home/holger/code/SecPal/frontend /home/holger/code/SecPal/contracts /home/holger/code/SecPal/android /home/holger/code/SecPal/secpal.app /home/holger/code/SecPal/changelog; do (cd "$repo" && bash /home/holger/code/SecPal/.github/scripts/validate-copilot-instructions.sh); done

## Issues

- Closes #374
- Part of #373
