### PR TITLE
Version Polyscope rollout automation and auto-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Changed:**
 
 - added `scripts/polyscope-rollout.py` as the versioned source of truth for SecPal Polyscope rollout state, including repo-local `polyscope.local.json` rendering, instruction-derived prompt/link sync into `~/.polyscope/polyscope.db`, and deterministic preview nginx config rendering
-- added `scripts/install-polyscope-rollout.sh` so the VPS can install a stable `~/.local/bin/polyscope-secpal-rollout.py` symlink plus a systemd user `polyscope-rollout-sync.service` and `polyscope-rollout-sync.path` hook that re-sync Polyscope whenever tracked instruction files change
+- added `scripts/install-polyscope-rollout.sh` so the VPS can install a stable `~/.local/bin/polyscope-secpal-rollout.py` symlink plus a systemd user `polyscope-rollout-sync.service` and `polyscope-rollout-sync.path` hook that re-syncs Polyscope whenever tracked instruction files change
 - added `tests/polyscope-rollout.sh` and wired the new automation into the repository's normal shell-test/preflight path, covering local config generation, instruction-derived prompt content, repository-link sync, nginx rendering, and auto-sync unit installation
 
 ## 2026-05-01 - Remove Stale Admin Model ADR Drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-01 - Version Polyscope Cursor Sync And Auto-Refresh
+
+**Changed:**
+
+- added `scripts/polyscope-rollout.py` as the versioned source of truth for SecPal Polyscope rollout state, including repo-local `polyscope.local.json` rendering, instruction-derived prompt/link sync into `~/.polyscope/polyscope.db`, and deterministic preview nginx config rendering
+- added `scripts/install-polyscope-rollout.sh` so the VPS can install a stable `~/.local/bin/polyscope-secpal-rollout.py` symlink plus a systemd user `polyscope-rollout-sync.service` and `polyscope-rollout-sync.path` hook that re-sync Polyscope whenever tracked instruction files change
+- added `tests/polyscope-rollout.sh` and wired the new automation into the repository's normal shell-test/preflight path, covering local config generation, instruction-derived prompt content, repository-link sync, nginx rendering, and auto-sync unit installation
+
 ## 2026-05-01 - Remove Stale Admin Model ADR Drift
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -40,6 +40,14 @@ INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
 SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
 PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
 
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT; do
+    _val="${!_var_name}"
+    if [[ "$_val" == *$'\n'* ]]; then
+        echo "Error: $_var_name must not contain newlines" >&2
+        exit 1
+    fi
+done
+
 mkdir -p "$BIN_DIR" "$UNIT_DIR"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_SCRIPT="$SCRIPT_DIR/polyscope-rollout.py"
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/code/SecPal}"
+BIN_DIR="$HOME/.local/bin"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --workspace-root)
+            WORKSPACE_ROOT="$2"
+            shift 2
+            ;;
+        --source-script)
+            SOURCE_SCRIPT="$2"
+            shift 2
+            ;;
+        --bin-dir)
+            BIN_DIR="$2"
+            shift 2
+            ;;
+        --unit-dir)
+            UNIT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
+SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
+PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
+
+mkdir -p "$BIN_DIR" "$UNIT_DIR"
+ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
+
+cat >"$SERVICE_UNIT" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Sync Polyscope prompts and preview config for SecPal
+
+[Service]
+Type=oneshot
+WorkingDirectory=$WORKSPACE_ROOT/.github
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT
+EOF
+
+cat >"$PATH_UNIT" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Watch SecPal instruction files for Polyscope sync
+
+[Path]
+PathChanged=$WORKSPACE_ROOT/api/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/api/.github/instructions
+PathChanged=$WORKSPACE_ROOT/frontend/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/frontend/.github/instructions
+PathChanged=$WORKSPACE_ROOT/contracts/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/contracts/.github/instructions
+PathChanged=$WORKSPACE_ROOT/android/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/android/.github/instructions
+PathChanged=$WORKSPACE_ROOT/secpal.app/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/secpal.app/.github/instructions
+PathChanged=$WORKSPACE_ROOT/changelog/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/changelog/.github/instructions
+PathChanged=$WORKSPACE_ROOT/.github/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/.github/.github/instructions
+PathChanged=$SOURCE_SCRIPT
+
+[Install]
+WantedBy=default.target
+EOF
+
+"$SYSTEMCTL_BIN" --user daemon-reload
+"$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
+"$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
+
+echo "Installed $INSTALL_TARGET"
+echo "Installed $SERVICE_UNIT"
+echo "Installed $PATH_UNIT"

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -463,13 +463,22 @@ def request_json(api_base: str, path: str, method: str = "GET", body: dict[str, 
         payload = json.dumps(body).encode()
         headers["Content-Type"] = "application/json"
     request = urllib.request.Request(api_base + path, data=payload, headers=headers, method=method)
-    with urllib.request.urlopen(request) as response:
+    with urllib.request.urlopen(request, timeout=30) as response:
         return json.load(response)
 
 
 def load_repo_state(repo_state_file: pathlib.Path) -> dict[str, dict[str, Any]]:
     raw = json.loads(repo_state_file.read_text())
-    return {name: raw[name] for name in REPO_SETTINGS}
+    result: dict[str, dict[str, Any]] = {}
+    for name in REPO_SETTINGS:
+        if name not in raw:
+            raise SystemExit(f"repo-state file is missing entry for '{name}'; regenerate it by running without --repo-state-file")
+        entry = raw[name]
+        for field in ("id", "path"):
+            if field not in entry:
+                raise SystemExit(f"repo-state entry for '{name}' is missing required field '{field}'")
+        result[name] = entry
+    return result
 
 
 def ensure_repositories_registered(api_base: str, repo_specs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -496,6 +505,8 @@ def ensure_repositories_registered(api_base: str, repo_specs: dict[str, dict[str
 
 
 def backup_db(db_path: pathlib.Path) -> pathlib.Path:
+    if not db_path.exists():
+        raise SystemExit(f"Polyscope DB not found at {db_path}; start Polyscope at least once so the DB is created before running this script")
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_path = db_path.parent / f"{db_path.name}.backup-{timestamp}"
     shutil.copy2(db_path, backup_path)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import pathlib
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+
+REPO_SETTINGS: dict[str, dict[str, Any]] = {
+    "api": {
+        "display_name": "SecPal/api",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/php-laravel.instructions.md"],
+        "preview_prefix": "api",
+        "review_focus": "Laravel 13, Pest 4, Request -> Controller -> Service -> Repository -> Model, Sanctum session versus bearer-token flows, and encrypted data handling via *_plain/*_idx without direct *_enc reads.",
+        "link_names": ["frontend", "contracts", "android"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": "https://api-{{folder}}.preview.secpal.dev"},
+            "scripts": {
+                "setup": [
+                    "test -d vendor || composer install",
+                    "test -d node_modules || npm install",
+                    "npm run build",
+                ],
+                "run": [
+                    {"label": "Queue Worker", "command": "php artisan queue:listen --tries=1", "runMode": "replace"},
+                    {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
+                    {"label": "Pest", "command": "php artisan test", "runMode": "preserve"},
+                    {"label": "Pint (dirty)", "command": "vendor/bin/pint --dirty", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review auth surface",
+                    "prompt": "Review the authentication and self-service surface for regressions. Focus on Sanctum session versus bearer-token behavior, route aliases, permission gates, and missing Pest coverage. If frontend behavior or contract shape is involved, ask for the relevant linked workspace before proposing changes.",
+                },
+                {
+                    "label": "Triage failing Pest",
+                    "prompt": "Reproduce the failing behavior, identify the smallest relevant Pest test to add or update first, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "frontend": {
+        "display_name": "SecPal/frontend",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/react-typescript.instructions.md"],
+        "preview_prefix": "frontend",
+        "review_focus": "React, Vite, strict TypeScript, generated API types, Testing Library/MSW boundaries, auth-storage discipline, and transport failure handling.",
+        "link_names": ["api", "contracts", "android"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": "https://frontend-{{folder}}.preview.secpal.dev"},
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "run": [
+                    {"label": "Build Watch", "command": "npx vite build --watch", "autostart": True, "runMode": "replace"},
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
+                    {"label": "Vitest", "command": "npm run test:watch", "runMode": "replace"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review UI/API contract",
+                    "prompt": "Review the touched frontend flow for contract drift, auth-state regressions, transport error handling, and missing Vitest coverage. If the issue touches API responses or auth rules, ask for the linked API workspace before proposing changes.",
+                },
+                {
+                    "label": "Triage failing Vitest",
+                    "prompt": "Reproduce the failing behavior, add or update the smallest relevant test first, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "contracts": {
+        "display_name": "SecPal/contracts",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/openapi.instructions.md"],
+        "preview_prefix": None,
+        "review_focus": "OpenAPI 3.1 as contract-first source of truth, reusable $ref schemas, consistent security schemes, complete response coverage, and Redocly validation.",
+        "link_names": ["api", "frontend"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci"],
+                "run": [
+                    {"label": "Validate", "command": "npm run validate", "runMode": "preserve"},
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "Format Check", "command": "npm run format:check", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review contract drift",
+                    "prompt": "Review the changed OpenAPI contract for breaking shape changes, enum drift, security scheme regressions, and missing example or Redocly validation coverage. If API or frontend implementation is involved, ask for the linked workspace before proposing changes.",
+                },
+                {
+                    "label": "Triage failing Redocly",
+                    "prompt": "Reproduce the failing contract validation, update the smallest relevant schema or example first, then rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "android": {
+        "display_name": "SecPal/android",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/react-capacitor.instructions.md"],
+        "preview_prefix": None,
+        "review_focus": "React plus Capacitor bridge boundaries, managed-mode and device-owner semantics, listener cleanup through remove(), and strict TypeScript around native interop.",
+        "link_names": ["api", "frontend"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci"],
+                "run": [
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
+                    {"label": "Vitest", "command": "npm run test:run", "runMode": "preserve"},
+                    {"label": "Native Verify", "command": "npm run native:verify", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review native boundary",
+                    "prompt": "Review the Android-side change for Capacitor bridge regressions, device-owner or managed-mode side effects, auth bootstrap behavior, and missing focused Vitest coverage. If the web build or API contract is involved, ask for the linked frontend or API workspace before proposing changes.",
+                },
+                {
+                    "label": "Triage Android validation",
+                    "prompt": "Reproduce the failing Android-side behavior, update the smallest relevant test first when possible, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "secpal.app": {
+        "display_name": "SecPal/secpal.app",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/astro-static.instructions.md"],
+        "preview_prefix": "secpal-app",
+        "review_focus": "Astro static rendering, minimal client-side JavaScript, semantic HTML, accessible landmarks, and strict TypeScript on the public site.",
+        "link_names": ["changelog"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": "https://secpal-app-{{folder}}.preview.secpal.dev"},
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "run": [
+                    {"label": "Astro Check", "command": "npm run check", "runMode": "preserve"},
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "Tests", "command": "npm run test", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review site semantics",
+                    "prompt": "Review the marketing-site change for static-build regressions, accessibility drift, semantic HTML changes, and missing test or Astro-check coverage. Keep the work scoped to the touched page or component.",
+                },
+                {
+                    "label": "Triage failing Astro",
+                    "prompt": "Reproduce the failing static-site behavior or Astro check, add or update the smallest relevant validation first, then implement the minimal fix and rerun the touched commands. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "changelog": {
+        "display_name": "SecPal/changelog",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/nextjs-changelog.instructions.md"],
+        "preview_prefix": "changelog",
+        "review_focus": "Next.js static-style changelog output, MDX content rules, Commit template conventions, CSP/feed safety, and no server-side runtime dependencies.",
+        "link_names": ["secpal.app"],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": "https://changelog-{{folder}}.preview.secpal.dev"},
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "run": [
+                    {"label": "Typecheck", "command": "npm run check", "runMode": "preserve"},
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "CSP Check", "command": "npm run csp:check", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review changelog export",
+                    "prompt": "Review the changelog-site change for static export regressions, feed or CSP drift, MDX rendering issues, and missing lint or typecheck coverage. Keep the work scoped to the touched entry or component.",
+                },
+                {
+                    "label": "Triage failing Next build",
+                    "prompt": "Reproduce the failing changelog build or typecheck, update the smallest relevant input first, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    ".github": {
+        "display_name": "SecPal/.github",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [".github/instructions/github-workflows.instructions.md"],
+        "preview_prefix": None,
+        "review_focus": "GitHub Actions permissions, timeout-minutes, pinned actions, reusable workflow invariants, preflight validation, and governance safety over cosmetic cleanup.",
+        "link_names": [],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci"],
+                "run": [
+                    {"label": "Preflight", "command": "./scripts/preflight.sh", "runMode": "preserve"},
+                    {"label": "Copilot Review Scan", "command": "npm run copilot:review:scan", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review workflow governance",
+                    "prompt": "Review the changed governance or workflow files for policy regressions, coverage gaps, permission drift, and missing validation. Keep the change scoped to one workflow or rule set.",
+                },
+                {
+                    "label": "Triage failing preflight",
+                    "prompt": "Reproduce the failing governance validation, update the smallest relevant rule or fixture first, then implement the minimal fix and rerun preflight. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+}
+
+
+def collapse_spaces(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def strip_frontmatter(text: str) -> str:
+    if text.startswith("---\n"):
+        parts = text.split("\n---\n", 1)
+        if len(parts) == 2:
+            return parts[1]
+    return text
+
+
+def extract_bullets_from_lines(lines: list[str]) -> list[str]:
+    bullets: list[str] = []
+    current: list[str] = []
+
+    def flush() -> None:
+        nonlocal current
+        if current:
+            bullets.append(collapse_spaces(" ".join(current)))
+            current = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            flush()
+            current.append(stripped[2:])
+            continue
+        if current and not stripped.startswith("#"):
+            current.append(stripped)
+            continue
+        flush()
+
+    flush()
+    return bullets
+
+
+def extract_all_bullets(text: str) -> list[str]:
+    return extract_bullets_from_lines(strip_frontmatter(text).splitlines())
+
+
+def parse_sections(text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in strip_frontmatter(text).splitlines():
+        heading_match = re.match(r"^##\s+(.*)$", line)
+        if heading_match:
+            if current_heading is not None:
+                sections[current_heading] = extract_bullets_from_lines(current_lines)
+            current_heading = heading_match.group(1).strip()
+            current_lines = []
+            continue
+        if current_heading is not None:
+            current_lines.append(line)
+
+    if current_heading is not None:
+        sections[current_heading] = extract_bullets_from_lines(current_lines)
+
+    return sections
+
+
+def dedupe_keep_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def select_bullets(bullets: list[str], keywords: list[str], limit: int) -> list[str]:
+    lowered_keywords = [keyword.lower() for keyword in keywords]
+    prioritized = [
+        bullet
+        for bullet in bullets
+        if any(keyword in bullet.lower() for keyword in lowered_keywords)
+    ]
+    return dedupe_keep_order(prioritized + bullets)[:limit]
+
+
+def format_bullets(bullets: list[str]) -> str:
+    return "; ".join(bullets)
+
+
+def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
+    repo_specs: dict[str, dict[str, Any]] = {}
+    for repo_name, settings in REPO_SETTINGS.items():
+        spec = copy.deepcopy(settings)
+        repo_path = workspace_root / repo_name
+        spec["path"] = repo_path
+        spec["copilot_instructions"] = repo_path / settings["copilot_instructions"]
+        spec["focus_instruction_paths"] = [repo_path / path for path in settings["focus_instruction_paths"]]
+        repo_specs[repo_name] = spec
+    return repo_specs
+
+
+def instruction_reference(spec: dict[str, Any]) -> str:
+    refs = [str(spec["copilot_instructions"])]
+    refs.extend(str(path) for path in spec["focus_instruction_paths"])
+    return "; ".join(refs)
+
+
+def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
+    copilot_text = pathlib.Path(spec["copilot_instructions"]).read_text()
+    sections = parse_sections(copilot_text)
+    focus_bullets: list[str] = []
+    for focus_path in spec["focus_instruction_paths"]:
+        focus_bullets.extend(extract_all_bullets(pathlib.Path(focus_path).read_text()))
+
+    always_on = select_bullets(
+        sections.get("Always-On Rules", []),
+        ["git status", "tdd", "validate-first", "one topic", "bypass", "changelog", "issue immediately", "domain policy"],
+        7,
+    )
+    validation = select_bullets(
+        sections.get("Required Validation", []),
+        ["scope", "tdd", "validation", "lint", "typecheck", "build", "pest", "preflight", "changelog", "issue", "gpg", "reuse", "no bypass"],
+        8,
+    )
+    triage = select_bullets(
+        sections.get("AI Findings Triage", []),
+        ["prove the defect", "green ci", "compatibility", "refactor", "regression", "security"],
+        5,
+    )
+    focus = select_bullets(
+        focus_bullets,
+        ["test", "validation", "strict typescript", "generated api types", "bridge", "openapi 3.1", "semantic", "permissions", "timeout-minutes", "pint", "form requests", "client-side javascript", "server actions"],
+        6,
+    )
+    issue_pr = select_bullets(
+        sections.get("Issue And PR Discipline", []),
+        ["draft", "english", "body-file", "one topic", "self-review"],
+        5,
+    )
+
+    instruction_ref = instruction_reference(spec)
+    review_prompt = collapse_spaces(
+        f"Apply the current SecPal instructions from {instruction_ref}. "
+        f"Non-negotiable rules: {format_bullets(always_on)}. "
+        f"Repository focus: {spec['review_focus']} "
+        f"Targeted file-scope rules: {format_bullets(focus)}. "
+        f"Review and AI-triage bar: {format_bullets(triage)}. "
+        "If shared auth, contract, mobile, or release behavior crosses repo boundaries, pull the relevant linked workspaces before proposing changes."
+    )
+    pr_prompt = collapse_spaces(
+        f"Write a concise English PR body for {spec['display_name']}. Apply {instruction_ref}. "
+        f"Keep the PR to one topic and reflect the PR discipline: {format_bullets(issue_pr)}. "
+        "Lead with the failing test, validation, or reproduced defect. Then summarize the user-, API-, contract-, or governance-visible change, the validations run, CHANGELOG impact, linked-repo impact, and any out-of-scope issues filed."
+    )
+    draft_pr_prompt = collapse_spaces(
+        f"Create a draft PR in English for {spec['display_name']}. Apply {instruction_ref}. "
+        f"Keep one topic per branch and follow: {format_bullets(issue_pr)}. "
+        "Lead with the failing test, validation, or reproduced defect, summarize the current change and validations already run, and note any linked workspaces or unresolved checks that still need follow-up before marking the PR ready."
+    )
+    merge_prompt = collapse_spaces(
+        f"Before merge for {spec['display_name']}, stop on the first failed check and enforce the current SecPal instructions from {instruction_ref}. "
+        f"Required validation gate: {format_bullets(validation)}. "
+        f"Also enforce: {format_bullets(select_bullets(always_on, ['one topic', 'bypass', 'changelog', 'issue immediately'], 4))}."
+    )
+    merge_and_push_prompt = collapse_spaces(
+        f"Before push and merge for {spec['display_name']}, apply {instruction_ref}. "
+        f"Run or re-run the touched checks demanded by the repo instructions, then verify: {format_bullets(select_bullets(validation, ['validation', 'lint', 'typecheck', 'build', 'pest', 'preflight', 'changelog', 'issue', 'gpg', 'reuse'], 7))}. "
+        "Do not bypass hooks or force operations, and after merge return the repo to the ready state described in the repo instructions."
+    )
+
+    return {
+        "review_prompt": review_prompt,
+        "pr_prompt": pr_prompt,
+        "draft_pr_prompt": draft_pr_prompt,
+        "merge_prompt": merge_prompt,
+        "merge_and_push_prompt": merge_and_push_prompt,
+    }
+
+
+def render_local_config(spec: dict[str, Any]) -> dict[str, Any]:
+    config = copy.deepcopy(spec["local_config"])
+    preamble = collapse_spaces(f"Apply the current SecPal instructions from {instruction_reference(spec)} before taking action.")
+    for task in config.get("tasks", []):
+        task["prompt"] = collapse_spaces(f"{preamble} {task['prompt']}")
+    return config
+
+
+def ensure_exclude(repo_path: pathlib.Path) -> None:
+    exclude_path = repo_path / ".git" / "info" / "exclude"
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = exclude_path.read_text() if exclude_path.exists() else ""
+    if "polyscope.local.json" not in {line.strip() for line in existing.splitlines()}:
+        with exclude_path.open("a") as handle:
+            if existing and not existing.endswith("\n"):
+                handle.write("\n")
+            handle.write("polyscope.local.json\n")
+
+
+def write_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
+    for spec in repo_specs.values():
+        repo_path = pathlib.Path(spec["path"])
+        config_path = repo_path / "polyscope.local.json"
+        config_path.write_text(json.dumps(render_local_config(spec), indent=2) + "\n")
+        ensure_exclude(repo_path)
+
+
+def request_json(api_base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None) -> Any:
+    payload = None
+    headers: dict[str, str] = {}
+    if body is not None:
+        payload = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(api_base + path, data=payload, headers=headers, method=method)
+    with urllib.request.urlopen(request) as response:
+        return json.load(response)
+
+
+def load_repo_state(repo_state_file: pathlib.Path) -> dict[str, dict[str, Any]]:
+    raw = json.loads(repo_state_file.read_text())
+    return {name: raw[name] for name in REPO_SETTINGS}
+
+
+def ensure_repositories_registered(api_base: str, repo_specs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    repos = request_json(api_base, "/repos")
+    by_path = {repo["path"]: repo for repo in repos}
+    state: dict[str, dict[str, Any]] = {}
+
+    for repo_name, spec in repo_specs.items():
+        repo_path = str(spec["path"])
+        repo = by_path.get(repo_path)
+        if repo is None:
+            request_json(
+                api_base,
+                "/repos",
+                method="POST",
+                body={"name": spec["display_name"], "path": repo_path, "base_branch": spec["base_branch"]},
+            )
+            repos = request_json(api_base, "/repos")
+            by_path = {entry["path"]: entry for entry in repos}
+            repo = by_path[repo_path]
+        state[repo_name] = repo
+
+    return state
+
+
+def backup_db(db_path: pathlib.Path) -> pathlib.Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = db_path.parent / f"{db_path.name}.backup-{timestamp}"
+    shutil.copy2(db_path, backup_path)
+    return backup_path
+
+
+def sync_repository_metadata(db_path: pathlib.Path, repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]]) -> pathlib.Path:
+    backup_path = backup_db(db_path)
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    managed_repo_ids = [repo_state[name]["id"] for name in REPO_SETTINGS]
+    placeholders = ", ".join("?" for _ in managed_repo_ids)
+    cur.execute(
+        f"delete from repository_links where repo_id in ({placeholders}) or linked_repo_id in ({placeholders})",
+        managed_repo_ids + managed_repo_ids,
+    )
+
+    for repo_name, spec in repo_specs.items():
+        repo_id = repo_state[repo_name]["id"]
+        for linked_name in spec["link_names"]:
+            cur.execute(
+                "insert or replace into repository_links (repo_id, linked_repo_id) values (?, ?)",
+                (repo_id, repo_state[linked_name]["id"]),
+            )
+
+        prompts = build_prompt_bundle(spec)
+        cur.execute(
+            """
+            update repositories
+            set review_prompt = ?,
+                pr_prompt = ?,
+                draft_pr_prompt = ?,
+                merge_prompt = ?,
+                merge_and_push_prompt = ?
+            where id = ?
+            """,
+            (
+                prompts["review_prompt"],
+                prompts["pr_prompt"],
+                prompts["draft_pr_prompt"],
+                prompts["merge_prompt"],
+                prompts["merge_and_push_prompt"],
+                repo_id,
+            ),
+        )
+
+    conn.commit()
+    conn.close()
+    return backup_path
+
+
+def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
+    api_id = repo_state["api"]["id"]
+    frontend_id = repo_state["frontend"]["id"]
+    secpal_app_id = repo_state["secpal.app"]["id"]
+    changelog_id = repo_state["changelog"]["id"]
+    return textwrap.dedent(
+        f"""
+        server {{
+            listen 80;
+            listen [::]:80;
+            server_name ~^(?<repo>api|frontend|secpal-app|changelog)-(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+
+            location /.well-known/acme-challenge/ {{
+                root /var/www/certbot;
+            }}
+
+            return 301 https://$host$request_uri;
+        }}
+
+        server {{
+            listen 443 ssl;
+            listen [::]:443 ssl;
+            server_name ~^(?<repo>api|frontend|secpal-app|changelog)-(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+
+            access_log /var/log/nginx/preview.secpal.dev.access.log;
+            error_log /var/log/nginx/preview.secpal.dev.error.log;
+
+            client_max_body_size 25m;
+            index index.html index.php;
+
+            ssl_certificate /etc/letsencrypt/live/preview.secpal.dev/fullchain.pem;
+            ssl_certificate_key /etc/letsencrypt/live/preview.secpal.dev/privkey.pem;
+            include /etc/letsencrypt/options-ssl-nginx.conf;
+            ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+            set $api_root /home/secpal/.polyscope/clones/{api_id}/$workspace;
+            set $api_public $api_root/public;
+            set $frontend_root /home/secpal/.polyscope/clones/{frontend_id}/$workspace;
+            set $frontend_dist $frontend_root/dist;
+            set $secpal_app_root /home/secpal/.polyscope/clones/{secpal_app_id}/$workspace;
+            set $secpal_app_dist $secpal_app_root/dist;
+            set $changelog_root /home/secpal/.polyscope/clones/{changelog_id}/$workspace;
+            set $changelog_out $changelog_root/out;
+            set $preview_docroot /home/secpal/.polyscope/empty;
+            set $route_mode static;
+
+            if ($repo = api) {{
+                set $preview_docroot $api_public;
+                set $route_mode api;
+            }}
+
+            if ($repo = frontend) {{
+                set $preview_docroot $frontend_dist;
+            }}
+
+            if ($repo = secpal-app) {{
+                set $preview_docroot $secpal_app_dist;
+            }}
+
+            if ($repo = changelog) {{
+                set $preview_docroot $changelog_out;
+            }}
+
+            root $preview_docroot;
+
+            add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "0" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Origin-Agent-Cluster "?1" always;
+            add_header X-Permitted-Cross-Domain-Policies "none" always;
+
+            location /.well-known/acme-challenge/ {{
+                root /var/www/certbot;
+            }}
+
+            location ~ /\\.(?!well-known) {{
+                deny all;
+            }}
+
+            location / {{
+                try_files $uri $uri/ @preview_router;
+            }}
+
+            location @preview_router {{
+                if ($route_mode = api) {{
+                    rewrite ^ /index.php last;
+                }}
+
+                try_files /index.html =404;
+            }}
+
+            location = /index.php {{
+                if (!-f $api_public/index.php) {{
+                    return 404;
+                }}
+
+                include snippets/fastcgi-php.conf;
+                fastcgi_pass unix:/run/php/php8.4-fpm-secpal-api.sock;
+                fastcgi_param SCRIPT_FILENAME $api_public/index.php;
+                fastcgi_param DOCUMENT_ROOT $api_public;
+                fastcgi_param HTTP_HOST $host;
+            }}
+
+            location ~ \\.php$ {{
+                return 404;
+            }}
+        }}
+        """
+    ).strip() + "\n"
+
+
+def build_summary(repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]], db_backup: pathlib.Path | None, nginx_output: pathlib.Path) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "db_backup": str(db_backup) if db_backup is not None else None,
+        "rendered_nginx_config": str(nginx_output),
+        "repositories": {},
+    }
+    for repo_name, spec in repo_specs.items():
+        prompts = build_prompt_bundle(spec)
+        summary["repositories"][repo_name] = {
+            "id": repo_state[repo_name]["id"],
+            "path": str(spec["path"]),
+            "copilot_instructions": str(spec["copilot_instructions"]),
+            "focus_instruction_paths": [str(path) for path in spec["focus_instruction_paths"]],
+            "linked_repositories": spec["link_names"],
+            "preview_prefix": spec["preview_prefix"],
+            "review_prompt_excerpt": prompts["review_prompt"][:280],
+        }
+    return summary
+
+
+def install_nginx_config(nginx_output: pathlib.Path) -> None:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_target = f"/etc/nginx/sites-available/preview.secpal.dev.bak-{timestamp}"
+    subprocess.run(["sudo", "cp", "/etc/nginx/sites-available/preview.secpal.dev", backup_target], check=True)
+    subprocess.run(["sudo", "install", "-m", "644", str(nginx_output), "/etc/nginx/sites-available/preview.secpal.dev"], check=True)
+    subprocess.run(["sudo", "nginx", "-t"], check=True)
+    subprocess.run(["sudo", "systemctl", "reload", "nginx"], check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync SecPal Polyscope prompts, links, and preview config.")
+    parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
+    parser.add_argument("--db-path", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "polyscope.db")
+    parser.add_argument("--polyscope-api-base", default="http://127.0.0.1:4321/api")
+    parser.add_argument("--repo-state-file", type=pathlib.Path)
+    parser.add_argument("--nginx-output", type=pathlib.Path, default=pathlib.Path.home() / "copilot-preview-secpal-dev.nginx.conf")
+    parser.add_argument("--summary-output", type=pathlib.Path)
+    parser.add_argument("--skip-local-configs", action="store_true")
+    parser.add_argument("--skip-db-sync", action="store_true")
+    parser.add_argument("--install-nginx", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_specs = build_repo_specs(args.workspace_root)
+
+    if not args.skip_local_configs:
+        write_local_configs(repo_specs)
+
+    if args.repo_state_file is not None:
+        repo_state = load_repo_state(args.repo_state_file)
+    else:
+        repo_state = ensure_repositories_registered(args.polyscope_api_base, repo_specs)
+
+    db_backup: pathlib.Path | None = None
+    if not args.skip_db_sync:
+        db_backup = sync_repository_metadata(args.db_path, repo_state, repo_specs)
+
+    args.nginx_output.write_text(render_nginx_config(repo_state))
+
+    if args.install_nginx:
+        install_nginx_config(args.nginx_output)
+
+    summary = build_summary(repo_state, repo_specs, db_backup, args.nginx_output)
+    if args.summary_output is not None:
+        args.summary_output.write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -161,6 +161,15 @@ if [ -f tests/validate-copilot-instructions.sh ]; then
   }
 fi
 
+if [ -f tests/polyscope-rollout.sh ]; then
+  bash tests/polyscope-rollout.sh || {
+    echo "" >&2
+    echo "❌ Polyscope rollout regression test failed!" >&2
+    echo "Fix scripts/polyscope-rollout.py or scripts/install-polyscope-rollout.sh before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4,13 +4,12 @@
 
 set -euo pipefail
 
-SCRIPT_NAME="polyscope-rollout"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_SCRIPT="$REPO_ROOT/scripts/polyscope-rollout.py"
 INSTALL_SCRIPT="$REPO_ROOT/scripts/install-polyscope-rollout.sh"
 
-workspace="$(mktemp -d "${TMPDIR:-/tmp}/${SCRIPT_NAME}.XXXXXX")"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-rollout.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
 workspace_root="$workspace/SecPal"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_NAME="polyscope-rollout"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_SCRIPT="$REPO_ROOT/scripts/polyscope-rollout.py"
+INSTALL_SCRIPT="$REPO_ROOT/scripts/install-polyscope-rollout.sh"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/${SCRIPT_NAME}.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+workspace_root="$workspace/SecPal"
+home_dir="$workspace/home"
+mkdir -p "$workspace_root" "$home_dir"
+
+create_repo() {
+    local repo_name="$1"
+    local copilot_body="$2"
+    local focus_filename="$3"
+    local focus_body="$4"
+
+    local repo_dir="$workspace_root/$repo_name"
+    mkdir -p "$repo_dir/.github/instructions" "$repo_dir/.git/info"
+    printf '%s\n' "$copilot_body" > "$repo_dir/.github/copilot-instructions.md"
+    printf '%s\n' "$focus_body" > "$repo_dir/.github/instructions/$focus_filename"
+    : > "$repo_dir/.git/info/exclude"
+}
+
+common_header='<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->'
+
+create_repo "api" "$common_header
+
+# API Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD is mandatory for behavior and code changes.
+- Update CHANGELOG.md in the same change set for real changes.
+- Never use bypasses such as --no-verify or force-push.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+- Use --body-file when creating or editing multi-line PR bodies.
+
+## Required Validation
+
+- the active branch and PR scope still address exactly one topic
+- TDD happened for any behavior or code change: the relevant Pest test failed first and now passes
+- the smallest relevant Pest coverage for the touched area passed
+- vendor/bin/pint --dirty ran after PHP changes
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "php-laravel.instructions.md" "---
+name: Laravel PHP Rules
+applyTo: '**/*.php'
+---
+
+# Laravel PHP Rules
+
+- Use Form Requests for validation and services for business logic.
+- Add or update the smallest relevant Pest test for each PHP change, then run the affected tests.
+- Use vendor/bin/pint --dirty after changes.
+"
+
+create_repo "frontend" "$common_header
+
+# Frontend Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD is mandatory.
+- Keep one topic per change.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- TDD happened: the relevant test failed first and now passes
+- the smallest relevant validation for the touched area passed: tests, typecheck, and lint when applicable
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "react-typescript.instructions.md" "---
+name: React TypeScript Rules
+applyTo: 'src/**/*.tsx'
+---
+
+# React TypeScript Rules
+
+- Preserve strict TypeScript and generated API types.
+- Test user-visible behavior with Testing Library.
+- Keep load, action, and destructive-flow error state separate.
+"
+
+create_repo "contracts" "$common_header
+
+# Contracts Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD and contract-first discipline are mandatory.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- contract-first and test-first behavior happened
+- the relevant contract validation passed, including npm run lint and formatting when needed
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "openapi.instructions.md" "---
+name: OpenAPI Contract Rules
+applyTo: 'docs/openapi.yaml'
+---
+
+# OpenAPI Contract Rules
+
+- Use OpenAPI 3.1 syntax only.
+- Reuse components with \$ref.
+- Run the relevant Redocly validation and formatting after edits.
+"
+
+create_repo "android" "$common_header
+
+# Android Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD is mandatory for behavior and code changes.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- the smallest relevant validation for the touched area passed: tests, typecheck, and lint when applicable
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "react-capacitor.instructions.md" "---
+name: React Capacitor Rules
+applyTo: 'src/**/*.tsx'
+---
+
+# React Capacitor Rules
+
+- Keep Android enterprise implementation details behind explicit bridge boundaries.
+- Verify bridge-facing behavior with focused unit tests and mocks.
+- For bridge or listener fixes, assert both registration arguments and returned handle behavior.
+"
+
+create_repo "secpal.app" "$common_header
+
+# secpal.app Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- Validate-first.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "astro-static.instructions.md" "---
+name: Astro Static Site Rules
+applyTo: 'src/**/*.astro'
+---
+
+# Astro Static Site Rules
+
+- Prefer semantic HTML, accessible landmarks, and keyboard-safe interactions.
+- Keep client-side JavaScript minimal.
+- Run formatting, lint, typecheck, and build.
+"
+
+create_repo "changelog" "$common_header
+
+# Changelog Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- Validate-first.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "nextjs-changelog.instructions.md" "---
+name: Next.js Changelog Rules
+applyTo: 'src/**/*.tsx'
+---
+
+# Next.js Changelog Rules
+
+- Keep client-side JavaScript minimal.
+- Do not introduce server actions.
+- Run npm run build as the primary validation after source changes.
+"
+
+create_repo ".github" "$common_header
+
+# Org Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD is mandatory for behavior, automation, or executable policy changes.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- TDD happened where executable behavior or validation changed
+- the smallest relevant validation for the touched area passed, and ./scripts/preflight.sh ran for substantial governance or workflow changes
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "github-workflows.instructions.md" "---
+name: GitHub Workflow Rules
+applyTo: '.github/workflows/**/*.yml'
+---
+
+# GitHub Workflow Rules
+
+- Always set timeout-minutes on every job.
+- Set explicit permissions on every workflow.
+- Pin external actions to a specific version.
+"
+
+db_path="$workspace/polyscope.db"
+repos_json="$workspace/repos.json"
+nginx_output="$workspace/preview.secpal.dev.conf"
+summary_output="$workspace/summary.json"
+
+python3 - <<'PY' "$db_path" "$repos_json" "$workspace_root"
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+db_path = Path(sys.argv[1])
+repos_json = Path(sys.argv[2])
+workspace_root = Path(sys.argv[3])
+
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+cur.execute('create table repositories (id text primary key, name text not null, path text not null, created_at text, base_branch text, default_model text, merge_prompt text, pr_prompt text, draft_pr_prompt text, merge_and_push_prompt text, worktree_base_from_origin integer, github_assign_self_enabled integer default 0 not null, review_model text, review_prompt text)')
+cur.execute('create table repository_links (repo_id text not null, linked_repo_id text not null, created_at text default (datetime(\'now\')) not null, primary key (repo_id, linked_repo_id))')
+
+repo_state = {
+    'api': {'id': 'api12345', 'name': 'SecPal/api', 'path': str(workspace_root / 'api')},
+    'frontend': {'id': 'fe123456', 'name': 'SecPal/frontend', 'path': str(workspace_root / 'frontend')},
+    'contracts': {'id': 'co123456', 'name': 'SecPal/contracts', 'path': str(workspace_root / 'contracts')},
+    'android': {'id': 'an123456', 'name': 'SecPal/android', 'path': str(workspace_root / 'android')},
+    'secpal.app': {'id': 'sa123456', 'name': 'SecPal/secpal.app', 'path': str(workspace_root / 'secpal.app')},
+    'changelog': {'id': 'ch123456', 'name': 'SecPal/changelog', 'path': str(workspace_root / 'changelog')},
+    '.github': {'id': 'gh123456', 'name': 'SecPal/.github', 'path': str(workspace_root / '.github')},
+}
+
+for repo in repo_state.values():
+    cur.execute('insert into repositories (id, name, path, created_at, base_branch, github_assign_self_enabled) values (?, ?, ?, datetime(\'now\'), ?, ?)', (repo['id'], repo['name'], repo['path'], 'main', 0))
+
+conn.commit()
+conn.close()
+repos_json.write_text(json.dumps(repo_state, indent=2))
+PY
+
+python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --db-path "$db_path" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$summary_output" \
+    > /dev/null
+
+grep -q 'api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
+grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
+grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
+grep -q 'polyscope.local.json' "$workspace_root/api/.git/info/exclude"
+grep -q 'server_name ~^(?<repo>api|frontend|secpal-app|changelog)-' "$nginx_output"
+grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
+
+python3 - <<'PY' "$db_path" "$summary_output"
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+db_path = Path(sys.argv[1])
+summary_path = Path(sys.argv[2])
+
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+
+api_prompt = cur.execute('select review_prompt from repositories where id = ?', ('api12345',)).fetchone()[0]
+frontend_prompt = cur.execute('select pr_prompt from repositories where id = ?', ('fe123456',)).fetchone()[0]
+links = cur.execute('select repo_id, linked_repo_id from repository_links order by repo_id, linked_repo_id').fetchall()
+
+assert 'api/.github/copilot-instructions.md' in api_prompt
+assert 'php-laravel.instructions.md' in api_prompt
+assert 'Run git status --short --branch before any write action.' in api_prompt
+assert 'Use Form Requests for validation and services for business logic.' in api_prompt
+assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
+assert ('api12345', 'an123456') in links
+assert ('api12345', 'co123456') in links
+assert ('api12345', 'fe123456') in links
+assert ('sa123456', 'ch123456') in links
+
+summary = json.loads(summary_path.read_text())
+assert summary['repositories']['api']['preview_prefix'] == 'api'
+assert summary['repositories']['contracts']['preview_prefix'] is None
+assert summary['repositories']['.github']['linked_repositories'] == []
+PY
+
+fake_bin_dir="$workspace/fake-bin"
+fake_unit_dir="$workspace/fake-units"
+fake_systemctl_dir="$workspace/fake-systemctl"
+fake_systemctl_log="$workspace/systemctl.log"
+mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir"
+
+cat >"$fake_systemctl_dir/systemctl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+chmod +x "$fake_systemctl_dir/systemctl"
+
+HOME="$home_dir" \
+WORKSPACE_ROOT="$workspace_root" \
+SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+SYSTEMCTL_LOG="$fake_systemctl_log" \
+PATH="$fake_systemctl_dir:$PATH" \
+bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir"
+
+test -L "$fake_bin_dir/polyscope-secpal-rollout.py"
+test -x "$fake_bin_dir/polyscope-secpal-rollout.py"
+grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
+grep -q '/.github/scripts/polyscope-rollout.py' "$fake_unit_dir/polyscope-rollout-sync.path"
+grep -q 'daemon-reload' "$fake_systemctl_log"
+grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
+grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -4,12 +4,11 @@
 
 set -euo pipefail
 
-SCRIPT_NAME="validate-copilot-instructions"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURES_DIR="$REPO_ROOT/tests/fixtures/validate-copilot-instructions"
 
-workspace="$(mktemp -d "${TMPDIR:-/tmp}/${SCRIPT_NAME}.XXXXXX")"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/validate-copilot-instructions.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/bin"


### PR DESCRIPTION
## Summary

- version the SecPal Polyscope rollout as repository-managed automation
- add a local installer that deploys the rollout script and enables a systemd user path/service auto-sync hook
- add regression coverage for local config rendering, prompt/link sync, nginx rendering, and installer behavior
- fix the existing portable mktemp regression uncovered by the shell test suite

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## Operational Verification

- deployed the validated rollout snapshot to the VPS under `/home/secpal/.local/share/polyscope-rollout-source`
- enabled `polyscope-rollout-sync.path` and verified the initial sync finished successfully
- verified generated `polyscope.local.json` prompt preambles and synced Polyscope DB review prompts on the VPS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new automation that writes Polyscope repository prompts/links into `~/.polyscope/polyscope.db` and renders/optionally installs preview Nginx config, plus a systemd path-triggered sync installer—mistakes could disrupt developer preview routing or local Polyscope state.
> 
> **Overview**
> Versions SecPal’s Polyscope rollout state as repo-managed automation via `scripts/polyscope-rollout.py`, including generating per-repo `polyscope.local.json`, syncing instruction-derived prompts and cross-repo links into the Polyscope SQLite DB, and deterministically rendering the `preview.secpal.dev` Nginx config (with an optional install/reload step).
> 
> Adds `scripts/install-polyscope-rollout.sh` to install a stable `~/.local/bin/polyscope-secpal-rollout.py` symlink and set up systemd user `polyscope-rollout-sync.service` + `.path` units that re-run sync whenever tracked instruction files or the rollout script change.
> 
> Wires a new `tests/polyscope-rollout.sh` regression test into `scripts/preflight.sh`, and fixes the shell test harness `mktemp` template in `tests/validate-copilot-instructions.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2c64e7a8bb6320fdedc0f8e19a4dcd9bf4d596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->