### PR TITLE
fix: restore generic polyscope preview hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-02 - Restore Generic Polyscope Preview Hosts
+
+**Changed:**
+
+- restored generic Polyscope preview URLs in generated repo-local `polyscope.local.json` files so workspaces resolve as `https://{{folder}}.preview.secpal.dev` again instead of requiring repo-prefixed hostnames
+- updated the rendered preview nginx config to accept both generic and legacy repo-prefixed hosts while keeping the newer `try_files /index.html =404` fallback so missing static outputs return a clean `404` instead of an internal rewrite loop
+- corrected the generated preview nginx missing-workspace fallback so it now points at a non-existent sentinel docroot and returns `404` instead of leaking into directory-index `403` responses
+- updated the Polyscope rollout prompt source so repository-specific prompts and task preambles also include each repo's shared `org-shared.instructions.md` overlay instead of only the repo baseline plus one focus instruction
+- changed the generated frontend Polyscope setup to build preview artifacts in `--mode preview` against the matching `https://api-${PWD##*/}.preview.secpal.dev` host, so each `frontend` workspace now talks to its linked API workspace instead of the shared `api.secpal.dev` host
+- added direct frontend Polyscope run entries for local preview smoke, workspace-preview smoke, workspace-preview authenticated Playwright, and `app.secpal.dev` staging, so browser-E2E flows are available from the workspace without retyping the commands
+- added an API Polyscope run that does `migrate:fresh --seed` and rewrites the seeded preview login to `test@password.com` / `password`, so the linked API workspace can be reset to a known E2E state before authenticated frontend preview runs
+- documented the reserved nginx prefix routing rule (`api-`, `frontend-`, `secpal-app-`, `changelog-`) for preview hosts so future contributors know those prefixes are reserved for legacy per-repo routing
+
 ## 2026-05-02 - Restore Markdown Prettier Compliance
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -25,14 +25,17 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/api",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/php-laravel.instructions.md"],
-        "preview_prefix": "api",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/php-laravel.instructions.md",
+        ],
+        "preview_prefix": None,
         "review_focus": "Laravel 13, Pest 4, Request -> Controller -> Service -> Repository -> Model, Sanctum session versus bearer-token flows, and encrypted data handling via *_plain/*_idx without direct *_enc reads.",
         "link_names": ["frontend", "contracts", "android"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://api-{{folder}}.preview.secpal.dev"},
+            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
             "scripts": {
                 "setup": [
                     "test -d vendor || composer install",
@@ -40,6 +43,11 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 "run": [
                     {"label": "Queue Worker", "command": "php artisan queue:listen --tries=1", "runMode": "replace"},
                     {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
+                    {
+                        "label": "Refresh Preview DB + E2E User",
+                        "command": "php artisan migrate:fresh --seed && php artisan tinker --execute=\"\\App\\Models\\User::where('email', 'test@example.com')->firstOrFail()->forceFill(['email' => 'test@password.com', 'password' => bcrypt('password'), 'email_verified_at' => now()])->save();\"",
+                        "runMode": "preserve",
+                    },
                     {"label": "Pest", "command": "php artisan test", "runMode": "preserve"},
                     {"label": "Pint (dirty)", "command": "vendor/bin/pint --dirty", "runMode": "preserve"},
                 ],
@@ -60,21 +68,52 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/frontend",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/react-typescript.instructions.md"],
-        "preview_prefix": "frontend",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/react-typescript.instructions.md",
+        ],
+        "preview_prefix": None,
         "review_focus": "React, Vite, strict TypeScript, generated API types, Testing Library/MSW boundaries, auth-storage discipline, and transport failure handling.",
         "link_names": ["api", "contracts", "android"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://frontend-{{folder}}.preview.secpal.dev"},
+            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
             "scripts": {
-                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "setup": [
+                    "test -d node_modules || npm ci",
+                    "VITE_API_URL=https://api-${PWD##*/}.preview.secpal.dev npm run build -- --mode preview",
+                ],
                 "run": [
-                    {"label": "Build Watch", "command": "npx vite build --watch", "autostart": True, "runMode": "replace"},
+                    {
+                        "label": "Build Watch",
+                        "command": "VITE_API_URL=https://api-${PWD##*/}.preview.secpal.dev npx vite build --watch --mode preview",
+                        "autostart": True,
+                        "runMode": "replace",
+                    },
                     {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
                     {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
                     {"label": "Vitest", "command": "npm run test:watch", "runMode": "replace"},
+                    {
+                        "label": "Playwright Local Preview Smoke",
+                        "command": "npm run test:e2e:ci",
+                        "runMode": "preserve",
+                    },
+                    {
+                        "label": "Playwright Workspace Preview Smoke",
+                        "command": "CI=true PLAYWRIGHT_BASE_URL=https://frontend-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome",
+                        "runMode": "preserve",
+                    },
+                    {
+                        "label": "Playwright Workspace Preview Authenticated",
+                        "command": "TEST_USER_EMAIL=test@password.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://frontend-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-${PWD##*/}.preview.secpal.dev npx playwright test",
+                        "runMode": "preserve",
+                    },
+                    {
+                        "label": "Playwright Live Staging",
+                        "command": "npm run test:e2e:staging",
+                        "runMode": "preserve",
+                    },
                 ],
             },
             "tasks": [
@@ -93,7 +132,10 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/contracts",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/openapi.instructions.md"],
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/openapi.instructions.md",
+        ],
         "preview_prefix": None,
         "review_focus": "OpenAPI 3.1 as contract-first source of truth, reusable $ref schemas, consistent security schemes, complete response coverage, and Redocly validation.",
         "link_names": ["api", "frontend"],
@@ -124,7 +166,10 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/android",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/react-capacitor.instructions.md"],
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/react-capacitor.instructions.md",
+        ],
         "preview_prefix": None,
         "review_focus": "React plus Capacitor bridge boundaries, managed-mode and device-owner semantics, listener cleanup through remove(), and strict TypeScript around native interop.",
         "link_names": ["api", "frontend"],
@@ -156,14 +201,17 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/secpal.app",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/astro-static.instructions.md"],
-        "preview_prefix": "secpal-app",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/astro-static.instructions.md",
+        ],
+        "preview_prefix": None,
         "review_focus": "Astro static rendering, minimal client-side JavaScript, semantic HTML, accessible landmarks, and strict TypeScript on the public site.",
         "link_names": ["changelog"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://secpal-app-{{folder}}.preview.secpal.dev"},
+            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
             "scripts": {
                 "setup": ["test -d node_modules || npm ci", "npm run build"],
                 "run": [
@@ -188,14 +236,17 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "display_name": "SecPal/changelog",
         "base_branch": "main",
         "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [".github/instructions/nextjs-changelog.instructions.md"],
-        "preview_prefix": "changelog",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/nextjs-changelog.instructions.md",
+        ],
+        "preview_prefix": None,
         "review_focus": "Next.js static-style changelog output, MDX content rules, Commit template conventions, CSP/feed safety, and no server-side runtime dependencies.",
         "link_names": ["secpal.app"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://changelog-{{folder}}.preview.secpal.dev"},
+            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
             "scripts": {
                 "setup": ["test -d node_modules || npm ci", "npm run build"],
                 "run": [
@@ -705,7 +756,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?<repo>api|frontend|secpal-app|changelog)-(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -717,7 +768,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
-            server_name ~^(?<repo>api|frontend|secpal-app|changelog)-(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -738,24 +789,47 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $secpal_app_dist $secpal_app_root/dist;
             set $changelog_root /home/secpal/.polyscope/clones/{changelog_id}/$workspace;
             set $changelog_out $changelog_root/out;
-            set $preview_docroot /home/secpal/.polyscope/empty;
+            set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $route_mode static;
 
-            if ($repo = api) {{
+            if (-f $api_public/index.php) {{
                 set $preview_docroot $api_public;
                 set $route_mode api;
             }}
 
-            if ($repo = frontend) {{
+            if (-f $frontend_dist/index.html) {{
                 set $preview_docroot $frontend_dist;
+                set $route_mode static;
             }}
 
-            if ($repo = secpal-app) {{
+            if (-f $secpal_app_dist/index.html) {{
                 set $preview_docroot $secpal_app_dist;
+                set $route_mode static;
+            }}
+
+            if (-f $changelog_out/index.html) {{
+                set $preview_docroot $changelog_out;
+                set $route_mode static;
             }}
 
             if ($repo = changelog) {{
                 set $preview_docroot $changelog_out;
+                set $route_mode static;
+            }}
+
+            if ($repo = secpal-app) {{
+                set $preview_docroot $secpal_app_dist;
+                set $route_mode static;
+            }}
+
+            if ($repo = frontend) {{
+                set $preview_docroot $frontend_dist;
+                set $route_mode static;
+            }}
+
+            if ($repo = api) {{
+                set $preview_docroot $api_public;
+                set $route_mode api;
             }}
 
             root $preview_docroot;
@@ -779,7 +853,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             }}
 
             location / {{
-                try_files $uri $uri/ @preview_router;
+                try_files $uri @preview_router;
             }}
 
             location @preview_router {{

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -751,6 +751,10 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
     frontend_id = repo_state["frontend"]["id"]
     secpal_app_id = repo_state["secpal.app"]["id"]
     changelog_id = repo_state["changelog"]["id"]
+    # NOTE: workspace names starting with api-, frontend-, secpal-app-, or changelog- are
+    # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
+    # Generic workspaces must not use those prefixes; the regex will treat them as legacy
+    # hosts and route them to the wrong backend.
     return textwrap.dedent(
         f"""
         server {{
@@ -768,7 +772,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
-            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -35,6 +35,16 @@ create_repo() {
     mkdir -p "$repo_dir/.github/instructions" "$repo_dir/.git/info"
     printf '%s\n' "$copilot_body" > "$repo_dir/.github/copilot-instructions.md"
     printf '%s\n' "$focus_body" > "$repo_dir/.github/instructions/$focus_filename"
+    printf '%s\n' "---
+name: Org Shared Rules
+applyTo: '**'
+---
+
+# Org Shared Rules
+
+- Keep changes repo-local, minimal, and consistent with the repository stack.
+- Apply the SecPal domain policy and issue triage rules.
+" > "$repo_dir/.github/instructions/org-shared.instructions.md"
     : > "$repo_dir/.git/info/exclude"
 }
 
@@ -58,6 +68,8 @@ package_scripts = {
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
         "test:watch": "vitest",
+        "test:e2e:ci": "cross-env CI=true playwright test",
+        "test:e2e:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev playwright test",
     },
     "contracts": {
         "validate": "redocly lint docs/openapi.yaml",
@@ -471,9 +483,20 @@ python3 "$PYTHON_SCRIPT" \
     --summary-output "$summary_output" \
     > /dev/null
 
-grep -q 'api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
+grep -q 'https://{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
+grep -q 'org-shared.instructions.md' "$workspace_root/api/polyscope.local.json"
+grep -qF 'php artisan migrate:fresh --seed && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
+grep -qF "test@password.com" "$workspace_root/api/polyscope.local.json"
 grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
+grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
+grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"
+grep -q 'npm run test:e2e:ci' "$workspace_root/frontend/polyscope.local.json"
+grep -qF "PLAYWRIGHT_BASE_URL=https://frontend-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"
+grep -qF "PLAYWRIGHT_API_BASE_URL=https://api-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome' "$workspace_root/frontend/polyscope.local.json"
+grep -qF "TEST_USER_EMAIL=test@password.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://frontend-\${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-\${PWD##*/}.preview.secpal.dev npx playwright test" "$workspace_root/frontend/polyscope.local.json"
+grep -q 'npm run test:e2e:staging' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'polyscope.local.json' "$workspace_root/api/.git/info/exclude"
 if grep -q 'npm install' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not run npm install" >&2
@@ -490,8 +513,35 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-grep -q 'server_name ~^(?<repo>api|frontend|secpal-app|changelog)-' "$nginx_output"
+grep -q 'server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
+grep -qF "try_files \$uri @preview_router;" "$nginx_output"
+grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
+
+if grep -qF "try_files \$uri \$uri/ @preview_router;" "$nginx_output"; then
+    echo "preview nginx config must not treat a missing workspace docroot as a directory hit" >&2
+    exit 1
+fi
+
+if grep -qF '/home/secpal/.polyscope/empty' "$nginx_output"; then
+    echo "preview nginx config must not use a real empty directory as the missing-workspace docroot" >&2
+    exit 1
+fi
+
+api_if_line="$(grep -nF "if (-f \$api_public/index.php) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
+frontend_if_line="$(grep -nF "if (-f \$frontend_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
+secpal_app_if_line="$(grep -nF "if (-f \$secpal_app_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
+changelog_if_line="$(grep -nF "if (-f \$changelog_out/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
+
+test -n "$api_if_line"
+test -n "$frontend_if_line"
+test -n "$secpal_app_if_line"
+test -n "$changelog_if_line"
+
+if (( api_if_line >= frontend_if_line || frontend_if_line >= secpal_app_if_line || secpal_app_if_line >= changelog_if_line )); then
+    echo "generic preview precedence must prefer changelog > secpal.app > frontend > api" >&2
+    exit 1
+fi
 
 "$PRETTIER_BIN" --check \
     "$workspace_root/api/polyscope.local.json" \
@@ -520,9 +570,11 @@ frontend_prompt = cur.execute('select pr_prompt from repositories where id = ?',
 links = cur.execute('select repo_id, linked_repo_id from repository_links order by repo_id, linked_repo_id').fetchall()
 
 assert 'api/.github/copilot-instructions.md' in api_prompt
+assert 'org-shared.instructions.md' in api_prompt
 assert 'php-laravel.instructions.md' in api_prompt
 assert 'Run git status --short --branch before any write action.' in api_prompt
 assert 'Use Form Requests for validation and services for business logic.' in api_prompt
+assert 'Keep changes repo-local, minimal, and consistent with the repository stack.' in api_prompt
 assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
 assert ('api12345', 'an123456') in links
 assert ('api12345', 'co123456') in links
@@ -530,8 +582,9 @@ assert ('api12345', 'fe123456') in links
 assert ('sa123456', 'ch123456') in links
 
 summary = json.loads(summary_path.read_text())
-assert summary['repositories']['api']['preview_prefix'] == 'api'
+assert summary['repositories']['api']['preview_prefix'] is None
 assert summary['repositories']['contracts']['preview_prefix'] is None
+assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
 assert summary['repositories']['.github']['linked_repositories'] == []
 PY
 


### PR DESCRIPTION
## Summary

- restore generic `https://{{workspace}}.preview.secpal.dev` preview URLs in generated Polyscope repo-local config while keeping legacy repo-prefixed hosts working
- extend the rollout generator to include shared org instructions in repo prompts and task preambles
- add preview-mode frontend build and workspace-preview Playwright entries plus an API preview reset command for authenticated E2E flows
- render preview nginx with explicit generic-host precedence `changelog > secpal.app > frontend > api` and a missing-workspace `404` sentinel docroot

## Validation

- `git diff --check`
- `npm exec -- prettier --check CHANGELOG.md`
- `bash -n tests/polyscope-rollout.sh`
- `bash ./tests/polyscope-rollout.sh`
- commit hook: `reuse`, `prettier`, `markdownlint-cli2`, `shellcheck`, whitespace and merge-conflict guards
- `bash ./scripts/install-polyscope-rollout.sh`
- `PYTHONDONTWRITEBYTECODE=1 ./scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal --install-nginx --summary-output /tmp/polyscope-rollout-live-summary.json`
- `curl` verification of generic, legacy, API, and missing preview hosts after nginx reload
- `CI=true PLAYWRIGHT_BASE_URL=https://frontend-dashboard-seed.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-dashboard-seed.preview.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome --reporter=line`

## Notes

- Repo-wide `./scripts/preflight.sh` is still blocked by unrelated Markdown Prettier drift tracked in #414.
- Live verification after rollout showed:
  - `https://dashboard-seed.preview.secpal.dev/` -> `200` (`SecPal Changelog`), proving generic-host precedence
  - `https://changelog-dashboard-seed.preview.secpal.dev/` -> `200`
  - `https://secpal-app-dashboard-seed.preview.secpal.dev/` -> `200`
  - `https://frontend-dashboard-seed.preview.secpal.dev/` -> `200`
  - `https://api-dashboard-seed.preview.secpal.dev/sanctum/csrf-cookie` -> `204`
  - `https://missing-workspace-verify.preview.secpal.dev/` -> `404`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview-host routing and generated Polyscope workspace configs; mistakes could misroute traffic or break preview environments and E2E flows. Changes are deterministic and covered by updated rollout tests, reducing blast radius.
> 
> **Overview**
> Restores generic Polyscope preview URLs (`https://{{folder}}.preview.secpal.dev`) across generated `polyscope.local.json` configs and removes per-repo `preview_prefix` usage (while keeping legacy repo-prefixed hosts working).
> 
> Updates preview nginx rendering to accept both generic and legacy host patterns, route generic hosts by *artifact presence* with explicit precedence (changelog > secpal.app > frontend > api), and return clean `404`s for missing workspaces/static outputs (sentinel docroot + `try_files /index.html =404`).
> 
> Extends rollout-generated prompts/tasks to always include `org-shared.instructions.md`, adds frontend preview-mode build + Playwright run entries wired to the matching `api-<workspace>.preview` host, and adds an API command to reset preview DB + seed a known E2E login; rollout tests are expanded to assert these behaviors and guard against nginx regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826ab4019329af0caa110602644db5ae592f401b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->