### PR TITLE
fix(polyscope): skip invalid stub worktrees during provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Skip Invalid Polyscope Stub Directories During Provisioning
+
+**Changed:**
+
+- hardened `scripts/polyscope-rollout.py` so automatic worktree provisioning now skips clone-root stub directories that are missing the real repo structure required for provisioning instead of trying to sync local config, install hooks, or run setup commands inside them
+- taught API preview-storage cleanup to ignore those invalid stub directories too, so orphaned preview databases are no longer kept alive just because a broken `fix` or `feat` directory exists under the clone root
+- extended `tests/polyscope-rollout.sh` to prove valid worktrees still provision normally when invalid stub directories are present, and to verify stale preview databases for those invalid stubs are cleaned on the next provisioning pass
+
 ## 2026-05-09 - Align ADR-010 Retention Terminology With Current Backend Model
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -335,7 +335,7 @@ def cleanup_removed_api_preview_databases(
         build_preview_database_name(base_database, worktree_path.name)
         for worktree_path in api_clone_root.iterdir()
         if worktree_path.is_dir()
-        if is_provisionable_worktree("api", api_spec, worktree_path, api_validation_commands, log_skip_reason=False)
+        if is_provisionable_worktree("api", worktree_path, api_validation_commands, log_skip_reason=False)
     }
 
     cleaned_databases: list[str] = []
@@ -1027,7 +1027,6 @@ def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
 
 def is_provisionable_worktree(
     repo_name: str,
-    spec: dict[str, Any],
     worktree_path: pathlib.Path,
     validation_commands: list[str],
     *,
@@ -1038,13 +1037,17 @@ def is_provisionable_worktree(
             print(f"Skipping {repo_name} worktree {worktree_path.name} at {worktree_path}: {reason}")
         return False
 
-    if not (worktree_path / ".git").exists():
-        return skip("missing .git")
+    try:
+        git_dir = resolve_git_dir(worktree_path)
+        if not git_dir.is_dir():
+            return skip("missing .git")
+    except SystemExit:
+        return skip("invalid .git pointer")
 
-    copilot_instructions_path = worktree_path / str(spec["copilot_instructions"])
+    copilot_instructions_rel = REPO_SETTINGS[repo_name]["copilot_instructions"]
+    copilot_instructions_path = worktree_path / copilot_instructions_rel
     if not copilot_instructions_path.is_file():
-        missing_path = copilot_instructions_path.relative_to(worktree_path)
-        return skip(f"missing required repo file {missing_path}")
+        return skip(f"missing required repo file {copilot_instructions_rel}")
 
     package_scripts = load_package_scripts(worktree_path)
     try:
@@ -1215,7 +1218,7 @@ def provision_worktrees(
         config_text = rendered_configs[repo_name]
 
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
-            if not is_provisionable_worktree(repo_name, spec, worktree_path, validation_commands):
+            if not is_provisionable_worktree(repo_name, worktree_path, validation_commands):
                 continue
 
             sync_worktree_local_config(worktree_path, config_text)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -329,10 +329,13 @@ def cleanup_removed_api_preview_databases(
     if not base_database:
         return []
 
+    api_spec = repo_specs["api"]
+    api_validation_commands = render_local_config(api_spec).get("scripts", {}).get("setup", [])
     active_targets = {
         build_preview_database_name(base_database, worktree_path.name)
         for worktree_path in api_clone_root.iterdir()
         if worktree_path.is_dir()
+        if is_provisionable_worktree("api", api_spec, worktree_path, api_validation_commands, log_skip_reason=False)
     }
 
     cleaned_databases: list[str] = []
@@ -1022,6 +1025,37 @@ def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
                 validate_local_config_command(repo_name, repo_path, package_scripts, command)
 
 
+def is_provisionable_worktree(
+    repo_name: str,
+    spec: dict[str, Any],
+    worktree_path: pathlib.Path,
+    validation_commands: list[str],
+    *,
+    log_skip_reason: bool = True,
+) -> bool:
+    def skip(reason: str) -> bool:
+        if log_skip_reason:
+            print(f"Skipping {repo_name} worktree {worktree_path.name} at {worktree_path}: {reason}")
+        return False
+
+    if not (worktree_path / ".git").exists():
+        return skip("missing .git")
+
+    copilot_instructions_path = worktree_path / str(spec["copilot_instructions"])
+    if not copilot_instructions_path.is_file():
+        missing_path = copilot_instructions_path.relative_to(worktree_path)
+        return skip(f"missing required repo file {missing_path}")
+
+    package_scripts = load_package_scripts(worktree_path)
+    try:
+        for command in validation_commands:
+            validate_local_config_command(repo_name, worktree_path, package_scripts, command)
+    except SystemExit as error:
+        return skip(str(error))
+
+    return True
+
+
 def resolve_git_dir(repo_path: pathlib.Path) -> pathlib.Path:
     git_path = repo_path / ".git"
     if git_path.is_dir():
@@ -1173,13 +1207,17 @@ def provision_worktrees(
             continue
 
         local_config = render_local_config(spec)
-        setup_commands = local_config.get("scripts", {}).get("setup", [])
+        validation_commands = local_config.get("scripts", {}).get("setup", [])
+        setup_commands = validation_commands
         if repo_name == "api":
             setup_commands = setup_commands[1:]
         setup_hash = build_setup_hash(setup_commands)
         config_text = rendered_configs[repo_name]
 
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
+            if not is_provisionable_worktree(repo_name, spec, worktree_path, validation_commands):
+                continue
+
             sync_worktree_local_config(worktree_path, config_text)
             ensure_worktree_hooks(worktree_path)
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -117,6 +117,26 @@ for repo_name, scripts in package_scripts.items():
 PY
 }
 
+seed_api_worktree_files() {
+    local worktree_dir="$1"
+
+    mkdir -p "$worktree_dir/.github"
+    printf '# test clone\n' > "$worktree_dir/.github/copilot-instructions.md"
+    printf '{}\n' > "$worktree_dir/composer.json"
+    printf '#!/usr/bin/env php\n' > "$worktree_dir/artisan"
+    chmod +x "$worktree_dir/artisan"
+}
+
+seed_node_worktree_files() {
+    local worktree_dir="$1"
+    local package_name="$2"
+
+    mkdir -p "$worktree_dir/.github"
+    printf '# test clone\n' > "$worktree_dir/.github/copilot-instructions.md"
+    printf '{\n  "name": "%s",\n  "private": true,\n  "scripts": {\n    "build": "vite build"\n  }\n}\n' "$package_name" > "$worktree_dir/package.json"
+    printf '{\n  "name": "%s",\n  "lockfileVersion": 3,\n  "requires": true,\n  "packages": {}\n}\n' "$package_name" > "$worktree_dir/package-lock.json"
+}
+
 assert_rollout_rejects_invalid_local_config() {
     local source_script="$1"
     local old_text="$2"
@@ -607,8 +627,10 @@ fake_pg_state="$workspace/postgres-state.json"
 fake_exec_dir="$workspace/fake-exec"
 service_path="$fake_exec_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 api_clone="$home_dir/.polyscope/clones/api12345/auto-hawk"
+broken_api_clone="$home_dir/.polyscope/clones/api12345/fix"
 frontend_clone="$home_dir/.polyscope/clones/fe123456/auto-hawk"
-mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts"
+broken_frontend_clone="$home_dir/.polyscope/clones/fe123456/feat"
+mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone"
 mkdir -p "$home_dir/.local/bin"
 
 python3 - <<'PY' "$fake_pg_state"
@@ -747,7 +769,11 @@ SANCTUM_STATEFUL_DOMAINS=app.secpal.dev
 CORS_ALLOWED_ORIGINS=https://app.secpal.dev
 EOF
 
+seed_api_worktree_files "$api_clone"
+seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
+
 cp "$workspace_root/api/.env" "$api_clone/.env"
+: > "$broken_api_clone/.env"
 
 cat >"$api_clone/.pre-commit-config.yaml" <<'EOF'
 repos: []
@@ -796,6 +822,8 @@ provisioned = summary.get('provisioned_worktrees', [])
 cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:auto-hawk' in provisioned, f"expected api:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in provisioned_worktrees, got {provisioned}"
+assert 'api:fix' not in provisioned, f"did not expect api:fix in provisioned_worktrees, got {provisioned}"
+assert 'frontend:feat' not in provisioned, f"did not expect frontend:feat in provisioned_worktrees, got {provisioned}"
 assert cleaned == [], f"expected no cleaned preview databases on first provisioning run, got {cleaned}"
 PY
 
@@ -819,6 +847,10 @@ test -L "$frontend_clone/.git/hooks/pre-push"
 test "$(readlink "$frontend_clone/.git/hooks/pre-push")" = '../../scripts/preflight.sh'
 test -f "$api_clone/.polyscope-secpal-provisioned.json"
 test -f "$frontend_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$broken_api_clone/polyscope.local.json"
+test ! -f "$broken_api_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$broken_frontend_clone/polyscope.local.json"
+test ! -f "$broken_frontend_clone/.polyscope-secpal-provisioned.json"
 grep -qF "composer:$api_clone:install" "$provision_log"
 grep -qF "php:$api_clone:artisan config:clear" "$provision_log"
 grep -qF "php:$api_clone:artisan migrate --force" "$provision_log"
@@ -831,6 +863,16 @@ grep -qF "pre-commit:$frontend_clone:install --install-hooks --hook-type pre-com
 grep -qF "SELECT 1 FROM pg_database WHERE datname = 'secpal__preview__auto_hawk'" "$fake_psql_log"
 grep -qF 'CREATE DATABASE "secpal__preview__auto_hawk"' "$fake_psql_log"
 
+if grep -qF "$broken_api_clone" "$provision_log"; then
+    echo "provisioning must skip invalid api stub directories" >&2
+    exit 1
+fi
+
+if grep -qF "$broken_frontend_clone" "$provision_log"; then
+    echo "provisioning must skip invalid frontend stub directories" >&2
+    exit 1
+fi
+
 python3 - <<'PY' "$fake_pg_state"
 import json
 import sys
@@ -840,8 +882,48 @@ assert 'secpal' in state['databases']
 assert 'secpal__preview__auto_hawk' in state['databases']
 PY
 
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+state['databases'].append('secpal__preview__fix')
+open(sys.argv[1], 'w').write(json.dumps(state))
+PY
+
+invalid_dir_cleanup_summary_json="$workspace/invalid-dir-cleanup-summary.json"
+env HOME="$home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$invalid_dir_cleanup_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$invalid_dir_cleanup_summary_json" "$fake_pg_state" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+state = json.loads(open(sys.argv[2]).read())
+
+assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
+assert summary.get('cleaned_preview_storage_targets', []) == ['secpal__preview__fix'], summary.get('cleaned_preview_storage_targets', [])
+assert 'secpal__preview__fix' not in state['databases'], state['databases']
+PY
+
+grep -qF 'DROP DATABASE IF EXISTS "secpal__preview__fix" WITH (FORCE)' "$fake_psql_log"
+
 stale_api_clone="$home_dir/.polyscope/clones/api12345/stale-otter"
 mkdir -p "$stale_api_clone/.git/info" "$stale_api_clone/.git/hooks" "$stale_api_clone/scripts"
+seed_api_worktree_files "$stale_api_clone"
 
 cat >"$stale_api_clone/.pre-commit-config.yaml" <<'EOF'
 repos: []
@@ -976,6 +1058,8 @@ schema_cleanup_summary_json="$workspace/schema-cleanup-summary.json"
 
 mkdir -p "$schema_home_dir/.local/bin" "$schema_api_clone/.git/info" "$schema_api_clone/.git/hooks" "$schema_api_clone/scripts" "$schema_frontend_clone/.git/info" "$schema_frontend_clone/.git/hooks" "$schema_frontend_clone/scripts"
 cp "$home_dir/.local/bin/pre-commit" "$schema_home_dir/.local/bin/pre-commit"
+seed_api_worktree_files "$schema_api_clone"
+seed_node_worktree_files "$schema_frontend_clone" "frontend-schema-badger"
 
 python3 - <<'PY' "$schema_pg_state"
 import json

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -628,9 +628,11 @@ fake_exec_dir="$workspace/fake-exec"
 service_path="$fake_exec_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 api_clone="$home_dir/.polyscope/clones/api12345/auto-hawk"
 broken_api_clone="$home_dir/.polyscope/clones/api12345/fix"
+garbled_git_api_clone="$home_dir/.polyscope/clones/api12345/chore"
 frontend_clone="$home_dir/.polyscope/clones/fe123456/auto-hawk"
 broken_frontend_clone="$home_dir/.polyscope/clones/fe123456/feat"
-mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone"
+mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$garbled_git_api_clone" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone"
+printf 'not-a-git-pointer\n' > "$garbled_git_api_clone/.git"
 mkdir -p "$home_dir/.local/bin"
 
 python3 - <<'PY' "$fake_pg_state"
@@ -823,6 +825,7 @@ cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:auto-hawk' in provisioned, f"expected api:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'api:fix' not in provisioned, f"did not expect api:fix in provisioned_worktrees, got {provisioned}"
+assert 'api:chore' not in provisioned, f"did not expect api:chore in provisioned_worktrees, got {provisioned}"
 assert 'frontend:feat' not in provisioned, f"did not expect frontend:feat in provisioned_worktrees, got {provisioned}"
 assert cleaned == [], f"expected no cleaned preview databases on first provisioning run, got {cleaned}"
 PY
@@ -849,6 +852,8 @@ test -f "$api_clone/.polyscope-secpal-provisioned.json"
 test -f "$frontend_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$broken_api_clone/polyscope.local.json"
 test ! -f "$broken_api_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$garbled_git_api_clone/polyscope.local.json"
+test ! -f "$garbled_git_api_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$broken_frontend_clone/polyscope.local.json"
 test ! -f "$broken_frontend_clone/.polyscope-secpal-provisioned.json"
 grep -qF "composer:$api_clone:install" "$provision_log"
@@ -865,6 +870,11 @@ grep -qF 'CREATE DATABASE "secpal__preview__auto_hawk"' "$fake_psql_log"
 
 if grep -qF "$broken_api_clone" "$provision_log"; then
     echo "provisioning must skip invalid api stub directories" >&2
+    exit 1
+fi
+
+if grep -qF "$garbled_git_api_clone" "$provision_log"; then
+    echo "provisioning must skip api worktrees with garbled .git files" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Closes #440.

Polyscope rollout now skips invalid clone-root stub directories instead of trying to provision them as real worktrees. This prevents background provisioning from aborting on broken `fix`/`feat` leftovers and lets valid worktrees continue to receive their preview config, hooks, and build artifacts.

## TDD / Validate-First Evidence
- Failing proof before implementation: `systemctl --user status polyscope-worktree-provision.service` showed provisioning aborting on orphaned clone-root stub directories such as `~/.polyscope/clones/47d112dd/fix`, and fresh external preview requests for the affected frontend returned `404` because the rollout had not regenerated `dist/index.html`.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `./scripts/preflight.sh` both pass, and the rollout regression now proves invalid stub directories are skipped while valid worktrees still provision and stale preview databases for stub names are cleaned.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## What Changed
- added `is_provisionable_worktree()` guards in `scripts/polyscope-rollout.py` before local-config sync, hook installation, setup execution, and API preview-target discovery
- updated API preview-storage cleanup so invalid stub directories no longer keep orphaned preview databases alive
- added regression helpers and provisioning/cleanup assertions in `tests/polyscope-rollout.sh`
- updated `CHANGELOG.md`

## Validation
- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## Runtime Impact
- fixes the live failure where `polyscope-worktree-provision.service` aborted on orphaned stub directories and left preview frontends without `dist/index.html`
