### PR TITLE
fix: restore markdown preflight compliance

### DIFF
--- a/.github/CLA_SETUP.md
+++ b/.github/CLA_SETUP.md
@@ -23,15 +23,18 @@ When you link an organization with CLA Assistant:
 ### Initial Organization Configuration
 
 1. **Sign in to CLA Assistant**
+
    - Visit <https://cla-assistant.io/>
    - Sign in with your GitHub account (requires **owner** access to SecPal organization)
 
 2. **Link Organization**
+
    - Click "Link Organization" button
    - Grant CLA Assistant the required authorization scopes to create webhooks for the organization
    - Select `SecPal` organization
 
 3. **Configure CLA**
+
    - Link CLA document: `https://github.com/SecPal/.github/blob/main/CLA.md`
    - Save configuration
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,11 +65,11 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Install Prettier
-        run: npm install -g prettier
+      - name: Install Node dependencies
+        run: npm ci
 
       - name: Run Prettier Check
-        run: prettier --check '**/*.{md,yml,yaml,json}'
+        run: npx prettier --check '**/*.{md,yml,yaml,json}'
 
   markdown-lint:
     name: Lint Markdown Files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,12 @@ repos:
       - id: reuse
 
   # Code formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: Prettier
+        entry: bash -c 'npx --yes prettier@3.5.3 --write "$@"' --
+        language: system
         types_or: [markdown, yaml, json, javascript]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Changed:**
 
-- reformatted the pre-existing Markdown drift in `.github/CLA_SETUP.md`, `SECURITY.md`, `docs/adr/*.md`, `docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md`, `docs/development-principles.md`, `docs/feature-requirements.md`, `docs/ideas-backlog.md`, and `scripts/README.md` so repo-wide `./scripts/preflight.sh` no longer fails for unrelated topic branches on documentation-only Prettier issues
+- aligned the local pre-commit Prettier hook and this repository's code-quality workflow to the pinned repository Prettier `3.5.3`, so commit hooks, local `./scripts/preflight.sh`, and repo CI check the same formatter version instead of drifting between `pre-commit` mirror releases and npm-installed Prettier
+- reformatted the pre-existing Markdown drift in `CHANGELOG.md`, `.github/CLA_SETUP.md`, `SECURITY.md`, `docs/adr/*.md`, `docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md`, `docs/development-principles.md`, `docs/feature-requirements.md`, `docs/ideas-backlog.md`, and `scripts/README.md` so repo-wide `./scripts/preflight.sh` no longer fails for unrelated topic branches on documentation-only Prettier issues
 
 ## 2026-05-02 - Add OpenAPI Verified-Endpoint Presence Guard
 
@@ -561,6 +562,7 @@ are the reliable way to keep organization principles and repository-specific gui
 **Changed:**
 
 - **`.github/copilot-config.yaml`** - Extended AI source of truth with additional principles
+
   - Added `kiss`: Keep It Simple, Stupid principle
   - Added `yagni`: You Aren't Gonna Need It principle
   - Added `separation_of_concerns`: Controller → Service → Repository pattern
@@ -621,6 +623,7 @@ api/
 **Changed:**
 
 - **`.codecov.yml` configuration** - Adjusted to allow Dependabot PRs while maintaining coverage enforcement
+
   - Set `require_ci_to_pass: false` - Codecov won't wait for CI checks before reporting
   - Set `wait_for_ci: false` - Don't wait for all CI to complete
   - Kept `informational: false` - Coverage remains **REQUIRED** for normal developer PRs
@@ -666,6 +669,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 **Added:**
 
 - **Critical Rule #6: Issue Management Protocol** - ZERO TOLERANCE enforcement for immediate issue creation
+
   - MANDATORY: Create GitHub issue immediately when bug/issue found in old code that cannot be fixed now
   - MANDATORY: EPIC + sub-issues structure for ALL features requiring >1 PR (>600 lines, multi-module, >1 day work)
   - Top-level `issue_management` section in `copilot-config.yaml` (200+ lines) with complete protocol, workflows, examples
@@ -684,11 +688,13 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 **Changed:**
 
 - **Streamlined `review_automation` section** - Replaced 70-line `issue_management` subsection with concise cross-reference
+
   - Maintains DRY principle: Single authoritative source for issue management rules
   - Old section duplicated information now in top-level `issue_management` section
   - Reduced review_automation from 180 lines to ~115 lines
 
 - **Pre-Commit Checklist enhanced** - Added "Issue Creation Protocol" item (4 validation points)
+
   - "All discovered bugs/improvements have GitHub issues?"
   - "No 'TODO: fix later' comments without issue reference?"
   - "Complex features (>1 PR) have EPIC + sub-issues structure?"
@@ -712,6 +718,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 **Added:**
 
 - **SOLID Principles:** Added comprehensive SOLID principles to core development guidelines
+
   - Single Responsibility Principle (SRP): One class/function = one reason to change
   - Open/Closed Principle (OCP): Open for extension, closed for modification
   - Liskov Substitution Principle (LSP): Subtypes must be substitutable for base types
@@ -720,6 +727,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
   - Documentation added to both `.github/copilot-instructions.md` and `.github/copilot-config.yaml`
 
 - **English-Only Communication Rule:** Clarified language policy for GitHub communication
+
   - All issues, PRs, comments, and documentation MUST be in English
   - Ensures accessibility for international contributors
   - Exceptions: German legal documents (CLA, licenses) and user-facing i18n translations
@@ -734,6 +742,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 **Changed:**
 
 - **Pre-Commit Checklist (Markdown & YAML):** Updated with new validation items
+
   - Added SOLID Principles check to both markdown documentation and YAML source of truth
   - Added English Only communication check to both markdown and YAML
   - Added No Literal Quotes check to both markdown and YAML
@@ -741,6 +750,7 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
   - YAML `copilot-config.yaml:checklists.pre_commit` is the authoritative source
 
 - **Core Development Principles:** Restructured and expanded
+
   - DRY (Don't Repeat Yourself) now part of formal development principles
   - Quality Over Speed explicitly documented (removed from Critical Rules to avoid duplication)
   - All principles with validation guidance and examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-02 - Restore Markdown Prettier Compliance
+
+**Changed:**
+
+- reformatted the pre-existing Markdown drift in `.github/CLA_SETUP.md`, `SECURITY.md`, `docs/adr/*.md`, `docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md`, `docs/development-principles.md`, `docs/feature-requirements.md`, `docs/ideas-backlog.md`, and `scripts/README.md` so repo-wide `./scripts/preflight.sh` no longer fails for unrelated topic branches on documentation-only Prettier issues
+
 ## 2026-05-02 - Add OpenAPI Verified-Endpoint Presence Guard
 
 **Added:**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,20 +118,24 @@ All PRs automatically run:
 ### Secure Development Guidelines
 
 1. **Never commit secrets:**
+
    - Use environment variables (`.env`)
    - Utilize secret management services
    - Enable push protection (automatically enabled)
 
 2. **Keep dependencies updated:**
+
    - Dependabot creates PRs daily (04:00 CET)
    - Security updates have priority
    - Review and merge promptly
 
 3. **Follow OWASP Top 10:**
+
    - [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
    - Regular security training encouraged
 
 4. **Validate all inputs:**
+
    - Server-side validation (never trust client)
    - Sanitize outputs to prevent XSS
    - Use framework's built-in protection (Laravel, React)

--- a/docs/adr/20251027-event-sourcing-for-guard-book.md
+++ b/docs/adr/20251027-event-sourcing-for-guard-book.md
@@ -67,18 +67,21 @@ Write Side (Commands)          Read Side (Queries)
 ### Implementation Components
 
 1. **Event Store Table** (`guard_book_events`):
+
    - Stores ALL changes as immutable events
    - SHA-256 checksum per event
    - Chain linking (previous_event_id)
    - PostgreSQL Row-Level Security (RLS) for append-only enforcement
 
 2. **Projection Tables** (e.g., `guard_book_entries`):
+
    - Materialized views for fast queries
    - Built from event stream
    - Can be rebuilt anytime via event replay
    - Allows soft deletes (events remain!)
 
 3. **Event Store Service**:
+
    - `appendEvent()` - Write new events
    - `verifyIntegrity()` - Check chain integrity
    - `replayEvents()` - Rebuild projections

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -18,6 +18,7 @@ SPDX-License-Identifier: CC0-1.0
 This ADR defines the architecture for flexible, unlimited-depth organizational hierarchies in SecPal. **Two independent hierarchical systems** are implemented:
 
 1. **Internal Structure** (`organizational_units`): Security service company hierarchy (Holding → Company → Region → Branch → Division)
+
    - For **internal employees** (Guards, Managers, explicitly scoped operators)
    - Access control via `user_internal_organizational_scopes`
    - Fine-grained RBAC: From branch-wide access down to specific object areas
@@ -1028,11 +1029,13 @@ DB::transaction(function () use ($unit, $newParent) {
 ## References
 
 - **Related ADRs:**
+
   - [ADR-001: Event Sourcing for Guard Book Entries](20251027-event-sourcing-for-guard-book.md)
   - [ADR-004: RBAC System with Spatie Laravel-Permission](20251108-rbac-spatie-temporal-extension.md)
   - [ADR-005: RBAC Design Decisions](20251111-rbac-design-decisions.md)
 
 - **Related Issues:**
+
   - Issue #5: RBAC System (Scope-based permissions)
   - Future Epic: Flexible Organizational Structure (TBD)
 
@@ -1054,6 +1057,7 @@ DB::transaction(function () use ($unit, $newParent) {
 **Two Independent Systems:**
 
 1. **Internal Organizational Structure** (`organizational_units`)
+
    - Security service company hierarchy (Holding → Region → Branch)
    - For **internal employees only** (Guards, Managers, explicitly scoped operators)
    - Access control via `user_internal_organizational_scopes`

--- a/docs/adr/20251221-activity-logging-audit-trail-strategy.md
+++ b/docs/adr/20251221-activity-logging-audit-trail-strategy.md
@@ -48,6 +48,7 @@ SecPal requires a **legally compliant, tamper-proof audit trail** for all user a
 #### Business Requirements
 
 1. **Comprehensive Logging:**
+
    - All CRUD operations on critical data (employees, contracts, salaries)
    - Authentication events (login, logout, failed attempts)
    - Permission changes (role assignments, scope modifications)
@@ -55,16 +56,19 @@ SecPal requires a **legally compliant, tamper-proof audit trail** for all user a
    - Data exports and reports
 
 2. **Organizational Scope Isolation:**
+
    - Regional subsidiaries see only their logs
    - Parent organizations cannot access blocked subsidiary logs
    - Respects inheritance blocking (ADR-009)
 
 3. **Tamper-Proof Evidence:**
+
    - Detect any modification or deletion of log entries
    - Cryptographically verifiable integrity
    - Legally admissible in court proceedings
 
 4. **Performance:**
+
    - Logging must not impact application performance
    - Fast queries for audit dashboards
    - Efficient storage for millions of logs

--- a/docs/adr/20251227-simplify-management-level-to-integer-field-adr011.md
+++ b/docs/adr/20251227-simplify-management-level-to-integer-field-adr011.md
@@ -177,20 +177,24 @@ UserInternalOrganizationalScope::create([
 ### Positive
 
 1. ✅ **Massive Code Reduction:**
+
    - Backend: -2536 lines (removed LeadershipLevel model, controller, policies, migrations, tests)
    - Frontend: -3211 lines (removed LeadershipLevel management UI)
    - **Total: -5747 lines removed** 🎉
 
 2. ✅ **Simpler Schema:**
+
    - Single integer field instead of foreign key relationship
    - No separate table to manage
    - Faster queries (no JOIN needed)
 
 3. ✅ **Easier Migrations:**
+
    - Pre-1.0 (0.x.x): Can use `migrate:fresh --seed`
    - Direct field updates instead of model synchronization
 
 4. ✅ **Consistent with Industry Standards:**
+
    - 1 = CEO (highest authority)
    - 2 = Branch Director
    - 3 = Area Manager
@@ -201,6 +205,7 @@ UserInternalOrganizationalScope::create([
    - 0 = Non-management (Guards)
 
 5. ✅ **Preserved Core Functionality:**
+
    - Hierarchical access control still works (ADR-009)
    - Organizational scopes unchanged
    - Permission inheritance blocking unchanged
@@ -214,11 +219,13 @@ UserInternalOrganizationalScope::create([
 ### Negative
 
 1. ⚠️ **No Custom Level Names:**
+
    - Cannot define tenant-specific names (e.g., "ML3 - Regional Manager")
    - Workaround: Use organizational unit structure instead
    - Impact: LOW (not required for MVP)
 
 2. ⚠️ **No Level Descriptions:**
+
    - Cannot add metadata (responsibilities, access rights, salary ranges)
    - Workaround: Document in organizational policies
    - Impact: LOW (nice-to-have feature)
@@ -478,6 +485,7 @@ it('requires dual scopes to view all employees', function () {
 ## Related Decisions
 
 - **ADR-009:** Permission Inheritance Blocking & Leadership-Based Access Control
+
   - Status: **Partially Updated** (organizational scopes preserved, LeadershipLevel model removed)
   - Scope filtering logic unchanged (min/max viewable rank still works)
   - Dual scope pattern still required for full access

--- a/docs/adr/20260406-single-app-android-distribution-and-private-provisioning-adr012.md
+++ b/docs/adr/20260406-single-app-android-distribution-and-private-provisioning-adr012.md
@@ -76,10 +76,12 @@ Provisioning QR rules are:
 ## Alternatives Considered
 
 1. **Split Android distribution into multiple packages**
+
    - Pro: clearer separation between managed and unmanaged installs
    - Contra: breaks the single-product experience and complicates signing, updates, and support
 
 2. **Publish a public static provisioning QR code**
+
    - Pro: simpler first rollout
    - Contra: exposes provisioning data publicly and does not support audited, permission-gated enrollment
 

--- a/docs/adr/20260415-issue-first-planning-governance-adr013.md
+++ b/docs/adr/20260415-issue-first-planning-governance-adr013.md
@@ -69,10 +69,12 @@ The documentation action plan attached to this decision is:
 ## Alternatives Considered
 
 1. **GitHub Issues plus actively maintained Project Board as dual canonical sources**
+
    - Pro: strong visual planning workflow
    - Contra: creates two places where status can drift and increases maintenance cost
 
 2. **Project Board as primary planning source**
+
    - Pro: easy visual triage
    - Contra: weak auditability, poor durability for acceptance criteria, and unsuitable as a public roadmap source
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ What are the positive and negative outcomes?
 What other options did we evaluate?
 
 1. **Option 1:** Description
+
    - Pro: ...
    - Contra: ...
 

--- a/docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md
+++ b/docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md
@@ -58,17 +58,20 @@
 ### Security-Sensitive Patterns Reviewed
 
 1. **Cryptographic weaknesses** (finding #1, #2):
+
    - Merkle tree second-preimage attack documented with full explanation
    - Fix provided with domain separation prefixes
    - ✅ Correctly identifies breaking change needed before release
 
 2. **Race conditions** (findings #4, #5, #10, #12, #13):
+
    - TOCTOU in onboarding token completion documented
    - Employee status transition race confirmed
    - Cache deletion race in frontend identified
    - ✅ All include timing scenarios and probability assessment
 
 3. **Data exposure** (finding #6):
+
    - Sensitive employee fields (tax ID, SSN, documents) over-exposed
    - ✅ Correctly identifies least-privilege violation
    - ✅ Permission-based fix suggested

--- a/docs/development-principles.md
+++ b/docs/development-principles.md
@@ -455,14 +455,17 @@ function updateCustomer(customer: Customer, data: UpdateData): Customer {
 **Rules:**
 
 1. **Always Validate Input**
+
    - Use DTOs/Form Requests/Zod schemas
    - Never trust user input
 
 2. **Never Log Sensitive Data**
+
    - ❌ Don't: `logger.info('Password:', password)`
    - ✅ Do: `logger.info('User authenticated', { userId })`
 
 3. **Encrypt at Rest**
+
    - Use encryption casts/transformers
    - Store sensitive data encrypted
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -41,6 +41,7 @@ Security companies have different organizational structures and job titles:
 **Requirements:**
 
 1. **Predefined Roles (Templates):**
+
    - HR / Compliance Reviewer (broad personnel and compliance access)
    - Company Manager (organization-wide access)
    - Operations Manager (shift planning, reporting)
@@ -50,6 +51,7 @@ Security companies have different organizational structures and job titles:
    - Client (read-only, restricted)
 
 2. **Custom Roles:**
+
    - ✅ Users can create custom roles
    - ✅ Define permissions per role (granular)
    - ✅ Rename roles to match company terminology
@@ -807,20 +809,24 @@ Acceptance Criteria:
 #### Organizational Structure Rules
 
 1. **No Artificial Depth Limits:**
+
    - System must support hierarchies from 1 level (flat) to 10+ levels (holding structures)
    - No hardcoded "maximum depth" constraint
 
 2. **Flexible Unit Types:**
+
    - Predefined types: Holding, Company, Region, Branch, Division
    - Support custom types (e.g., "Department", "Team")
    - Custom types must have same capabilities as predefined types
 
 3. **Single Tenant Isolation:**
+
    - Each security service company is isolated tenant
    - Cannot see or access other tenants' data
    - Organizational units are tenant-scoped
 
 4. **Hierarchical Access Inheritance:**
+
    - Access to parent organizational unit can include all descendants (configurable)
    - Regional Manager with "include descendants" sees all branches in region
    - Branch Manager with "exclude descendants" sees only own branch
@@ -833,18 +839,21 @@ Acceptance Criteria:
 #### Customer Hierarchy Rules
 
 1. **Independence from Internal Structure:**
+
    - Customer hierarchies are **completely separate** from internal organizational units
    - Customer users do NOT see which branch manages them
    - Internal employees see both structures (for management)
    - Link between customer and managing unit is internal-only metadata
 
 2. **Read-Only Customer Access:**
+
    - Customer users (Client role) have read-only access by default
    - Cannot create, update, or delete guard book entries
    - Cannot see internal employee data or organizational structure
    - Exception: Customer admins can manage their own customer users
 
 3. **Hierarchical Customer Access:**
+
    - Corporate customer user can access all descendant customers' objects
    - Regional customer user limited to own region
    - Local customer user limited to specific objects
@@ -859,11 +868,13 @@ Acceptance Criteria:
 #### Object Area Segmentation Rules
 
 1. **Optional Segmentation:**
+
    - Small objects: Single guard book for entire object (default)
    - Large objects: Multiple areas with separate guard books (optional)
    - Decision made per object based on operational needs
 
 2. **Area-Specific Guard Books:**
+
    - Each area can require separate guard book (configurable)
    - Guards assigned to area only access that area's guard book
    - Parent object must exist before areas can be created
@@ -877,12 +888,14 @@ Acceptance Criteria:
 #### Guard Book Report Rules
 
 1. **Event Stream Model:**
+
    - Guard books are continuous event streams (not closed physical books)
    - No manual "closing" of books at month-end
    - Reports generated on-demand for any time period
    - Historical events remain accessible indefinitely
 
 2. **Report Filters:**
+
    - Time period (start date/time, end date/time)
    - Event types (incident, patrol, maintenance, access control, alarm, note)
    - Severity (critical, high, medium, low)
@@ -948,6 +961,7 @@ SecPal uses the **Closure Table Pattern** for storing and querying hierarchical 
 **Two Independent Hierarchies:**
 
 1. **Internal Structure** (`organizational_units`):
+
    - Security service company hierarchy (Holding → Region → Branch)
    - For internal employees (Guards, Managers, Admins)
    - Access control via `user_internal_organizational_scopes`
@@ -987,17 +1001,20 @@ SecPal/api#228 - Epic: Flexible Organizational Structure & Multi-Level Hierarchi
 ### Future Enhancements
 
 1. **Geofencing (Post-MVP):**
+
    - GPS verification for guard check-ins at specific areas
    - Alerts when guard entries are created outside area boundaries
    - Requires legal review and works council approval
 
 2. **Advanced Reporting (Phase 2):**
+
    - Automated scheduled reports (daily, weekly, monthly)
    - Comparison reports (current vs. previous period)
    - Trend analysis (incident frequency over time)
    - Multi-area combined reports with area breakdown
 
 3. **Organizational Structure Versioning (Phase 2):**
+
    - Historical tracking of organizational changes
    - "Point-in-time" queries (what was the structure on date X?)
    - Audit trail for compliance
@@ -1082,18 +1099,21 @@ on Employee updated (status: active → terminated):
 For each automatic action, implementers MUST follow these error handling guidelines:
 
 1. **User account creation fails (e.g., email already exists, validation error):**
+
    - Log the error with full context (employee ID, error message).
    - Abort onboarding flow for this employee; do NOT proceed to send onboarding email.
    - Notify HR/operations staff via dashboard alert or email.
    - Status remains `pre_contract` until resolved manually.
 
 2. **Email sending fails (e.g., SMTP error, invalid email):**
+
    - Log the error with full context.
    - Queue a retry operation (max 3 attempts, exponential backoff).
    - If all retries fail, notify HR/operations staff for manual intervention.
    - Do NOT activate employee until onboarding email is successfully sent.
 
 3. **Role assignment fails (e.g., role doesn't exist):**
+
    - Log the error and abort role assignment.
    - Do NOT activate employee account; status remains unchanged.
    - Notify system administrator to resolve missing role configuration.
@@ -2999,6 +3019,7 @@ Guards must patrol routes and scan checkpoints to prove presence.
 **Technologies:**
 
 1. **NFC Tags** (**Primary - Recommended**)
+
    - NFC tags mounted at checkpoints (tamper-resistant housing)
    - Guard taps phone to scan
    - **Advantages:**
@@ -3011,6 +3032,7 @@ Guards must patrol routes and scan checkpoints to prove presence.
    - **Use Case:** Professional installations where reliability matters
 
 2. **QR Codes** (Cost-Effective Alternative)
+
    - Print QR codes, mount at checkpoints (laminated/weatherproof)
    - Guard scans with phone camera
    - **Advantages:**

--- a/docs/ideas-backlog.md
+++ b/docs/ideas-backlog.md
@@ -927,12 +927,14 @@ Managers need to send important information to all employees or specific groups 
 **Example Use Cases:**
 
 1. **Weather Emergency:**
+
    - "Due to heavy snowfall, Object B is closed today. Scheduled employees will be reassigned."
    - Target: All employees scheduled for Object B today
    - Urgent flag: Yes
    - Channels: Email + Push + SMS
 
 2. **Policy Update:**
+
    - "New GDPR training required for all employees. Deadline: 30.11.2025."
    - Target: All active employees
    - Acknowledgment required: Yes

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,23 +73,28 @@ Validates Copilot instructions and configuration files across all repositories.
 **Tests Performed:**
 
 1. **File Existence**
+
    - Checks for `copilot-instructions.md`
    - `copilot-config.yaml` check always skips (file removed 2026-04-11)
 
 2. **REUSE Compliance**
+
    - Validates `copilot-instructions.md.license` exists
    - `copilot-config.yaml.license` check always skips (file removed 2026-04-11)
    - Verifies CC0-1.0 license
 
 3. **Markdown Linting**
+
    - Runs markdownlint-cli2 on instructions
    - Suggests auto-fix command on failure
 
 4. **YAML Syntax**
+
    - Validates YAML syntax using yq
    - Skips if yq not installed
 
 5. **Inheritance Check**
+
    - Verifies `@EXTENDS` reference in repo-specific instructions
    - Skips for org-level instructions
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ git fetch origin "$BASE" 2>/dev/null || true
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
-  npx --yes prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
+  npx --yes prettier@3.5.3 --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
   npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
 fi
 # Workflow linting is enforced by pre-commit hooks and CI.


### PR DESCRIPTION
## Summary

- align the local pre-commit Prettier hook and this repository's code-quality workflow to the pinned repository Prettier `3.5.3`
- reformat the markdown files that were failing `./scripts/preflight.sh` under that pinned formatter version
- keep the fix repo-local so unrelated topic branches no longer trip a formatter-version mismatch before their own validations run

## Validation

- `pre-commit run prettier --all-files`
- `npm exec -- prettier --check CHANGELOG.md .github/CLA_SETUP.md SECURITY.md docs/adr/20251027-event-sourcing-for-guard-book.md docs/adr/20251126-organizational-structure-hierarchy.md docs/adr/20251221-activity-logging-audit-trail-strategy.md docs/adr/20251227-simplify-management-level-to-integer-field-adr011.md docs/adr/20260406-single-app-android-distribution-and-private-provisioning-adr012.md docs/adr/20260415-issue-first-planning-governance-adr013.md docs/adr/README.md docs/audits/2026-03-31-adversarial-review-LOCAL-REVIEW.md docs/development-principles.md docs/feature-requirements.md docs/ideas-backlog.md scripts/README.md`
- `pre-commit run actionlint --files .github/workflows/quality.yml`
- `pre-commit run check-yaml --files .github/workflows/quality.yml .pre-commit-config.yaml`
- `./scripts/preflight.sh`

## Issue

- Closes #414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tooling/CI formatting enforcement and markdown reformatting, with no runtime or security-sensitive logic. Main risk is CI or local hooks failing if Node dependencies aren’t installed as expected.
> 
> **Overview**
> Aligns formatting enforcement by pinning Prettier `3.5.3` everywhere: `pre-commit` now runs a local `npx prettier@3.5.3` hook, `scripts/preflight.sh` uses the same pinned version, and `quality.yml` installs npm deps and runs `npx prettier` instead of a globally installed binary.
> 
> Reformats existing documentation Markdown (and a few YAML/MD snippets) to eliminate Prettier drift so `./scripts/preflight.sh` and CI no longer fail on unrelated doc-only formatting differences; records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742d44de58eabeb10668fa2ca9137421db2031d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->