### PR TITLE
fix: restore portable mktemp test templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-25 - Restore Portable mktemp Test Templates
+
+**Changed:**
+
+- `tests/setup-project-board.sh`: replaced deprecated `mktemp -d -t ...` usage with the repository's existing full-template `${TMPDIR:-/tmp}/...XXXXXX` style
+- `tests/validate-copilot-instructions.sh`: same portable `mktemp` template-path cleanup as `tests/setup-project-board.sh`
+- `tests/mktemp-portability.sh`: added a focused regression test, wired into local preflight, so deprecated `mktemp -t` usage in these shell tests is caught before push
+- `CHANGELOG.md`: corrected the prior 2026-04-24 wording so it no longer claims the `mktemp -t` change improved portability
+
+---
+
 ## 2026-04-25 - Exclude Git Metadata From Local Markdownlint Preflight
 
 **Changed:**
@@ -27,7 +38,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - `docs/ideas-backlog.md`: replaced the unclear "baseline shift-planning work is reintroduced" prerequisite with an explicit list of required functionality (manual shift assignment, schedule editing, and conflict checks)
 - `docs/ideas-backlog.md`: removed the undefined "Phase 2" phase reference from the mobile notification "When to revisit" condition in favour of a concrete observable milestone
 - `tests/setup-project-board.sh`: implemented actual integration test scenarios (gh unavailable, prompt-decline, prompt-accept) replacing the previous placeholder enforcement variable; the `REQUIRE_SETUP_PROJECT_BOARD_INTEGRATION_TESTED` guard now runs real tests instead of checking for an external marker variable
-- `tests/validate-copilot-instructions.sh`: updated the `mktemp` call to use the `-t` flag instead of an explicit `/tmp`-prefixed template for better portability and consistency with supported `mktemp` usage
+- `tests/validate-copilot-instructions.sh`: updated the `mktemp` call to use the `-t` flag instead of an explicit `/tmp`-prefixed template, aligning with BSD/macOS-style `mktemp` usage (with portability trade-offs on GNU systems)
 - `tests/validate-copilot-instructions.sh`: replaced fragile `set +e` / `set -e` pattern in `run_validator` with a safer `if/else` exit-code capture
 - `tests/validate-copilot-instructions.sh`: eliminated duplicated AI-lines literal in `wrong_license_repo` fixture by reusing the `$valid_api_extra_ai_lines` variable (DRY)
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -143,6 +143,15 @@ if [ -f tests/preflight-markdownlint-scope.sh ]; then
   }
 fi
 
+if [ -f tests/mktemp-portability.sh ]; then
+  bash tests/mktemp-portability.sh || {
+    echo "" >&2
+    echo "❌ mktemp portability regression test failed!" >&2
+    echo "Restore portable mktemp template usage in the affected shell tests before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/validate-copilot-instructions.sh ]; then
   bash tests/validate-copilot-instructions.sh || {
     echo "" >&2

--- a/tests/mktemp-portability.sh
+++ b/tests/mktemp-portability.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fq "$expected" "$path"; then
+    echo "Expected to find '$expected' in $path" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local path="$1"
+  local unexpected="$2"
+
+  if grep -Fq "$unexpected" "$path"; then
+    echo "Did not expect to find '$unexpected' in $path" >&2
+    exit 1
+  fi
+}
+
+# shellcheck disable=SC2016
+assert_contains "$REPO_ROOT/tests/setup-project-board.sh" 'mktemp -d "${TMPDIR:-/tmp}/setup-project-board.XXXXXX"'
+assert_not_contains "$REPO_ROOT/tests/setup-project-board.sh" 'mktemp -d -t setup-project-board.XXXXXX'
+
+# shellcheck disable=SC2016
+assert_contains "$REPO_ROOT/tests/validate-copilot-instructions.sh" 'mktemp -d "${TMPDIR:-/tmp}/validate-copilot-instructions.XXXXXX"'
+assert_not_contains "$REPO_ROOT/tests/validate-copilot-instructions.sh" 'mktemp -d -t validate-copilot-instructions.XXXXXX'

--- a/tests/setup-project-board.sh
+++ b/tests/setup-project-board.sh
@@ -58,7 +58,7 @@ assert_not_contains "$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md" "Specified in f
 
 run_setup_project_board_integration_tests() {
   local tmp_dir
-  tmp_dir="$(mktemp -d -t setup-project-board.XXXXXX)"
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/setup-project-board.XXXXXX")"
   trap 'rm -rf "$tmp_dir"' RETURN
 
   local stub_dir="$tmp_dir/bin"

--- a/tests/setup-project-board.sh
+++ b/tests/setup-project-board.sh
@@ -59,7 +59,7 @@ assert_not_contains "$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md" "Specified in f
 run_setup_project_board_integration_tests() {
   local tmp_dir
   tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/setup-project-board.XXXXXX")"
-  trap 'rm -rf "$tmp_dir"' RETURN
+  trap 'rm -rf "$tmp_dir"' RETURN EXIT
 
   local stub_dir="$tmp_dir/bin"
   mkdir -p "$stub_dir"

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURES_DIR="$REPO_ROOT/tests/fixtures/validate-copilot-instructions"
 
-workspace="$(mktemp -d -t validate-copilot-instructions.XXXXXX)"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/validate-copilot-instructions.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/bin"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
<!-- SPDX-License-Identifier: CC0-1.0 -->

## Summary

- restore portable full-template `mktemp` usage in the two affected shell regression tests
- add a focused regression check plus local preflight wiring so deprecated `mktemp -t` usage is caught before push
- correct the changelog wording that previously overstated portability

## Testing

- `bash tests/mktemp-portability.sh`
- `bash tests/setup-project-board.sh`
- `bash tests/validate-copilot-instructions.sh`
- `npx --yes prettier --check CHANGELOG.md`
- `npx --yes markdownlint-cli2 CHANGELOG.md`
- `bash -n scripts/preflight.sh tests/setup-project-board.sh tests/validate-copilot-instructions.sh tests/mktemp-portability.sh`
- `reuse lint`

## Notes

- `./scripts/preflight.sh` was run but is currently blocked by unrelated markdownlint input drift that scans `.git/logs/...`; tracked separately in `#390`.

Closes #389
