### PR TITLE
fix: document cursoragent in CLA Assistant allowlist

### DIFF
--- a/.github/CLA_SETUP.md
+++ b/.github/CLA_SETUP.md
@@ -36,9 +36,10 @@ When you link an organization with CLA Assistant:
    - Save configuration
 
 4. **Allowlist Configuration**
-   - Add bot users to allowlist: `bot*`, `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`
+   - Add bot users to allowlist: `bot*`, `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`, `cursoragent`
    - This allows automated PRs without CLA signature
    - Copilot-created pull requests in SecPal currently appear as author `copilot-swe-agent`; keep that exact account in the allowlist alongside Dependabot
+   - Cursor agent-assisted commits can appear in CLA Assistant as `cursoragent`; keep that exact account in the allowlist as well so bot-assisted PRs do not block on `cla/check`
 
 ### How It Works
 
@@ -54,7 +55,7 @@ Changing the allowlist in documentation is not enough. Because CLA Assistant is 
 
 Use this checklist:
 
-1. Confirm the allowlist includes `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent`
+1. Confirm the allowlist includes `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`, and `cursoragent`
 2. Confirm the organization or repository link still points to the current SecPal CLA document
 3. Confirm the expected required status check is `cla/check`
 4. Verify a recent automated PR shows `cla/check` passing instead of blocking on signature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 - `docs/contract-drift/US-001-evidence-matrix.md` and `docs/contract-drift/US-008-validation-and-draft-prs.md` — contract-drift evidence documentation
 - `package.json` — added `test` and `test:openapi-verified-presence` scripts plus `js-yaml` devDependency so the guard runs via `npm run test` (picked up by `npm run --if-present test` in the standard preflight Node install path)
 
+## 2026-05-01 - Document Cursor agent CLA Allowlist Exception
+
+**Changed:**
+
+- documented that Cursor agent-assisted commits can appear in CLA Assistant as `cursoragent` and must be allowlisted alongside `copilot-swe-agent` and the existing Dependabot bot exceptions so `cla/check` does not block bot-assisted pull requests
+
 ## 2026-05-01 - Version Polyscope Cursor Sync And Auto-Refresh
 
 **Changed:**

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ To enable CLA checks in your SecPal repository:
 2. Click "Configure CLA"
 3. Select your repository from the dropdown
 4. Link it to the SecPal CLA Gist (ask an organization admin for the Gist URL)
-5. Add automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` to the CLA Assistant allowlist
+5. Add automated bot identities such as `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`, and `cursoragent` to the CLA Assistant allowlist
 6. Verify that `cla/check` passes on a recent automated PR instead of blocking on signature
 7. If the live CLA Assistant state does not match the documented setup, track that drift in `SecPal/.github` before closing the repository-local symptom issue
 8. Done! CLA Assistant will automatically monitor all pull requests

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -28,7 +28,7 @@ This directory contains reusable GitHub Actions workflow templates for SecPal re
 - All repositories automatically protected
 - Contributors sign via <https://cla-assistant.io/>
 - Signatures are centrally managed
-- Allowlist automated authors such as `dependabot[bot]`, `dependabot-preview[bot]`, and `copilot-swe-agent` directly in CLA Assistant
+- Allowlist automated bot identities such as `dependabot[bot]`, `dependabot-preview[bot]`, `copilot-swe-agent`, and `cursoragent` directly in CLA Assistant
 - Verify the live `cla/check` status on a recent automated PR after changing CLA Assistant settings; documentation alone does not prove the external service is in sync
 - Track any live CLA Assistant config drift in `SecPal/.github` before treating a repository-specific CLA blockage as resolved
 


### PR DESCRIPTION
## Summary

Document `cursoragent` as a required CLA Assistant allowlist entry alongside `copilot-swe-agent` and Dependabot bot identities so `cla/check` does not block Cursor agent-assisted pull requests.

## Changes

- `.github/CLA_SETUP.md`: added `cursoragent` to the allowlist checklist item and added a note explaining when it appears
- `README.md`: updated the repository CLA setup steps to list `cursoragent`
- `workflow-templates/README.md`: updated CLA allowlist bullet to include `cursoragent`
- `CHANGELOG.md`: added entry dated 2026-05-01

## Related

Closes #410

## Validation

Documentation-only change; no executable paths modified. Passes pre-commit hooks (REUSE, Prettier, markdownlint).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; low risk aside from potential confusion if the live CLA Assistant allowlist is not updated to match.
> 
> **Overview**
> Documents `cursoragent` as an additional CLA Assistant allowlist entry (alongside Dependabot and `copilot-swe-agent`) across CLA setup docs so Cursor agent-assisted PRs don’t get blocked by `cla/check`.
> 
> Adds a changelog entry capturing the documentation update and reinforces the verification checklist to confirm the live CLA Assistant configuration includes `cursoragent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca95536f1d0b017fa716d75f5eb592a695806506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->