### PR TITLE
fix: isolate Polyscope preview API storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-03 - Isolate Polyscope Preview Storage Per API Workspace
+
+**Changed:**
+
+- updated `scripts/polyscope-rollout.py` so API worktree preparation now isolates PostgreSQL preview storage per workspace: when the role can create databases it provisions a deterministic preview database, and when it cannot it falls back to a deterministic preview schema wired through `DB_URL?search_path=...`; in both cases the original shared base database is persisted in `POLYSCOPE_BASE_DB_DATABASE`, so a fresh `frontend-<workspace>.preview.secpal.dev` no longer shares mutable API data with other preview workspaces by default
+- taught the worktree provisioner to prune orphaned API preview storage targets when the matching Polyscope workspace directory disappears, dropping stale preview databases or schemas as appropriate so repeated provisioning stays idempotent without accumulating abandoned preview state on the host
+- changed the generated API `polyscope.local.json` setup to call the shared rollout helper directly for worktree preparation, so manual Polyscope setup and automatic `--provision-worktrees` runs use the same database-isolation path instead of drifting between inline env rewrites and background provisioning behavior
+- extended `tests/polyscope-rollout.sh` to prove both workspace-specific preview-database provisioning and schema fallback, tracked base-database metadata, cleanup of removed workspaces, and idempotent reruns after cleanup
+
 ## 2026-05-02 - Return Direct Preview URLs From Polyscope Share
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -17,6 +17,7 @@ import sqlite3
 import subprocess
 import sys
 import textwrap
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +25,13 @@ from typing import Any
 
 POLYSCOPE_LOCAL_CONFIG_NAME = "polyscope.local.json"
 PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
+ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
+PREVIEW_DATABASE_BASE_ENV_KEY = "POLYSCOPE_BASE_DB_DATABASE"
+PREVIEW_SCHEMA_ENV_KEY = "POLYSCOPE_PREVIEW_SCHEMA"
+PREVIEW_STORAGE_MODE_ENV_KEY = "POLYSCOPE_PREVIEW_STORAGE_MODE"
+POSTGRES_PREVIEW_DATABASE_SEPARATOR = "__preview__"
+POSTGRES_IDENTIFIER_MAX_LENGTH = 63
+ENV_ASSIGNMENT_PATTERN = re.compile(r"^([A-Z0-9_]+)=(.*)$")
 
 
 def build_preview_url_template(preview_prefix: str | None) -> str:
@@ -32,54 +40,317 @@ def build_preview_url_template(preview_prefix: str | None) -> str:
     return "https://{{folder}}.preview.secpal.dev"
 
 
-def build_api_preview_env_setup_command() -> str:
-    script = textwrap.dedent(
-        """
-        from pathlib import Path
-        import os
-        import re
+def build_api_preview_env_setup_command(source_repo_path: pathlib.Path) -> str:
+    rollout_script = shlex.quote(str(ROLLOUT_SCRIPT_PATH))
+    source_repo = shlex.quote(str(source_repo_path))
+    return (
+        f"python3 {rollout_script} --prepare-api-worktree \"$PWD\" "
+        f"--source-repo-path {source_repo}"
+    )
 
-        workspace = os.environ["POLYSCOPE_WORKSPACE"]
-        env_path = Path(".env")
-        if not env_path.exists():
-            raise SystemExit(".env not found; copy the preview environment into place before running Polyscope setup.")
 
-        values = {
-            "APP_URL": f"https://api-{workspace}.preview.secpal.dev",
-            "FRONTEND_URL": f"https://frontend-{workspace}.preview.secpal.dev",
-            "SESSION_DOMAIN": ".secpal.dev",
-            "SANCTUM_STATEFUL_DOMAINS": ",".join(
-                (
-                    f"frontend-{workspace}.preview.secpal.dev",
-                    f"{workspace}.preview.secpal.dev",
-                    "app.secpal.dev",
-                )
-            ),
-            "CORS_ALLOWED_ORIGINS": ",".join(
-                (
-                    f"https://frontend-{workspace}.preview.secpal.dev",
-                    f"https://{workspace}.preview.secpal.dev",
-                    "https://app.secpal.dev",
-                )
-            ),
-        }
+def decode_env_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
+        return value[1:-1]
+    return value
 
-        text = env_path.read_text()
-        for key, value in values.items():
-            pattern = re.compile(rf"^{re.escape(key)}=.*$", re.MULTILINE)
-            replacement = f"{key}={value}"
-            if pattern.search(text):
-                text = pattern.sub(replacement, text)
-            else:
-                if text and not text.endswith("\\n"):
-                    text += "\\n"
-                text += replacement + "\\n"
 
-        env_path.write_text(text)
-        """
-    ).strip()
+def load_env_assignments(env_path: pathlib.Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in env_path.read_text().splitlines():
+        match = ENV_ASSIGNMENT_PATTERN.match(line.strip())
+        if match is None:
+            continue
+        values[match.group(1)] = decode_env_value(match.group(2))
+    return values
 
-    return f'POLYSCOPE_WORKSPACE="${{PWD##*/}}" python3 -c {shlex.quote(script)}'
+
+def upsert_env_assignments(text: str, updates: dict[str, str]) -> str:
+    for key, value in updates.items():
+        pattern = re.compile(rf"^{re.escape(key)}=.*$", re.MULTILINE)
+        replacement = f"{key}={value}"
+        if pattern.search(text):
+            text = pattern.sub(replacement, text)
+            continue
+        if text and not text.endswith("\n"):
+            text += "\n"
+        text += replacement + "\n"
+    return text
+
+
+def sanitize_postgres_identifier_component(value: str, fallback: str) -> str:
+    sanitized = re.sub(r"[^a-z0-9_]+", "_", value.lower()).strip("_")
+    return sanitized or fallback
+
+
+def shorten_postgres_identifier_component(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    if limit <= 9:
+        return value[:limit]
+    digest = hashlib.sha1(value.encode()).hexdigest()[:8]
+    head = value[: limit - len(digest) - 1].rstrip("_") or value[: limit - len(digest) - 1]
+    if not head:
+        head = value[:1]
+    return f"{head}_{digest}"
+
+
+def build_preview_database_prefix(base_database: str) -> str:
+    base_component = sanitize_postgres_identifier_component(base_database, "app")
+    available = POSTGRES_IDENTIFIER_MAX_LENGTH - len(POSTGRES_PREVIEW_DATABASE_SEPARATOR) - 16
+    return shorten_postgres_identifier_component(base_component, max(1, available)) + POSTGRES_PREVIEW_DATABASE_SEPARATOR
+
+
+def build_preview_database_name(base_database: str, workspace: str) -> str:
+    prefix = build_preview_database_prefix(base_database)
+    workspace_component = sanitize_postgres_identifier_component(workspace, "workspace")
+    available = POSTGRES_IDENTIFIER_MAX_LENGTH - len(prefix)
+    workspace_component = shorten_postgres_identifier_component(workspace_component, max(1, available))
+    return prefix + workspace_component
+
+
+def resolve_base_database_name(env_values: dict[str, str], workspace: str) -> str | None:
+    explicit_base = env_values.get(PREVIEW_DATABASE_BASE_ENV_KEY)
+    if explicit_base:
+        return explicit_base
+
+    current_database = env_values.get("DB_DATABASE")
+    if not current_database:
+        return None
+
+    preview_suffix = POSTGRES_PREVIEW_DATABASE_SEPARATOR + sanitize_postgres_identifier_component(workspace, "workspace")
+    if current_database.endswith(preview_suffix):
+        candidate = current_database[: -len(preview_suffix)]
+        if candidate:
+            return candidate
+
+    return current_database
+
+
+def build_postgres_command_env(env_values: dict[str, str]) -> dict[str, str]:
+    command_env = os.environ.copy()
+    for source_key, target_key in {
+        "DB_HOST": "PGHOST",
+        "DB_PORT": "PGPORT",
+        "DB_USERNAME": "PGUSER",
+        "DB_PASSWORD": "PGPASSWORD",
+    }.items():
+        if source_key in env_values:
+            command_env[target_key] = env_values[source_key]
+    return command_env
+
+
+def run_postgres_command(env_values: dict[str, str], database_name: str, sql: str) -> str:
+    try:
+        result = subprocess.run(
+            ["psql", "-v", "ON_ERROR_STOP=1", "-d", database_name, "-Atqc", sql],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=build_postgres_command_env(env_values),
+        )
+    except FileNotFoundError as error:
+        raise SystemExit("psql is required to manage Polyscope preview databases") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() or error.stdout.strip() or str(error)
+        raise SystemExit(f"failed to manage Polyscope preview database via psql: {stderr}") from error
+
+    return result.stdout.strip()
+
+
+def postgres_role_can_create_databases(env_values: dict[str, str], base_database: str) -> bool:
+    result = run_postgres_command(
+        env_values,
+        base_database,
+        "SELECT rolcreatedb FROM pg_roles WHERE rolname = current_user",
+    )
+    return result.lower() in {"1", "t", "true", "yes", "on"}
+
+
+def ensure_postgres_preview_database(env_values: dict[str, str], base_database: str, preview_database: str) -> None:
+    exists = run_postgres_command(
+        env_values,
+        base_database,
+        f"SELECT 1 FROM pg_database WHERE datname = '{preview_database}'",
+    )
+    if exists == "1":
+        return
+
+    run_postgres_command(env_values, base_database, f'CREATE DATABASE "{preview_database}"')
+
+
+def list_postgres_preview_databases(env_values: dict[str, str], base_database: str) -> list[str]:
+    prefix = build_preview_database_prefix(base_database)
+    output = run_postgres_command(
+        env_values,
+        base_database,
+        f"SELECT datname FROM pg_database WHERE datname LIKE '{prefix}%' ORDER BY datname",
+    )
+    return [line for line in output.splitlines() if line]
+
+
+def drop_postgres_preview_database(env_values: dict[str, str], base_database: str, preview_database: str) -> None:
+    run_postgres_command(
+        env_values,
+        base_database,
+        f'DROP DATABASE IF EXISTS "{preview_database}" WITH (FORCE)',
+    )
+
+
+def list_postgres_preview_schemas(env_values: dict[str, str], base_database: str) -> list[str]:
+    prefix = build_preview_database_prefix(base_database)
+    output = run_postgres_command(
+        env_values,
+        base_database,
+        f"SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '{prefix}%' ORDER BY schema_name",
+    )
+    return [line for line in output.splitlines() if line]
+
+
+def ensure_postgres_preview_schema(env_values: dict[str, str], base_database: str, preview_schema: str) -> None:
+    run_postgres_command(env_values, base_database, f'CREATE SCHEMA IF NOT EXISTS "{preview_schema}"')
+
+
+def drop_postgres_preview_schema(env_values: dict[str, str], base_database: str, preview_schema: str) -> None:
+    run_postgres_command(env_values, base_database, f'DROP SCHEMA IF EXISTS "{preview_schema}" CASCADE')
+
+
+def build_postgres_url(env_values: dict[str, str], database_name: str, search_path: str | None = None) -> str:
+    username = env_values.get("DB_USERNAME", "")
+    password = env_values.get("DB_PASSWORD", "")
+    host = env_values.get("DB_HOST", "")
+    port = env_values.get("DB_PORT", "")
+
+    authority = ""
+    if username:
+        authority = urllib.parse.quote(username, safe="")
+        if password:
+            authority += ":" + urllib.parse.quote(password, safe="")
+        authority += "@"
+    authority += host
+    if port:
+        authority += f":{port}"
+
+    query = ""
+    if search_path is not None:
+        query = urllib.parse.urlencode({"search_path": search_path})
+
+    return urllib.parse.urlunsplit(
+        (
+            "postgresql",
+            authority,
+            "/" + urllib.parse.quote(database_name, safe=""),
+            query,
+            "",
+        )
+    )
+
+
+def build_api_preview_env_updates(workspace: str) -> dict[str, str]:
+    return {
+        "APP_URL": f"https://api-{workspace}.preview.secpal.dev",
+        "FRONTEND_URL": f"https://frontend-{workspace}.preview.secpal.dev",
+        "SESSION_DOMAIN": ".secpal.dev",
+        "SANCTUM_STATEFUL_DOMAINS": ",".join(
+            (
+                f"frontend-{workspace}.preview.secpal.dev",
+                f"{workspace}.preview.secpal.dev",
+                "app.secpal.dev",
+            )
+        ),
+        "CORS_ALLOWED_ORIGINS": ",".join(
+            (
+                f"https://frontend-{workspace}.preview.secpal.dev",
+                f"https://{workspace}.preview.secpal.dev",
+                "https://app.secpal.dev",
+            )
+        ),
+    }
+
+
+def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> bool:
+    env_path = worktree_path / ".env"
+    if not env_path.exists():
+        source_env_path = source_repo_path / ".env"
+        if not source_env_path.exists():
+            print(
+                f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
+                f".env missing and source preview env not found at {source_env_path}"
+            )
+            return False
+        shutil.copy2(source_env_path, env_path)
+
+    env_values = load_env_assignments(env_path)
+    workspace = worktree_path.name
+    updated_values = build_api_preview_env_updates(workspace)
+
+    if env_values.get("DB_CONNECTION", "").lower() == "pgsql":
+        base_database = resolve_base_database_name(env_values, workspace)
+        if not base_database:
+            raise SystemExit(f"api worktree {worktree_path} is missing DB_DATABASE in .env")
+        preview_target = build_preview_database_name(base_database, workspace)
+        if postgres_role_can_create_databases(env_values, base_database):
+            ensure_postgres_preview_database(env_values, base_database, preview_target)
+            updated_values["DB_DATABASE"] = preview_target
+            updated_values["DB_URL"] = ""
+            updated_values[PREVIEW_STORAGE_MODE_ENV_KEY] = "database"
+            updated_values[PREVIEW_SCHEMA_ENV_KEY] = ""
+        else:
+            ensure_postgres_preview_schema(env_values, base_database, preview_target)
+            updated_values["DB_DATABASE"] = base_database
+            updated_values["DB_URL"] = build_postgres_url(env_values, base_database, preview_target)
+            updated_values[PREVIEW_STORAGE_MODE_ENV_KEY] = "schema"
+            updated_values[PREVIEW_SCHEMA_ENV_KEY] = preview_target
+        updated_values[PREVIEW_DATABASE_BASE_ENV_KEY] = base_database
+
+    env_path.write_text(upsert_env_assignments(env_path.read_text(), updated_values))
+    return True
+
+
+def cleanup_removed_api_preview_databases(
+    repo_state: dict[str, dict[str, Any]],
+    repo_specs: dict[str, dict[str, Any]],
+    clone_root: pathlib.Path,
+) -> list[str]:
+    api_clone_root = clone_root / repo_state["api"]["id"]
+    if not api_clone_root.exists():
+        return []
+
+    source_env_path = pathlib.Path(repo_specs["api"]["path"]) / ".env"
+    if not source_env_path.exists():
+        return []
+
+    env_values = load_env_assignments(source_env_path)
+    if env_values.get("DB_CONNECTION", "").lower() != "pgsql":
+        return []
+
+    base_database = resolve_base_database_name(env_values, "source")
+    if not base_database:
+        return []
+
+    active_targets = {
+        build_preview_database_name(base_database, worktree_path.name)
+        for worktree_path in api_clone_root.iterdir()
+        if worktree_path.is_dir()
+    }
+
+    cleaned_databases: list[str] = []
+    if postgres_role_can_create_databases(env_values, base_database):
+        for preview_database in list_postgres_preview_databases(env_values, base_database):
+            if preview_database in active_targets:
+                continue
+            drop_postgres_preview_database(env_values, base_database, preview_database)
+            cleaned_databases.append(preview_database)
+        return cleaned_databases
+
+    for preview_schema in list_postgres_preview_schemas(env_values, base_database):
+        if preview_schema in active_targets:
+            continue
+        drop_postgres_preview_schema(env_values, base_database, preview_schema)
+        cleaned_databases.append(preview_schema)
+
+    return cleaned_databases
 
 
 def build_frontend_preview_env_setup_command() -> str:
@@ -160,7 +431,6 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "preview": {"url": build_preview_url_template("api")},
             "scripts": {
                 "setup": [
-                    build_api_preview_env_setup_command(),
                     "test -d vendor || composer install",
                     build_api_preview_seed_command(),
                 ],
@@ -524,6 +794,8 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
         spec["path"] = repo_path
         spec["copilot_instructions"] = repo_path / settings["copilot_instructions"]
         spec["focus_instruction_paths"] = [repo_path / path for path in settings["focus_instruction_paths"]]
+        if repo_name == "api":
+            spec["local_config"]["scripts"]["setup"].insert(0, build_api_preview_env_setup_command(repo_path))
         repo_specs[repo_name] = spec
     return repo_specs
 
@@ -826,23 +1098,6 @@ def run_setup_commands(worktree_path: pathlib.Path, commands: list[str]) -> None
         )
 
 
-def ensure_api_preview_env(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> bool:
-    env_path = worktree_path / ".env"
-    if env_path.exists():
-        return True
-
-    source_env_path = source_repo_path / ".env"
-    if source_env_path.exists():
-        shutil.copy2(source_env_path, env_path)
-        return True
-
-    print(
-        f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
-        f".env missing and source preview env not found at {source_env_path}"
-    )
-    return False
-
-
 def sync_worktree_local_config(worktree_path: pathlib.Path, config_text: str) -> None:
     (worktree_path / POLYSCOPE_LOCAL_CONFIG_NAME).write_text(config_text)
     ensure_exclude(worktree_path, {POLYSCOPE_LOCAL_CONFIG_NAME, PROVISION_MARKER_FILENAME})
@@ -905,9 +1160,14 @@ def ensure_worktree_hooks(worktree_path: pathlib.Path) -> None:
     ensure_pre_push_hook(worktree_path)
 
 
-def provision_worktrees(repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]], clone_root: pathlib.Path) -> list[str]:
+def provision_worktrees(
+    repo_state: dict[str, dict[str, Any]],
+    repo_specs: dict[str, dict[str, Any]],
+    clone_root: pathlib.Path,
+) -> tuple[list[str], list[str]]:
     rendered_configs = render_local_configs(repo_specs)
     provisioned_worktrees: list[str] = []
+    cleaned_preview_databases = cleanup_removed_api_preview_databases(repo_state, repo_specs, clone_root)
 
     for repo_name, spec in repo_specs.items():
         repo_clone_root = clone_root / repo_state[repo_name]["id"]
@@ -916,6 +1176,8 @@ def provision_worktrees(repo_state: dict[str, dict[str, Any]], repo_specs: dict[
 
         local_config = render_local_config(spec)
         setup_commands = local_config.get("scripts", {}).get("setup", [])
+        if repo_name == "api":
+            setup_commands = setup_commands[1:]
         setup_hash = build_setup_hash(local_config)
         config_text = rendered_configs[repo_name]
 
@@ -923,8 +1185,9 @@ def provision_worktrees(repo_state: dict[str, dict[str, Any]], repo_specs: dict[
             sync_worktree_local_config(worktree_path, config_text)
             ensure_worktree_hooks(worktree_path)
 
-            if repo_name == "api" and not ensure_api_preview_env(worktree_path, spec["path"]):
-                continue
+            if repo_name == "api":
+                if not ensure_api_worktree_ready(worktree_path, spec["path"]):
+                    continue
 
             marker_path = worktree_path / PROVISION_MARKER_FILENAME
             marker = load_provision_marker(marker_path)
@@ -949,7 +1212,7 @@ def provision_worktrees(repo_state: dict[str, dict[str, Any]], repo_specs: dict[
             )
             provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
 
-    return provisioned_worktrees
+    return provisioned_worktrees, cleaned_preview_databases
 
 
 def request_json(api_base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None) -> Any:
@@ -1203,11 +1466,13 @@ def build_summary(
     db_backup: pathlib.Path | None,
     nginx_output: pathlib.Path,
     provisioned_worktrees: list[str],
+    cleaned_preview_databases: list[str],
 ) -> dict[str, Any]:
     summary: dict[str, Any] = {
         "db_backup": str(db_backup) if db_backup is not None else None,
         "rendered_nginx_config": str(nginx_output),
         "provisioned_worktrees": provisioned_worktrees,
+        "cleaned_preview_databases": cleaned_preview_databases,
         "repositories": {},
     }
     for repo_name, spec in repo_specs.items():
@@ -1235,6 +1500,8 @@ def install_nginx_config(nginx_output: pathlib.Path) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Sync SecPal Polyscope prompts, links, and preview config.")
+    parser.add_argument("--prepare-api-worktree", type=pathlib.Path)
+    parser.add_argument("--source-repo-path", type=pathlib.Path)
     parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
     parser.add_argument("--db-path", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "polyscope.db")
     parser.add_argument("--clone-root", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "clones")
@@ -1251,6 +1518,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+
+    if args.prepare_api_worktree is not None:
+        if args.source_repo_path is None:
+            raise SystemExit("--source-repo-path is required with --prepare-api-worktree")
+        return 0 if ensure_api_worktree_ready(args.prepare_api_worktree, args.source_repo_path) else 1
+
     repo_specs = build_repo_specs(args.workspace_root)
 
     validate_repo_local_configs(repo_specs)
@@ -1273,10 +1546,18 @@ def main() -> int:
         install_nginx_config(args.nginx_output)
 
     provisioned_worktrees: list[str] = []
+    cleaned_preview_databases: list[str] = []
     if args.provision_worktrees:
-        provisioned_worktrees = provision_worktrees(repo_state, repo_specs, args.clone_root)
+        provisioned_worktrees, cleaned_preview_databases = provision_worktrees(repo_state, repo_specs, args.clone_root)
 
-    summary = build_summary(repo_state, repo_specs, db_backup, args.nginx_output, provisioned_worktrees)
+    summary = build_summary(
+        repo_state,
+        repo_specs,
+        db_backup,
+        args.nginx_output,
+        provisioned_worktrees,
+        cleaned_preview_databases,
+    )
     if args.summary_output is not None:
         args.summary_output.write_text(json.dumps(summary, indent=2) + "\n")
     print(json.dumps(summary, indent=2))

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1069,8 +1069,7 @@ def render_local_configs(repo_specs: dict[str, dict[str, Any]]) -> dict[str, str
     }
 
 
-def build_setup_hash(config: dict[str, Any]) -> str:
-    setup_commands = config.get("scripts", {}).get("setup", [])
+def build_setup_hash(setup_commands: list[str]) -> str:
     payload = json.dumps(setup_commands, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(payload.encode()).hexdigest()
 
@@ -1178,21 +1177,21 @@ def provision_worktrees(
         setup_commands = local_config.get("scripts", {}).get("setup", [])
         if repo_name == "api":
             setup_commands = setup_commands[1:]
-        setup_hash = build_setup_hash(local_config)
+        setup_hash = build_setup_hash(setup_commands)
         config_text = rendered_configs[repo_name]
 
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
             sync_worktree_local_config(worktree_path, config_text)
             ensure_worktree_hooks(worktree_path)
 
-            if repo_name == "api":
-                if not ensure_api_worktree_ready(worktree_path, spec["path"]):
-                    continue
-
             marker_path = worktree_path / PROVISION_MARKER_FILENAME
             marker = load_provision_marker(marker_path)
             if marker is not None and marker.get("setup_hash") == setup_hash:
                 continue
+
+            if repo_name == "api":
+                if not ensure_api_worktree_ready(worktree_path, spec["path"]):
+                    continue
 
             if setup_commands:
                 print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -342,7 +342,6 @@ def cleanup_removed_api_preview_databases(
                 continue
             drop_postgres_preview_database(env_values, base_database, preview_database)
             cleaned_databases.append(preview_database)
-        return cleaned_databases
 
     for preview_schema in list_postgres_preview_schemas(env_values, base_database):
         if preview_schema in active_targets:
@@ -1166,7 +1165,7 @@ def provision_worktrees(
 ) -> tuple[list[str], list[str]]:
     rendered_configs = render_local_configs(repo_specs)
     provisioned_worktrees: list[str] = []
-    cleaned_preview_databases = cleanup_removed_api_preview_databases(repo_state, repo_specs, clone_root)
+    cleaned_preview_storage_targets = cleanup_removed_api_preview_databases(repo_state, repo_specs, clone_root)
 
     for repo_name, spec in repo_specs.items():
         repo_clone_root = clone_root / repo_state[repo_name]["id"]
@@ -1211,7 +1210,7 @@ def provision_worktrees(
             )
             provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
 
-    return provisioned_worktrees, cleaned_preview_databases
+    return provisioned_worktrees, cleaned_preview_storage_targets
 
 
 def request_json(api_base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None) -> Any:
@@ -1465,13 +1464,13 @@ def build_summary(
     db_backup: pathlib.Path | None,
     nginx_output: pathlib.Path,
     provisioned_worktrees: list[str],
-    cleaned_preview_databases: list[str],
+    cleaned_preview_storage_targets: list[str],
 ) -> dict[str, Any]:
     summary: dict[str, Any] = {
         "db_backup": str(db_backup) if db_backup is not None else None,
         "rendered_nginx_config": str(nginx_output),
         "provisioned_worktrees": provisioned_worktrees,
-        "cleaned_preview_databases": cleaned_preview_databases,
+        "cleaned_preview_storage_targets": cleaned_preview_storage_targets,
         "repositories": {},
     }
     for repo_name, spec in repo_specs.items():
@@ -1545,9 +1544,9 @@ def main() -> int:
         install_nginx_config(args.nginx_output)
 
     provisioned_worktrees: list[str] = []
-    cleaned_preview_databases: list[str] = []
+    cleaned_preview_storage_targets: list[str] = []
     if args.provision_worktrees:
-        provisioned_worktrees, cleaned_preview_databases = provision_worktrees(repo_state, repo_specs, args.clone_root)
+        provisioned_worktrees, cleaned_preview_storage_targets = provision_worktrees(repo_state, repo_specs, args.clone_root)
 
     summary = build_summary(
         repo_state,
@@ -1555,7 +1554,7 @@ def main() -> int:
         db_backup,
         args.nginx_output,
         provisioned_worktrees,
-        cleaned_preview_databases,
+        cleaned_preview_storage_targets,
     )
     if args.summary_output is not None:
         args.summary_output.write_text(json.dumps(summary, indent=2) + "\n")

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -793,7 +793,7 @@ python3 - "$provision_summary_json" <<'PY'
 import json, sys
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
-cleaned = summary.get('cleaned_preview_databases', [])
+cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:auto-hawk' in provisioned, f"expected api:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert cleaned == [], f"expected no cleaned preview databases on first provisioning run, got {cleaned}"
@@ -873,7 +873,7 @@ python3 - "$stale_provision_summary_json" <<'PY'
 import json, sys
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
-cleaned = summary.get('cleaned_preview_databases', [])
+cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:stale-otter' in provisioned, f"expected api:stale-otter in provisioned_worktrees, got {provisioned}"
 assert cleaned == [], f"expected no cleaned preview databases while stale-otter still exists, got {cleaned}"
 PY
@@ -894,6 +894,15 @@ assert 'secpal__preview__stale_otter' in state['databases']
 PY
 
 rm -rf "$stale_api_clone"
+
+# Inject a stale schema alongside the stale database to verify that in database mode
+# (rolcreatedb=true) the cleanup also prunes orphaned schemas from a previous schema-mode run.
+python3 - "$fake_pg_state" <<'PY'
+import json, sys
+state = json.loads(open(sys.argv[1]).read())
+state.setdefault("schemas", []).append("secpal__preview__legacy_schema_otter")
+open(sys.argv[1], "w").write(json.dumps(state))
+PY
 
 cleanup_summary_json="$workspace/cleanup-summary.json"
 env HOME="$home_dir" \
@@ -919,9 +928,12 @@ summary = json.loads(open(sys.argv[1]).read())
 state = json.loads(open(sys.argv[2]).read())
 
 assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
-assert summary.get('cleaned_preview_databases', []) == ['secpal__preview__stale_otter'], summary.get('cleaned_preview_databases', [])
+cleaned = summary.get('cleaned_preview_storage_targets', [])
+assert 'secpal__preview__stale_otter' in cleaned, f"expected stale db in cleaned, got {cleaned}"
+assert 'secpal__preview__legacy_schema_otter' in cleaned, f"expected stale schema in cleaned even in database mode, got {cleaned}"
 assert 'secpal__preview__auto_hawk' in state['databases']
 assert 'secpal__preview__stale_otter' not in state['databases']
+assert 'secpal__preview__legacy_schema_otter' not in state.get('schemas', [])
 PY
 
 grep -qF 'SELECT datname FROM pg_database WHERE datname LIKE '"'"'secpal__preview__%'"'" "$fake_psql_log"
@@ -952,7 +964,7 @@ import sys
 
 summary = json.loads(open(sys.argv[1]).read())
 assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
-assert summary.get('cleaned_preview_databases', []) == [], summary.get('cleaned_preview_databases', [])
+assert summary.get('cleaned_preview_storage_targets', []) == [], summary.get('cleaned_preview_storage_targets', [])
 PY
 
 schema_home_dir="$workspace/schema-home"
@@ -1020,7 +1032,7 @@ import sys
 
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
-cleaned = summary.get('cleaned_preview_databases', [])
+cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:schema-badger' in provisioned, provisioned
 assert 'frontend:schema-badger' in provisioned, provisioned
 assert cleaned == [], cleaned
@@ -1069,7 +1081,7 @@ summary = json.loads(open(sys.argv[1]).read())
 state = json.loads(open(sys.argv[2]).read())
 
 assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
-assert summary.get('cleaned_preview_databases', []) == ['secpal__preview__schema_badger'], summary.get('cleaned_preview_databases', [])
+assert summary.get('cleaned_preview_storage_targets', []) == ['secpal__preview__schema_badger'], summary.get('cleaned_preview_storage_targets', [])
 assert 'secpal__preview__schema_badger' not in state['schemas'], state['schemas']
 PY
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -486,13 +486,7 @@ python3 "$PYTHON_SCRIPT" \
 grep -q 'https://api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
 grep -q 'org-shared.instructions.md' "$workspace_root/api/polyscope.local.json"
-grep -qF 'POLYSCOPE_WORKSPACE' "$workspace_root/api/polyscope.local.json"
-grep -qF 'python3 -c' "$workspace_root/api/polyscope.local.json"
-grep -qF 'APP_URL' "$workspace_root/api/polyscope.local.json"
-grep -qF 'FRONTEND_URL' "$workspace_root/api/polyscope.local.json"
-grep -qF 'SANCTUM_STATEFUL_DOMAINS' "$workspace_root/api/polyscope.local.json"
-grep -qF 'CORS_ALLOWED_ORIGINS' "$workspace_root/api/polyscope.local.json"
-grep -qF 'frontend-{workspace}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
+grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF 'php artisan config:clear && php artisan migrate --force && php artisan db:seed --force && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
 grep -qF "test@example.com" "$workspace_root/api/polyscope.local.json"
 grep -qF 'Preview Only: Refresh DB + E2E User' "$workspace_root/api/polyscope.local.json"
@@ -608,12 +602,22 @@ assert summary['repositories']['.github']['linked_repositories'] == []
 PY
 
 provision_log="$workspace/provision.log"
+fake_psql_log="$workspace/psql.log"
+fake_pg_state="$workspace/postgres-state.json"
 fake_exec_dir="$workspace/fake-exec"
 service_path="$fake_exec_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 api_clone="$home_dir/.polyscope/clones/api12345/auto-hawk"
 frontend_clone="$home_dir/.polyscope/clones/fe123456/auto-hawk"
 mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts"
 mkdir -p "$home_dir/.local/bin"
+
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(json.dumps({"databases": ["secpal"], "schemas": [], "rolcreatedb": True}))
+PY
 
 cat >"$fake_exec_dir/composer" <<'STUB'
 #!/usr/bin/env bash
@@ -643,6 +647,79 @@ exit 0
 STUB
 chmod +x "$fake_exec_dir/npm"
 
+cat >"$fake_exec_dir/psql" <<'STUB'
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+log_path = Path(os.environ["FAKE_PSQL_LOG"])
+state_path = Path(os.environ["FAKE_PSQL_STATE"])
+
+state = {"databases": [], "schemas": [], "rolcreatedb": True}
+if state_path.exists():
+    state = json.loads(state_path.read_text())
+
+args = sys.argv[1:]
+sql = ""
+if "-Atqc" in args:
+    sql = args[args.index("-Atqc") + 1]
+elif "-c" in args:
+    sql = args[args.index("-c") + 1]
+
+with log_path.open("a") as handle:
+    handle.write(f"psql:{os.getcwd()}:{sql}\n")
+
+databases = state.get("databases", [])
+schemas = state.get("schemas", [])
+role_match = re.search(r"SELECT rolcreatedb FROM pg_roles WHERE rolname = current_user", sql)
+exists_match = re.search(r"SELECT 1 FROM pg_database WHERE datname = '([^']+)'", sql)
+list_match = re.search(r"SELECT datname FROM pg_database WHERE datname LIKE '([^']+)'", sql)
+create_match = re.search(r'CREATE DATABASE "([^"]+)"', sql)
+drop_match = re.search(r'DROP DATABASE IF EXISTS "([^"]+)"(?: WITH \(FORCE\))?', sql)
+schema_list_match = re.search(r"SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '([^']+)'", sql)
+create_schema_match = re.search(r'CREATE SCHEMA IF NOT EXISTS "([^"]+)"', sql)
+drop_schema_match = re.search(r'DROP SCHEMA IF EXISTS "([^"]+)" CASCADE', sql)
+
+if role_match:
+    sys.stdout.write("t\n" if state.get("rolcreatedb", False) else "f\n")
+elif exists_match:
+    database_name = exists_match.group(1)
+    if database_name in databases:
+        sys.stdout.write("1\n")
+elif list_match:
+    prefix = list_match.group(1).replace("%", "")
+    matches = sorted(database_name for database_name in databases if database_name.startswith(prefix))
+    if matches:
+        sys.stdout.write("\n".join(matches) + "\n")
+elif schema_list_match:
+    prefix = schema_list_match.group(1).replace("%", "")
+    matches = sorted(schema_name for schema_name in schemas if schema_name.startswith(prefix))
+    if matches:
+        sys.stdout.write("\n".join(matches) + "\n")
+elif create_match:
+    database_name = create_match.group(1)
+    if database_name not in databases:
+        databases.append(database_name)
+elif drop_match:
+    database_name = drop_match.group(1)
+    databases = [entry for entry in databases if entry != database_name]
+elif create_schema_match:
+    schema_name = create_schema_match.group(1)
+    if schema_name not in schemas:
+        schemas.append(schema_name)
+elif drop_schema_match:
+    schema_name = drop_schema_match.group(1)
+    schemas = [entry for entry in schemas if entry != schema_name]
+
+state["databases"] = sorted(databases)
+state["schemas"] = sorted(schemas)
+state_path.write_text(json.dumps(state))
+STUB
+chmod +x "$fake_exec_dir/psql"
+
 cat >"$home_dir/.local/bin/pre-commit" <<'STUB'
 #!/usr/bin/env bash
 printf 'pre-commit:%s:%s\n' "$PWD" "$*" >> "$PROVISION_LOG"
@@ -659,6 +736,12 @@ chmod +x "$home_dir/.local/bin/pre-commit"
 cat >"$workspace_root/api/.env" <<'EOF'
 APP_URL=https://api.secpal.dev
 FRONTEND_URL=https://app.secpal.dev
+DB_CONNECTION=pgsql
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_DATABASE=secpal
+DB_USERNAME=secpal
+DB_PASSWORD=
 SESSION_DOMAIN=.secpal.dev
 SANCTUM_STATEFUL_DOMAINS=app.secpal.dev
 CORS_ALLOWED_ORIGINS=https://app.secpal.dev
@@ -694,6 +777,8 @@ provision_summary_json="$workspace/provision-summary.json"
 env HOME="$home_dir" \
     PATH="$service_path" \
     PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
     python3 "$PYTHON_SCRIPT" \
     --workspace-root "$workspace_root" \
     --repo-state-file "$repos_json" \
@@ -708,12 +793,17 @@ python3 - "$provision_summary_json" <<'PY'
 import json, sys
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
+cleaned = summary.get('cleaned_preview_databases', [])
 assert 'api:auto-hawk' in provisioned, f"expected api:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in provisioned_worktrees, got {provisioned}"
+assert cleaned == [], f"expected no cleaned preview databases on first provisioning run, got {cleaned}"
 PY
 
 grep -qF 'APP_URL=https://api-auto-hawk.preview.secpal.dev' "$api_clone/.env"
 grep -qF 'FRONTEND_URL=https://frontend-auto-hawk.preview.secpal.dev' "$api_clone/.env"
+grep -qF 'DB_CONNECTION=pgsql' "$api_clone/.env"
+grep -qF 'DB_DATABASE=secpal__preview__auto_hawk' "$api_clone/.env"
+grep -qF 'POLYSCOPE_BASE_DB_DATABASE=secpal' "$api_clone/.env"
 grep -qF 'SANCTUM_STATEFUL_DOMAINS=frontend-auto-hawk.preview.secpal.dev,auto-hawk.preview.secpal.dev,app.secpal.dev' "$api_clone/.env"
 grep -qF 'CORS_ALLOWED_ORIGINS=https://frontend-auto-hawk.preview.secpal.dev,https://auto-hawk.preview.secpal.dev,https://app.secpal.dev' "$api_clone/.env"
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.local"
@@ -738,6 +828,17 @@ grep -qF "npm:$frontend_clone:ci" "$provision_log"
 grep -qF "npm:$frontend_clone:run build -- --mode preview" "$provision_log"
 grep -qF "pre-commit:$api_clone:install --install-hooks --hook-type pre-commit" "$provision_log"
 grep -qF "pre-commit:$frontend_clone:install --install-hooks --hook-type pre-commit" "$provision_log"
+grep -qF "SELECT 1 FROM pg_database WHERE datname = 'secpal__preview__auto_hawk'" "$fake_psql_log"
+grep -qF 'CREATE DATABASE "secpal__preview__auto_hawk"' "$fake_psql_log"
+
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+assert 'secpal' in state['databases']
+assert 'secpal__preview__auto_hawk' in state['databases']
+PY
 
 stale_api_clone="$home_dir/.polyscope/clones/api12345/stale-otter"
 mkdir -p "$stale_api_clone/.git/info" "$stale_api_clone/.git/hooks" "$stale_api_clone/scripts"
@@ -756,6 +857,8 @@ stale_provision_summary_json="$workspace/stale-provision-summary.json"
 env HOME="$home_dir" \
     PATH="$service_path" \
     PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
     python3 "$PYTHON_SCRIPT" \
     --workspace-root "$workspace_root" \
     --repo-state-file "$repos_json" \
@@ -770,27 +873,208 @@ python3 - "$stale_provision_summary_json" <<'PY'
 import json, sys
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
+cleaned = summary.get('cleaned_preview_databases', [])
 assert 'api:stale-otter' in provisioned, f"expected api:stale-otter in provisioned_worktrees, got {provisioned}"
+assert cleaned == [], f"expected no cleaned preview databases while stale-otter still exists, got {cleaned}"
 PY
 
 grep -qF 'APP_URL=https://api-stale-otter.preview.secpal.dev' "$stale_api_clone/.env"
 grep -qF 'FRONTEND_URL=https://frontend-stale-otter.preview.secpal.dev' "$stale_api_clone/.env"
+grep -qF 'DB_DATABASE=secpal__preview__stale_otter' "$stale_api_clone/.env"
+grep -qF 'POLYSCOPE_BASE_DB_DATABASE=secpal' "$stale_api_clone/.env"
 test -f "$stale_api_clone/.polyscope-secpal-provisioned.json"
+grep -qF 'CREATE DATABASE "secpal__preview__stale_otter"' "$fake_psql_log"
 
-provision_log_lines_before="$(wc -l < "$provision_log")"
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+assert 'secpal__preview__stale_otter' in state['databases']
+PY
+
+rm -rf "$stale_api_clone"
+
+cleanup_summary_json="$workspace/cleanup-summary.json"
 env HOME="$home_dir" \
     PATH="$service_path" \
     PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
     python3 "$PYTHON_SCRIPT" \
     --workspace-root "$workspace_root" \
     --repo-state-file "$repos_json" \
     --nginx-output "$nginx_output" \
+    --summary-output "$cleanup_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$cleanup_summary_json" "$fake_pg_state" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+state = json.loads(open(sys.argv[2]).read())
+
+assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
+assert summary.get('cleaned_preview_databases', []) == ['secpal__preview__stale_otter'], summary.get('cleaned_preview_databases', [])
+assert 'secpal__preview__auto_hawk' in state['databases']
+assert 'secpal__preview__stale_otter' not in state['databases']
+PY
+
+grep -qF 'SELECT datname FROM pg_database WHERE datname LIKE '"'"'secpal__preview__%'"'" "$fake_psql_log"
+grep -qF 'DROP DATABASE IF EXISTS "secpal__preview__stale_otter" WITH (FORCE)' "$fake_psql_log"
+
+provision_log_lines_before="$(wc -l < "$provision_log")"
+idempotent_summary_json="$workspace/idempotent-summary.json"
+env HOME="$home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$idempotent_summary_json" \
     --skip-local-configs \
     --skip-db-sync \
     --provision-worktrees \
     > /dev/null
 
 test "$provision_log_lines_before" -eq "$(wc -l < "$provision_log")"
+
+python3 - "$idempotent_summary_json" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
+assert summary.get('cleaned_preview_databases', []) == [], summary.get('cleaned_preview_databases', [])
+PY
+
+schema_home_dir="$workspace/schema-home"
+schema_api_clone="$schema_home_dir/.polyscope/clones/api12345/schema-badger"
+schema_frontend_clone="$schema_home_dir/.polyscope/clones/fe123456/schema-badger"
+schema_pg_state="$workspace/postgres-schema-state.json"
+schema_summary_json="$workspace/schema-summary.json"
+schema_cleanup_summary_json="$workspace/schema-cleanup-summary.json"
+
+mkdir -p "$schema_home_dir/.local/bin" "$schema_api_clone/.git/info" "$schema_api_clone/.git/hooks" "$schema_api_clone/scripts" "$schema_frontend_clone/.git/info" "$schema_frontend_clone/.git/hooks" "$schema_frontend_clone/scripts"
+cp "$home_dir/.local/bin/pre-commit" "$schema_home_dir/.local/bin/pre-commit"
+
+python3 - <<'PY' "$schema_pg_state"
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(json.dumps({"databases": ["secpal"], "schemas": [], "rolcreatedb": False}))
+PY
+
+cp "$workspace_root/api/.env" "$schema_api_clone/.env"
+
+cat >"$schema_api_clone/.pre-commit-config.yaml" <<'EOF'
+repos: []
+EOF
+
+cat >"$schema_api_clone/scripts/preflight.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$schema_api_clone/scripts/preflight.sh"
+
+cat >"$schema_frontend_clone/.env.local" <<'EOF'
+VITE_API_URL=https://api.secpal.dev
+EOF
+
+cat >"$schema_frontend_clone/.pre-commit-config.yaml" <<'EOF'
+repos: []
+EOF
+
+cat >"$schema_frontend_clone/scripts/preflight.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$schema_frontend_clone/scripts/preflight.sh"
+
+env HOME="$schema_home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$schema_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$schema_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$schema_summary_json" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+cleaned = summary.get('cleaned_preview_databases', [])
+assert 'api:schema-badger' in provisioned, provisioned
+assert 'frontend:schema-badger' in provisioned, provisioned
+assert cleaned == [], cleaned
+PY
+
+grep -qF 'DB_DATABASE=secpal' "$schema_api_clone/.env"
+grep -qF 'DB_URL=postgresql://secpal@127.0.0.1:5432/secpal?search_path=secpal__preview__schema_badger' "$schema_api_clone/.env"
+grep -qF 'POLYSCOPE_BASE_DB_DATABASE=secpal' "$schema_api_clone/.env"
+grep -qF 'POLYSCOPE_PREVIEW_STORAGE_MODE=schema' "$schema_api_clone/.env"
+grep -qF 'POLYSCOPE_PREVIEW_SCHEMA=secpal__preview__schema_badger' "$schema_api_clone/.env"
+grep -qF 'VITE_API_URL=https://api-schema-badger.preview.secpal.dev' "$schema_frontend_clone/.env.local"
+grep -qF 'SELECT rolcreatedb FROM pg_roles WHERE rolname = current_user' "$fake_psql_log"
+grep -qF 'CREATE SCHEMA IF NOT EXISTS "secpal__preview__schema_badger"' "$fake_psql_log"
+
+python3 - <<'PY' "$schema_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+assert state['databases'] == ['secpal'], state['databases']
+assert 'secpal__preview__schema_badger' in state['schemas'], state['schemas']
+PY
+
+rm -rf "$schema_api_clone" "$schema_frontend_clone"
+
+env HOME="$schema_home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$schema_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$schema_cleanup_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$schema_cleanup_summary_json" "$schema_pg_state" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+state = json.loads(open(sys.argv[2]).read())
+
+assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
+assert summary.get('cleaned_preview_databases', []) == ['secpal__preview__schema_badger'], summary.get('cleaned_preview_databases', [])
+assert 'secpal__preview__schema_badger' not in state['schemas'], state['schemas']
+PY
+
+grep -qF 'SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '"'"'secpal__preview__%'"'" "$fake_psql_log"
+grep -qF 'DROP SCHEMA IF EXISTS "secpal__preview__schema_badger" CASCADE' "$fake_psql_log"
 
 assert_rollout_rejects_invalid_local_config \
     "$PYTHON_SCRIPT" \


### PR DESCRIPTION
## Summary

- isolate Polyscope preview API storage per workspace
- provision a deterministic preview database when the PostgreSQL role can create databases, otherwise fall back to a deterministic preview schema wired through `DB_URL?search_path=...`
- prune orphaned preview databases or schemas when the matching API workspace disappears
- reuse the same API worktree preparation helper for generated setup commands and background `--provision-worktrees` runs

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- live verification on the SecPal preview host: created a fresh API/frontend workspace pair, confirmed frontend `200`, confirmed API `sanctum/csrf-cookie` `204`, and confirmed cleanup after workspace removal

## Notes

- Closes #427.
- live host fallback currently uses schema isolation because the active role `secpal_app` has `rolcreatedb=false`
- after merge, repoint `/home/secpal/.local/bin/polyscope-secpal-rollout.py` from the temporary worktree path back to the merged `.github` checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Polyscope provisions API worktrees by creating/dropping PostgreSQL databases or schemas and rewriting DB connection env vars, which could impact preview stability or delete unintended state if misconfigured.
> 
> **Overview**
> Polyscope API worktree provisioning now isolates PostgreSQL state per workspace: it deterministically creates a per-workspace preview *database* when the role has `CREATEDB`, otherwise it provisions a per-workspace *schema* and routes via `DB_URL?search_path=...`, while persisting the original base database in `POLYSCOPE_BASE_DB_DATABASE`.
> 
> The rollout script adds a shared `--prepare-api-worktree` helper and updates generated `api/polyscope.local.json` setup to call it, keeping manual setup and `--provision-worktrees` behavior aligned. Provisioning also prunes orphaned preview databases/schemas when API workspace directories are removed and reports cleaned targets in the summary output.
> 
> `tests/polyscope-rollout.sh` is expanded with a `psql` stub to cover database vs schema modes, base-db metadata tracking, orphan cleanup, and idempotent re-runs, and `CHANGELOG.md` documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae211577cfd1e897331cb57477160f783b76055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->