### PR TITLE
Remove stale admin-model ADR drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-01 - Remove Stale Admin Model ADR Drift
+
+**Changed:**
+
+- updated ADR-005, ADR-008, ADR-009 references, and activity-log examples so `.github` architecture documents no longer describe an `Admin` role, an `admin` organizational scope level, or a `super-admin` model as part of SecPal's supported authorization design after the binding cleanup decision in `.github#404`
+
 ## 2026-04-25 - Restore Portable mktemp Test Templates
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Changed:**
 
-- updated ADR-005, ADR-008, ADR-009 references, and activity-log examples so `.github` architecture documents no longer describe an `Admin` role, an `admin` organizational scope level, or a `super-admin` model as part of SecPal's supported authorization design after the binding cleanup decision in `.github#404`
+- updated ADR-005, ADR-008, ADR-009 references, and activity-log examples so `.github` architecture documents no longer describe an `Admin` role, an `admin` organizational scope level, or a `super-admin` model as part of SecPal's supported authorization design after the binding cleanup decision in `SecPal/.github#404`
 
 ## 2026-04-25 - Restore Portable mktemp Test Templates
 

--- a/docs/adr/20251111-rbac-design-decisions.md
+++ b/docs/adr/20251111-rbac-design-decisions.md
@@ -33,7 +33,7 @@ The SecPal RBAC system (Issue #5) required fundamental architectural decisions a
 
 **Context:**
 
-During RBAC design, we considered protecting predefined roles (Admin, Manager, Guard, Client, Works Council) from deletion or modification. Common patterns include:
+During RBAC design, we considered protecting predefined roles (Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council) from deletion or modification. Common patterns include:
 
 - `is_system_role` boolean flag
 - `protected` boolean flag
@@ -52,7 +52,7 @@ public function destroy(Role $role)
         ]);
     }
 
-    $role->delete(); // Works for Admin, Manager, Custom, any role
+    $role->delete(); // Works for Manager, HR, custom, or any other role
 }
 ```
 
@@ -64,17 +64,23 @@ class RolesAndPermissionsSeeder extends Seeder
     public function run(): void
     {
         // Creates if not exists, skips if exists
-        $admin = Role::firstOrCreate(
-            ['name' => 'Admin', 'guard_name' => 'sanctum'],
-            ['description' => 'Full system access']
+        $manager = Role::firstOrCreate(
+            ['name' => 'Manager', 'guard_name' => 'sanctum'],
+            ['description' => 'Operational management within assigned scopes']
         );
 
         // Sync permissions only if role has none
-        if ($admin->permissions()->count() === 0) {
-            $admin->syncPermissions(['*']);
+        if ($manager->permissions()->count() === 0) {
+            $manager->syncPermissions([
+                'customers.read',
+                'customers.create',
+                'sites.read',
+                'employees.read',
+                'shifts.read',
+            ]);
         }
 
-        // Repeat for Manager, Guard, Client, Works Council
+        // Repeat for Employee, Employee Read Only, HR, Guard, Client, Works Council
     }
 }
 ```
@@ -375,13 +381,13 @@ public function handle()
 
 ### Leadership-Based Access Control (See ADR-009)
 
-This ADR establishes the foundation for role-based access control. **No role has default privileges** - all roles (including "Admin") are equal and access is controlled exclusively through:
+This ADR establishes the foundation for role-based access control. **No role has default privileges** and access is controlled exclusively through:
 
 1. **Permissions:** Spatie Laravel-Permission system (e.g., `employee.read`, `employee.update`)
 2. **Organizational Scopes:** Access to specific organizational units (ADR-007)
 3. **Leadership Level Filters:** Rank-based visibility control (ADR-009)
 
-**Note:** The "Admin" role is a regular role name without special meaning to the system. It typically receives broad permissions via the seeder, but can be modified, deleted, or renamed like any other role.
+**Note:** Predefined roles are just seeded permission bundles. They can be modified, deleted, or renamed like any other role, and none of them bypass the explicit permission-plus-scope model.
 
 ADR-009 extends this with:
 

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: CC0-1.0
 This ADR defines the architecture for flexible, unlimited-depth organizational hierarchies in SecPal. **Two independent hierarchical systems** are implemented:
 
 1. **Internal Structure** (`organizational_units`): Security service company hierarchy (Holding → Company → Region → Branch → Division)
-   - For **internal employees** (Guards, Managers, Admins)
+   - For **internal employees** (Guards, Managers, explicitly scoped operators)
    - Access control via `user_internal_organizational_scopes`
    - Fine-grained RBAC: From branch-wide access down to specific object areas
 
@@ -351,7 +351,7 @@ We will implement a **Closure Table Pattern** for organizational hierarchies com
 │  └─ ProSec Nord GmbH                                            │
 │     └─ Region Berlin-Brandenburg                                │
 │        └─ Niederlassung Berlin                                  │
-│           └─ [EMPLOYEES: Guards, Managers, Admins]              │
+│           └─ [EMPLOYEES: Guards, Managers, explicitly scoped operators] │
 │              ├─ User: Regional Manager Berlin                   │
 │              │  Role: Manager                                   │
 │              │  Scope: user_internal_organizational_scopes      │
@@ -411,7 +411,7 @@ SHARED RBAC INFRASTRUCTURE:
 
 #### 1. Internal Organizational Units (Security Service Company Structure)
 
-**Purpose:** Represents the **security service company's** internal structure (holding, branches, divisions, etc.). This is for **internal employees only** (guards, managers, admins).
+**Purpose:** Represents the **security service company's** internal structure (holding, branches, divisions, etc.). This is for **internal employees only** (guards, managers, explicitly scoped operators).
 
 **Core Table:**
 
@@ -775,7 +775,7 @@ if (!$user->hasPermissionTo('guard_book.read')) {
 
 **Key Difference:**
 
-- **Internal RBAC:** Guards, Managers, Admins → Access based on organizational_units
+- **Internal RBAC:** Guards, Managers, explicitly scoped operators → Access based on organizational_units
 - **Customer Access:** Client users → Access based on customer hierarchy + specific objects
 
 ```php
@@ -1055,7 +1055,7 @@ DB::transaction(function () use ($unit, $newParent) {
 
 1. **Internal Organizational Structure** (`organizational_units`)
    - Security service company hierarchy (Holding → Region → Branch)
-   - For **internal employees only** (Guards, Managers, Admins)
+   - For **internal employees only** (Guards, Managers, explicitly scoped operators)
    - Access control via `user_internal_organizational_scopes`
    - Full CRUD permissions within scope
 

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -60,7 +60,7 @@ Security service companies have diverse organizational structures:
 
 #### Part A: Internal Organizational Structures (Security Service Company)
 
-These scenarios show the **security service's own organizational structure** and how internal employees (Guards, Managers, Admins) access data based on their position in the hierarchy.
+These scenarios show the **security service's own organizational structure** and how internal employees (Guards, Managers, and explicitly scoped operators) access data based on their position in the hierarchy.
 
 **Scenario 1: Small Security Service (Flat Structure)**
 
@@ -73,8 +73,8 @@ organizational_units: [none - flat, all employees report directly]
 
 Internal Employees & RBAC:
 ├─ User: Inhaber Schmidt
-│  Role: Admin
-│  Scope: All customers/objects (no restrictions)
+│  Access: Explicit permissions + root `manage` scope
+│  Scope: All customers/objects within the assigned root unit
 │
 ├─ User: Einsatzleiter Müller
 │  Role: Manager
@@ -174,8 +174,8 @@ ProSec Holding (holding)
 └─ ProSec Süd GmbH (company)
    └─ Region Bayern
 
-Vorstand ProSec Holding (Admin)
-→ Sees EVERYTHING across all subsidiaries
+Vorstand ProSec Holding (explicit permissions + root `manage` scope)
+→ Sees everything across explicitly assigned subsidiaries
 ```
 
 #### Part B: Customer Organizational Structures (External Organizations)
@@ -1349,7 +1349,7 @@ $table->enum('type', ['permanent', 'temporary'])->default('permanent');
 
 - **ADR-005:** RBAC Design Decisions (role/permission foundation)
 - **ADR-008:** User-Based Tenant Resolution (tenant isolation)
-- **ADR-009:** Permission Inheritance Blocking & Super-Admin Privileges ⭐️ **CRITICAL EXTENSION**
+- **ADR-009:** Permission Inheritance Blocking & Leadership-Based Access Control ⭐️ **CRITICAL EXTENSION**
 
 ### ADR-009 Integration: Organizational Autonomy & Security
 

--- a/docs/adr/20251219-user-based-tenant-resolution.md
+++ b/docs/adr/20251219-user-based-tenant-resolution.md
@@ -453,9 +453,9 @@ If a tenant has multiple root organizational units (e.g., acquired companies), a
 ```
 Tenant: "SecureGuard Services GmbH"
   ├─ Holding A (root, parent_id = null)
-    │  └─ Scoped User A (`manage` scope: Holding A only)
+  │  └─ Scoped User A (`manage` scope: Holding A only)
   └─ Holding B (root, parent_id = null)
-            └─ Scoped User B (`manage` scope: Holding B only)
+     └─ Scoped User B (`manage` scope: Holding B only)
 
 → User A cannot access Holding B data (separate root unit)
 → User B cannot access Holding A data (separate root unit)

--- a/docs/adr/20251219-user-based-tenant-resolution.md
+++ b/docs/adr/20251219-user-based-tenant-resolution.md
@@ -221,7 +221,7 @@ $tenantId = $request->user()->currentAccessToken()->abilities['tenant_id'];
 - ❌ Token must be regenerated if user changes tenant
 - ❌ Denormalized data (tenant_id in two places)
 - ❌ Complex token management
-- ❌ Still requires User → Tenant relationship for admin operations
+- ❌ Still requires User → Tenant relationship for privileged provisioning operations
 
 **Why Rejected:**
 
@@ -435,34 +435,35 @@ This decision prioritizes **production readiness** and **simplicity** over featu
 
 - **ADR-005:** RBAC Design Decisions (role/permission system)
 - **ADR-007:** Organizational Structure Hierarchy (organizational scopes)
-- **ADR-009:** Permission Inheritance Blocking & Super-Admin Privileges (organizational-level isolation)
+- **ADR-009:** Permission Inheritance Blocking & Leadership-Based Access Control (organizational-level isolation)
 
-### ADR-009 Integration: Multi-Tenant Super-Admin Context
+### ADR-009 Integration: Multi-Tenant Root-Scope Context
 
 While ADR-008 establishes **tenant-level isolation** (user → tenant relationship), ADR-009 adds **organizational-level isolation** within tenants:
 
 - **Tenant isolation:** User can only access data from their assigned tenant
 - **Organizational isolation:** User can only access data from their organizational scopes
 - **Inheritance blocking:** Child organizations can protect themselves from parent access
-- **Super-admin scope:** Restricted to root organizational units within tenant
+- **Root-unit scope:** Explicit `manage` / `write` / `read` scopes remain limited to the root organizational units they reference within a tenant
 
-**Multi-Tenant Super-Admin Scenario:**
+**Multi-Tenant Root-Scope Scenario:**
 
-If a tenant has multiple root organizational units (e.g., acquired companies), super-admin privileges are **specific to each root unit**:
+If a tenant has multiple root organizational units (e.g., acquired companies), a user with explicit permissions plus a root `manage` scope on one unit remains isolated from the others:
 
 ```
 Tenant: "SecureGuard Services GmbH"
   ├─ Holding A (root, parent_id = null)
-  │  └─ Super-Admin User A (scope: Holding A only)
+    │  └─ Scoped User A (`manage` scope: Holding A only)
   └─ Holding B (root, parent_id = null)
-      └─ Super-Admin User B (scope: Holding B only)
+            └─ Scoped User B (`manage` scope: Holding B only)
 
 → User A cannot access Holding B data (separate root unit)
 → User B cannot access Holding A data (separate root unit)
-→ Both are isolated at organizational level within same tenant
+→ Both still need explicit permissions for the actions they perform
+→ Both are isolated at organizational level within the same tenant
 ```
 
-For complete details, see **ADR-009: Permission Inheritance Blocking & Super-Admin Privileges**.
+For complete details, see **ADR-009: Permission Inheritance Blocking & Leadership-Based Access Control**.
 
 ---
 

--- a/docs/adr/20251221-activity-logging-audit-trail-strategy.md
+++ b/docs/adr/20251221-activity-logging-audit-trail-strategy.md
@@ -432,7 +432,7 @@ activity('scope_changes')
     ->performedOn($user)
     ->withProperties([
         'organizational_unit' => 'Regional GmbH',
-        'access_level' => 'admin',
+        'access_level' => 'manage',
     ])
     ->log('scope_granted');
 
@@ -1149,16 +1149,16 @@ test('inheritance blocking prevents parent access', function () {
         ],
     ]);
 
-    $holdingAdmin = User::factory()->create();
-    $holdingAdmin->organizationalScopes()->create([
+    $holdingManager = User::factory()->create();
+    $holdingManager->organizationalScopes()->create([
         'organizational_unit_id' => $holding->id,
-        'access_level' => 'admin',
+        'access_level' => 'manage',
         'include_descendants' => true,
     ]);
 
     $log = Activity::create(['organizational_unit_id' => $regional->id, ...]);
 
-    actingAs($holdingAdmin)->get("/v1/activity-logs/{$log->id}")
+    actingAs($holdingManager)->get("/v1/activity-logs/{$log->id}")
         ->assertForbidden();
 });
 ```
@@ -1176,7 +1176,7 @@ test('cannot access other tenant logs', function () {
 
 test('cannot modify activity logs', function () {
     $log = Activity::create([...]);
-    $user = User::factory()->admin()->create();
+    $user = User::factory()->create();
 
     actingAs($user)->patch("/v1/activity-logs/{$log->id}", ['description' => 'HACKED'])
         ->assertMethodNotAllowed();
@@ -1208,7 +1208,7 @@ test('hash chain detects injection attacks', function () {
 - **ADR-005:** RBAC Design Decisions (role changes are logged)
 - **ADR-007:** Organizational Structure Hierarchy (scope-based log access)
 - **ADR-008:** User-Based Tenant Resolution (tenant isolation for logs)
-- **ADR-009:** Permission Inheritance Blocking & Super-Admin Privileges (emergency access is logged)
+- **ADR-009:** Permission Inheritance Blocking & Leadership-Based Access Control (emergency access is logged)
 
 ---
 

--- a/docs/adr/20251221-inheritance-blocking-and-leadership-access-control.md
+++ b/docs/adr/20251221-inheritance-blocking-and-leadership-access-control.md
@@ -866,7 +866,7 @@ user_internal_organizational_scopes:
 - ✅ Clear separation: Permissions (what) vs. Scopes (where) vs. Levels (who)
 - ✅ Fine-grained control: Rank ranges
 - ✅ Flexible: Tenant defines own levels
-- ✅ No special "admin" concept
+- ✅ No obsolete privileged-scope concept
 
 ### Migration Strategy
 
@@ -918,12 +918,12 @@ UserInternalOrganizationalScope::where('access_level', 'admin')->each(function (
 
 ### Privilege Escalation Prevention
 
-**Scenario: Child Admin Attempts Parent Access**
+**Scenario: Child-Scoped Operator Attempts Parent Access**
 
 ```php
 // Attempted attack
 POST /employees
-Authorization: Bearer <child-admin-token>
+Authorization: Bearer <child-scoped-operator-token>
 // Query attempts to access parent org employees
 
 // Prevention
@@ -1255,7 +1255,7 @@ public function rules(): array
 
 **3. Simplified Architecture:**
 
-- ✅ No "admin" vs "super-admin" confusion
+- ✅ No obsolete admin-scope terminology
 - ✅ Clear permission model (Permissions + Scopes + Levels)
 - ✅ No "breaking glass" complexity
 


### PR DESCRIPTION
## Summary

- update ADR-005, ADR-008, and ADR-009 examples and cross-references so they no longer describe Admin, admin-scope, or super-admin semantics as current SecPal behavior
- align hierarchy and activity-log ADR snippets with explicit permissions plus explicit manage scopes
- record the cleanup in the governance changelog

## Validation

- npm exec -- prettier --check CHANGELOG.md docs/adr/20251111-rbac-design-decisions.md docs/adr/20251126-organizational-structure-hierarchy.md docs/adr/20251219-user-based-tenant-resolution.md docs/adr/20251221-activity-logging-audit-trail-strategy.md docs/adr/20251221-inheritance-blocking-and-leadership-access-control.md
- npm exec -- markdownlint-cli2 CHANGELOG.md docs/adr/20251111-rbac-design-decisions.md docs/adr/20251126-organizational-structure-hierarchy.md docs/adr/20251219-user-based-tenant-resolution.md docs/adr/20251221-activity-logging-audit-trail-strategy.md docs/adr/20251221-inheritance-blocking-and-leadership-access-control.md
- ./scripts/preflight.sh (fails only on the existing mktemp portability regression tracked in SecPal/.github#405)

## References

- Refs SecPal/.github#404
- Related SecPal/.github#405
