### PR TITLE
fix: exclude .git from preflight markdownlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-04-25 - Exclude Git Metadata From Local Markdownlint Preflight
+
+**Changed:**
+
+- `scripts/preflight.sh`: excluded `.git` from the local `markdownlint-cli2` glob set so Git ref and log metadata cannot fail Markdown validation for repository content
+- `tests/preflight-markdownlint-scope.sh`: added a focused regression test, wired into local preflight, that verifies the markdownlint invocation includes the `.git` exclusion
+
+---
+
 ## 2026-04-24 - Clarify Backlog Prerequisites And Improve Test Coverage
 
 **Changed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -48,7 +48,7 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' || FORMAT_EXIT=1
+  npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
 fi
 # Workflow linting is enforced by pre-commit hooks and CI.
 # Local preflight keeps this as guidance only because direct actionlint runs
@@ -130,6 +130,15 @@ if [ -f tests/setup-project-board.sh ]; then
     echo "" >&2
     echo "❌ Project board helper regression test failed!" >&2
     echo "Fix project board helper collateral before continuing." >&2
+    exit 1
+  }
+fi
+
+if [ -f tests/preflight-markdownlint-scope.sh ]; then
+  bash tests/preflight-markdownlint-scope.sh || {
+    echo "" >&2
+    echo "❌ Preflight markdownlint scope regression test failed!" >&2
+    echo "Exclude Git metadata from the local markdownlint scan before continuing." >&2
     exit 1
   }
 fi

--- a/tests/preflight-markdownlint-scope.sh
+++ b/tests/preflight-markdownlint-scope.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/preflight-markdownlint-scope.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/scripts" "$workspace/bin"
+cp "$REPO_ROOT/scripts/preflight.sh" "$workspace/scripts/preflight.sh"
+
+log_file="$workspace/npx.log"
+
+cat >"$workspace/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$LOG_FILE"
+exit 0
+EOF
+chmod +x "$workspace/bin/npx"
+
+cat >"$workspace/bin/reuse" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$workspace/bin/reuse"
+
+cat >"$workspace/README.md" <<'EOF'
+# Test Workspace
+EOF
+
+(
+  cd "$workspace"
+  git init --quiet
+  git config user.name 'SecPal Test'
+  git config user.email 'test@secpal.dev'
+  git add README.md
+  git commit --quiet -m 'test: seed preflight workspace'
+  git checkout --quiet -b test-branch
+  git update-ref refs/remotes/origin/main HEAD
+  git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+  LOG_FILE="$log_file" PATH="$workspace/bin:$PATH" bash scripts/preflight.sh >/dev/null 2>&1
+)
+
+if ! grep -F 'markdownlint-cli2' "$log_file" | grep -Fq '#.git'; then
+  echo "Expected preflight markdownlint invocation to exclude .git paths" >&2
+  cat "$log_file" >&2
+  exit 1
+fi


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
<!-- SPDX-License-Identifier: CC0-1.0 -->

## Summary

- exclude `.git` from the local `markdownlint-cli2` glob set in `scripts/preflight.sh`
- add a focused regression test and wire it into local preflight so Git metadata cannot silently re-enter the Markdown scan
- document the fix in `CHANGELOG.md`

## Testing

- `bash tests/preflight-markdownlint-scope.sh`
- `./scripts/preflight.sh`

Closes #390
