### PR TITLE
docs(governance): document signed-pr remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Document Signed-Commit Deadlock Remediation For Legacy PR Branches
+
+**Changed:**
+
+- updated `docs/workflows/QUICK_REFERENCE.md` with the supported replacement-PR flow when signed-commit enforcement blocks a legacy branch with unsigned history
+- documented that the policy-safe path is to supersede the blocked PR from a fresh signed branch instead of force-pushing or bypassing branch protection
+
 ## 2026-05-08 - Require PR Evidence For TDD Or Explicit Non-Executable Changes
 
 **Changed:**

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -146,7 +146,8 @@ git pull --ff-only origin main
 git switch -c replacement/topic
 git cherry-pick -x -S <signed-or-recreated-commit>
 git push -u origin replacement/topic
-gh pr create --draft
+printf '%s\n' '## Description' '' 'Replacement PR for blocked unsigned history.' '' '## Related Pull Requests' '' 'Supersedes PR #123' > /tmp/replacement-pr-body.md
+gh pr create --draft --title "replacement title" --body-file /tmp/replacement-pr-body.md
 ```
 
 If the old branch contains mixed signed and unsigned history, re-commit the intended change on the fresh branch instead of merging the blocked branch forward.

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -126,6 +126,31 @@ Use the no-executable-change reason only for docs/content/template-only PRs.
 - English-only GitHub communication remains reviewer-enforced for now.
 - Signed commit verification is enforced by CI.
 
+### Signed-Commit Deadlock Remediation
+
+If a legacy PR branch already contains an unsigned historical commit, do not force-push and do not bypass branch protection.
+
+Use a replacement PR from a fresh signed branch instead:
+
+1. Switch to an up-to-date `main` and create a new topic branch.
+2. Re-apply the intended changes onto that fresh branch with signed commits only.
+3. Push the fresh branch and open a replacement draft PR.
+4. Mark the blocked PR as superseded by the replacement PR instead of trying to revive the unsigned branch history.
+5. Continue review and thread resolution on the replacement PR.
+
+Minimal CLI flow:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c replacement/topic
+git cherry-pick -x -S <signed-or-recreated-commit>
+git push -u origin replacement/topic
+gh pr create --draft
+```
+
+If the old branch contains mixed signed and unsigned history, re-commit the intended change on the fresh branch instead of merging the blocked branch forward.
+
 ## 🏷️ Label Reference
 
 | Label               | Status     | Use Case                   |

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -144,10 +144,12 @@ Minimal CLI flow:
 git switch main
 git pull --ff-only origin main
 git switch -c replacement/topic
-git cherry-pick -x -S <signed-or-recreated-commit>
+git cherry-pick -x -S <commit-from-blocked-branch>
 git push -u origin replacement/topic
-printf '%s\n' '## Description' '' 'Replacement PR for blocked unsigned history.' '' '## Related Pull Requests' '' 'Supersedes PR #123' > /tmp/replacement-pr-body.md
-gh pr create --draft --title "replacement title" --body-file /tmp/replacement-pr-body.md
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/replacement-pr-body.XXXXXX")
+printf '%s\n' '## Description' '' 'Replacement PR for blocked unsigned history.' '' '## Related Pull Requests' '' 'Supersedes PR #123' > "$tmpfile"
+gh pr create --draft --title "replacement title" --body-file "$tmpfile"
+rm -f "$tmpfile"
 ```
 
 If the old branch contains mixed signed and unsigned history, re-commit the intended change on the fresh branch instead of merging the blocked branch forward.


### PR DESCRIPTION
## Description

Document the supported replacement-PR workflow when signed-commit enforcement blocks a legacy branch that still contains unsigned history.

This gives maintainers and agents a policy-safe remediation path that does not require force-pushes or branch-protection bypasses.

## Related Issues

Closes #436

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

Manual validation:
- ./scripts/preflight.sh

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A
- Passing proof after implementation: N/A
- Validate-first exception reference: N/A
- No executable change reason: Documentation-only governance guidance; no executable behavior or validation changed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor guidance without altering any CI, validation, or enforcement behavior.
> 
> **Overview**
> Adds a *Signed-Commit Deadlock Remediation* section to `docs/workflows/QUICK_REFERENCE.md` describing the supported workflow for replacing a PR when signed-commit enforcement blocks a legacy branch with unsigned history (supersede with a fresh signed branch; avoid force-pushes or bypassing protection).
> 
> Records this new guidance in `CHANGELOG.md` under a 2026-05-09 entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494015933931e1ca98dd5983aa5f2791ee8a0fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->