### PR TITLE
fix: harden Polyscope preview rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-02 - Return Direct Preview URLs From Polyscope Share
+
+**Changed:**
+
+- added `scripts/polyscope-expose-wrapper.sh` and taught `scripts/install-polyscope-rollout.sh` to install it as the live `~/.polyscope/bin/expose-linux-x64` entrypoint with `expose-linux-x64.real` kept as the fallback binary, so Polyscope `tunnel.start` now returns the existing `https://*.preview.secpal.dev` URL directly for SecPal preview hosts instead of handing browser-share links off to the unreliable free `sharedwithexpose.com` edge
+- restored repo-prefixed canonical preview hosts in generated Polyscope config for preview-capable repositories (`api-`, `frontend-`, `secpal-app-`, `changelog-`), and aligned the API preview `FRONTEND_URL` rewrite with `frontend-<workspace>.preview.secpal.dev`, so shared/opened preview URLs now keep the repository type in front of the workspace name instead of collapsing back to the generic host alias
+- taught `scripts/polyscope-rollout.py` to heal API worktrees missing `.env` by copying the source preview environment from the primary `api` checkout before applying workspace-specific rewrites, and to skip cleanly with a journal-visible message if no source preview env exists, so stale clones no longer fail `polyscope-worktree-provision.service`
+- added `scripts/polyscope-git-wrapper.sh` and wired the Polyscope systemd units to a dedicated PATH layer plus explicit `SSH_AUTH_SOCK`, so Polyscope-driven `git commit` calls now force `-S` through the configured SSH signing key instead of depending on the agent's internal commit path honoring repo config
+- kept non-SecPal or non-preview Expose calls on the original binary path, so the share override stays narrowly scoped to the already-public SecPal preview domain rather than replacing Expose globally
+- extended `tests/polyscope-rollout.sh` to cover API env healing for stale worktrees, git-wrapper installation and signed-commit enforcement, preview-domain short-circuiting, and fallback execution for non-preview hosts
+
 ## 2026-05-02 - Auto-Provision Fresh Polyscope Worktrees
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -6,13 +6,22 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_SCRIPT="$SCRIPT_DIR/polyscope-rollout.py"
+WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-expose-wrapper.sh"
+GIT_WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-git-wrapper.sh"
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/code/SecPal}"
 BIN_DIR="$HOME/.local/bin"
 UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 POLYSCOPE_SERVER_BIN="${POLYSCOPE_SERVER_BIN:-$(command -v polyscope-server || true)}"
+POLYSCOPE_REAL_GIT_BIN="${POLYSCOPE_REAL_GIT_BIN:-$(command -v git || true)}"
 POLYSCOPE_API_BASE="${POLYSCOPE_API_BASE:-http://127.0.0.1:4321/api}"
 POLYSCOPE_CLONE_ROOT="${POLYSCOPE_CLONE_ROOT:-$HOME/.polyscope/clones}"
+POLYSCOPE_HOME="${POLYSCOPE_HOME:-$HOME/.polyscope}"
+POLYSCOPE_EXPOSE_BIN="${POLYSCOPE_EXPOSE_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64}"
+POLYSCOPE_EXPOSE_REAL_BIN="${POLYSCOPE_EXPOSE_REAL_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64.real}"
+POLYSCOPE_GIT_BIN_DIR="${POLYSCOPE_GIT_BIN_DIR:-$HOME/.local/lib/polyscope/bin}"
+POLYSCOPE_GIT_WRAPPER_BIN="${POLYSCOPE_GIT_WRAPPER_BIN:-$POLYSCOPE_GIT_BIN_DIR/git}"
+SERVICE_PATH="${POLYSCOPE_SERVICE_PATH:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -43,7 +52,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ -z "$SERVICE_PATH" ]]; then
+    SERVICE_PATH="$POLYSCOPE_GIT_BIN_DIR:$BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+fi
+
 INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
+EXPOSE_WRAPPER_TARGET="$BIN_DIR/polyscope-expose-wrapper.sh"
+GIT_WRAPPER_TARGET="$BIN_DIR/polyscope-git-wrapper.sh"
 SERVER_UNIT="$UNIT_DIR/polyscope-server.service"
 SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
 PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
@@ -61,7 +76,17 @@ if [[ ! -x "$POLYSCOPE_SERVER_BIN" ]]; then
     exit 1
 fi
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT POLYSCOPE_SERVER_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT; do
+if [[ -z "$POLYSCOPE_REAL_GIT_BIN" ]]; then
+    echo "Error: git binary not found. Pass POLYSCOPE_REAL_GIT_BIN or ensure git is in PATH." >&2
+    exit 1
+fi
+
+if [[ ! -x "$POLYSCOPE_REAL_GIT_BIN" ]]; then
+    echo "Error: git binary is not executable: $POLYSCOPE_REAL_GIT_BIN" >&2
+    exit 1
+fi
+
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN SERVICE_PATH; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -73,8 +98,17 @@ for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT POLYSCOPE_SERVER_BIN POLYSCOPE_API
     fi
 done
 
-mkdir -p "$BIN_DIR" "$UNIT_DIR"
+mkdir -p "$BIN_DIR" "$UNIT_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
+ln -sfn "$WRAPPER_SOURCE" "$EXPOSE_WRAPPER_TARGET"
+ln -sfn "$GIT_WRAPPER_SOURCE" "$GIT_WRAPPER_TARGET"
+
+if [[ -e "$POLYSCOPE_EXPOSE_BIN" && ! -L "$POLYSCOPE_EXPOSE_BIN" ]]; then
+    mv -f "$POLYSCOPE_EXPOSE_BIN" "$POLYSCOPE_EXPOSE_REAL_BIN"
+fi
+
+ln -sfn "$EXPOSE_WRAPPER_TARGET" "$POLYSCOPE_EXPOSE_BIN"
+ln -sfn "$GIT_WRAPPER_TARGET" "$POLYSCOPE_GIT_WRAPPER_BIN"
 
 cat >"$SERVER_UNIT" <<EOF
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
@@ -86,6 +120,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=PATH=$SERVICE_PATH
+Environment=SSH_AUTH_SOCK=%t/openssh_agent
+Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
 ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
 Restart=on-failure
@@ -105,6 +142,9 @@ After=polyscope-server.service
 [Service]
 Type=oneshot
 WorkingDirectory=$WORKSPACE_ROOT/.github
+Environment=PATH=$SERVICE_PATH
+Environment=SSH_AUTH_SOCK=%t/openssh_agent
+Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE
 EOF
 
@@ -145,6 +185,9 @@ After=polyscope-rollout-sync.service
 [Service]
 Type=oneshot
 WorkingDirectory=$WORKSPACE_ROOT/.github
+Environment=PATH=$SERVICE_PATH
+Environment=SSH_AUTH_SOCK=%t/openssh_agent
+Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --skip-db-sync --provision-worktrees
 EOF
 
@@ -170,12 +213,17 @@ EOF
 
 "$SYSTEMCTL_BIN" --user daemon-reload
 "$SYSTEMCTL_BIN" --user enable --now polyscope-server.service
+"$SYSTEMCTL_BIN" --user restart polyscope-server.service
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
 "$SYSTEMCTL_BIN" --user start polyscope-worktree-provision.service
 
 echo "Installed $INSTALL_TARGET"
+echo "Installed $EXPOSE_WRAPPER_TARGET"
+echo "Installed $GIT_WRAPPER_TARGET"
+echo "Installed expose wrapper at $POLYSCOPE_EXPOSE_BIN"
+echo "Installed git wrapper at $POLYSCOPE_GIT_WRAPPER_BIN"
 echo "Installed $SERVER_UNIT"
 echo "Installed $SERVICE_UNIT"
 echo "Installed $PATH_UNIT"

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -104,6 +104,11 @@ ln -sfn "$WRAPPER_SOURCE" "$EXPOSE_WRAPPER_TARGET"
 ln -sfn "$GIT_WRAPPER_SOURCE" "$GIT_WRAPPER_TARGET"
 
 if [[ -e "$POLYSCOPE_EXPOSE_BIN" && ! -L "$POLYSCOPE_EXPOSE_BIN" ]]; then
+    if [[ -e "$POLYSCOPE_EXPOSE_REAL_BIN" ]]; then
+        echo "Error: $POLYSCOPE_EXPOSE_REAL_BIN already exists; will not overwrite it." >&2
+        echo "Remove or rename $POLYSCOPE_EXPOSE_REAL_BIN manually before re-running the installer." >&2
+        exit 1
+    fi
     mv -f "$POLYSCOPE_EXPOSE_BIN" "$POLYSCOPE_EXPOSE_REAL_BIN"
 fi
 

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+POLYSCOPE_HOME="${POLYSCOPE_HOME:-$HOME/.polyscope}"
+REAL_EXPOSE_BIN="${POLYSCOPE_EXPOSE_REAL_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64.real}"
+
+normalize_preview_url() {
+	local raw_url="$1"
+	local scheme_and_rest rest host_port host path host
+
+	case "$raw_url" in
+		http://*|https://*)
+			;;
+		*)
+			return 1
+			;;
+	esac
+
+	scheme_and_rest="${raw_url#*://}"
+	rest="$scheme_and_rest"
+	host_port="$rest"
+	path=""
+
+	if [[ "$rest" == */* ]]; then
+		host_port="${rest%%/*}"
+		path="/${rest#*/}"
+	fi
+
+	host="${host_port%%:*}"
+
+	if [[ ! "$host" =~ ^[A-Za-z0-9.-]+\.preview\.secpal\.dev$ ]]; then
+		return 1
+	fi
+
+	printf 'https://%s' "$host"
+	if [[ -n "$path" && "$path" != "/" ]]; then
+		printf '%s' "$path"
+	fi
+	printf '\n'
+}
+
+announce_direct_preview() {
+	local shared_site="$1"
+	local direct_url="$2"
+
+	printf '%s\n' 'Expose'
+	printf 'Shared site              %s\n' "$shared_site"
+	printf 'Public URL               %s\n' "$direct_url"
+
+	if [[ "${POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE:-0}" == "1" ]]; then
+		exit 0
+	fi
+
+	trap 'exit 0' INT TERM HUP
+	while true; do
+		sleep 3600 &
+		wait "$!"
+	done
+}
+
+if [[ $# -ge 2 && "$1" == "share" ]]; then
+	direct_preview_url="$(normalize_preview_url "$2" || true)"
+	if [[ -n "$direct_preview_url" ]]; then
+		announce_direct_preview "$2" "$direct_preview_url"
+	fi
+fi
+
+if [[ ! -x "$REAL_EXPOSE_BIN" ]]; then
+	echo "Error: Expose fallback binary not found at $REAL_EXPOSE_BIN" >&2
+	exit 1
+fi
+
+exec "$REAL_EXPOSE_BIN" "$@"

--- a/scripts/polyscope-git-wrapper.sh
+++ b/scripts/polyscope-git-wrapper.sh
@@ -9,12 +9,21 @@ REAL_GIT_BIN="${POLYSCOPE_REAL_GIT_BIN:-/usr/bin/git}"
 has_commit_signing_flag() {
 	for arg in "$@"; do
 		case "$arg" in
-			-S|--gpg-sign|--gpg-sign=*|--no-gpg-sign)
+			-S|--gpg-sign|--gpg-sign=*)
 				return 0
 				;;
 		esac
 	done
 
+	return 1
+}
+
+has_no_gpg_sign_flag() {
+	for arg in "$@"; do
+		if [[ "$arg" == "--no-gpg-sign" ]]; then
+			return 0
+		fi
+	done
 	return 1
 }
 
@@ -64,6 +73,10 @@ done
 
 if [[ "$subcommand" == "commit" ]]; then
 	commit_args=("${argv[@]:subcommand_index + 1}")
+	if has_no_gpg_sign_flag "${commit_args[@]}"; then
+		echo "Error: --no-gpg-sign is not allowed in Polyscope-managed git commits." >&2
+		exit 1
+	fi
 	if ! has_commit_signing_flag "${commit_args[@]}"; then
 		exec "$REAL_GIT_BIN" "${prefix[@]}" commit -S "${commit_args[@]}"
 	fi

--- a/scripts/polyscope-git-wrapper.sh
+++ b/scripts/polyscope-git-wrapper.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+REAL_GIT_BIN="${POLYSCOPE_REAL_GIT_BIN:-/usr/bin/git}"
+
+has_commit_signing_flag() {
+	for arg in "$@"; do
+		case "$arg" in
+			-S|--gpg-sign|--gpg-sign=*|--no-gpg-sign)
+				return 0
+				;;
+		esac
+	done
+
+	return 1
+}
+
+if [[ ! -x "$REAL_GIT_BIN" ]]; then
+	echo "Error: git fallback binary not found at $REAL_GIT_BIN" >&2
+	exit 1
+fi
+
+argv=("$@")
+prefix=()
+subcommand=""
+subcommand_index=-1
+index=0
+
+while (( index < ${#argv[@]} )); do
+	arg="${argv[index]}"
+	case "$arg" in
+		-C|--git-dir|--work-tree|--namespace|--super-prefix|-c|--config-env)
+			if (( index + 1 >= ${#argv[@]} )); then
+				break
+			fi
+			prefix+=("$arg" "${argv[index + 1]}")
+			((index += 2))
+			;;
+		--exec-path=*|--git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*|--config-env=*|-c*)
+			prefix+=("$arg")
+			((index += 1))
+			;;
+		--literal-pathspecs|--no-literal-pathspecs|--glob-pathspecs|--noglob-pathspecs|--icase-pathspecs|--no-pager|--paginate|--no-optional-locks|--no-replace-objects|--bare)
+			prefix+=("$arg")
+			((index += 1))
+			;;
+		--)
+			break
+			;;
+		-*)
+			prefix+=("$arg")
+			((index += 1))
+			;;
+		*)
+			subcommand="$arg"
+			subcommand_index=$index
+			break
+			;;
+	esac
+done
+
+if [[ "$subcommand" == "commit" ]]; then
+	commit_args=("${argv[@]:subcommand_index + 1}")
+	if ! has_commit_signing_flag "${commit_args[@]}"; then
+		exec "$REAL_GIT_BIN" "${prefix[@]}" commit -S "${commit_args[@]}"
+	fi
+fi
+
+exec "$REAL_GIT_BIN" "$@"

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -26,6 +26,12 @@ POLYSCOPE_LOCAL_CONFIG_NAME = "polyscope.local.json"
 PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
 
 
+def build_preview_url_template(preview_prefix: str | None) -> str:
+    if preview_prefix:
+        return f"https://{preview_prefix}-{{{{folder}}}}.preview.secpal.dev"
+    return "https://{{folder}}.preview.secpal.dev"
+
+
 def build_api_preview_env_setup_command() -> str:
     script = textwrap.dedent(
         """
@@ -40,7 +46,7 @@ def build_api_preview_env_setup_command() -> str:
 
         values = {
             "APP_URL": f"https://api-{workspace}.preview.secpal.dev",
-            "FRONTEND_URL": f"https://{workspace}.preview.secpal.dev",
+            "FRONTEND_URL": f"https://frontend-{workspace}.preview.secpal.dev",
             "SESSION_DOMAIN": ".secpal.dev",
             "SANCTUM_STATEFUL_DOMAINS": ",".join(
                 (
@@ -145,13 +151,13 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             ".github/instructions/org-shared.instructions.md",
             ".github/instructions/php-laravel.instructions.md",
         ],
-        "preview_prefix": None,
+        "preview_prefix": "api",
         "review_focus": "Laravel 13, Pest 4, Request -> Controller -> Service -> Repository -> Model, Sanctum session versus bearer-token flows, and encrypted data handling via *_plain/*_idx without direct *_enc reads.",
         "link_names": ["frontend", "contracts", "android"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
+            "preview": {"url": build_preview_url_template("api")},
             "scripts": {
                 "setup": [
                     build_api_preview_env_setup_command(),
@@ -161,8 +167,10 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 "run": [
                     {"label": "Queue Worker", "command": "php artisan queue:listen --tries=1", "runMode": "replace"},
                     {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
+                    # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.
+                    # It intentionally reseeds the canonical E2E login `test@example.com` / `password` and must never target production.
                     {
-                        "label": "Refresh Preview DB + E2E User",
+                        "label": "Preview Only: Refresh DB + E2E User",
                         "command": "php artisan migrate:fresh --seed",
                         "runMode": "preserve",
                     },
@@ -190,13 +198,13 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             ".github/instructions/org-shared.instructions.md",
             ".github/instructions/react-typescript.instructions.md",
         ],
-        "preview_prefix": None,
+        "preview_prefix": "frontend",
         "review_focus": "React, Vite, strict TypeScript, generated API types, Testing Library/MSW boundaries, auth-storage discipline, and transport failure handling.",
         "link_names": ["api", "contracts", "android"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
+            "preview": {"url": build_preview_url_template("frontend")},
             "scripts": {
                 "setup": [
                     build_frontend_preview_env_setup_command(),
@@ -324,13 +332,13 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             ".github/instructions/org-shared.instructions.md",
             ".github/instructions/astro-static.instructions.md",
         ],
-        "preview_prefix": None,
+        "preview_prefix": "secpal-app",
         "review_focus": "Astro static rendering, minimal client-side JavaScript, semantic HTML, accessible landmarks, and strict TypeScript on the public site.",
         "link_names": ["changelog"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
+            "preview": {"url": build_preview_url_template("secpal-app")},
             "scripts": {
                 "setup": ["test -d node_modules || npm ci", "npm run build"],
                 "run": [
@@ -359,13 +367,13 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             ".github/instructions/org-shared.instructions.md",
             ".github/instructions/nextjs-changelog.instructions.md",
         ],
-        "preview_prefix": None,
+        "preview_prefix": "changelog",
         "review_focus": "Next.js static-style changelog output, MDX content rules, Commit template conventions, CSP/feed safety, and no server-side runtime dependencies.",
         "link_names": ["secpal.app"],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
-            "preview": {"url": "https://{{folder}}.preview.secpal.dev"},
+            "preview": {"url": build_preview_url_template("changelog")},
             "scripts": {
                 "setup": ["test -d node_modules || npm ci", "npm run build"],
                 "run": [
@@ -818,6 +826,23 @@ def run_setup_commands(worktree_path: pathlib.Path, commands: list[str]) -> None
         )
 
 
+def ensure_api_preview_env(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> bool:
+    env_path = worktree_path / ".env"
+    if env_path.exists():
+        return True
+
+    source_env_path = source_repo_path / ".env"
+    if source_env_path.exists():
+        shutil.copy2(source_env_path, env_path)
+        return True
+
+    print(
+        f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
+        f".env missing and source preview env not found at {source_env_path}"
+    )
+    return False
+
+
 def sync_worktree_local_config(worktree_path: pathlib.Path, config_text: str) -> None:
     (worktree_path / POLYSCOPE_LOCAL_CONFIG_NAME).write_text(config_text)
     ensure_exclude(worktree_path, {POLYSCOPE_LOCAL_CONFIG_NAME, PROVISION_MARKER_FILENAME})
@@ -897,6 +922,9 @@ def provision_worktrees(repo_state: dict[str, dict[str, Any]], repo_specs: dict[
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
             sync_worktree_local_config(worktree_path, config_text)
             ensure_worktree_hooks(worktree_path)
+
+            if repo_name == "api" and not ensure_api_preview_env(worktree_path, spec["path"]):
+                continue
 
             marker_path = worktree_path / PROVISION_MARKER_FILENAME
             marker = load_provision_marker(marker_path)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -483,7 +483,7 @@ python3 "$PYTHON_SCRIPT" \
     --summary-output "$summary_output" \
     > /dev/null
 
-grep -q 'https://{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
+grep -q 'https://api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
 grep -q 'org-shared.instructions.md' "$workspace_root/api/polyscope.local.json"
 grep -qF 'POLYSCOPE_WORKSPACE' "$workspace_root/api/polyscope.local.json"
@@ -495,7 +495,11 @@ grep -qF 'CORS_ALLOWED_ORIGINS' "$workspace_root/api/polyscope.local.json"
 grep -qF 'frontend-{workspace}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -qF 'php artisan config:clear && php artisan migrate --force && php artisan db:seed --force && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
 grep -qF "test@example.com" "$workspace_root/api/polyscope.local.json"
+grep -qF 'Preview Only: Refresh DB + E2E User' "$workspace_root/api/polyscope.local.json"
 grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
+grep -q 'https://frontend-{{folder}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
+grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
+grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
 grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
 grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"
@@ -594,7 +598,10 @@ assert ('api12345', 'fe123456') in links
 assert ('sa123456', 'ch123456') in links
 
 summary = json.loads(summary_path.read_text())
-assert summary['repositories']['api']['preview_prefix'] is None
+assert summary['repositories']['api']['preview_prefix'] == 'api'
+assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
+assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
+assert summary['repositories']['changelog']['preview_prefix'] == 'changelog'
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
 assert summary['repositories']['.github']['linked_repositories'] == []
@@ -649,13 +656,15 @@ exit 0
 STUB
 chmod +x "$home_dir/.local/bin/pre-commit"
 
-cat >"$api_clone/.env" <<'EOF'
+cat >"$workspace_root/api/.env" <<'EOF'
 APP_URL=https://api.secpal.dev
 FRONTEND_URL=https://app.secpal.dev
 SESSION_DOMAIN=.secpal.dev
 SANCTUM_STATEFUL_DOMAINS=app.secpal.dev
 CORS_ALLOWED_ORIGINS=https://app.secpal.dev
 EOF
+
+cp "$workspace_root/api/.env" "$api_clone/.env"
 
 cat >"$api_clone/.pre-commit-config.yaml" <<'EOF'
 repos: []
@@ -704,7 +713,7 @@ assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in pro
 PY
 
 grep -qF 'APP_URL=https://api-auto-hawk.preview.secpal.dev' "$api_clone/.env"
-grep -qF 'FRONTEND_URL=https://auto-hawk.preview.secpal.dev' "$api_clone/.env"
+grep -qF 'FRONTEND_URL=https://frontend-auto-hawk.preview.secpal.dev' "$api_clone/.env"
 grep -qF 'SANCTUM_STATEFUL_DOMAINS=frontend-auto-hawk.preview.secpal.dev,auto-hawk.preview.secpal.dev,app.secpal.dev' "$api_clone/.env"
 grep -qF 'CORS_ALLOWED_ORIGINS=https://frontend-auto-hawk.preview.secpal.dev,https://auto-hawk.preview.secpal.dev,https://app.secpal.dev' "$api_clone/.env"
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.local"
@@ -729,6 +738,44 @@ grep -qF "npm:$frontend_clone:ci" "$provision_log"
 grep -qF "npm:$frontend_clone:run build -- --mode preview" "$provision_log"
 grep -qF "pre-commit:$api_clone:install --install-hooks --hook-type pre-commit" "$provision_log"
 grep -qF "pre-commit:$frontend_clone:install --install-hooks --hook-type pre-commit" "$provision_log"
+
+stale_api_clone="$home_dir/.polyscope/clones/api12345/stale-otter"
+mkdir -p "$stale_api_clone/.git/info" "$stale_api_clone/.git/hooks" "$stale_api_clone/scripts"
+
+cat >"$stale_api_clone/.pre-commit-config.yaml" <<'EOF'
+repos: []
+EOF
+
+cat >"$stale_api_clone/scripts/preflight.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$stale_api_clone/scripts/preflight.sh"
+
+stale_provision_summary_json="$workspace/stale-provision-summary.json"
+env HOME="$home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$stale_provision_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$stale_provision_summary_json" <<'PY'
+import json, sys
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+assert 'api:stale-otter' in provisioned, f"expected api:stale-otter in provisioned_worktrees, got {provisioned}"
+PY
+
+grep -qF 'APP_URL=https://api-stale-otter.preview.secpal.dev' "$stale_api_clone/.env"
+grep -qF 'FRONTEND_URL=https://frontend-stale-otter.preview.secpal.dev' "$stale_api_clone/.env"
+test -f "$stale_api_clone/.polyscope-secpal-provisioned.json"
 
 provision_log_lines_before="$(wc -l < "$provision_log")"
 env HOME="$home_dir" \
@@ -762,7 +809,11 @@ fake_unit_dir="$workspace/fake-units"
 fake_systemctl_dir="$workspace/fake-systemctl"
 fake_systemctl_log="$workspace/systemctl.log"
 fake_server_bin="$workspace/fake-tools/polyscope-server"
-mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir"
+fake_expose_real_log="$workspace/expose-real.log"
+fake_git_real_log="$workspace/git-real.log"
+fake_polyscope_bin_dir="$home_dir/.polyscope/bin"
+fake_polyscope_git_dir="$home_dir/.local/lib/polyscope/bin"
+mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir" "$fake_polyscope_bin_dir" "$fake_polyscope_git_dir"
 mkdir -p "$(dirname "$fake_server_bin")"
 
 cat >"$fake_server_bin" <<'STUB'
@@ -770,6 +821,13 @@ cat >"$fake_server_bin" <<'STUB'
 exit 0
 STUB
 chmod +x "$fake_server_bin"
+
+cat >"$fake_polyscope_bin_dir/expose-linux-x64" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_EXPOSE_REAL_LOG"
+exit 0
+STUB
+chmod +x "$fake_polyscope_bin_dir/expose-linux-x64"
 
 cat >"$fake_systemctl_dir/systemctl" <<'STUB'
 #!/usr/bin/env bash
@@ -782,28 +840,89 @@ env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
     bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
 
 test -L "$fake_bin_dir/polyscope-secpal-rollout.py"
 test -x "$fake_bin_dir/polyscope-secpal-rollout.py"
+test -L "$fake_bin_dir/polyscope-expose-wrapper.sh"
+test -x "$fake_bin_dir/polyscope-expose-wrapper.sh"
+test -L "$fake_bin_dir/polyscope-git-wrapper.sh"
+test -x "$fake_bin_dir/polyscope-git-wrapper.sh"
+test -L "$fake_polyscope_git_dir/git"
+test -x "$fake_polyscope_git_dir/git"
+test "$(readlink "$fake_polyscope_git_dir/git")" = "$fake_bin_dir/polyscope-git-wrapper.sh"
+test -L "$fake_polyscope_bin_dir/expose-linux-x64"
+test -x "$fake_polyscope_bin_dir/expose-linux-x64"
+test -x "$fake_polyscope_bin_dir/expose-linux-x64.real"
+test "$(readlink "$fake_polyscope_bin_dir/expose-linux-x64")" = "$fake_bin_dir/polyscope-expose-wrapper.sh"
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$fake_unit_dir/polyscope-server.service"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.service"
+grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-server.service"
+grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-server.service"
+grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-server.service"
 grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-server.service"
 grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
 grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
+grep -q 'restart polyscope-server.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
 grep -q 'start polyscope-worktree-provision.service' "$fake_systemctl_log"
+
+fake_real_git_bin="$workspace/fake-tools/git-real"
+cat >"$fake_real_git_bin" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_GIT_REAL_LOG"
+exit 0
+STUB
+chmod +x "$fake_real_git_bin"
+
+env FAKE_GIT_REAL_LOG="$fake_git_real_log" \
+    POLYSCOPE_REAL_GIT_BIN="$fake_real_git_bin" \
+    "$fake_polyscope_git_dir/git" -C /tmp/example commit -m preview-fix >/dev/null
+
+grep -q '^-C /tmp/example commit -S -m preview-fix$' "$fake_git_real_log"
+
+env FAKE_GIT_REAL_LOG="$fake_git_real_log" \
+    POLYSCOPE_REAL_GIT_BIN="$fake_real_git_bin" \
+    "$fake_polyscope_git_dir/git" -C /tmp/example commit -S -m already-signed >/dev/null
+
+grep -q '^-C /tmp/example commit -S -m already-signed$' "$fake_git_real_log"
+
+preview_wrapper_out="$workspace/expose-wrapper-preview.out"
+env HOME="$home_dir" \
+    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://frontend-auto-hawk.preview.secpal.dev:443 >"$preview_wrapper_out"
+
+grep -q 'Shared site              https://frontend-auto-hawk.preview.secpal.dev:443' "$preview_wrapper_out"
+grep -q 'Public URL               https://frontend-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
+
+if [[ -s "$fake_expose_real_log" ]]; then
+    echo "preview-domain Expose wrapper must not invoke the real Expose binary" >&2
+    exit 1
+fi
+
+env HOME="$home_dir" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://example.com:443 >/dev/null
+
+grep -q 'share https://example.com:443' "$fake_expose_real_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -878,7 +878,8 @@ chmod +x "$fake_guard_expose_bin"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_guard_expose_real"
 chmod +x "$fake_guard_expose_real"
 install_real_guard_exit=0
-env WORKSPACE_ROOT="$workspace_root" \
+env HOME="$home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
     POLYSCOPE_EXPOSE_BIN="$fake_guard_expose_bin" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -857,6 +857,44 @@ test -L "$fake_polyscope_bin_dir/expose-linux-x64"
 test -x "$fake_polyscope_bin_dir/expose-linux-x64"
 test -x "$fake_polyscope_bin_dir/expose-linux-x64.real"
 test "$(readlink "$fake_polyscope_bin_dir/expose-linux-x64")" = "$fake_bin_dir/polyscope-expose-wrapper.sh"
+
+# Re-running the installer when .real already exists must exit non-zero (guard against clobbering)
+install_real_guard_exit=0
+env WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null \
+    || install_real_guard_exit=$?
+if [[ "$install_real_guard_exit" -eq 0 ]]; then
+    echo "installer must refuse to overwrite existing .real binary" >&2
+    exit 1
+fi
+
+# installer must refuse to overwrite an existing .real binary
+# Simulate: expose-linux-x64 is a regular file AND .real already holds a previous real binary
+fake_guard_dir="$workspace/guard-test"
+mkdir -p "$fake_guard_dir"
+fake_guard_expose_bin="$fake_guard_dir/expose-linux-x64"
+fake_guard_expose_real="$fake_guard_dir/expose-linux-x64.real"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_guard_expose_bin"
+chmod +x "$fake_guard_expose_bin"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_guard_expose_real"
+chmod +x "$fake_guard_expose_real"
+install_real_guard_exit=0
+env WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    POLYSCOPE_EXPOSE_BIN="$fake_guard_expose_bin" \
+    POLYSCOPE_EXPOSE_REAL_BIN="$fake_guard_expose_real" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null \
+    || install_real_guard_exit=$?
+if [[ "$install_real_guard_exit" -eq 0 ]]; then
+    echo "installer guard: must refuse to overwrite existing .real binary" >&2
+    exit 1
+fi
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$fake_unit_dir/polyscope-server.service"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-server.service"
@@ -907,6 +945,15 @@ env FAKE_GIT_REAL_LOG="$fake_git_real_log" \
     "$fake_polyscope_git_dir/git" -C /tmp/example commit -S -m already-signed >/dev/null
 
 grep -q '^-C /tmp/example commit -S -m already-signed$' "$fake_git_real_log"
+
+# --no-gpg-sign must be rejected by the git wrapper
+no_gpg_sign_exit=0
+env POLYSCOPE_REAL_GIT_BIN="$fake_real_git_bin" \
+    "$fake_polyscope_git_dir/git" commit --no-gpg-sign -m bypass 2>/dev/null || no_gpg_sign_exit=$?
+if [[ "$no_gpg_sign_exit" -eq 0 ]]; then
+    echo "git wrapper must reject --no-gpg-sign for commit" >&2
+    exit 1
+fi
 
 preview_wrapper_out="$workspace/expose-wrapper-preview.out"
 env HOME="$home_dir" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -858,19 +858,14 @@ test -x "$fake_polyscope_bin_dir/expose-linux-x64"
 test -x "$fake_polyscope_bin_dir/expose-linux-x64.real"
 test "$(readlink "$fake_polyscope_bin_dir/expose-linux-x64")" = "$fake_bin_dir/polyscope-expose-wrapper.sh"
 
-# Re-running the installer when .real already exists must exit non-zero (guard against clobbering)
-install_real_guard_exit=0
-env WORKSPACE_ROOT="$workspace_root" \
+# Re-running the installer after the expose binary has been wrapped must stay idempotent.
+env HOME="$home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
-    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null \
-    || install_real_guard_exit=$?
-if [[ "$install_real_guard_exit" -eq 0 ]]; then
-    echo "installer must refuse to overwrite existing .real binary" >&2
-    exit 1
-fi
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
 
 # installer must refuse to overwrite an existing .real binary
 # Simulate: expose-linux-x64 is a regular file AND .real already holds a previous real binary


### PR DESCRIPTION
## Summary

- install a direct-preview Expose wrapper plus repo-prefixed preview host generation so Polyscope share links stay on the working `*.preview.secpal.dev` hosts instead of falling back to `sharedwithexpose`
- harden worktree provisioning by healing stale API clones that are missing `.env`, keeping `polyscope-worktree-provision.service` successful instead of failing on old clones
- force signed Polyscope-driven commits through a dedicated git wrapper and explicit systemd environment so the SSH signing key is used consistently outside the interactive shell path
- clarify the preview-only API DB reset command in generated Polyscope config and label it as a development-only action that intentionally reseeds the canonical E2E login

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- `bash scripts/install-polyscope-rollout.sh`
- `systemctl --user show polyscope-worktree-provision.service -p Result -p ActiveState`
- `ls -l /home/secpal/.polyscope/clones/47d112dd/agile-bear/.env`
- `grep -n 'Preview Only: Refresh DB + E2E User' /home/secpal/code/SecPal/api/polyscope.local.json`
- `grep -n 'Preview Only: Refresh DB + E2E User' /home/secpal/.polyscope/clones/47d112dd/agile-bear/polyscope.local.json`
- `POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 /home/secpal/.polyscope/bin/expose-linux-x64 share https://frontend-silent-koala.preview.secpal.dev:443`
- temporary repo proof via the live Polyscope git wrapper path: signed `git commit -m 'test signed wrapper commit'`

## Issues

- Closes #418
- Closes #422

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Polyscope rollout/provisioning automation (systemd units, worktree setup, URL rewriting) and intercepts `expose`/`git` execution paths, so misconfiguration could break preview sharing or Polyscope-managed commits on the VPS.
> 
> **Overview**
> **Polyscope preview sharing now prefers direct `*.preview.secpal.dev` URLs.** The installer wraps Polyscope’s `expose-linux-x64` with `scripts/polyscope-expose-wrapper.sh`, short-circuiting `share` for SecPal preview hosts while keeping a `.real` fallback for non-preview usage.
> 
> **Preview URL generation was re-canonicalized to repo-prefixed hosts.** `scripts/polyscope-rollout.py` now emits repo-prefixed preview URLs (`api-`, `frontend-`, `secpal-app-`, `changelog-`) and aligns the API `FRONTEND_URL` rewrite to `frontend-<workspace>.preview.secpal.dev`, plus clarifies the destructive API reset command label as preview-only.
> 
> **Worktree provisioning is more resilient and commit signing is enforced.** API worktrees missing `.env` are healed by copying from the primary `api` checkout (or skipped with a visible message), and a new `scripts/polyscope-git-wrapper.sh` forces Polyscope-driven `git commit` to use `-S` (rejecting `--no-gpg-sign`). The systemd units are updated to use a dedicated `PATH`, set `SSH_AUTH_SOCK`, and pass `POLYSCOPE_REAL_GIT_BIN`. Tests expand coverage for these behaviors and installer idempotency/guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c757ad6e31bb4a98bb6700f35dc5fa9b9d465cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->