### PR TITLE
fix: harden Polyscope rollout validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - corrected the generated `api` Polyscope setup so Laravel clones no longer run nonexistent root-level `npm install` or `npm run build` steps, fixing issue-loading failures on the VPS when Polyscope initializes API workspaces
 - hardened `scripts/polyscope-rollout.py` with fail-fast validation for repo-local Polyscope commands, so future rollout drift now aborts immediately when a repo config references missing root manifests, lockfiles, npm scripts, or checked-in relative script paths
 - hardened `tests/polyscope-rollout.sh` so the fake `systemctl` stub receives `SYSTEMCTL_LOG` reliably and path assertions do not depend on the clone directory containing a `/.github/scripts/` segment (local Polyscope workspaces versus GitHub Actions checkouts)
+- pinned Prettier in this repository and run `tests/polyscope-rollout.sh` against `node_modules/.bin/prettier` so generated `polyscope.local.json` formatting checks do not use `npx` at test time; taught rollout validation to surface invalid `package.json` and to reject relative script paths that escape the repository root
 
 ## 2026-05-01 - Remove Stale Admin Model ADR Drift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added `tests/polyscope-rollout.sh` and wired the new automation into the repository's normal shell-test/preflight path, covering local config generation, instruction-derived prompt content, repository-link sync, nginx rendering, and auto-sync unit installation
 - corrected the generated `api` Polyscope setup so Laravel clones no longer run nonexistent root-level `npm install` or `npm run build` steps, fixing issue-loading failures on the VPS when Polyscope initializes API workspaces
 - hardened `scripts/polyscope-rollout.py` with fail-fast validation for repo-local Polyscope commands, so future rollout drift now aborts immediately when a repo config references missing root manifests, lockfiles, npm scripts, or checked-in relative script paths
+- hardened `tests/polyscope-rollout.sh` so the fake `systemctl` stub receives `SYSTEMCTL_LOG` reliably and path assertions do not depend on the clone directory containing a `/.github/scripts/` segment (local Polyscope workspaces versus GitHub Actions checkouts)
 
 ## 2026-05-01 - Remove Stale Admin Model ADR Drift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added `scripts/polyscope-rollout.py` as the versioned source of truth for SecPal Polyscope rollout state, including repo-local `polyscope.local.json` rendering, instruction-derived prompt/link sync into `~/.polyscope/polyscope.db`, and deterministic preview nginx config rendering
 - added `scripts/install-polyscope-rollout.sh` so the VPS can install a stable `~/.local/bin/polyscope-secpal-rollout.py` symlink plus a systemd user `polyscope-rollout-sync.service` and `polyscope-rollout-sync.path` hook that re-syncs Polyscope whenever tracked instruction files change
 - added `tests/polyscope-rollout.sh` and wired the new automation into the repository's normal shell-test/preflight path, covering local config generation, instruction-derived prompt content, repository-link sync, nginx rendering, and auto-sync unit installation
+- corrected the generated `api` Polyscope setup so Laravel clones no longer run nonexistent root-level `npm install` or `npm run build` steps, fixing issue-loading failures on the VPS when Polyscope initializes API workspaces
+- hardened `scripts/polyscope-rollout.py` with fail-fast validation for repo-local Polyscope commands, so future rollout drift now aborts immediately when a repo config references missing root manifests, lockfiles, npm scripts, or checked-in relative script paths
 
 ## 2026-05-01 - Remove Stale Admin Model ADR Drift
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,26 @@
     "": {
       "name": "secpal-github-config",
       "version": "1.0.0",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "devDependencies": {
+        "prettier": "3.5.3"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "keywords": [],
   "author": "SecPal Contributors",
-  "license": "CC0-1.0"
+  "license": "CC0-1.0",
+  "devDependencies": {
+    "prettier": "3.5.3"
+  }
 }

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -445,7 +445,7 @@ def prefix_first_line(prefix: str, text: str) -> str:
     return "\n".join(lines)
 
 
-def render_pretty_json(value: Any, indent: int = 0) -> str:
+def render_pretty_json(value: Any, indent: int = 0, first_line_prefix_len: int = 0) -> str:
     current_indent = "  " * indent
     next_indent = "  " * (indent + 1)
 
@@ -456,8 +456,9 @@ def render_pretty_json(value: Any, indent: int = 0) -> str:
         items = list(value.items())
         lines: list[str] = []
         for index, (key, nested_value) in enumerate(items):
-            rendered_value = render_pretty_json(nested_value, indent + 1)
-            line = prefix_first_line(f"{next_indent}{json.dumps(key)}: ", rendered_value)
+            key_prefix = f"{json.dumps(key)}: "
+            rendered_value = render_pretty_json(nested_value, indent + 1, len(key_prefix))
+            line = prefix_first_line(f"{next_indent}{key_prefix}", rendered_value)
             if index < len(items) - 1:
                 line += ","
             lines.append(line)
@@ -470,7 +471,7 @@ def render_pretty_json(value: Any, indent: int = 0) -> str:
 
         rendered_items = [render_pretty_json(item, indent + 1) for item in value]
         inline_candidate = "[" + ", ".join(rendered_items) + "]"
-        if all("\n" not in item for item in rendered_items) and len(current_indent) + len(inline_candidate) <= 80:
+        if all("\n" not in item for item in rendered_items) and len(current_indent) + first_line_prefix_len + len(inline_candidate) <= 80:
             return inline_candidate
 
         lines: list[str] = []

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -491,10 +491,15 @@ def load_package_scripts(repo_path: pathlib.Path) -> set[str]:
     if not package_json_path.exists():
         return set()
 
-    package_data = json.loads(package_json_path.read_text())
+    raw_text = package_json_path.read_text()
+    try:
+        package_data = json.loads(raw_text)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"invalid package.json for rollout validation ({package_json_path}): {error}") from error
+
     scripts = package_data.get("scripts", {})
     if not isinstance(scripts, dict):
-        return set()
+        raise SystemExit(f"invalid package.json for rollout validation ({package_json_path}): scripts must be an object")
 
     return {str(script_name) for script_name in scripts}
 
@@ -537,8 +542,20 @@ def validate_local_config_command(repo_name: str, repo_path: pathlib.Path, packa
         elif len(tokens) > 1 and tokens[0] in {"bash", "node", "php", "python", "python3"} and tokens[1].startswith("./"):
             relative_path_token = tokens[1]
 
-    if relative_path_token is not None and not (repo_path / relative_path_token[2:]).exists():
-        raise SystemExit(f"{repo_name} polyscope config references missing relative path '{relative_path_token}'")
+    if relative_path_token is not None:
+        suffix = relative_path_token[2:]
+        if not suffix or suffix.startswith("/"):
+            raise SystemExit(f"{repo_name} polyscope config has invalid relative path '{relative_path_token}'")
+        candidate = (repo_path / suffix).resolve()
+        anchor = repo_path.resolve()
+        try:
+            candidate.relative_to(anchor)
+        except ValueError:
+            raise SystemExit(
+                f"{repo_name} polyscope config references relative path outside repo root: '{relative_path_token}'"
+            )
+        if not candidate.exists():
+            raise SystemExit(f"{repo_name} polyscope config references missing relative path '{relative_path_token}'")
 
 
 def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -9,6 +9,7 @@ import copy
 import json
 import pathlib
 import re
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -35,8 +36,6 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "scripts": {
                 "setup": [
                     "test -d vendor || composer install",
-                    "test -d node_modules || npm install",
-                    "npm run build",
                 ],
                 "run": [
                     {"label": "Queue Worker", "command": "php artisan queue:listen --tries=1", "runMode": "replace"},
@@ -437,6 +436,125 @@ def render_local_config(spec: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def prefix_first_line(prefix: str, text: str) -> str:
+    lines = text.splitlines()
+    if not lines:
+        return prefix
+
+    lines[0] = prefix + lines[0]
+    return "\n".join(lines)
+
+
+def render_pretty_json(value: Any, indent: int = 0) -> str:
+    current_indent = "  " * indent
+    next_indent = "  " * (indent + 1)
+
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+
+        items = list(value.items())
+        lines: list[str] = []
+        for index, (key, nested_value) in enumerate(items):
+            rendered_value = render_pretty_json(nested_value, indent + 1)
+            line = prefix_first_line(f"{next_indent}{json.dumps(key)}: ", rendered_value)
+            if index < len(items) - 1:
+                line += ","
+            lines.append(line)
+
+        return "{\n" + "\n".join(lines) + f"\n{current_indent}" + "}"
+
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+
+        rendered_items = [render_pretty_json(item, indent + 1) for item in value]
+        inline_candidate = "[" + ", ".join(rendered_items) + "]"
+        if all("\n" not in item for item in rendered_items) and len(current_indent) + len(inline_candidate) <= 80:
+            return inline_candidate
+
+        lines: list[str] = []
+        for index, rendered_item in enumerate(rendered_items):
+            line = prefix_first_line(next_indent, rendered_item)
+            if index < len(rendered_items) - 1:
+                line += ","
+            lines.append(line)
+
+        return "[\n" + "\n".join(lines) + f"\n{current_indent}" + "]"
+
+    return json.dumps(value)
+
+
+def load_package_scripts(repo_path: pathlib.Path) -> set[str]:
+    package_json_path = repo_path / "package.json"
+    if not package_json_path.exists():
+        return set()
+
+    package_data = json.loads(package_json_path.read_text())
+    scripts = package_data.get("scripts", {})
+    if not isinstance(scripts, dict):
+        return set()
+
+    return {str(script_name) for script_name in scripts}
+
+
+def validate_local_config_command(repo_name: str, repo_path: pathlib.Path, package_scripts: set[str], command: str) -> None:
+    package_json_path = repo_path / "package.json"
+    package_lock_path = repo_path / "package-lock.json"
+    composer_json_path = repo_path / "composer.json"
+    artisan_path = repo_path / "artisan"
+
+    if re.search(r"\bcomposer\s+install\b", command) and not composer_json_path.exists():
+        raise SystemExit(f"{repo_name} polyscope config references composer without a composer.json at the repo root")
+
+    if re.search(r"\bphp\s+artisan\b", command) and not artisan_path.exists():
+        raise SystemExit(f"{repo_name} polyscope config references artisan without an artisan file at the repo root")
+
+    references_npm = any(
+        re.search(pattern, command)
+        for pattern in (r"\bnpm\s+ci\b", r"\bnpm\s+install\b", r"\bnpm\s+run\b", r"\bnpx\b")
+    )
+    if references_npm and not package_json_path.exists():
+        raise SystemExit(f"{repo_name} polyscope config references npm without a package.json at the repo root")
+
+    if re.search(r"\bnpm\s+ci\b", command) and not package_lock_path.exists():
+        raise SystemExit(f"{repo_name} polyscope config references npm ci without a package-lock.json at the repo root")
+
+    for script_name in re.findall(r"\bnpm\s+run\s+([A-Za-z0-9:_-]+)\b", command):
+        if script_name not in package_scripts:
+            raise SystemExit(f"{repo_name} polyscope config references missing npm script '{script_name}'")
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError as error:
+        raise SystemExit(f"{repo_name} polyscope config command could not be parsed: {command}: {error}") from error
+
+    relative_path_token: str | None = None
+    if tokens:
+        if tokens[0].startswith("./"):
+            relative_path_token = tokens[0]
+        elif len(tokens) > 1 and tokens[0] in {"bash", "node", "php", "python", "python3"} and tokens[1].startswith("./"):
+            relative_path_token = tokens[1]
+
+    if relative_path_token is not None and not (repo_path / relative_path_token[2:]).exists():
+        raise SystemExit(f"{repo_name} polyscope config references missing relative path '{relative_path_token}'")
+
+
+def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
+    for repo_name, spec in repo_specs.items():
+        repo_path = pathlib.Path(spec["path"])
+        config = render_local_config(spec)
+        package_scripts = load_package_scripts(repo_path)
+
+        for command in config.get("scripts", {}).get("setup", []):
+            validate_local_config_command(repo_name, repo_path, package_scripts, command)
+
+        for item in config.get("scripts", {}).get("run", []):
+            command = item.get("command")
+            if isinstance(command, str):
+                validate_local_config_command(repo_name, repo_path, package_scripts, command)
+
+
 def ensure_exclude(repo_path: pathlib.Path) -> None:
     exclude_path = repo_path / ".git" / "info" / "exclude"
     exclude_path.parent.mkdir(parents=True, exist_ok=True)
@@ -452,7 +570,7 @@ def write_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
     for spec in repo_specs.values():
         repo_path = pathlib.Path(spec["path"])
         config_path = repo_path / "polyscope.local.json"
-        config_path.write_text(json.dumps(render_local_config(spec), indent=2) + "\n")
+        config_path.write_text(render_pretty_json(render_local_config(spec)) + "\n")
         ensure_exclude(repo_path)
 
 
@@ -720,6 +838,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     repo_specs = build_repo_specs(args.workspace_root)
+
+    validate_repo_local_configs(repo_specs)
 
     if not args.skip_local_configs:
         write_local_configs(repo_specs)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -8,6 +8,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_SCRIPT="$REPO_ROOT/scripts/polyscope-rollout.py"
 INSTALL_SCRIPT="$REPO_ROOT/scripts/install-polyscope-rollout.sh"
+PRETTIER_BIN="$REPO_ROOT/node_modules/.bin/prettier"
+
+if [[ ! -x "$PRETTIER_BIN" ]]; then
+    (cd "$REPO_ROOT" && npm ci)
+fi
+if [[ ! -x "$PRETTIER_BIN" ]]; then
+    echo "expected pinned Prettier at $PRETTIER_BIN after npm ci" >&2
+    exit 1
+fi
 
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-rollout.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
@@ -106,9 +115,13 @@ assert_rollout_rejects_invalid_local_config() {
     local db_copy="$workspace/invalid-polyscope.db"
     local nginx_copy="$workspace/invalid-preview.secpal.dev.conf"
     local summary_copy="$workspace/invalid-summary.json"
+    local invalid_out
+    local invalid_err
 
     script_basename="$(basename "$source_script" .py)"
     script_copy="$workspace/${script_basename}-invalid.py"
+    invalid_out="${script_copy%.py}.stdout"
+    invalid_err="${script_copy%.py}.stderr"
 
     cp "$source_script" "$script_copy"
 
@@ -135,12 +148,12 @@ if python3 "$script_copy" \
         --repo-state-file "$repos_json" \
         --nginx-output "$nginx_copy" \
         --summary-output "$summary_copy" \
-        >/tmp/polyscope-rollout-invalid.stdout 2>/tmp/polyscope-rollout-invalid.stderr; then
+        >"$invalid_out" 2>"$invalid_err"; then
         echo "invalid Polyscope local_config mutation should have failed" >&2
         exit 1
     fi
 
-    grep -q "$expected_error" /tmp/polyscope-rollout-invalid.stderr
+    grep -q "$expected_error" "$invalid_err"
 }
 
 common_header='<!--
@@ -480,7 +493,7 @@ fi
 grep -q 'server_name ~^(?<repo>api|frontend|secpal-app|changelog)-' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 
-npx --yes prettier --check \
+"$PRETTIER_BIN" --check \
     "$workspace_root/api/polyscope.local.json" \
     "$workspace_root/frontend/polyscope.local.json" \
     "$workspace_root/contracts/polyscope.local.json" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -29,6 +29,120 @@ create_repo() {
     : > "$repo_dir/.git/info/exclude"
 }
 
+write_repo_runtime_files() {
+    python3 - <<'PY' "$workspace_root"
+import json
+import sys
+from pathlib import Path
+
+workspace_root = Path(sys.argv[1])
+
+(workspace_root / "api" / "composer.json").write_text("{}\n")
+(workspace_root / "api" / "artisan").write_text("#!/usr/bin/env php\n")
+
+(workspace_root / ".github" / "scripts").mkdir(parents=True, exist_ok=True)
+(workspace_root / ".github" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
+
+package_scripts = {
+    "frontend": {
+        "build": "vite build",
+        "lint": "eslint .",
+        "typecheck": "tsc --noEmit",
+        "test:watch": "vitest",
+    },
+    "contracts": {
+        "validate": "redocly lint docs/openapi.yaml",
+        "lint": "redocly lint docs/openapi.yaml",
+        "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
+    },
+    "android": {
+        "lint": "eslint .",
+        "typecheck": "tsc --noEmit",
+        "test:run": "vitest run --bail=1",
+        "native:verify": "test -f android/settings.gradle",
+    },
+    "secpal.app": {
+        "build": "astro build",
+        "check": "astro check",
+        "lint": "eslint .",
+        "test": "node --test tests/**/*.mjs",
+    },
+    "changelog": {
+        "build": "next build",
+        "check": "tsc --noEmit",
+        "lint": "eslint .",
+        "csp:check": "node scripts/generate-csp.mjs --check",
+    },
+    ".github": {
+        "copilot:review:scan": "./scripts/copilot-review-tool.sh scan",
+    },
+}
+
+for repo_name, scripts in package_scripts.items():
+    repo_dir = workspace_root / repo_name
+    package_json = {
+        "name": repo_name.replace(".", "-"),
+        "private": True,
+        "scripts": scripts,
+    }
+    package_lock = {
+        "name": repo_name.replace(".", "-"),
+        "lockfileVersion": 3,
+        "requires": True,
+        "packages": {},
+    }
+    (repo_dir / "package.json").write_text(json.dumps(package_json, indent=2) + "\n")
+    (repo_dir / "package-lock.json").write_text(json.dumps(package_lock, indent=2) + "\n")
+PY
+}
+
+assert_rollout_rejects_invalid_local_config() {
+    local source_script="$1"
+    local old_text="$2"
+    local new_text="$3"
+    local expected_error="$4"
+    local script_basename
+    local script_copy
+    local db_copy="$workspace/invalid-polyscope.db"
+    local nginx_copy="$workspace/invalid-preview.secpal.dev.conf"
+    local summary_copy="$workspace/invalid-summary.json"
+
+    script_basename="$(basename "$source_script" .py)"
+    script_copy="$workspace/${script_basename}-invalid.py"
+
+    cp "$source_script" "$script_copy"
+
+    python3 - <<'PY' "$script_copy" "$old_text" "$new_text"
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+old_text = sys.argv[2]
+new_text = sys.argv[3].encode("utf-8").decode("unicode_escape")
+contents = script_path.read_text()
+
+if old_text not in contents:
+    raise SystemExit(f"mutation marker not found: {old_text}")
+
+script_path.write_text(contents.replace(old_text, new_text, 1))
+PY
+
+cp "$db_path" "$db_copy"
+
+if python3 "$script_copy" \
+        --workspace-root "$workspace_root" \
+        --db-path "$db_copy" \
+        --repo-state-file "$repos_json" \
+        --nginx-output "$nginx_copy" \
+        --summary-output "$summary_copy" \
+        >/tmp/polyscope-rollout-invalid.stdout 2>/tmp/polyscope-rollout-invalid.stderr; then
+        echo "invalid Polyscope local_config mutation should have failed" >&2
+        exit 1
+    fi
+
+    grep -q "$expected_error" /tmp/polyscope-rollout-invalid.stderr
+}
+
 common_header='<!--
 SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -296,6 +410,8 @@ applyTo: '.github/workflows/**/*.yml'
 - Pin external actions to a specific version.
 "
 
+write_repo_runtime_files
+
 db_path="$workspace/polyscope.db"
 repos_json="$workspace/repos.json"
 nginx_output="$workspace/preview.secpal.dev.conf"
@@ -346,8 +462,33 @@ grep -q 'api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
 grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'polyscope.local.json' "$workspace_root/api/.git/info/exclude"
+if grep -q 'npm install' "$workspace_root/api/polyscope.local.json"; then
+    echo "api polyscope config must not run npm install" >&2
+    exit 1
+fi
+
+if grep -q 'npm run build' "$workspace_root/api/polyscope.local.json"; then
+    echo "api polyscope config must not run npm build" >&2
+    exit 1
+fi
+
+if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
+    echo "api polyscope config must not reference node_modules" >&2
+    exit 1
+fi
+
 grep -q 'server_name ~^(?<repo>api|frontend|secpal-app|changelog)-' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
+
+npx --yes prettier --check \
+    "$workspace_root/api/polyscope.local.json" \
+    "$workspace_root/frontend/polyscope.local.json" \
+    "$workspace_root/contracts/polyscope.local.json" \
+    "$workspace_root/android/polyscope.local.json" \
+    "$workspace_root/secpal.app/polyscope.local.json" \
+    "$workspace_root/changelog/polyscope.local.json" \
+    "$workspace_root/.github/polyscope.local.json" \
+    >/dev/null
 
 python3 - <<'PY' "$db_path" "$summary_output"
 import json
@@ -380,6 +521,18 @@ assert summary['repositories']['api']['preview_prefix'] == 'api'
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['.github']['linked_repositories'] == []
 PY
+
+assert_rollout_rejects_invalid_local_config \
+    "$PYTHON_SCRIPT" \
+    '"test -d vendor || composer install",' \
+    '"test -d vendor || composer install",\n                    "test -d node_modules || npm ci",' \
+    "api polyscope config references npm without a package.json at the repo root"
+
+assert_rollout_rejects_invalid_local_config \
+    "$PYTHON_SCRIPT" \
+    '"command": "npm run copilot:review:scan"' \
+    '"command": "npm run missing:scan"' \
+    ".github polyscope config references missing npm script 'missing:scan'"
 
 fake_bin_dir="$workspace/fake-bin"
 fake_unit_dir="$workspace/fake-units"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -547,18 +547,18 @@ exit 0
 STUB
 chmod +x "$fake_systemctl_dir/systemctl"
 
-HOME="$home_dir" \
-WORKSPACE_ROOT="$workspace_root" \
-SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
-SYSTEMCTL_LOG="$fake_systemctl_log" \
-PATH="$fake_systemctl_dir:$PATH" \
-bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir"
+env HOME="$home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir"
 
 test -L "$fake_bin_dir/polyscope-secpal-rollout.py"
 test -x "$fake_bin_dir/polyscope-secpal-rollout.py"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
-grep -q '/.github/scripts/polyscope-rollout.py' "$fake_unit_dir/polyscope-rollout-sync.path"
+grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"


### PR DESCRIPTION
## Summary
- fix the generated API Polyscope setup so Laravel workspaces no longer reference nonexistent root npm commands
- harden `scripts/polyscope-rollout.py` with fail-fast validation for repo-local manifests, lockfiles, npm scripts, and checked-in relative script paths
- extend `tests/polyscope-rollout.sh` with generic positive and negative coverage for rollout consistency and Prettier-compatible `polyscope.local.json` output

## Validation
- `bash ./tests/polyscope-rollout.sh`
- `python3 ./scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal --summary-output /tmp/polyscope-rollout-summary.json`
- `./scripts/preflight.sh`

## Notes
- `CHANGELOG.md` updated
- no additional out-of-scope issues were identified during this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Polyscope rollout generator to fail fast on invalid repo-local commands and alters the emitted `polyscope.local.json` formatting, which could break existing rollout flows if assumptions differ across repos.
> 
> **Overview**
> Fixes Polyscope workspace generation so the `api` repo no longer emits root-level `npm install`/`npm run build` steps that don’t exist, avoiding VPS initialization failures.
> 
> Adds fail-fast validation in `scripts/polyscope-rollout.py` for repo-local Polyscope commands (presence of `composer.json`/`artisan`/`package.json`/`package-lock.json`, referenced `npm run` scripts, and checked-in `./` script paths that must exist and stay within the repo root), and switches `polyscope.local.json` output to a deterministic pretty-printer.
> 
> Pins `prettier@3.5.3` in this repo and updates `tests/polyscope-rollout.sh` to use the pinned binary, add negative validation cases, and harden the systemd install test environment handling and path assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565f2a961870c83766bb8b5d4dcbd38e610cb7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->