### PR TITLE
feat(governance): validate pull request evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,8 +52,8 @@ Use the no-executable-change reason only for docs/content/template-only PRs.
 
 - Failing proof before implementation: REPLACE_WITH_FAILING_PROOF
 - Passing proof after implementation: REPLACE_WITH_PASSING_PROOF
-- Validate-first exception reference: N/A (only if the repository instructions explicitly allow validate-first; cite the instruction and the failing/passing check)
-- No executable change reason: REPLACE_WITH_NO_EXECUTABLE_CHANGE_REASON
+- Validate-first exception reference: N/A
+- No executable change reason: N/A
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,19 @@ Closes #
 - [ ] Added/updated integration tests
 - [ ] Manual testing performed
 
+## TDD / Validate-First Evidence
+
+<!--
+Required for executable, behavior, automation, or contract changes.
+Use validate-first only if the repository instructions explicitly allow validate-first.
+Use the no-executable-change reason only for docs/content/template-only PRs.
+-->
+
+- Failing proof before implementation: REPLACE_WITH_FAILING_PROOF
+- Passing proof after implementation: REPLACE_WITH_PASSING_PROOF
+- Validate-first exception reference: N/A (only if the repository instructions explicitly allow validate-first; cite the instruction and the failing/passing check)
+- No executable change reason: N/A (use this only when no executable behavior or validation changed)
+
 ## Checklist
 
 - [ ] Code follows project style guidelines

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,7 +53,7 @@ Use the no-executable-change reason only for docs/content/template-only PRs.
 - Failing proof before implementation: REPLACE_WITH_FAILING_PROOF
 - Passing proof after implementation: REPLACE_WITH_PASSING_PROOF
 - Validate-first exception reference: N/A (only if the repository instructions explicitly allow validate-first; cite the instruction and the failing/passing check)
-- No executable change reason: N/A (use this only when no executable behavior or validation changed)
+- No executable change reason: REPLACE_WITH_NO_EXECUTABLE_CHANGE_REASON
 
 ## Checklist
 

--- a/.github/workflows/pull-request-evidence.yml
+++ b/.github/workflows/pull-request-evidence.yml
@@ -1,0 +1,34 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Pull Request Evidence
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    name: Validate PR Evidence
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate pull request evidence section
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: bash scripts/validate-pull-request-evidence.sh

--- a/.github/workflows/pull-request-evidence.yml
+++ b/.github/workflows/pull-request-evidence.yml
@@ -5,7 +5,7 @@
 name: Pull Request Evidence
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Validate pull request evidence section
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-08 - Require PR Evidence For TDD Or Explicit Non-Executable Changes
+
+**Changed:**
+
+- added `scripts/validate-pull-request-evidence.sh`, `tests/pull-request-evidence.sh`, and `.github/workflows/pull-request-evidence.yml` so `.github` pull requests now fail fast when the body omits concrete fail-first evidence or an explicit no-executable-change reason
+- updated `.github/pull_request_template.md` and `docs/workflows/QUICK_REFERENCE.md` with a dedicated `TDD / Validate-First Evidence` section that keeps validate-first exceptions tied to repository instructions instead of leaving them implicit
+- wired the new regression test into `scripts/preflight.sh` so local governance checks catch PR-evidence drift before a branch is pushed
+
 ## 2026-05-03 - Isolate Polyscope Preview Storage Per API Workspace
 
 **Changed:**

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -102,6 +102,13 @@ Resolves #789
 - [ ] Unit tests added
 - [ ] Manual testing done
 
+## TDD / Validate-First Evidence
+
+- Failing proof before implementation: `<command or reproduced defect>`
+- Passing proof after implementation: `<command or validation that now passes>`
+- Validate-first exception reference: `N/A unless the repository instructions explicitly allow validate-first`
+- No executable change reason: `N/A unless this PR is docs/content/template-only`
+
 ## Checklist
 
 - [ ] Code follows style guide

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -218,3 +218,71 @@ Enhancement → 💡 Ideas
            ↓ (start draft PR)
          🚧 In Progress
            ↓ (mark ready)
+         👀 In Review
+           ↓ (merge)
+         ✅ Done
+
+High Priority → 📥 Backlog → 📋 Planned → ...
+
+Reopen → 💬 Discussion
+Close (not planned) → 🚫 Won't Do
+```
+
+## 🎯 Single Maintainer Flow
+
+When working alone:
+
+```bash
+# 1. Create issue
+gh issue create --label "core-feature" --title "..."
+
+# 2. Start work (draft PR)
+gh pr create --draft --body "Closes #123"
+# → Issue: 🚧 In Progress
+
+# 3. Self-review ready
+gh pr ready <PR>
+# → Issue: 👀 In Review
+
+# 4. Copilot found issues?
+gh pr ready --undo <PR>
+# → Issue: 🚧 In Progress (signals: "fixing issues")
+
+# 5. Fixed and ready
+gh pr ready <PR>
+# → Issue: 👀 In Review
+
+# 6. Merge
+gh pr merge <PR> --squash
+# → Issue: ✅ Done (auto-closed)
+```
+
+## 📱 Shortcuts
+
+```bash
+# Create enhancement issue
+alias gh-idea='gh issue create --label "enhancement"'
+
+# Create core feature issue
+alias gh-feature='gh issue create --label "core-feature"'
+
+# Create blocker issue
+alias gh-blocker='gh issue create --label "priority: blocker"'
+
+# Create draft PR
+alias gh-draft='gh pr create --draft'
+
+# Mark PR ready
+alias gh-ready='gh pr ready'
+
+# Convert to draft
+alias gh-wip='gh pr ready --undo'
+```
+
+Add to your `.zshrc` or `.bashrc`.
+
+## 🔗 Quick Links
+
+- [Full Documentation](./PROJECT_AUTOMATION.md)
+- [Rollout Guide](./ROLLOUT_GUIDE.md)
+- [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -106,8 +106,11 @@ Resolves #789
 
 - Failing proof before implementation: `<command or reproduced defect>`
 - Passing proof after implementation: `<command or validation that now passes>`
-- Validate-first exception reference: `N/A unless the repository instructions explicitly allow validate-first`
-- No executable change reason: `N/A unless this PR is docs/content/template-only`
+- Validate-first exception reference: `N/A`
+- No executable change reason: `N/A`
+
+Use the validate-first exception only when the repository instructions explicitly allow validate-first.
+Use the no-executable-change reason only for docs/content/template-only PRs.
 
 ## Checklist
 
@@ -215,71 +218,3 @@ Enhancement → 💡 Ideas
            ↓ (start draft PR)
          🚧 In Progress
            ↓ (mark ready)
-         👀 In Review
-           ↓ (merge)
-         ✅ Done
-
-High Priority → 📥 Backlog → 📋 Planned → ...
-
-Reopen → 💬 Discussion
-Close (not planned) → 🚫 Won't Do
-```
-
-## 🎯 Single Maintainer Flow
-
-When working alone:
-
-```bash
-# 1. Create issue
-gh issue create --label "core-feature" --title "..."
-
-# 2. Start work (draft PR)
-gh pr create --draft --body "Closes #123"
-# → Issue: 🚧 In Progress
-
-# 3. Self-review ready
-gh pr ready <PR>
-# → Issue: 👀 In Review
-
-# 4. Copilot found issues?
-gh pr ready --undo <PR>
-# → Issue: 🚧 In Progress (signals: "fixing issues")
-
-# 5. Fixed and ready
-gh pr ready <PR>
-# → Issue: 👀 In Review
-
-# 6. Merge
-gh pr merge <PR> --squash
-# → Issue: ✅ Done (auto-closed)
-```
-
-## 📱 Shortcuts
-
-```bash
-# Create enhancement issue
-alias gh-idea='gh issue create --label "enhancement"'
-
-# Create core feature issue
-alias gh-feature='gh issue create --label "core-feature"'
-
-# Create blocker issue
-alias gh-blocker='gh issue create --label "priority: blocker"'
-
-# Create draft PR
-alias gh-draft='gh pr create --draft'
-
-# Mark PR ready
-alias gh-ready='gh pr ready'
-
-# Convert to draft
-alias gh-wip='gh pr ready --undo'
-```
-
-Add to your `.zshrc` or `.bashrc`.
-
-## 🔗 Quick Links
-
-- [Full Documentation](./PROJECT_AUTOMATION.md)
-- [Rollout Guide](./ROLLOUT_GUIDE.md)
-- [SecPal Roadmap](https://github.com/orgs/SecPal/projects/1)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -125,6 +125,15 @@ if [ -f tests/pull-request-template.sh ]; then
   }
 fi
 
+if [ -f tests/pull-request-evidence.sh ]; then
+  bash tests/pull-request-evidence.sh || {
+    echo "" >&2
+    echo "❌ Pull request evidence regression test failed!" >&2
+    echo "Restore the PR evidence template section, validator script, and workflow wiring before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/setup-project-board.sh ]; then
   bash tests/setup-project-board.sh || {
     echo "" >&2

--- a/scripts/validate-pull-request-evidence.sh
+++ b/scripts/validate-pull-request-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+PR_BODY="${PR_BODY:-}"
+
+require_body() {
+  if [ -z "${PR_BODY//[[:space:]]/}" ]; then
+    echo "Pull request body is required for PR evidence validation." >&2
+    exit 1
+  fi
+}
+
+require_section() {
+  if ! printf '%s\n' "$PR_BODY" | grep -Fq '## TDD / Validate-First Evidence'; then
+    echo 'TDD / Validate-First Evidence section is required.' >&2
+    exit 1
+  fi
+}
+
+extract_field() {
+  local label="$1"
+
+  printf '%s\n' "$PR_BODY" | sed -nE "s/^[*-][[:space:]]+${label}:[[:space:]]*(.*)$/\1/p" | head -n 1
+}
+
+normalize_value() {
+  local value="$1"
+
+  value="$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  if [[ "$value" == \`*\` ]]; then
+    value="${value#\`}"
+    value="${value%\`}"
+  fi
+  printf '%s' "$value"
+}
+
+is_empty_or_na() {
+  local value="$1"
+
+  if [ -z "$value" ]; then
+    return 0
+  fi
+
+  printf '%s\n' "$value" | grep -qiE '^(n/?a|none|not applicable)$'
+}
+
+is_placeholder() {
+  local value="$1"
+
+  printf '%s\n' "$value" | grep -qE '^REPLACE_WITH_(FAILING_PROOF|PASSING_PROOF|VALIDATE_FIRST_REFERENCE|NO_EXECUTABLE_CHANGE_REASON)$'
+}
+
+main() {
+  local failing_proof
+  local passing_proof
+  local validate_first_reference
+  local no_executable_change_reason
+
+  require_body
+  require_section
+
+  failing_proof="$(normalize_value "$(extract_field 'Failing proof before implementation')")"
+  passing_proof="$(normalize_value "$(extract_field 'Passing proof after implementation')")"
+  validate_first_reference="$(normalize_value "$(extract_field 'Validate-first exception reference')")"
+  no_executable_change_reason="$(normalize_value "$(extract_field 'No executable change reason')")"
+
+  if is_placeholder "$failing_proof" \
+    || is_placeholder "$passing_proof" \
+    || is_placeholder "$validate_first_reference" \
+    || is_placeholder "$no_executable_change_reason"; then
+    echo 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' >&2
+    exit 1
+  fi
+
+  if ! is_empty_or_na "$no_executable_change_reason"; then
+    exit 0
+  fi
+
+  if ! is_empty_or_na "$failing_proof" && ! is_empty_or_na "$passing_proof"; then
+    exit 0
+  fi
+
+  echo 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' >&2
+  exit 1
+}
+
+main "$@"

--- a/scripts/validate-pull-request-evidence.sh
+++ b/scripts/validate-pull-request-evidence.sh
@@ -31,7 +31,7 @@ normalize_value() {
 
   value="$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
   if [[ "$value" == \`*\` ]]; then
-    value="${value#\`}"
+    value="${value#\`}" 
     value="${value%\`}"
   fi
   printf '%s' "$value"
@@ -44,13 +44,13 @@ is_empty_or_na() {
     return 0
   fi
 
-  printf '%s\n' "$value" | grep -qiE '^(n/?a|none|not applicable)$'
+  printf '%s\n' "$value" | grep -qiE '^(n/?a([[:space:][:punct:]].*)?|none|not applicable)$'
 }
 
 is_placeholder() {
   local value="$1"
 
-  printf '%s\n' "$value" | grep -qE '^REPLACE_WITH_(FAILING_PROOF|PASSING_PROOF|VALIDATE_FIRST_REFERENCE|NO_EXECUTABLE_CHANGE_REASON)$'
+  printf '%s\n' "$value" | grep -qE 'REPLACE_WITH_(FAILING_PROOF|PASSING_PROOF|VALIDATE_FIRST_REFERENCE|NO_EXECUTABLE_CHANGE_REASON)'
 }
 
 main() {

--- a/tests/pull-request-evidence.sh
+++ b/tests/pull-request-evidence.sh
@@ -45,6 +45,16 @@ if ! grep -Fq 'github.event.pull_request.body' "$WORKFLOW"; then
   exit 1
 fi
 
+if ! grep -Fq 'pull_request_target:' "$WORKFLOW"; then
+  echo "Workflow must run from the base branch context so PRs cannot self-bypass the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.base.sha' "$WORKFLOW"; then
+  echo "Workflow must check out the base revision before running the validator." >&2
+  exit 1
+fi
+
 if ! grep -Fq 'edited' "$WORKFLOW"; then
   echo "Workflow must rerun when the pull request body is edited." >&2
   exit 1
@@ -141,19 +151,27 @@ if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an expli
   exit 1
 fi
 
-template_default_body="$(sed \
-  -e 's/REPLACE_WITH_FAILING_PROOF/N\/A/' \
-  -e 's/REPLACE_WITH_PASSING_PROOF/N\/A/' \
-  "$TEMPLATE"
+template_default_body="$(cat <<'EOF'
+## Description
+
+Still using the instructional defaults.
+
+## TDD / Validate-First Evidence
+
+- Failing proof before implementation: N/A unless the repository instructions explicitly allow validate-first
+- Passing proof after implementation: N/A
+- Validate-first exception reference: N/A unless the repository instructions explicitly allow validate-first
+- No executable change reason: N/A (use this only when no executable behavior or validation changed)
+EOF
 )"
 
-if PR_BODY="$template_default_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-template-default.log 2>&1; then
-  echo "Validator unexpectedly accepted the template default no-executable-change placeholder." >&2
+if PR_BODY="$template_default_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-defaults.log 2>&1; then
+  echo "Validator unexpectedly accepted instructional default text as real evidence." >&2
   exit 1
 fi
 
-if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' /tmp/pull-request-evidence-template-default.log; then
-  cat /tmp/pull-request-evidence-template-default.log >&2
-  echo "Validator did not explain the template default placeholder failure." >&2
+if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' /tmp/pull-request-evidence-defaults.log; then
+  cat /tmp/pull-request-evidence-defaults.log >&2
+  echo "Validator did not explain why instructional default text is invalid evidence." >&2
   exit 1
 fi

--- a/tests/pull-request-evidence.sh
+++ b/tests/pull-request-evidence.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$REPO_ROOT/scripts/validate-pull-request-evidence.sh"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+WORKFLOW="$REPO_ROOT/.github/workflows/pull-request-evidence.yml"
+
+if [ ! -f "$VALIDATOR" ]; then
+  echo "Expected validator script was not found: $VALIDATOR" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "Expected PR template was not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+if ! grep -Fq '## TDD / Validate-First Evidence' "$TEMPLATE"; then
+  echo "PR template is missing the TDD / Validate-First Evidence section." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'only if the repository instructions explicitly allow validate-first' "$TEMPLATE"; then
+  echo "PR template must keep validate-first exceptions explicitly tied to repository instructions." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'scripts/validate-pull-request-evidence.sh' "$WORKFLOW"; then
+  echo "Workflow does not invoke the pull-request evidence validator script." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.body' "$WORKFLOW"; then
+  echo "Workflow does not pass the pull request body into the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'edited' "$WORKFLOW"; then
+  echo "Workflow must rerun when the pull request body is edited." >&2
+  exit 1
+fi
+
+positive_body="$(cat <<'EOF'
+## Description
+
+Tighten PR governance around fail-first proof.
+
+## Related Issues
+
+Refs #426
+
+## TDD / Validate-First Evidence
+
+- Failing proof before implementation: `bash tests/pull-request-evidence.sh` failed because the validator script and workflow did not exist yet.
+- Passing proof after implementation: `bash tests/pull-request-evidence.sh`
+- Validate-first exception reference: N/A
+- No executable change reason: N/A
+EOF
+)"
+
+if ! PR_BODY="$positive_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-positive.log 2>&1; then
+  cat /tmp/pull-request-evidence-positive.log >&2
+  echo "Validator rejected a PR body with concrete failing and passing evidence." >&2
+  exit 1
+fi
+
+docs_only_body="$(cat <<'EOF'
+## Description
+
+Refresh documentation wording only.
+
+## Related Issues
+
+Refs #426
+
+## TDD / Validate-First Evidence
+
+- Failing proof before implementation: N/A
+- Passing proof after implementation: N/A
+- Validate-first exception reference: N/A
+- No executable change reason: Documentation-only change; no executable behavior or validation changed.
+EOF
+)"
+
+if ! PR_BODY="$docs_only_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-docs.log 2>&1; then
+  cat /tmp/pull-request-evidence-docs.log >&2
+  echo "Validator rejected a documentation-only PR body with an explicit no-executable-change reason." >&2
+  exit 1
+fi
+
+missing_section_body="$(cat <<'EOF'
+## Description
+
+Missing the required evidence section.
+EOF
+)"
+
+if PR_BODY="$missing_section_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-missing.log 2>&1; then
+  echo "Validator unexpectedly accepted a PR body without the evidence section." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'TDD / Validate-First Evidence section is required.' /tmp/pull-request-evidence-missing.log; then
+  cat /tmp/pull-request-evidence-missing.log >&2
+  echo "Validator did not explain the missing evidence section failure." >&2
+  exit 1
+fi
+
+placeholder_body="$(cat <<'EOF'
+## Description
+
+Still using placeholders.
+
+## TDD / Validate-First Evidence
+
+- Failing proof before implementation: REPLACE_WITH_FAILING_PROOF
+- Passing proof after implementation: REPLACE_WITH_PASSING_PROOF
+- Validate-first exception reference: N/A
+- No executable change reason: N/A
+EOF
+)"
+
+if PR_BODY="$placeholder_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-placeholder.log 2>&1; then
+  echo "Validator unexpectedly accepted placeholder evidence." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' /tmp/pull-request-evidence-placeholder.log; then
+  cat /tmp/pull-request-evidence-placeholder.log >&2
+  echo "Validator did not explain the placeholder evidence failure." >&2
+  exit 1
+fi

--- a/tests/pull-request-evidence.sh
+++ b/tests/pull-request-evidence.sh
@@ -140,3 +140,20 @@ if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an expli
   echo "Validator did not explain the placeholder evidence failure." >&2
   exit 1
 fi
+
+template_default_body="$(sed \
+  -e 's/REPLACE_WITH_FAILING_PROOF/N\/A/' \
+  -e 's/REPLACE_WITH_PASSING_PROOF/N\/A/' \
+  "$TEMPLATE"
+)"
+
+if PR_BODY="$template_default_body" bash "$VALIDATOR" >/tmp/pull-request-evidence-template-default.log 2>&1; then
+  echo "Validator unexpectedly accepted the template default no-executable-change placeholder." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Replace the evidence placeholders with concrete proof or an explicit no-executable-change reason.' /tmp/pull-request-evidence-template-default.log; then
+  cat /tmp/pull-request-evidence-template-default.log >&2
+  echo "Validator did not explain the template default placeholder failure." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Description

Add a pull-request evidence guardrail in the `.github` repository so PRs must include either concrete fail-first proof or an explicit no-executable-change reason.

This change adds the validator script, a PR workflow for this repository, a shared template section, quick-reference guidance, and a regression test wired into local preflight.

This is the `.github` repository slice of the broader governance work in #426; cross-repository caller adoption remains follow-up work.

## Related Issues

Refs #426

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/pull-request-evidence.sh` failed with `Expected validator script was not found: /home/secpal/code/SecPal/.github/scripts/validate-pull-request-evidence.sh`.
- Passing proof after implementation: `bash tests/pull-request-evidence.sh`, `bash tests/pull-request-template.sh`, `pre-commit run shellcheck --files scripts/validate-pull-request-evidence.sh tests/pull-request-evidence.sh`, and `./scripts/preflight.sh`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `pull_request_target` workflow and shell validator that can block PRs based on PR body content; misparsing or edge cases could create CI friction for contributors.
> 
> **Overview**
> Adds a **PR evidence guardrail** for this repo: PR bodies must include a new `## TDD / Validate-First Evidence` section with either concrete failing+passing proof or an explicit *no-executable-change* reason.
> 
> Enforces this via a new `pull_request_target` GitHub Actions workflow that runs `scripts/validate-pull-request-evidence.sh` against the PR body (base-sha checkout), plus a regression test (`tests/pull-request-evidence.sh`) wired into `scripts/preflight.sh`; documentation/template updates and a changelog entry accompany the new requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20d5290ef9b2cceed6fef11850265e50c49b226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->