### PR TITLE
Clarify under-1.x compatibility removal guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,11 @@ At minimum verify:
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or automation mutations that move executable code across scope boundaries or "simplify" filters without positive and negative evidence.
 - Reject AI-generated governance cleanups that relax validator coverage, reusable workflow enforcement, or repo-specific guardrails without focused regression tests plus positive and negative fixtures.
+- Reject AI-generated compatibility keep-alives that preserve obsolete
+  governance contracts, deprecated workflow inputs, or legacy automation shims
+  without a proven live caller. Because the SecPal project is still under
+  `1.x`, prefer removing unnecessary compatibility paths over carrying them
+  forward when they weaken security, correctness, or policy clarity.
 
 ## Issue And PR Discipline
 
@@ -114,6 +119,11 @@ Treat `api.secpal.app` as a deprecated web host.
 ## Repository Conventions
 
 - This repository is not versioned; keep its changelog chronological.
+- Even though this repository itself is not versioned, apply the broader
+  SecPal under-`1.x` rule: breaking governance changes are acceptable when
+  they remove insecure or obsolete compatibility layers. When taking that
+  route, update validation coverage and `CHANGELOG.md` in the same change set
+  instead of keeping a legacy path alive by default.
 - Hidden files and automation files are first-class source artifacts.
 - For GitHub workflows, set explicit permissions, set `timeout-minutes` on every job, pin external actions, and never expose secrets in logs.
 - Workflow templates for other repositories live in `workflow-templates/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
-
 ## 2026-04-19 - Clarify Under-1.x Compatibility Removal Guidance
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+
+## 2026-04-19 - Clarify Under-1.x Compatibility Removal Guidance
+
+**Changed:**
+
+- `.github/copilot-instructions.md`: clarified that even this non-versioned governance repository follows the broader SecPal under-`1.x` rule, so obsolete compatibility shims should be removed instead of preserved by default when they weaken policy clarity, correctness, or security
+- added a tiny tracked Apache-2.0 REUSE fixture under `tests/` so repo-wide REUSE validation and staged-file pre-commit validation agree on Apache license usage
+
 ## 2026-04-19 - Add Validator Regression Coverage For AI Triage And REUSE Edge Cases
 
 **Changed:**

--- a/tests/reuse-apache-fixture.txt
+++ b/tests/reuse-apache-fixture.txt
@@ -1,0 +1,1 @@
+Apache REUSE fixture for staged-file validation.

--- a/tests/reuse-apache-fixture.txt.license
+++ b/tests/reuse-apache-fixture.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: Apache-2.0

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -162,6 +162,8 @@ mkdir -p "$wrong_license_repo"
 touch "$wrong_license_repo/composer.json"
 write_common_instruction_file "$wrong_license_repo" '- Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
 - Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.'
+# Keep an Apache-2.0 sidecar fixture here because this validator must reject
+# Apache-2.0 for .github/copilot-instructions.md.license.
 cp "$FIXTURES_DIR/wrong-copilot-instructions-license-fixture.txt" \
     "$wrong_license_repo/.github/copilot-instructions.md.license"
 


### PR DESCRIPTION
## Summary
- clarify that this non-versioned governance repository still follows the broader SecPal under-1.x compatibility-removal rule
- add a tracked Apache-2.0 REUSE fixture so repo-wide REUSE validation and staged-file pre-commit validation agree
- document the governance update in the changelog

## Validation
- git diff --check
- ./scripts/preflight.sh

Closes #384
