### PR TITLE
feat(governance): enforce English PR communication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 
 ## Description
 
+<!-- GitHub-facing communication in pull request titles and bodies must be in English. -->
 <!-- Describe what this PR accomplishes -->
 
 ## Related Issues

--- a/.github/workflows/pull-request-english.yml
+++ b/.github/workflows/pull-request-english.yml
@@ -5,7 +5,7 @@
 name: Pull Request English Communication
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pull-request-english.yml
+++ b/.github/workflows/pull-request-english.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 ---
-
 name: Pull Request English Communication
 
 on:

--- a/.github/workflows/pull-request-english.yml
+++ b/.github/workflows/pull-request-english.yml
@@ -1,6 +1,7 @@
----
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
 
 name: Pull Request English Communication
 

--- a/.github/workflows/pull-request-english.yml
+++ b/.github/workflows/pull-request-english.yml
@@ -1,0 +1,38 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Pull Request English Communication
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate PR Title And Body Language
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Validate pull request title and body language
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: bash scripts/validate-pull-request-english.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-08 - Block Obvious German PR Titles And Bodies In .github
+
+**Changed:**
+
+- added `scripts/validate-pull-request-english.sh`, `tests/pull-request-english.sh`, and `.github/workflows/pull-request-english.yml` so `.github` pull requests now fail when their title or author-written body contains obvious German markers instead of English GitHub-facing communication
+- wired the new language regression test into `scripts/preflight.sh` so local governance checks catch PR-language guardrail drift before push time
+- updated `.github/pull_request_template.md` and `docs/workflows/QUICK_REFERENCE.md` to tell authors that PR titles and author-written bodies must be in English, while comments and review text remain reviewer-enforced until a narrower follow-up strategy is proven
+
 ## 2026-05-03 - Isolate Polyscope Preview Storage Per API Workspace
 
 **Changed:**

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -108,6 +108,12 @@ Resolves #789
 - [ ] Documentation updated
 ```
 
+## 🔐 Policy Enforcement
+
+- PR titles and author-written PR bodies must be in English.
+- CI blocks obvious German PR title/body markers.
+- Comments and review text remain reviewer-enforced for now.
+
 ## 🏷️ Label Reference
 
 | Label               | Status     | Use Case                   |

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -125,6 +125,15 @@ if [ -f tests/pull-request-template.sh ]; then
   }
 fi
 
+if [ -f tests/pull-request-english.sh ]; then
+  bash tests/pull-request-english.sh || {
+    echo "" >&2
+    echo "❌ Pull request English-language regression test failed!" >&2
+    echo "Restore the English PR validator script, workflow wiring, template reminder, and enforcement/advisory documentation before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/setup-project-board.sh ]; then
   bash tests/setup-project-board.sh || {
     echo "" >&2

--- a/scripts/validate-pull-request-english.sh
+++ b/scripts/validate-pull-request-english.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+PR_TITLE="${PR_TITLE:-}"
+PR_BODY="${PR_BODY:-}"
+
+if [ -z "${PR_TITLE//[[:space:]]/}" ] && [ -z "${PR_BODY//[[:space:]]/}" ]; then
+  echo 'Pull request title or body is required for PR language validation.' >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'Node.js is required to validate PR title/body language.' >&2
+  exit 1
+fi
+
+node <<'NODE'
+const title = String(process.env.PR_TITLE || '');
+const body = String(process.env.PR_BODY || '');
+
+const strongMarkers = [
+  { label: 'einladung', regex: /\beinladung(?:s)?\b/u },
+  { label: 'abgleichen', regex: /\babgleichen\b/u },
+  { label: 'aktualisiert', regex: /\baktualisiert\b/u },
+  { label: 'behoben', regex: /\bbehoben\b/u },
+  { label: 'hinzugefügt', regex: /\bhinzugef(?:ü|u)gt\b/u },
+  { label: 'weitere repos', regex: /\bweitere\s+repos\b/u },
+  { label: 'pflichtangaben', regex: /\bpflichtangaben\b/u },
+  { label: 'persönliche', regex: /\bpers(?:ö|o)nliche\b/u },
+  { label: 'erforderlich', regex: /\berforderlich\b/u },
+  { label: 'wichtig', regex: /\bwichtig\b/u },
+];
+
+const softMarkers = [
+  { label: 'inhalte', regex: /\binhalte\b/u },
+  { label: 'unterstützte', regex: /\bunterst(?:ü|u)tzte\b/u },
+  { label: 'schritte', regex: /\bschritte\b/u },
+  { label: 'abschnitte', regex: /\babschnitte\b/u },
+  { label: 'belege', regex: /\bbelege\b/u },
+  { label: 'sowie', regex: /\bsowie\b/u },
+  { label: 'ohne', regex: /\bohne\b/u },
+];
+
+const germanCharacterMarker = { label: 'umlaut-or-esszett', regex: /[äöüß]/u };
+
+function stripGeneratedSections(markdown) {
+  return markdown
+    .replace(/<!--\s*CURSOR_SUMMARY\s*-->[\s\S]*?<!--\s*\/CURSOR_SUMMARY\s*-->/giu, ' ')
+    .replace(/<!--[^]*?-->/g, ' ')
+    .replace(/```[^]*?```/g, ' ')
+    .replace(/`[^`\n]+`/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/https?:\/\/\S+/g, ' ');
+}
+
+function normalize(text) {
+  return stripGeneratedSections(text)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function findLabels(text, markers) {
+  return markers.filter((marker) => marker.regex.test(text)).map((marker) => marker.label);
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function classify(text, { titleThreshold, bodyThreshold, strongThreshold }) {
+  const normalized = normalize(text);
+  const strong = findLabels(normalized, strongMarkers);
+  const soft = findLabels(normalized, softMarkers);
+  const germanCharacters = germanCharacterMarker.regex.test(normalized) ? [germanCharacterMarker.label] : [];
+  const total = unique([...strong, ...soft, ...germanCharacters]);
+
+  return {
+    strong,
+    soft,
+    germanCharacters,
+    total,
+    titleLikelyGerman: germanCharacters.length > 0 || strong.length >= strongThreshold || total.length >= titleThreshold,
+    bodyLikelyGerman: germanCharacters.length > 0 || strong.length >= strongThreshold || total.length >= bodyThreshold,
+  };
+}
+
+const titleResult = classify(title, { titleThreshold: 2, bodyThreshold: 3, strongThreshold: 1 });
+const bodyResult = classify(body, { titleThreshold: 2, bodyThreshold: 3, strongThreshold: 2 });
+
+if (!titleResult.titleLikelyGerman && !bodyResult.bodyLikelyGerman) {
+  process.exit(0);
+}
+
+console.error('PR title/body must be in English.');
+console.error('This check intentionally blocks only obvious German PR title/body markers to keep false positives low.');
+
+if (titleResult.titleLikelyGerman) {
+  console.error(`- title markers: ${titleResult.total.join(', ')}`);
+}
+
+if (bodyResult.bodyLikelyGerman) {
+  console.error(`- body markers: ${bodyResult.total.join(', ')}`);
+}
+
+process.exit(1);
+NODE

--- a/tests/pull-request-english.sh
+++ b/tests/pull-request-english.sh
@@ -41,6 +41,16 @@ if ! grep -Fq 'scripts/validate-pull-request-english.sh' "$WORKFLOW"; then
   exit 1
 fi
 
+if ! grep -Fq 'pull_request_target:' "$WORKFLOW"; then
+  echo "Workflow must run from the base branch context so PRs cannot self-bypass the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.base.sha' "$WORKFLOW"; then
+  echo "Workflow must check out the base revision before running the validator." >&2
+  exit 1
+fi
+
 if ! grep -Fq 'github.event.pull_request.title' "$WORKFLOW"; then
   echo "Workflow does not pass the pull request title into the validator." >&2
   exit 1

--- a/tests/pull-request-english.sh
+++ b/tests/pull-request-english.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$REPO_ROOT/scripts/validate-pull-request-english.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/pull-request-english.yml"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+QUICK_REFERENCE="$REPO_ROOT/docs/workflows/QUICK_REFERENCE.md"
+
+if [ ! -f "$VALIDATOR" ]; then
+  echo "Expected validator script was not found: $VALIDATOR" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "Expected PR template was not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+if [ ! -f "$QUICK_REFERENCE" ]; then
+  echo "Expected quick reference doc was not found: $QUICK_REFERENCE" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'GitHub-facing communication in pull request titles and bodies must be in English.' "$TEMPLATE"; then
+  echo "PR template must remind authors that pull request titles and bodies must be in English." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'scripts/validate-pull-request-english.sh' "$WORKFLOW"; then
+  echo "Workflow does not invoke the pull-request English validator script." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.title' "$WORKFLOW"; then
+  echo "Workflow does not pass the pull request title into the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'github.event.pull_request.body' "$WORKFLOW"; then
+  echo "Workflow does not pass the pull request body into the validator." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'edited' "$WORKFLOW"; then
+  echo "Workflow must rerun when the pull request title or body is edited." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'CI blocks obvious German PR title/body markers.' "$QUICK_REFERENCE"; then
+  echo "Quick reference must document that obvious German PR title/body markers are CI-blocked." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Comments and review text remain reviewer-enforced for now.' "$QUICK_REFERENCE"; then
+  echo "Quick reference must document that comments and review text remain reviewer-enforced." >&2
+  exit 1
+fi
+
+english_title='feat(governance): align onboarding attachment copy'
+english_body="$(cat <<'EOF'
+## Description
+
+Clarify the onboarding copy and keep BewachV, GewO, and Steuer-ID terminology unchanged where the domain requires it.
+
+Made with [Cursor](https://cursor.com)
+
+<!-- CURSOR_SUMMARY -->
+## Zusammenfassung
+
+- Deutsche Marker inside the generated summary must not affect the author-facing PR language check.
+<!-- /CURSOR_SUMMARY -->
+EOF
+)"
+
+if ! PR_TITLE="$english_title" PR_BODY="$english_body" bash "$VALIDATOR" >/tmp/pull-request-english-positive.log 2>&1; then
+  cat /tmp/pull-request-english-positive.log >&2
+  echo "Validator rejected an English PR title/body that only contains German markers inside an ignored generated summary block." >&2
+  exit 1
+fi
+
+german_title='feat: [US-009] Einladung und Wizard-Inhalte abgleichen'
+german_body="$(cat <<'EOF'
+## US-009: Einladung und Wizard-Inhalte abgleichen
+
+- Einladungs-E-Mail listet nur noch unterstützte Schritte: persönliche Pflichtangaben, optionale Abschnitte sowie Belege pro Schritt.
+
+**Weitere Repos:** Branch `onboarding-review-stories` (**frontend**), `onboarding-review-stories-link-3` (**api**).
+EOF
+)"
+
+if PR_TITLE="$german_title" PR_BODY="$german_body" bash "$VALIDATOR" >/tmp/pull-request-english-negative.log 2>&1; then
+  echo "Validator unexpectedly accepted an obviously German pull request title/body." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'PR title/body must be in English.' /tmp/pull-request-english-negative.log; then
+  cat /tmp/pull-request-english-negative.log >&2
+  echo "Validator did not explain the non-English failure." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'einladung' /tmp/pull-request-english-negative.log; then
+  cat /tmp/pull-request-english-negative.log >&2
+  echo "Validator did not report the detected German markers." >&2
+  exit 1
+fi

--- a/tests/pull-request-english.sh
+++ b/tests/pull-request-english.sh
@@ -10,6 +10,13 @@ VALIDATOR="$REPO_ROOT/scripts/validate-pull-request-english.sh"
 WORKFLOW="$REPO_ROOT/.github/workflows/pull-request-english.yml"
 TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
 QUICK_REFERENCE="$REPO_ROOT/docs/workflows/QUICK_REFERENCE.md"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pull-request-english.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
 
 if [ ! -f "$VALIDATOR" ]; then
   echo "Expected validator script was not found: $VALIDATOR" >&2
@@ -28,6 +35,16 @@ fi
 
 if [ ! -f "$QUICK_REFERENCE" ]; then
   echo "Expected quick reference doc was not found: $QUICK_REFERENCE" >&2
+  exit 1
+fi
+
+if [ "$(sed -n '1p' "$WORKFLOW")" != '# SPDX-FileCopyrightText: 2026 SecPal' ]; then
+  echo "Workflow must start with the SPDX copyright header." >&2
+  exit 1
+fi
+
+if grep -Eq '/tmp/pull-request-english-(positive|negative)\.log' "$0"; then
+  echo "Test must use per-run mktemp log files instead of fixed /tmp paths." >&2
   exit 1
 fi
 
@@ -92,8 +109,11 @@ Made with [Cursor](https://cursor.com)
 EOF
 )"
 
-if ! PR_TITLE="$english_title" PR_BODY="$english_body" bash "$VALIDATOR" >/tmp/pull-request-english-positive.log 2>&1; then
-  cat /tmp/pull-request-english-positive.log >&2
+positive_log="$TMP_DIR/positive.log"
+negative_log="$TMP_DIR/negative.log"
+
+if ! PR_TITLE="$english_title" PR_BODY="$english_body" bash "$VALIDATOR" >"$positive_log" 2>&1; then
+  cat "$positive_log" >&2
   echo "Validator rejected an English PR title/body that only contains German markers inside an ignored generated summary block." >&2
   exit 1
 fi
@@ -108,19 +128,19 @@ german_body="$(cat <<'EOF'
 EOF
 )"
 
-if PR_TITLE="$german_title" PR_BODY="$german_body" bash "$VALIDATOR" >/tmp/pull-request-english-negative.log 2>&1; then
+if PR_TITLE="$german_title" PR_BODY="$german_body" bash "$VALIDATOR" >"$negative_log" 2>&1; then
   echo "Validator unexpectedly accepted an obviously German pull request title/body." >&2
   exit 1
 fi
 
-if ! grep -Fq 'PR title/body must be in English.' /tmp/pull-request-english-negative.log; then
-  cat /tmp/pull-request-english-negative.log >&2
+if ! grep -Fq 'PR title/body must be in English.' "$negative_log"; then
+  cat "$negative_log" >&2
   echo "Validator did not explain the non-English failure." >&2
   exit 1
 fi
 
-if ! grep -Fq 'einladung' /tmp/pull-request-english-negative.log; then
-  cat /tmp/pull-request-english-negative.log >&2
+if ! grep -Fq 'einladung' "$negative_log"; then
+  cat "$negative_log" >&2
   echo "Validator did not report the detected German markers." >&2
   exit 1
 fi


### PR DESCRIPTION
## Description

Add a low-noise pull request language check that blocks obvious German PR titles and author-written PR bodies in the `.github` repository.

The guardrail intentionally stays narrow: it strips the known generated summary block, ignores code/comment noise, and only fails on high-signal German markers so SecPal domain terms such as BewachV, GewO, or Steuer-ID do not create avoidable false positives.

This is the English-communication slice of #424 and is intentionally separate from the signed-commit slice in PR #432.

## Related Issues

Closes #433
Refs #424
Refs #432

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

## TDD / Validate-First Evidence

- Failing proof before implementation: `tmpdir=$(mktemp -d) && git archive main | tar -x -C "$tmpdir" && mkdir -p "$tmpdir/tests" && cp tests/pull-request-english.sh "$tmpdir/tests/pull-request-english.sh" && bash "$tmpdir/tests/pull-request-english.sh"` failed with `Expected validator script was not found: /tmp/.../scripts/validate-pull-request-english.sh`.
- Passing proof after implementation: `bash tests/pull-request-english.sh`, `pre-commit run shellcheck --files scripts/validate-pull-request-english.sh tests/pull-request-english.sh`, and `./scripts/preflight.sh`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate on PR title/body content using heuristic language detection; misclassification or workflow misconfiguration could block legitimate PRs or create noisy failures.
> 
> **Overview**
> Adds a new PR language guardrail that **fails `.github` pull requests when the title or author-written body contains obvious German markers**, via `scripts/validate-pull-request-english.sh` and a new `pull_request_target` workflow.
> 
> Wires a regression test (`tests/pull-request-english.sh`) into `scripts/preflight.sh`, and updates the PR template plus `docs/workflows/QUICK_REFERENCE.md`/`CHANGELOG.md` to document the new English-only requirement and what is (and isn’t) enforced.
> 
> Also hardens `tests/pull-request-commit-signatures.sh` to use portable `mktemp -d "${TMPDIR:-/tmp}/...XXXXXX"` temp directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 306885452bb47e2a136b9623a6e0cf5740f9ee0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->