### PR TITLE
fix: respect system-managed Polyscope server installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 - changed the generated API `polyscope.local.json` setup to call the shared rollout helper directly for worktree preparation, so manual Polyscope setup and automatic `--provision-worktrees` runs use the same database-isolation path instead of drifting between inline env rewrites and background provisioning behavior
 - extended `tests/polyscope-rollout.sh` to prove both workspace-specific preview-database provisioning and schema fallback, tracked base-database metadata, cleanup of removed workspaces, and idempotent reruns after cleanup
 
+## 2026-05-03 - Respect System-Managed Polyscope Server Installs
+
+**Changed:**
+
+- hardened `scripts/install-polyscope-rollout.sh` to auto-detect an existing system-managed `polyscope-server.service` and install a SecPal runtime drop-in there instead of blindly creating a competing user `polyscope-server.service`, so repeated rollout installs no longer reintroduce port-4321 restart loops on hosts where Polyscope already runs as a system service
+- kept the user-managed rollout sync and worktree-provision path units, but decoupled them from the user server unit when the system service is authoritative, so prompt sync and fresh-workspace provisioning still run immediately after install without reviving the conflicting user server path
+- made Expose wrapper installation idempotent when `expose-linux-x64.real` already exists and the live `expose-linux-x64` path has been restored to the original binary contents, so re-running the installer repairs the wrapper instead of aborting on a stale-but-safe backup state
+- extended `tests/polyscope-rollout.sh` to cover both the repaired Expose rewrap path and the auto-detected system-service install path, including generated drop-in content and the absence of a competing user Polyscope server unit
+
 ## 2026-05-02 - Return Direct Preview URLs From Polyscope Share
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -24,7 +24,6 @@ POLYSCOPE_GIT_WRAPPER_BIN="${POLYSCOPE_GIT_WRAPPER_BIN:-$POLYSCOPE_GIT_BIN_DIR/g
 POLYSCOPE_SERVER_SCOPE="${POLYSCOPE_SERVER_SCOPE:-auto}"
 POLYSCOPE_SYSTEM_SERVER_UNIT="${POLYSCOPE_SYSTEM_SERVER_UNIT:-polyscope-server.service}"
 POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="${POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR:-/etc/systemd/system/$POLYSCOPE_SYSTEM_SERVER_UNIT.d}"
-POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK="${POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK:-/run/user/$(id -u)/openssh_agent}"
 SERVICE_PATH="${POLYSCOPE_SERVICE_PATH:-}"
 SUDO_BIN="${SUDO_BIN:-sudo}"
 
@@ -142,7 +141,7 @@ if [[ ! -x "$POLYSCOPE_REAL_GIT_BIN" ]]; then
     exit 1
 fi
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK SERVICE_PATH SUDO_BIN; do
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR SERVICE_PATH SUDO_BIN; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -154,8 +153,38 @@ for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE 
     fi
 done
 
+# Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.
+for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE INSTALL_TARGET; do
+    _val="${!_var_name}"
+    if [[ "$_val" =~ [^a-zA-Z0-9/_.:-] ]]; then
+        echo "Error: $_var_name contains characters that are unsafe in shell command strings; only letters, digits, /, _, ., :, - are permitted" >&2
+        exit 1
+    fi
+done
+
+# Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.
+for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE INSTALL_TARGET; do
+    _val="${!_var_name}"
+    if [[ "$_val" =~ [^a-zA-Z0-9/_.:-] ]]; then
+        echo "Error: $_var_name contains characters that are unsafe in shell command strings; only letters, digits, /, _, ., :, - are permitted" >&2
+        exit 1
+    fi
+done
+
 server_scope="$(resolve_server_scope)"
 system_server_fragment_path="$(detect_system_server_fragment_path)"
+
+if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]]; then
+    echo "Error: --polyscope-server-scope system was requested but no system $POLYSCOPE_SYSTEM_SERVER_UNIT unit was found." >&2
+    echo "Hint: use --polyscope-server-scope user to install the user-managed server unit instead." >&2
+    exit 1
+fi
+
+if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]]; then
+    echo "Error: --polyscope-server-scope system was requested but no system $POLYSCOPE_SYSTEM_SERVER_UNIT unit was found." >&2
+    echo "Hint: use --polyscope-server-scope user to install the user-managed server unit instead." >&2
+    exit 1
+fi
 
 if [[ "$server_scope" == "system" ]] && ! can_run_privileged_commands; then
     echo "Error: detected existing system $POLYSCOPE_SYSTEM_SERVER_UNIT at ${system_server_fragment_path:-<unknown>}, but non-interactive sudo or root access is unavailable." >&2
@@ -225,7 +254,7 @@ ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
 ExecStartPost=
 ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
 Environment=PATH=$SERVICE_PATH
-Environment=SSH_AUTH_SOCK=$POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK
+Environment=SSH_AUTH_SOCK=/run/user/%U/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 EOF
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -162,23 +162,8 @@ for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE INSTALL_TARGET; do
     fi
 done
 
-# Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.
-for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE INSTALL_TARGET; do
-    _val="${!_var_name}"
-    if [[ "$_val" =~ [^a-zA-Z0-9/_.:-] ]]; then
-        echo "Error: $_var_name contains characters that are unsafe in shell command strings; only letters, digits, /, _, ., :, - are permitted" >&2
-        exit 1
-    fi
-done
-
 server_scope="$(resolve_server_scope)"
 system_server_fragment_path="$(detect_system_server_fragment_path)"
-
-if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]]; then
-    echo "Error: --polyscope-server-scope system was requested but no system $POLYSCOPE_SYSTEM_SERVER_UNIT unit was found." >&2
-    echo "Hint: use --polyscope-server-scope user to install the user-managed server unit instead." >&2
-    exit 1
-fi
 
 if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]]; then
     echo "Error: --polyscope-server-scope system was requested but no system $POLYSCOPE_SYSTEM_SERVER_UNIT unit was found." >&2

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -21,7 +21,12 @@ POLYSCOPE_EXPOSE_BIN="${POLYSCOPE_EXPOSE_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x
 POLYSCOPE_EXPOSE_REAL_BIN="${POLYSCOPE_EXPOSE_REAL_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64.real}"
 POLYSCOPE_GIT_BIN_DIR="${POLYSCOPE_GIT_BIN_DIR:-$HOME/.local/lib/polyscope/bin}"
 POLYSCOPE_GIT_WRAPPER_BIN="${POLYSCOPE_GIT_WRAPPER_BIN:-$POLYSCOPE_GIT_BIN_DIR/git}"
+POLYSCOPE_SERVER_SCOPE="${POLYSCOPE_SERVER_SCOPE:-auto}"
+POLYSCOPE_SYSTEM_SERVER_UNIT="${POLYSCOPE_SYSTEM_SERVER_UNIT:-polyscope-server.service}"
+POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="${POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR:-/etc/systemd/system/$POLYSCOPE_SYSTEM_SERVER_UNIT.d}"
+POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK="${POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK:-/run/user/$(id -u)/openssh_agent}"
 SERVICE_PATH="${POLYSCOPE_SERVICE_PATH:-}"
+SUDO_BIN="${SUDO_BIN:-sudo}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -45,6 +50,10 @@ while [[ $# -gt 0 ]]; do
             POLYSCOPE_SERVER_BIN="$2"
             shift 2
             ;;
+        --polyscope-server-scope)
+            POLYSCOPE_SERVER_SCOPE="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -66,6 +75,53 @@ PROVISION_SERVICE_UNIT="$UNIT_DIR/polyscope-worktree-provision.service"
 PROVISION_PATH_UNIT="$UNIT_DIR/polyscope-worktree-provision.path"
 ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
+detect_system_server_fragment_path() {
+    "$SYSTEMCTL_BIN" show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
+}
+
+detect_user_server_fragment_path() {
+    "$SYSTEMCTL_BIN" --user show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
+}
+
+resolve_server_scope() {
+    case "$POLYSCOPE_SERVER_SCOPE" in
+        auto)
+            local system_fragment user_fragment
+            system_fragment="$(detect_system_server_fragment_path)"
+            user_fragment="$(detect_user_server_fragment_path)"
+            if [[ -n "$system_fragment" && "$system_fragment" != "$user_fragment" ]]; then
+                printf 'system\n'
+            else
+                printf 'user\n'
+            fi
+            ;;
+        user|system)
+            printf '%s\n' "$POLYSCOPE_SERVER_SCOPE"
+            ;;
+        *)
+            echo "Error: POLYSCOPE_SERVER_SCOPE must be one of: auto, user, system" >&2
+            exit 1
+            ;;
+    esac
+}
+
+can_run_privileged_commands() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        return 0
+    fi
+
+    "$SUDO_BIN" -n true >/dev/null 2>&1
+}
+
+run_privileged() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "$@"
+        return
+    fi
+
+    "$SUDO_BIN" -n "$@"
+}
+
 if [[ -z "$POLYSCOPE_SERVER_BIN" ]]; then
     echo "Error: polyscope-server binary not found. Pass --polyscope-server-bin or ensure it is in PATH." >&2
     exit 1
@@ -86,7 +142,7 @@ if [[ ! -x "$POLYSCOPE_REAL_GIT_BIN" ]]; then
     exit 1
 fi
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN SERVICE_PATH; do
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK SERVICE_PATH SUDO_BIN; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -98,6 +154,15 @@ for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE 
     fi
 done
 
+server_scope="$(resolve_server_scope)"
+system_server_fragment_path="$(detect_system_server_fragment_path)"
+
+if [[ "$server_scope" == "system" ]] && ! can_run_privileged_commands; then
+    echo "Error: detected existing system $POLYSCOPE_SYSTEM_SERVER_UNIT at ${system_server_fragment_path:-<unknown>}, but non-interactive sudo or root access is unavailable." >&2
+    echo "Refusing to create a competing user polyscope-server.service on port 4321." >&2
+    exit 1
+fi
+
 mkdir -p "$BIN_DIR" "$UNIT_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
 ln -sfn "$WRAPPER_SOURCE" "$EXPOSE_WRAPPER_TARGET"
@@ -105,16 +170,25 @@ ln -sfn "$GIT_WRAPPER_SOURCE" "$GIT_WRAPPER_TARGET"
 
 if [[ -e "$POLYSCOPE_EXPOSE_BIN" && ! -L "$POLYSCOPE_EXPOSE_BIN" ]]; then
     if [[ -e "$POLYSCOPE_EXPOSE_REAL_BIN" ]]; then
-        echo "Error: $POLYSCOPE_EXPOSE_REAL_BIN already exists; will not overwrite it." >&2
-        echo "Remove or rename $POLYSCOPE_EXPOSE_REAL_BIN manually before re-running the installer." >&2
-        exit 1
+        if cmp -s "$POLYSCOPE_EXPOSE_BIN" "$POLYSCOPE_EXPOSE_REAL_BIN"; then
+            rm -f "$POLYSCOPE_EXPOSE_BIN"
+        else
+            echo "Error: $POLYSCOPE_EXPOSE_REAL_BIN already exists; will not overwrite it." >&2
+            echo "Remove or rename $POLYSCOPE_EXPOSE_REAL_BIN manually before re-running the installer." >&2
+            exit 1
+        fi
+    else
+        mv -f "$POLYSCOPE_EXPOSE_BIN" "$POLYSCOPE_EXPOSE_REAL_BIN"
     fi
-    mv -f "$POLYSCOPE_EXPOSE_BIN" "$POLYSCOPE_EXPOSE_REAL_BIN"
 fi
 
 ln -sfn "$EXPOSE_WRAPPER_TARGET" "$POLYSCOPE_EXPOSE_BIN"
 ln -sfn "$GIT_WRAPPER_TARGET" "$POLYSCOPE_GIT_WRAPPER_BIN"
 
+rollout_sync_after='After=polyscope-server.service'
+installed_server_target="$SERVER_UNIT"
+
+if [[ "$server_scope" == "user" ]]; then
 cat >"$SERVER_UNIT" <<EOF
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
@@ -136,13 +210,36 @@ RestartSec=5s
 [Install]
 WantedBy=default.target
 EOF
+else
+    rm -f "$SERVER_UNIT"
+    rollout_sync_after='After=network-online.target'
+    installed_server_target="$POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR/zz-secpal-runtime.conf"
+
+    system_dropin_tmp="$(mktemp)"
+    cat >"$system_dropin_tmp" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Service]
+ExecStart=
+ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
+ExecStartPost=
+ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
+Environment=PATH=$SERVICE_PATH
+Environment=SSH_AUTH_SOCK=$POLYSCOPE_SYSTEM_SERVICE_SSH_AUTH_SOCK
+Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
+EOF
+
+    run_privileged install -d -m 0755 "$POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR"
+    run_privileged install -m 0644 "$system_dropin_tmp" "$installed_server_target"
+    rm -f "$system_dropin_tmp"
+fi
 
 cat >"$SERVICE_UNIT" <<EOF
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 [Unit]
 Description=Sync Polyscope prompts and preview config for SecPal
-After=polyscope-server.service
+$rollout_sync_after
 
 [Service]
 Type=oneshot
@@ -217,8 +314,17 @@ WantedBy=default.target
 EOF
 
 "$SYSTEMCTL_BIN" --user daemon-reload
-"$SYSTEMCTL_BIN" --user enable --now polyscope-server.service
-"$SYSTEMCTL_BIN" --user restart polyscope-server.service
+
+if [[ "$server_scope" == "user" ]]; then
+    "$SYSTEMCTL_BIN" --user enable --now polyscope-server.service
+    "$SYSTEMCTL_BIN" --user restart polyscope-server.service
+else
+    run_privileged "$SYSTEMCTL_BIN" daemon-reload
+    run_privileged "$SYSTEMCTL_BIN" enable --now "$POLYSCOPE_SYSTEM_SERVER_UNIT"
+    run_privileged "$SYSTEMCTL_BIN" restart "$POLYSCOPE_SYSTEM_SERVER_UNIT"
+    "$SYSTEMCTL_BIN" --user disable --now polyscope-server.service >/dev/null 2>&1 || true
+fi
+
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
@@ -229,7 +335,7 @@ echo "Installed $EXPOSE_WRAPPER_TARGET"
 echo "Installed $GIT_WRAPPER_TARGET"
 echo "Installed expose wrapper at $POLYSCOPE_EXPOSE_BIN"
 echo "Installed git wrapper at $POLYSCOPE_GIT_WRAPPER_BIN"
-echo "Installed $SERVER_UNIT"
+echo "Installed $installed_server_target"
 echo "Installed $SERVICE_UNIT"
 echo "Installed $PATH_UNIT"
 echo "Installed $PROVISION_SERVICE_UNIT"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1271,7 +1271,7 @@ test -f "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q "Environment=PATH=$system_polyscope_git_dir:$system_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
-grep -q "Environment=SSH_AUTH_SOCK=/run/user/$(id -u)/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q "Environment=SSH_AUTH_SOCK=/run/user/%U/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
 grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"
@@ -1315,6 +1315,66 @@ grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
 grep -q 'start polyscope-worktree-provision.service' "$fake_systemctl_log"
+
+# installer must refuse when system scope is detected but sudo is unavailable
+no_sudo_home_dir="$workspace/no-sudo-home"
+no_sudo_bin_dir="$workspace/no-sudo-bin"
+no_sudo_unit_dir="$workspace/no-sudo-units"
+no_sudo_polyscope_bin_dir="$no_sudo_home_dir/.polyscope/bin"
+no_sudo_polyscope_git_dir="$no_sudo_home_dir/.local/lib/polyscope/bin"
+no_sudo_sudo_dir="$workspace/no-sudo-fake-sudo"
+no_sudo_systemctl_log="$workspace/no-sudo-systemctl.log"
+no_sudo_fragment_dir="$workspace/no-sudo-fragments"
+no_sudo_fragment_path="$no_sudo_fragment_dir/polyscope-server.service"
+mkdir -p "$no_sudo_bin_dir" "$no_sudo_unit_dir" "$no_sudo_polyscope_bin_dir" "$no_sudo_polyscope_git_dir" "$no_sudo_sudo_dir" "$no_sudo_fragment_dir"
+printf '[Unit]\nDescription=Polyscope Server\n' > "$no_sudo_fragment_path"
+
+cat >"$no_sudo_polyscope_bin_dir/expose-linux-x64" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$no_sudo_polyscope_bin_dir/expose-linux-x64"
+
+cat >"$no_sudo_sudo_dir/sudo" <<'STUB'
+#!/usr/bin/env bash
+# Simulate unavailable non-interactive sudo
+if [[ "${1:-}" == "-n" ]]; then
+    echo "sudo: a password is required" >&2
+    exit 1
+fi
+exec "$@"
+STUB
+chmod +x "$no_sudo_sudo_dir/sudo"
+
+no_sudo_exit=0
+env HOME="$no_sudo_home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$no_sudo_systemctl_log" \
+    SUDO_BIN="$no_sudo_sudo_dir/sudo" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$no_sudo_fragment_path" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$no_sudo_bin_dir" --unit-dir "$no_sudo_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null || no_sudo_exit=$?
+if [[ "$no_sudo_exit" -eq 0 ]]; then
+    echo "installer must refuse when system scope detected but sudo is unavailable" >&2
+    exit 1
+fi
+test ! -e "$no_sudo_unit_dir/polyscope-server.service"
+
+# installer must also refuse when --polyscope-server-scope system is forced but no unit exists
+no_unit_exit=0
+env HOME="$no_sudo_home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$no_sudo_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$no_sudo_bin_dir" --unit-dir "$no_sudo_unit_dir" --polyscope-server-bin "$fake_server_bin" --polyscope-server-scope system 2>/dev/null || no_unit_exit=$?
+if [[ "$no_unit_exit" -eq 0 ]]; then
+    echo "installer must refuse when --polyscope-server-scope system but no system unit exists" >&2
+    exit 1
+fi
+test ! -e "$no_sudo_unit_dir/polyscope-server.service"
 
 fake_real_git_bin="$workspace/fake-tools/git-real"
 cat >"$fake_real_git_bin" <<'STUB'

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1104,12 +1104,13 @@ fake_bin_dir="$workspace/fake-bin"
 fake_unit_dir="$workspace/fake-units"
 fake_systemctl_dir="$workspace/fake-systemctl"
 fake_systemctl_log="$workspace/systemctl.log"
+fake_sudo_dir="$workspace/fake-sudo"
 fake_server_bin="$workspace/fake-tools/polyscope-server"
 fake_expose_real_log="$workspace/expose-real.log"
 fake_git_real_log="$workspace/git-real.log"
 fake_polyscope_bin_dir="$home_dir/.polyscope/bin"
 fake_polyscope_git_dir="$home_dir/.local/lib/polyscope/bin"
-mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir" "$fake_polyscope_bin_dir" "$fake_polyscope_git_dir"
+mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir" "$fake_sudo_dir" "$fake_polyscope_bin_dir" "$fake_polyscope_git_dir"
 mkdir -p "$(dirname "$fake_server_bin")"
 
 cat >"$fake_server_bin" <<'STUB'
@@ -1128,9 +1129,38 @@ chmod +x "$fake_polyscope_bin_dir/expose-linux-x64"
 cat >"$fake_systemctl_dir/systemctl" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+user_scope=0
+if [[ "${1:-}" == "--user" ]]; then
+    user_scope=1
+    shift
+fi
+
+if [[ "${1:-}" == "show" && "${2:-}" == "-p" && "${3:-}" == "FragmentPath" && "${4:-}" == "--value" && "${5:-}" == "polyscope-server.service" ]]; then
+    if [[ "$user_scope" -eq 1 ]]; then
+        printf '%s\n' "${FAKE_USER_POLYSCOPE_SERVER_FRAGMENT:-}"
+    else
+        printf '%s\n' "${FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT:-}"
+    fi
+fi
 exit 0
 STUB
 chmod +x "$fake_systemctl_dir/systemctl"
+
+cat >"$fake_sudo_dir/sudo" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SUDO_LOG"
+
+if [[ "${1:-}" == "-n" ]]; then
+    shift
+fi
+
+if [[ "${1:-}" == "true" ]]; then
+    exit 0
+fi
+
+exec "$@"
+STUB
+chmod +x "$fake_sudo_dir/sudo"
 
 env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
@@ -1163,6 +1193,22 @@ env HOME="$home_dir" \
     PATH="$fake_systemctl_dir:$PATH" \
     bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
 
+# If the wrapped Expose path is replaced with the original real binary while .real already exists,
+# the installer must still repair it idempotently instead of failing.
+rm -f "$fake_polyscope_bin_dir/expose-linux-x64"
+cp "$fake_polyscope_bin_dir/expose-linux-x64.real" "$fake_polyscope_bin_dir/expose-linux-x64"
+
+env HOME="$home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
+
+test -L "$fake_polyscope_bin_dir/expose-linux-x64"
+test "$(readlink "$fake_polyscope_bin_dir/expose-linux-x64")" = "$fake_bin_dir/polyscope-expose-wrapper.sh"
+
 # installer must refuse to overwrite an existing .real binary
 # Simulate: expose-linux-x64 is a regular file AND .real already holds a previous real binary
 fake_guard_dir="$workspace/guard-test"
@@ -1171,7 +1217,7 @@ fake_guard_expose_bin="$fake_guard_dir/expose-linux-x64"
 fake_guard_expose_real="$fake_guard_dir/expose-linux-x64.real"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_guard_expose_bin"
 chmod +x "$fake_guard_expose_bin"
-printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_guard_expose_real"
+printf '#!/usr/bin/env bash\nexit 7\n' >"$fake_guard_expose_real"
 chmod +x "$fake_guard_expose_real"
 install_real_guard_exit=0
 env HOME="$home_dir" \
@@ -1187,6 +1233,58 @@ if [[ "$install_real_guard_exit" -eq 0 ]]; then
     echo "installer guard: must refuse to overwrite existing .real binary" >&2
     exit 1
 fi
+
+system_home_dir="$workspace/system-home"
+system_bin_dir="$workspace/system-bin"
+system_user_unit_dir="$workspace/system-user-units"
+system_dropin_dir="$workspace/system-service-units/polyscope-server.service.d"
+system_polyscope_bin_dir="$system_home_dir/.polyscope/bin"
+system_polyscope_git_dir="$system_home_dir/.local/lib/polyscope/bin"
+system_systemctl_log="$workspace/system-systemctl.log"
+system_sudo_log="$workspace/system-sudo.log"
+system_fragment_dir="$workspace/system-fragments"
+system_fragment_path="$system_fragment_dir/polyscope-server.service"
+mkdir -p "$system_bin_dir" "$system_user_unit_dir" "$system_polyscope_bin_dir" "$system_polyscope_git_dir" "$system_fragment_dir"
+printf '[Unit]\nDescription=Polyscope Server\n' > "$system_fragment_path"
+
+cat >"$system_polyscope_bin_dir/expose-linux-x64" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_EXPOSE_REAL_LOG"
+exit 0
+STUB
+chmod +x "$system_polyscope_bin_dir/expose-linux-x64"
+
+env HOME="$system_home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$system_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$system_sudo_log" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
+    POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$system_dropin_dir" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$system_bin_dir" --unit-dir "$system_user_unit_dir" --polyscope-server-bin "$fake_server_bin"
+
+test ! -e "$system_user_unit_dir/polyscope-server.service"
+test -f "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q "Environment=PATH=$system_polyscope_git_dir:$system_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q "Environment=SSH_AUTH_SOCK=/run/user/$(id -u)/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
+grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"
+grep -q '^daemon-reload$' "$system_systemctl_log"
+grep -q '^enable --now polyscope-server.service$' "$system_systemctl_log"
+grep -q '^restart polyscope-server.service$' "$system_systemctl_log"
+grep -q '^--user disable --now polyscope-server.service$' "$system_systemctl_log"
+grep -q '^--user daemon-reload$' "$system_systemctl_log"
+grep -q '^--user enable --now polyscope-rollout-sync.path$' "$system_systemctl_log"
+grep -q '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
+grep -q '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log"
+grep -q '^--user start polyscope-worktree-provision.service$' "$system_systemctl_log"
+
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$fake_unit_dir/polyscope-server.service"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-server.service"


### PR DESCRIPTION
## Summary

- auto-detect existing system `polyscope-server.service` and install a SecPal runtime drop-in instead of creating a competing user service that causes port-4321 restart loops
- refuse to create a competing user service when non-interactive sudo is unavailable in system scope, with a clear error message
- decouple user-managed rollout sync and worktree-provision path units from the user server unit when the system service is authoritative, so prompt sync and fresh-workspace provisioning still run after install
- make Expose wrapper installation idempotent when `expose-linux-x64.real` already exists and the live path has been restored to the original binary contents, so re-running the installer repairs the wrapper instead of aborting
- extend `tests/polyscope-rollout.sh` to cover the repaired Expose rewrap path and the auto-detected system-service install path, including generated drop-in content and the absence of a competing user server unit

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- live verification on the SecPal host: confirmed system drop-in is installed and the competing user service is not started

## Notes

- Closes #425.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Polyscope rollout installation to conditionally write privileged systemd drop-ins and manage user/system units, which can affect service startup behavior on hosts. Risk is mitigated by added input validation, explicit refusal paths, and expanded installer tests.
> 
> **Overview**
> Prevents Polyscope rollout installs from creating a competing user `polyscope-server.service` when the server is already managed as a system unit: the installer now auto-detects system vs user scope (or allows forcing via `--polyscope-server-scope`) and, in system scope, writes a SecPal runtime systemd drop-in (`zz-secpal-runtime.conf`) and restarts the system service.
> 
> Keeps the user-scoped sync/provision units, but adjusts ordering so they still run immediately after install without depending on a user server unit when the system service is authoritative; also adds stricter validation for variables embedded in systemd `ExecStart*` strings and a hard fail if system scope is detected but non-interactive sudo/root is unavailable.
> 
> Makes the Expose wrapper install more idempotent when `expose-linux-x64.real` already exists (repairing safe stale states instead of aborting), and expands `tests/polyscope-rollout.sh` to cover the system-service path, refusal scenarios, and the Expose rewrap repair behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379fc88aee14abce2d6605f3cf6d30e250d1c5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->