### PR TITLE
feat(governance): enforce signed PR commits

### DIFF
--- a/.github/workflows/pull-request-commit-signatures.yml
+++ b/.github/workflows/pull-request-commit-signatures.yml
@@ -5,7 +5,7 @@
 name: Pull Request Commit Signatures
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -37,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_COMMITS_FILE: ${{ runner.temp }}/pull-request-commits.json
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" > "$PR_COMMITS_FILE"
+        run: gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits?per_page=100" > "$PR_COMMITS_FILE"
 
       - name: Validate pull request commit signatures
         env:

--- a/.github/workflows/pull-request-commit-signatures.yml
+++ b/.github/workflows/pull-request-commit-signatures.yml
@@ -1,0 +1,45 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Pull Request Commit Signatures
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate Signed PR Commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Fetch pull request commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_COMMITS_FILE: ${{ runner.temp }}/pull-request-commits.json
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" > "$PR_COMMITS_FILE"
+
+      - name: Validate pull request commit signatures
+        env:
+          PR_COMMITS_FILE: ${{ runner.temp }}/pull-request-commits.json
+        run: bash scripts/validate-pull-request-commit-signatures.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-08 - Enforce Signed PR Commits In .github
+
+**Changed:**
+
+- added `scripts/validate-pull-request-commit-signatures.sh`, `tests/pull-request-commit-signatures.sh`, and `.github/workflows/pull-request-commit-signatures.yml` so `.github` pull requests now fail when any branch commit is not GitHub-verified as signed
+- wired the new signed-commit regression test into `scripts/preflight.sh` so local governance checks catch validator or workflow drift before push time
+- documented in `docs/workflows/QUICK_REFERENCE.md` that signed commit verification is now CI-enforced while English-only GitHub communication remains reviewer-enforced until a narrower, low-noise lint strategy is proven
+
 ## 2026-05-03 - Isolate Polyscope Preview Storage Per API Workspace
 
 **Changed:**

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -108,6 +108,11 @@ Resolves #789
 - [ ] Documentation updated
 ```
 
+## 🔐 Policy Enforcement
+
+- Signed commit verification is enforced by CI.
+- English-only GitHub communication remains reviewer-enforced for now.
+
 ## 🏷️ Label Reference
 
 | Label               | Status     | Use Case                   |

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -125,6 +125,15 @@ if [ -f tests/pull-request-template.sh ]; then
   }
 fi
 
+if [ -f tests/pull-request-commit-signatures.sh ]; then
+  bash tests/pull-request-commit-signatures.sh || {
+    echo "" >&2
+    echo "❌ Pull request commit signature regression test failed!" >&2
+    echo "Restore the commit-signature validator script, workflow wiring, and enforcement/advisory documentation before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/setup-project-board.sh ]; then
   bash tests/setup-project-board.sh || {
     echo "" >&2

--- a/scripts/validate-pull-request-commit-signatures.sh
+++ b/scripts/validate-pull-request-commit-signatures.sh
@@ -16,7 +16,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [ -z "$payload_file" ] && [ -n "${PR_COMMITS_JSON:-}" ]; then
-  temporary_payload="$(mktemp "${TMPDIR:-/tmp}/pull-request-commits.XXXXXX.json")"
+  temporary_payload="$(mktemp "${TMPDIR:-/tmp}/pull-request-commits.XXXXXX")"
   printf '%s' "$PR_COMMITS_JSON" > "$temporary_payload"
   payload_file="$temporary_payload"
 fi

--- a/scripts/validate-pull-request-commit-signatures.sh
+++ b/scripts/validate-pull-request-commit-signatures.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+payload_file="${PR_COMMITS_FILE:-}"
+temporary_payload=''
+
+cleanup() {
+  if [ -n "$temporary_payload" ] && [ -f "$temporary_payload" ]; then
+    rm -f "$temporary_payload"
+  fi
+}
+
+trap cleanup EXIT
+
+if [ -z "$payload_file" ] && [ -n "${PR_COMMITS_JSON:-}" ]; then
+  temporary_payload="$(mktemp "${TMPDIR:-/tmp}/pull-request-commits.XXXXXX.json")"
+  printf '%s' "$PR_COMMITS_JSON" > "$temporary_payload"
+  payload_file="$temporary_payload"
+fi
+
+if [ -z "$payload_file" ] || [ ! -f "$payload_file" ] || [ ! -s "$payload_file" ]; then
+  echo 'Pull request commit payload is required.' >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'Node.js is required to validate pull request commit signatures.' >&2
+  exit 1
+fi
+
+node - "$payload_file" <<'NODE'
+const fs = require('fs');
+
+const payloadPath = process.argv[2];
+let commits;
+
+try {
+  commits = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
+} catch (error) {
+  console.error('Invalid pull request commit payload.');
+  process.exit(1);
+}
+
+if (!Array.isArray(commits)) {
+  console.error('Invalid pull request commit payload.');
+  process.exit(1);
+}
+
+if (commits.length === 0) {
+  console.error('No commits found in pull request payload.');
+  process.exit(1);
+}
+
+const failures = commits
+  .map((entry) => ({
+    sha: String(entry?.sha ?? 'unknown'),
+    verified: entry?.commit?.verification?.verified === true,
+    reason: String(entry?.commit?.verification?.reason ?? 'missing'),
+    message: String(entry?.commit?.message ?? '').split('\n')[0],
+  }))
+  .filter((entry) => !entry.verified);
+
+if (failures.length === 0) {
+  process.exit(0);
+}
+
+console.error('Unsigned or unverified commits were found in this pull request:');
+for (const failure of failures) {
+  console.error(`- ${failure.sha} reason=${failure.reason} message=${failure.message}`);
+}
+console.error('All commits in a pull request must be GitHub-verified signed commits.');
+process.exit(1);
+NODE

--- a/scripts/validate-pull-request-commit-signatures.sh
+++ b/scripts/validate-pull-request-commit-signatures.sh
@@ -49,6 +49,8 @@ if (!Array.isArray(commits)) {
   process.exit(1);
 }
 
+commits = commits.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
+
 if (commits.length === 0) {
   console.error('No commits found in pull request payload.');
   process.exit(1);

--- a/scripts/validate-pull-request-commit-signatures.sh
+++ b/scripts/validate-pull-request-commit-signatures.sh
@@ -16,7 +16,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [ -z "$payload_file" ] && [ -n "${PR_COMMITS_JSON:-}" ]; then
-  temporary_payload="$(mktemp "${TMPDIR:-/tmp}/pull-request-commits.XXXXXX")"
+  temporary_payload="$(mktemp "${TMPDIR:-/tmp}/pull-request-commits.json.XXXXXX")"
   printf '%s' "$PR_COMMITS_JSON" > "$temporary_payload"
   payload_file="$temporary_payload"
 fi
@@ -26,12 +26,20 @@ if [ -z "$payload_file" ] || [ ! -f "$payload_file" ] || [ ! -s "$payload_file" 
   exit 1
 fi
 
-if ! command -v node >/dev/null 2>&1; then
-  echo 'Node.js is required to validate pull request commit signatures.' >&2
-  exit 1
+python_command=''
+
+if command -v python3 >/dev/null 2>&1; then
+  python_command='python3'
+elif command -v python >/dev/null 2>&1 && python - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info.major == 3 else 1)
+PY
+then
+  python_command='python'
 fi
 
-node - "$payload_file" <<'NODE'
+if command -v node >/dev/null 2>&1; then
+  node - "$payload_file" <<'NODE'
 const fs = require('fs');
 
 const payloadPath = process.argv[2];
@@ -76,3 +84,68 @@ for (const failure of failures) {
 console.error('All commits in a pull request must be GitHub-verified signed commits.');
 process.exit(1);
 NODE
+  exit 0
+fi
+
+if [ -n "$python_command" ]; then
+  "$python_command" - "$payload_file" <<'PY'
+import json
+import sys
+
+payload_path = sys.argv[1]
+
+try:
+  with open(payload_path, 'r', encoding='utf-8') as payload_file_handle:
+    commits = json.load(payload_file_handle)
+except Exception:
+  print('Invalid pull request commit payload.', file=sys.stderr)
+  raise SystemExit(1)
+
+if not isinstance(commits, list):
+  print('Invalid pull request commit payload.', file=sys.stderr)
+  raise SystemExit(1)
+
+flattened_commits = []
+for entry in commits:
+  if isinstance(entry, list):
+    flattened_commits.extend(entry)
+  else:
+    flattened_commits.append(entry)
+
+if len(flattened_commits) == 0:
+  print('No commits found in pull request payload.', file=sys.stderr)
+  raise SystemExit(1)
+
+failures = []
+
+for entry in flattened_commits:
+  commit = entry.get('commit') if isinstance(entry, dict) else None
+  verification = commit.get('verification') if isinstance(commit, dict) else None
+  sha = str(entry.get('sha', 'unknown')) if isinstance(entry, dict) else 'unknown'
+  verified = isinstance(verification, dict) and verification.get('verified') is True
+  reason = str(verification.get('reason', 'missing')) if isinstance(verification, dict) else 'missing'
+  message = ''
+  if isinstance(commit, dict):
+    message = str(commit.get('message', ''))
+  message = message.split('\n', 1)[0]
+
+  if not verified:
+    failures.append({'sha': sha, 'reason': reason, 'message': message})
+
+if len(failures) == 0:
+  raise SystemExit(0)
+
+print('Unsigned or unverified commits were found in this pull request:', file=sys.stderr)
+for failure in failures:
+  print(
+    f"- {failure['sha']} reason={failure['reason']} message={failure['message']}",
+    file=sys.stderr,
+  )
+print('All commits in a pull request must be GitHub-verified signed commits.', file=sys.stderr)
+raise SystemExit(1)
+PY
+  exit 0
+fi
+
+echo 'Node.js or Python 3 is required to validate pull request commit signatures.' >&2
+exit 1

--- a/tests/pull-request-commit-signatures.sh
+++ b/tests/pull-request-commit-signatures.sh
@@ -9,6 +9,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VALIDATOR="$REPO_ROOT/scripts/validate-pull-request-commit-signatures.sh"
 WORKFLOW="$REPO_ROOT/.github/workflows/pull-request-commit-signatures.yml"
 QUICK_REFERENCE="$REPO_ROOT/docs/workflows/QUICK_REFERENCE.md"
+SHELL_BIN="${BASH:-$(command -v bash)}"
 
 if [ ! -f "$VALIDATOR" ]; then
   echo "Expected validator script was not found: $VALIDATOR" >&2
@@ -27,6 +28,16 @@ fi
 
 if ! grep -Fq 'scripts/validate-pull-request-commit-signatures.sh' "$WORKFLOW"; then
   echo "Workflow does not invoke the pull-request commit signature validator script." >&2
+  exit 1
+fi
+
+if grep -Fq 'XXXXXX.json' "$VALIDATOR"; then
+  echo "Validator uses a BSD-incompatible mktemp template with a suffix after the X placeholder." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'pull-request-commits.json.XXXXXX' "$VALIDATOR"; then
+  echo "Validator must use a portable mktemp template whose X placeholder is at the end." >&2
   exit 1
 fi
 
@@ -91,6 +102,53 @@ if ! PR_COMMITS_JSON="$verified_payload" bash "$VALIDATOR" >/tmp/pull-request-co
   echo "Validator rejected a pull request payload whose commits were verified." >&2
   exit 1
 fi
+
+python_command=''
+
+if command -v python3 >/dev/null 2>&1; then
+  python_command='python3'
+elif command -v python >/dev/null 2>&1 && python - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info.major == 3 else 1)
+PY
+then
+  python_command='python'
+fi
+
+if [ -n "$python_command" ]; then
+  parser_fallback_bin="$(mktemp -d)"
+  ln -s "$(command -v "$python_command")" "$parser_fallback_bin/$python_command"
+  ln -s "$(command -v mktemp)" "$parser_fallback_bin/mktemp"
+  ln -s "$(command -v rm)" "$parser_fallback_bin/rm"
+
+  if ! PATH="$parser_fallback_bin" PR_COMMITS_JSON="$verified_payload" "$SHELL_BIN" "$VALIDATOR" >/tmp/pull-request-commit-signatures-python-fallback.log 2>&1; then
+    cat /tmp/pull-request-commit-signatures-python-fallback.log >&2
+    echo "Validator rejected a verified payload when only the Python fallback parser was available." >&2
+    rm -rf "$parser_fallback_bin"
+    exit 1
+  fi
+
+  rm -rf "$parser_fallback_bin"
+fi
+
+parserless_bin="$(mktemp -d)"
+ln -s "$(command -v mktemp)" "$parserless_bin/mktemp"
+ln -s "$(command -v rm)" "$parserless_bin/rm"
+
+if PATH="$parserless_bin" PR_COMMITS_JSON="$verified_payload" "$SHELL_BIN" "$VALIDATOR" >/tmp/pull-request-commit-signatures-parserless.log 2>&1; then
+  echo "Validator unexpectedly succeeded without Node.js or Python 3 available." >&2
+  rm -rf "$parserless_bin"
+  exit 1
+fi
+
+if ! grep -Fq 'Node.js or Python 3 is required to validate pull request commit signatures.' /tmp/pull-request-commit-signatures-parserless.log; then
+  cat /tmp/pull-request-commit-signatures-parserless.log >&2
+  echo "Validator did not explain the missing parser runtime failure." >&2
+  rm -rf "$parserless_bin"
+  exit 1
+fi
+
+rm -rf "$parserless_bin"
 
 unsigned_payload="$(cat <<'EOF'
 [

--- a/tests/pull-request-commit-signatures.sh
+++ b/tests/pull-request-commit-signatures.sh
@@ -30,8 +30,28 @@ if ! grep -Fq 'scripts/validate-pull-request-commit-signatures.sh' "$WORKFLOW"; 
   exit 1
 fi
 
+if ! grep -Fq 'pull_request_target:' "$WORKFLOW"; then
+  echo "Workflow must run from the base branch context so PRs cannot self-bypass the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.base.sha' "$WORKFLOW"; then
+  echo "Workflow must check out the base revision before running the validator." >&2
+  exit 1
+fi
+
 if ! grep -Fq "pulls/\$PR_NUMBER/commits" "$WORKFLOW"; then
   echo "Workflow does not fetch the pull request commits payload from GitHub." >&2
+  exit 1
+fi
+
+if ! grep -Fq -- '--paginate' "$WORKFLOW"; then
+  echo "Workflow must paginate pull request commits so every commit is validated." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'per_page=100' "$WORKFLOW"; then
+  echo "Workflow must request the maximum pull request commit page size from GitHub." >&2
   exit 1
 fi
 
@@ -102,6 +122,47 @@ fi
 if ! grep -Fq 'reason=unsigned' /tmp/pull-request-commit-signatures-negative.log; then
   cat /tmp/pull-request-commit-signatures-negative.log >&2
   echo "Validator did not report the unsigned verification reason." >&2
+  exit 1
+fi
+
+paginated_unsigned_payload="$(cat <<'EOF'
+[
+  [
+    {
+      "sha": "57cce5b2c81fb2c72f1af4de51c4fd586f17972f",
+      "commit": {
+        "message": "feat(governance): page one",
+        "verification": {
+          "verified": true,
+          "reason": "valid"
+        }
+      }
+    }
+  ],
+  [
+    {
+      "sha": "cafebabecafebabecafebabecafebabecafebabe",
+      "commit": {
+        "message": "feat(governance): page two unsigned",
+        "verification": {
+          "verified": false,
+          "reason": "unsigned"
+        }
+      }
+    }
+  ]
+]
+EOF
+)"
+
+if PR_COMMITS_JSON="$paginated_unsigned_payload" bash "$VALIDATOR" >/tmp/pull-request-commit-signatures-paginated.log 2>&1; then
+  echo "Validator unexpectedly accepted an unsigned commit from a later paginated payload page." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'cafebabecafebabecafebabecafebabecafebabe' /tmp/pull-request-commit-signatures-paginated.log; then
+  cat /tmp/pull-request-commit-signatures-paginated.log >&2
+  echo "Validator did not report the unsigned commit from the later paginated payload page." >&2
   exit 1
 fi
 

--- a/tests/pull-request-commit-signatures.sh
+++ b/tests/pull-request-commit-signatures.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$REPO_ROOT/scripts/validate-pull-request-commit-signatures.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/pull-request-commit-signatures.yml"
+QUICK_REFERENCE="$REPO_ROOT/docs/workflows/QUICK_REFERENCE.md"
+
+if [ ! -f "$VALIDATOR" ]; then
+  echo "Expected validator script was not found: $VALIDATOR" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+if [ ! -f "$QUICK_REFERENCE" ]; then
+  echo "Expected quick reference doc was not found: $QUICK_REFERENCE" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'scripts/validate-pull-request-commit-signatures.sh' "$WORKFLOW"; then
+  echo "Workflow does not invoke the pull-request commit signature validator script." >&2
+  exit 1
+fi
+
+if ! grep -Fq "pulls/\$PR_NUMBER/commits" "$WORKFLOW"; then
+  echo "Workflow does not fetch the pull request commits payload from GitHub." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'synchronize' "$WORKFLOW"; then
+  echo "Workflow must rerun when new commits are pushed to the pull request." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Signed commit verification is enforced by CI.' "$QUICK_REFERENCE"; then
+  echo "Quick reference must document that signed commit verification is enforced by CI." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'English-only GitHub communication remains reviewer-enforced for now.' "$QUICK_REFERENCE"; then
+  echo "Quick reference must document that English-only GitHub communication is still reviewer-enforced." >&2
+  exit 1
+fi
+
+verified_payload="$(cat <<'EOF'
+[
+  {
+    "sha": "57cce5b2c81fb2c72f1af4de51c4fd586f17972f",
+    "commit": {
+      "message": "feat(governance): validate pull request evidence\n\nMore context.",
+      "verification": {
+        "verified": true,
+        "reason": "valid"
+      }
+    }
+  }
+]
+EOF
+)"
+
+if ! PR_COMMITS_JSON="$verified_payload" bash "$VALIDATOR" >/tmp/pull-request-commit-signatures-positive.log 2>&1; then
+  cat /tmp/pull-request-commit-signatures-positive.log >&2
+  echo "Validator rejected a pull request payload whose commits were verified." >&2
+  exit 1
+fi
+
+unsigned_payload="$(cat <<'EOF'
+[
+  {
+    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "commit": {
+      "message": "feat(governance): unsigned commit",
+      "verification": {
+        "verified": false,
+        "reason": "unsigned"
+      }
+    }
+  }
+]
+EOF
+)"
+
+if PR_COMMITS_JSON="$unsigned_payload" bash "$VALIDATOR" >/tmp/pull-request-commit-signatures-negative.log 2>&1; then
+  echo "Validator unexpectedly accepted an unsigned pull request commit." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' /tmp/pull-request-commit-signatures-negative.log; then
+  cat /tmp/pull-request-commit-signatures-negative.log >&2
+  echo "Validator did not report the unsigned commit SHA." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'reason=unsigned' /tmp/pull-request-commit-signatures-negative.log; then
+  cat /tmp/pull-request-commit-signatures-negative.log >&2
+  echo "Validator did not report the unsigned verification reason." >&2
+  exit 1
+fi
+
+empty_payload='[]'
+
+if PR_COMMITS_JSON="$empty_payload" bash "$VALIDATOR" >/tmp/pull-request-commit-signatures-empty.log 2>&1; then
+  echo "Validator unexpectedly accepted an empty pull request commit payload." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'No commits found in pull request payload.' /tmp/pull-request-commit-signatures-empty.log; then
+  cat /tmp/pull-request-commit-signatures-empty.log >&2
+  echo "Validator did not explain the empty payload failure." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Description

Add a repository-level pull request check that rejects branch commits unless GitHub reports them as verified signed commits.

This change adds a validator script, a dedicated `.github` PR workflow, local preflight coverage, and a short policy note that distinguishes the newly enforced signed-commit rule from the still reviewer-enforced English-only communication rule.

This is a scoped slice of #424. It intentionally enforces signed commits first and leaves English-only PR/body linting for a narrower follow-up once a low-noise strategy is proven.

## Related Issues

Refs #424

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/pull-request-commit-signatures.sh` failed with `Expected validator script was not found: /home/secpal/code/SecPal/.github/scripts/validate-pull-request-commit-signatures.sh`.
- Passing proof after implementation: `bash tests/pull-request-commit-signatures.sh`, `pre-commit run shellcheck --files scripts/validate-pull-request-commit-signatures.sh tests/pull-request-commit-signatures.sh`, `gh api repos/SecPal/.github/pulls/431/commits > /tmp/pr-431-commits.json && PR_COMMITS_FILE=/tmp/pr-431-commits.json bash scripts/validate-pull-request-commit-signatures.sh`, and `./scripts/preflight.sh`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new required `pull_request_target` workflow that can block merges and must be kept secure despite running with base-branch context (mitigated by read-only permissions and base-sha checkout).
> 
> **Overview**
> **Enforces signed commits on PRs.** Adds a new `.github/workflows/pull-request-commit-signatures.yml` `pull_request_target` check that fetches all PR commits via `gh api` pagination and fails when any commit is not GitHub-verified as signed.
> 
> Introduces `scripts/validate-pull-request-commit-signatures.sh` (Node-first with Python fallback) plus `tests/pull-request-commit-signatures.sh` and wires the regression test into `scripts/preflight.sh` to catch workflow/validator drift locally. Documentation and `CHANGELOG.md` are updated to reflect CI enforcement and the remaining reviewer-enforced English-only policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63d1acea93e68ba618df39160192506f6b4c521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->