### PR TITLE
fix: supervise polyscope startup sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-02 - Supervise Polyscope Server Startup And Sync
+
+**Changed:**
+
+- updated `scripts/install-polyscope-rollout.sh` to install a real `polyscope-server.service` user unit that binds the local Polyscope API to `127.0.0.1:4321`, restarts on failure, and triggers the SecPal rollout sync after each successful server start so fresh workspace creation sees the current instructions, principles, prompts, links, and provisioning config
+- kept `polyscope-rollout-sync.service` as the instruction-change sync path, but made its generated unit explicitly order after `polyscope-server.service` and pass the local API base through to the rollout script so runtime prompt/config refreshes stay aligned with the supervised server endpoint
+- extended `tests/polyscope-rollout.sh` to cover the new server unit, startup refresh hook, localhost bind, rollout API base wiring, and systemd activation sequence for the supervised Polyscope runtime
+
 ## 2026-05-02 - Restore Generic Polyscope Preview Hosts
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -10,6 +10,8 @@ WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/code/SecPal}"
 BIN_DIR="$HOME/.local/bin"
 UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+POLYSCOPE_SERVER_BIN="${POLYSCOPE_SERVER_BIN:-$(command -v polyscope-server || true)}"
+POLYSCOPE_API_BASE="${POLYSCOPE_API_BASE:-http://127.0.0.1:4321/api}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -29,6 +31,10 @@ while [[ $# -gt 0 ]]; do
             UNIT_DIR="$2"
             shift 2
             ;;
+        --polyscope-server-bin)
+            POLYSCOPE_SERVER_BIN="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -37,10 +43,22 @@ while [[ $# -gt 0 ]]; do
 done
 
 INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
+SERVER_UNIT="$UNIT_DIR/polyscope-server.service"
 SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
 PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
+ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT; do
+if [[ -z "$POLYSCOPE_SERVER_BIN" ]]; then
+    echo "Error: polyscope-server binary not found. Pass --polyscope-server-bin or ensure it is in PATH." >&2
+    exit 1
+fi
+
+if [[ ! -x "$POLYSCOPE_SERVER_BIN" ]]; then
+    echo "Error: polyscope-server binary is not executable: $POLYSCOPE_SERVER_BIN" >&2
+    exit 1
+fi
+
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT POLYSCOPE_SERVER_BIN POLYSCOPE_API_BASE; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -51,16 +69,36 @@ done
 mkdir -p "$BIN_DIR" "$UNIT_DIR"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
 
+cat >"$SERVER_UNIT" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Polyscope local API server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
+ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+EOF
+
 cat >"$SERVICE_UNIT" <<EOF
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 [Unit]
 Description=Sync Polyscope prompts and preview config for SecPal
+After=polyscope-server.service
 
 [Service]
 Type=oneshot
 WorkingDirectory=$WORKSPACE_ROOT/.github
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE
 EOF
 
 cat >"$PATH_UNIT" <<EOF
@@ -91,9 +129,11 @@ WantedBy=default.target
 EOF
 
 "$SYSTEMCTL_BIN" --user daemon-reload
+"$SYSTEMCTL_BIN" --user enable --now polyscope-server.service
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
 
 echo "Installed $INSTALL_TARGET"
+echo "Installed $SERVER_UNIT"
 echo "Installed $SERVICE_UNIT"
 echo "Installed $PATH_UNIT"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -604,7 +604,15 @@ fake_bin_dir="$workspace/fake-bin"
 fake_unit_dir="$workspace/fake-units"
 fake_systemctl_dir="$workspace/fake-systemctl"
 fake_systemctl_log="$workspace/systemctl.log"
+fake_server_bin="$workspace/fake-tools/polyscope-server"
 mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir"
+mkdir -p "$(dirname "$fake_server_bin")"
+
+cat >"$fake_server_bin" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$fake_server_bin"
 
 cat >"$fake_systemctl_dir/systemctl" <<'STUB'
 #!/usr/bin/env bash
@@ -618,13 +626,20 @@ env HOME="$home_dir" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
     PATH="$fake_systemctl_dir:$PATH" \
-    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir"
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
 
 test -L "$fake_bin_dir/polyscope-secpal-rollout.py"
 test -x "$fake_bin_dir/polyscope-secpal-rollout.py"
+grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$fake_unit_dir/polyscope-server.service"
+grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.service"
+grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-server.service"
+grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
+grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'daemon-reload' "$fake_systemctl_log"
+grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"


### PR DESCRIPTION
## Summary

- install a real `polyscope-server.service` user unit that binds the local API to `127.0.0.1:4321` and restarts on failure
- trigger the SecPal rollout sync after each successful server start so fresh workspace creation sees current instructions, principles, prompts, links, and provisioning config
- keep the existing instruction-change sync path, but order it after the supervised server and pass the local API base through explicitly
- extend the rollout installer regression to cover the new server unit, startup refresh hook, localhost bind, rollout API base wiring, and activation sequence

## Validation

- `bash -n scripts/install-polyscope-rollout.sh`
- `bash -n tests/polyscope-rollout.sh`
- `bash ./tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- live installer rollout on the VPS via `bash /home/secpal/code/SecPal/.github/scripts/install-polyscope-rollout.sh`
- `systemctl --user show --property=ActiveState,SubState,ExecMainPID,ExecMainStartTimestamp polyscope-server.service`
- `systemctl --user start polyscope-rollout-sync.service`
- live prompt DB check for `org-shared.instructions.md` and the `git status --short --branch` rule
- live `polyscope.local.json` check for preview URL, instruction preamble, and workspace-preview provisioning commands
- `CI=true PLAYWRIGHT_BASE_URL=https://frontend-dashboard-seed.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-dashboard-seed.preview.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome --reporter=line`

## Issue

- operational follow-up to the merged preview-host hardening in #415

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new user-level `systemd` service that supervises `polyscope-server` and triggers post-start rollout sync, which could affect local runtime behavior and startup sequencing if misconfigured. Changes are limited to install script + regression tests, reducing blast radius but still operationally sensitive.
> 
> **Overview**
> **Supervises the local Polyscope runtime via `systemd`.** The installer now generates and enables a `polyscope-server.service` user unit that binds the API to `127.0.0.1:4321`, restarts on failure, and runs a post-start hook that waits for the API and then executes the SecPal rollout sync.
> 
> **Aligns rollout sync with the supervised endpoint.** `polyscope-rollout-sync.service` is now ordered after `polyscope-server.service` and passes an explicit `--polyscope-api-base` through to the rollout script; the rollout installer tests were extended to assert the new unit contents, API-base wiring, and activation order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408a3d272bad8f72efcfab5a540148cce8c88c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->