### PR TITLE
docs: triage archived feature-requirements drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-19 - Triage Archived Feature-Requirements Planning Drift
+
+**Changed:**
+
+- `docs/feature-requirements.md`: added an explicit archive-triage snapshot, defined the long-term end state as a slim historical archive, and linked the few still-relevant areas to their live issue or ADR trackers instead of leaving the archive implicitly actionable
+- `docs/ideas-backlog.md`: removed stale instructions that pointed contributors back to `feature-requirements.md` for active planning, replaced the BWR migration note with the existing API delivery trail, and clarified that future activation must happen through repo-local issues or epics
+
 ## 2026-04-19 - Clarify Under-1.x Compatibility Removal Guidance
 
 **Changed:**

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -9,9 +9,21 @@ SPDX-License-Identifier: CC0-1.0
 
 **Status:** Archived for active planning as of 2026-04-15. Do not add new planning content here. Active planning lives in GitHub Issues, milestones, and ADRs as defined in `docs/planning.md` and ADR-013.
 
-**Preserved For:** Historical context, legacy references, and extracting deferred follow-up issues into repository-local trackers.
+**Preserved For:** Historical context, legacy references, and extracting explicitly reactivated slices into repository-local issues or ADRs.
 
-**Last Updated:** 2026-04-15
+**Last Updated:** 2026-04-19
+
+## Archive Triage Snapshot
+
+This file's long-term end state is a slim historical archive. Keep it available for background and legacy rationale, but do not expand it as a planning destination again. If a future initiative needs material from this archive, extract only the relevant slice into a repo-local issue or ADR and treat the extracted tracker as the canonical source of truth.
+
+| Area                                                                                  | Archive status                                            | Active tracker or rationale                                                                                |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Access control, organizational structure, and qualification models                    | Historical archive                                        | Re-open only through issue-first planning when implementation is explicitly scheduled                      |
+| Employee lifecycle, onboarding, and BWR compliance                                    | Historical archive with prior delivery trail              | SecPal/api#468, SecPal/api#469, and SecPal/api#471 capture the earlier BWR and onboarding planning lineage |
+| Digital signatures and legally relevant acknowledgments                               | Historical archive with durable decision inputs elsewhere | ADR-001, ADR-002, and SecPal/.github#46 carry the live decision and legal-review path                      |
+| Work instructions                                                                     | Active implementation is tracked outside this archive     | SecPal/frontend#32 is the current implementation tracker                                                   |
+| Shift planning, client portal, mobile field use, OWKS, device controls, and contracts | Historical archive or long-horizon concept only           | Promote future work into dedicated issues or epics before implementation instead of reviving this document |
 
 ---
 

--- a/docs/ideas-backlog.md
+++ b/docs/ideas-backlog.md
@@ -7,11 +7,11 @@ SPDX-License-Identifier: CC0-1.0
 
 **Purpose:** This document captures ideas, concepts, and features that are **not yet prioritized** but may become relevant later. Think of this as a "parking lot" for thoughts that don't warrant immediate action but shouldn't be forgotten.
 
-**Status:** Living document - Add ideas freely, review quarterly
+**Status:** Living document - non-canonical parking only; promote items into issues before implementation
 
-**Last Updated:** 2026-04-15
+**Last Updated:** 2026-04-19
 
-> **Note:** This document is non-canonical idea parking only. Active planning lives in GitHub Issues and milestones. Historical detailed specifications remain in `feature-requirements.md`, which is archived for active planning.
+> **Note:** This document is non-canonical idea parking only. Active planning lives in GitHub Issues and milestones. `feature-requirements.md` remains historical background only and is not a planning destination. Any actionable idea from this file must be promoted into a repo-local issue, epic, or ADR before implementation starts.
 
 ---
 
@@ -548,8 +548,8 @@ Run Laravel with Swoole/RoadRunner for massive performance gains.
 
 **Related:**
 
-- Issue #...
-- ADR-...
+- Repo-local issue or epic once the idea becomes actionable
+- ADR if durable rationale matters beyond the implementation issue
 ```
 
 ---
@@ -650,7 +650,8 @@ According to §11b BewachV (German Security Services Act), security companies mu
 - Employee Management (Core Feature)
 - Qualifications System (Core Feature)
 - Legal Compliance (docs/legal-compliance.md)
-- Issue #... (to be created for detailed specification)
+- Historical implementation trail: SecPal/api#468, SecPal/api#469, SecPal/api#471
+- Open a new repo-local issue only if additional BWR scope appears beyond that delivered foundation
 
 **Technical Notes:**
 
@@ -665,7 +666,7 @@ According to §11b BewachV (German Security Services Act), security companies mu
 ### Idea: (Semi-)Automated Shift Planning with Employee Suggestions
 
 **Context:**
-Manual shift planning is time-consuming. Managers need support to find available employees who meet all requirements (qualifications, working time law, preferences). Current `feature-requirements.md` includes basic auto-scheduling, but advanced AI-driven suggestions are not yet specified.
+Manual shift planning is time-consuming. Managers need support to find available employees who meet all requirements (qualifications, working time law, preferences). Baseline shift-planning scope exists only as archived historical context today, so these advanced suggestions need a dedicated future issue or epic before they become active planning.
 
 **Concept:**
 
@@ -738,7 +739,7 @@ Manual shift planning is time-consuming. Managers need support to find available
 
 **When to revisit:**
 
-- After basic shift planning (feature-requirements.md) is implemented
+- After baseline shift-planning work is reintroduced through a dedicated issue or epic and implemented
 - When historical data is available for ML training
 - When managers report bottlenecks in manual planning
 
@@ -756,7 +757,7 @@ Manual shift planning is time-consuming. Managers need support to find available
 ### Idea: Shift Plan Distribution via Push Notifications & Email
 
 **Context:**
-Employees need timely notification when new shift plans are published. While basic email notifications are mentioned in `feature-requirements.md`, advanced distribution features are not yet specified.
+Employees need timely notification when new shift plans are published. Baseline notification behavior exists only in archived historical notes today, so advanced distribution features need dedicated issue scope before they become active planning.
 
 **Concept:**
 
@@ -1262,5 +1263,5 @@ Security companies must provide uniforms and equipment to employees. With multip
 - Move Event Sourcing idea → ADR-001 ✅ Done
 - Review this doc every 3 months
 - Create GitHub Issues for "Now" or "Soon" priorities
-- **NEW:** BWR-Integration → Move to feature-requirements.md (Soon)
+- **NEW:** BWR-Integration → reopen only through a dedicated repo-local issue if additional scope appears
 - **NEW:** Clothing Management → Evaluate with stakeholders (Phase 3+)


### PR DESCRIPTION
## Summary

- add an archive-triage snapshot to `docs/feature-requirements.md` so the remaining actionable areas are either linked to live trackers or explicitly treated as historical only
- remove stale `docs/ideas-backlog.md` instructions that sent contributors back to `feature-requirements.md` for active planning and replace the BWR migration note with the existing API issue trail
- record the documentation-governance cleanup in `CHANGELOG.md`

## Validation

- `./scripts/preflight.sh`

## Related

- Closes #360

## Checklist

- [x] Single topic
- [x] CHANGELOG updated
- [x] Relevant validation passed
