### PR TITLE
Fix mktemp portability regression guard (closes #405)

### DIFF
--- a/tests/mktemp-portability.sh
+++ b/tests/mktemp-portability.sh
@@ -27,10 +27,22 @@ assert_not_contains() {
   fi
 }
 
-# shellcheck disable=SC2016
-assert_contains "$REPO_ROOT/tests/setup-project-board.sh" 'mktemp -d "${TMPDIR:-/tmp}/setup-project-board.XXXXXX"'
-assert_not_contains "$REPO_ROOT/tests/setup-project-board.sh" 'mktemp -d -t setup-project-board.XXXXXX'
-
-# shellcheck disable=SC2016
-assert_contains "$REPO_ROOT/tests/validate-copilot-instructions.sh" 'mktemp -d "${TMPDIR:-/tmp}/validate-copilot-instructions.XXXXXX"'
-assert_not_contains "$REPO_ROOT/tests/validate-copilot-instructions.sh" 'mktemp -d -t validate-copilot-instructions.XXXXXX'
+# Enforce "${TMPDIR:-/tmp}/<name>.XXXXXX" templates across shell tests. The
+# `mktemp -d -t <template>` pattern is not portable between GNU coreutils and BSD/macOS.
+while IFS='|' read -r rel_path slug; do
+  [ -n "${rel_path:-}" ] || continue
+  path="$REPO_ROOT/$rel_path"
+  # Match literal ${TMPDIR:-/tmp} in repository scripts (not shell expansion here).
+  # shellcheck disable=SC2016
+  expected='mktemp -d "${TMPDIR:-/tmp}/'"$slug"'.XXXXXX"'
+  forbidden='mktemp -d -t '"$slug"'.XXXXXX'
+  assert_contains "$path" "$expected"
+  assert_not_contains "$path" "$forbidden"
+done <<'EOF'
+tests/setup-project-board.sh|setup-project-board
+tests/validate-copilot-instructions.sh|validate-copilot-instructions
+tests/audit-closed-epics.sh|audit-closed-epics
+tests/setup-hooks.sh|setup-hooks
+tests/preflight-markdownlint-scope.sh|preflight-markdownlint-scope
+tests/polyscope-rollout.sh|polyscope-rollout
+EOF

--- a/tests/mktemp-portability.sh
+++ b/tests/mktemp-portability.sh
@@ -17,32 +17,26 @@ assert_contains() {
   fi
 }
 
-assert_not_contains() {
-  local path="$1"
-  local unexpected="$2"
-
-  if grep -Fq "$unexpected" "$path"; then
-    echo "Did not expect to find '$unexpected' in $path" >&2
+# Enforce "${TMPDIR:-/tmp}/<basename>.XXXXXX" for every tests/*.sh that uses mktemp
+# (slug matches the script basename so new tests are covered without editing this file).
+# The `mktemp -d -t <template>` pattern is not portable between GNU coreutils and BSD/macOS.
+shopt -s nullglob
+for path in "$REPO_ROOT"/tests/*.sh; do
+  base="${path##*/}"
+  if [ "$base" = "mktemp-portability.sh" ]; then
+    continue
+  fi
+  if ! grep -Fq 'mktemp' "$path"; then
+    continue
+  fi
+  if grep -Fq 'mktemp -d -t' "$path"; then
+    printf 'Non-portable mktemp -d -t usage in tests/%s; use explicit TMPDIR template paths ending in .XXXXXX (see tests/setup-hooks.sh).\n' "$base" >&2
     exit 1
   fi
-}
-
-# Enforce "${TMPDIR:-/tmp}/<name>.XXXXXX" templates across shell tests. The
-# `mktemp -d -t <template>` pattern is not portable between GNU coreutils and BSD/macOS.
-while IFS='|' read -r rel_path slug; do
-  [ -n "${rel_path:-}" ] || continue
-  path="$REPO_ROOT/$rel_path"
+  slug="${base%.sh}"
   # Match literal ${TMPDIR:-/tmp} in repository scripts (not shell expansion here).
   # shellcheck disable=SC2016
   expected='mktemp -d "${TMPDIR:-/tmp}/'"$slug"'.XXXXXX"'
-  forbidden='mktemp -d -t '"$slug"'.XXXXXX'
   assert_contains "$path" "$expected"
-  assert_not_contains "$path" "$forbidden"
-done <<'EOF'
-tests/setup-project-board.sh|setup-project-board
-tests/validate-copilot-instructions.sh|validate-copilot-instructions
-tests/audit-closed-epics.sh|audit-closed-epics
-tests/setup-hooks.sh|setup-hooks
-tests/preflight-markdownlint-scope.sh|preflight-markdownlint-scope
-tests/polyscope-rollout.sh|polyscope-rollout
-EOF
+done
+shopt -u nullglob


### PR DESCRIPTION
## Summary

Issue #405 reports local `./scripts/preflight.sh` failing on the mktemp portability regression check for `tests/validate-copilot-instructions.sh`. Upstream `main` already uses the portable `${TMPDIR:-/tmp}/...` template there.

This change strengthens the regression test so **every** `tests/*.sh` script that calls `mktemp` must keep the same portable pattern (and must not use `mktemp -d -t ...`), matching the documented GNU/BSD portability rationale.

## Changes

- Refactor `tests/mktemp-portability.sh` to drive checks from a small table (relative path + template slug).
- Add coverage for: `audit-closed-epics`, `setup-hooks`, `preflight-markdownlint-scope`, `polyscope-rollout` (existing scripts already use the correct form).

## Verification

- `bash tests/mktemp-portability.sh`
- `shellcheck tests/mktemp-portability.sh`

Closes #405.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only tightens a shell-based regression check and does not change production behavior. Main risk is CI/preflight failures if any test script’s `mktemp` invocation deviates from the expected template.
> 
> **Overview**
> Strengthens `tests/mktemp-portability.sh` by replacing per-file assertions with an automatic scan of all `tests/*.sh` scripts that call `mktemp`.
> 
> The check now **fails fast** on any non-portable `mktemp -d -t ...` usage and requires each matching script to use `mktemp -d "${TMPDIR:-/tmp}/<script-basename>.XXXXXX"`, ensuring future tests follow the GNU/BSD-compatible pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838bf918b2ca26cb0f230eaba44a5c60bf5e46e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->