### PR TITLE
fix: strip AI agent attribution trailers from commits and PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,9 @@ Other repositories must keep their own self-contained runtime instructions.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads
   using the approved non-comment workflow (`docs/copilot-review-automation.md` or `scripts/copilot-review-tool.sh`).
+- Do not add AI agent attribution to commits, pull requests, issues, or any GitHub-facing content. This includes
+  `Co-authored-by:` trailers for Cursor, Copilot, or any other AI tool. The `commit-msg` hook in
+  `scripts/strip-ai-trailers.sh` enforces this automatically; keep it installed in every managed worktree.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh dependencies where applicable as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
-## 2026-05-09 - Fix Repo-Type Misdetection in Copilot Instructions Validator
+## 2026-05-09 - Fix AI-Trailer Hook Robustness and Validator Misdetection
 
 **Fixed:**
 
+- `scripts/strip-ai-trailers.sh`: use `mktemp "${TMPDIR:-/tmp}/strip-ai-trailers.XXXXXX"` for portability
+  on BSD/macOS; replace the awk that collapsed all consecutive blank lines with a
+  trailing-only blank-line trimmer that preserves intentional blank lines in the commit body
+- `setup-hooks.sh`: resolve the hooks directory via `git rev-parse --git-path hooks`
+  instead of hardcoding `.git/hooks`, so the `commit-msg` hook installs correctly in
+  Git worktrees where `.git` is a `gitdir:` pointer file rather than a directory
 - `scripts/validate-copilot-instructions.sh`: `detect_repo_type()` now checks
   for `workflow-templates/` directory before the openapi-in-package.json check,
   so the `.github` org repository is correctly identified as `org` instead of
-  `contracts`; the misdetection caused the repo-specific AI risk guidance check
-  to fail whenever `.github/copilot-instructions.md` was touched in a PR
+  `contracts`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Strip AI Agent Attribution From Commits and PRs
+
+**Added:**
+
+- added `scripts/strip-ai-trailers.sh`, a `commit-msg` hook that removes
+  `Co-authored-by:` trailers injected by AI coding agents (Cursor, GitHub
+  Copilot) while preserving human co-author and dependabot trailers
+- Polyscope provisioning now installs the `commit-msg` hook as a symlink in
+  every managed worktree alongside the existing pre-commit and pre-push hooks
+- `setup-hooks.sh` installs the `commit-msg` hook in all SecPal repositories
+  as part of the local development environment setup
+
+**Changed:**
+
+- disabled `attributeCommitsToAgent` and `attributePRsToAgent` in the Cursor
+  CLI configuration so AI-generated attribution trailers are not added at the
+  source
+- hardened the no-AI-attribution policy in `.github/copilot-instructions.md`
+  with an explicit rule and a reference to the enforcement hook
+
 ## 2026-05-09 - Skip Invalid Polyscope Stub Directories During Provisioning
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Fix Repo-Type Misdetection in Copilot Instructions Validator
+
+**Fixed:**
+
+- `scripts/validate-copilot-instructions.sh`: `detect_repo_type()` now checks
+  for `workflow-templates/` directory before the openapi-in-package.json check,
+  so the `.github` org repository is correctly identified as `org` instead of
+  `contracts`; the misdetection caused the repo-specific AI risk guidance check
+  to fail whenever `.github/copilot-instructions.md` was touched in a PR
+
+---
+
 ## 2026-05-09 - Strip AI Agent Attribution From Commits and PRs
 
 **Added:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1190,9 +1190,31 @@ def ensure_pre_push_hook(worktree_path: pathlib.Path) -> None:
     hook_path.symlink_to(target)
 
 
+def ensure_commit_msg_hook(worktree_path: pathlib.Path) -> None:
+    strip_script = pathlib.Path(__file__).parent / "strip-ai-trailers.sh"
+    if not strip_script.exists():
+        return
+
+    hooks_dir = resolve_git_dir(worktree_path) / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    hook_path = hooks_dir / "commit-msg"
+    target = pathlib.Path(os.path.relpath(strip_script, hooks_dir))
+
+    if hook_path.is_symlink():
+        if pathlib.Path(os.readlink(hook_path)) == target:
+            return
+        hook_path.unlink()
+    elif hook_path.exists():
+        hook_path.replace(hook_path.with_name("commit-msg.backup"))
+
+    hook_path.symlink_to(target)
+
+
 def ensure_worktree_hooks(worktree_path: pathlib.Path) -> None:
     ensure_pre_commit_hook(worktree_path)
     ensure_pre_push_hook(worktree_path)
+    ensure_commit_msg_hook(worktree_path)
 
 
 def provision_worktrees(

--- a/scripts/strip-ai-trailers.sh
+++ b/scripts/strip-ai-trailers.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+#
+# commit-msg hook: strip Co-authored-by trailers added by AI coding agents.
+#
+# Install as .git/hooks/commit-msg (executable) or symlink to this file.
+# Polyscope provisioning installs it automatically in every managed worktree.
+#
+# Patterns stripped (case-insensitive match on the email address or username):
+#   Co-authored-by: Cursor …<cursoragent@cursor.com>
+#   Co-authored-by: Cursor Agent …<cursoragent@cursor.com>
+#   Co-authored-by: GitHub Copilot <…@github.com>          (copilot bot accounts)
+#   Co-authored-by: copilot-pull-request-reviewer[bot] …
+#
+# Human co-authors and dependabot are intentionally NOT stripped.
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="${1:?commit-msg hook requires the commit message file path}"
+
+if [[ ! -f "$COMMIT_MSG_FILE" ]]; then
+    echo "strip-ai-trailers: commit message file not found: $COMMIT_MSG_FILE" >&2
+    exit 1
+fi
+
+# Build a sed expression that removes known AI co-authored-by trailer lines.
+# Use ERE (-E) for readability; match the full line including line-ending.
+AI_PATTERN='Co-[Aa]uthored-[Bb]y:[[:space:]]*(Cursor[^<]*<cursoragent@cursor\.com>|[Cc]ursor[[:space:]]+[Aa]gent[^<]*<[^>]*>|GitHub[[:space:]]+Copilot[^<]*<[^>]*@github\.com>|copilot-pull-request-reviewer(\[bot\])?[^<]*<[^>]*>)'
+
+# Write the filtered content back to the file in-place.
+# Use a temp file to avoid clobbering the original on sed failure.
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+sed -E "/$AI_PATTERN/d" "$COMMIT_MSG_FILE" > "$tmp_file"
+
+# Collapse multiple consecutive blank lines at the end of the message
+# that may be left behind after stripping trailers.
+awk 'NF || prev_nf { print; prev_nf = NF }' "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
+
+mv "$tmp_file" "$COMMIT_MSG_FILE"

--- a/scripts/strip-ai-trailers.sh
+++ b/scripts/strip-ai-trailers.sh
@@ -30,13 +30,19 @@ AI_PATTERN='Co-[Aa]uthored-[Bb]y:[[:space:]]*(Cursor[^<]*<cursoragent@cursor\.co
 
 # Write the filtered content back to the file in-place.
 # Use a temp file to avoid clobbering the original on sed failure.
-tmp_file="$(mktemp)"
-trap 'rm -f "$tmp_file"' EXIT
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/strip-ai-trailers.XXXXXX")"
+trap 'rm -f "$tmp_file" "${tmp_file}.2"' EXIT
 
 sed -E "/$AI_PATTERN/d" "$COMMIT_MSG_FILE" > "$tmp_file"
 
-# Collapse multiple consecutive blank lines at the end of the message
-# that may be left behind after stripping trailers.
-awk 'NF || prev_nf { print; prev_nf = NF }' "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
+# Trim only trailing blank lines left behind after stripping trailers.
+# Buffer all lines, then print up to and including the last non-blank line.
+# This preserves intentional blank lines within the commit message body.
+awk '{ lines[NR] = $0 }
+END {
+    last = NR
+    while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+    for (i = 1; i <= last; i++) print lines[i]
+}' "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
 
 mv "$tmp_file" "$COMMIT_MSG_FILE"

--- a/scripts/strip-ai-trailers.sh.license
+++ b/scripts/strip-ai-trailers.sh.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -67,6 +67,11 @@ detect_repo_type() {
         return
     fi
 
+    if [ -d "workflow-templates" ]; then
+        echo "org"
+        return
+    fi
+
     if [ -f "docs/openapi.yaml" ] || { [ -f "package.json" ] && grep -q "openapi" package.json 2>/dev/null; }; then
         echo "contracts"
         return

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -65,6 +65,30 @@ for repo in "${REPOS[@]}"; do
                 FAILED_REPOS+=("$repo (setup-pre-commit.sh missing)")
         fi
 
+        # Setup commit-msg hook (strips AI attribution trailers)
+        STRIP_SCRIPT="$WORKSPACE_ROOT/.github/scripts/strip-ai-trailers.sh"
+        HOOK_PATH=".git/hooks/commit-msg"
+        if [ -f "$STRIP_SCRIPT" ]; then
+                RELATIVE_TARGET="$(python3 -c "import os; print(os.path.relpath('$STRIP_SCRIPT', '$(pwd)/.git/hooks'))")"
+                if [ -L "$HOOK_PATH" ]; then
+                        CURRENT_TARGET="$(readlink "$HOOK_PATH")"
+                        if [ "$CURRENT_TARGET" != "$RELATIVE_TARGET" ]; then
+                                ln -sf "$RELATIVE_TARGET" "$HOOK_PATH"
+                        fi
+                elif [ -f "$HOOK_PATH" ]; then
+                        mv "$HOOK_PATH" "${HOOK_PATH}.backup"
+                        ln -sf "$RELATIVE_TARGET" "$HOOK_PATH"
+                else
+                        mkdir -p "$(dirname "$HOOK_PATH")"
+                        ln -sf "$RELATIVE_TARGET" "$HOOK_PATH"
+                fi
+                echo "  ✓ Commit-msg hook (AI trailer stripping) installed"
+                SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+        else
+                echo "  ✗ strip-ai-trailers.sh not found at $STRIP_SCRIPT"
+                FAILED_REPOS+=("$repo (commit-msg hook missing)")
+        fi
+
         cd "$WORKSPACE_ROOT"
         echo ""
 done
@@ -96,6 +120,7 @@ else
 	echo "📝 What's installed:"
 	echo "  • Pre-commit hooks: Formatting, linting, REUSE compliance"
 	echo "  • Pre-push hooks: Comprehensive quality checks (via scripts/preflight.sh)"
+	echo "  • Commit-msg hooks: Strip AI agent attribution trailers (Cursor, Copilot)"
 	echo ""
 	echo "💡 Usage:"
 	echo "  • Hooks run automatically on commit/push"

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -67,9 +67,11 @@ for repo in "${REPOS[@]}"; do
 
         # Setup commit-msg hook (strips AI attribution trailers)
         STRIP_SCRIPT="$WORKSPACE_ROOT/.github/scripts/strip-ai-trailers.sh"
-        HOOK_PATH=".git/hooks/commit-msg"
         if [ -f "$STRIP_SCRIPT" ]; then
-                RELATIVE_TARGET="$(python3 -c "import os; print(os.path.relpath('$STRIP_SCRIPT', '$(pwd)/.git/hooks'))")"
+                HOOKS_DIR="$(git rev-parse --git-path hooks)"
+                HOOK_PATH="$HOOKS_DIR/commit-msg"
+                RELATIVE_TARGET="$(python3 -c "import os; print(os.path.relpath('$STRIP_SCRIPT', '$HOOKS_DIR'))")"
+                mkdir -p "$HOOKS_DIR"
                 if [ -L "$HOOK_PATH" ]; then
                         CURRENT_TARGET="$(readlink "$HOOK_PATH")"
                         if [ "$CURRENT_TARGET" != "$RELATIVE_TARGET" ]; then
@@ -79,7 +81,6 @@ for repo in "${REPOS[@]}"; do
                         mv "$HOOK_PATH" "${HOOK_PATH}.backup"
                         ln -sf "$RELATIVE_TARGET" "$HOOK_PATH"
                 else
-                        mkdir -p "$(dirname "$HOOK_PATH")"
                         ln -sf "$RELATIVE_TARGET" "$HOOK_PATH"
                 fi
                 echo "  ✓ Commit-msg hook (AI trailer stripping) installed"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -845,9 +845,13 @@ grep -qF '.polyscope-secpal-provisioned.json' "$api_clone/.git/info/exclude"
 test -x "$api_clone/.git/hooks/pre-commit"
 test -L "$api_clone/.git/hooks/pre-push"
 test "$(readlink "$api_clone/.git/hooks/pre-push")" = '../../scripts/preflight.sh'
+test -L "$api_clone/.git/hooks/commit-msg"
+readlink "$api_clone/.git/hooks/commit-msg" | grep -qF 'strip-ai-trailers.sh'
 test -x "$frontend_clone/.git/hooks/pre-commit"
 test -L "$frontend_clone/.git/hooks/pre-push"
 test "$(readlink "$frontend_clone/.git/hooks/pre-push")" = '../../scripts/preflight.sh'
+test -L "$frontend_clone/.git/hooks/commit-msg"
+readlink "$frontend_clone/.git/hooks/commit-msg" | grep -qF 'strip-ai-trailers.sh'
 test -f "$api_clone/.polyscope-secpal-provisioned.json"
 test -f "$frontend_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$broken_api_clone/polyscope.local.json"


### PR DESCRIPTION
## Summary

AI coding agents (Cursor, GitHub Copilot) automatically add `Co-authored-by:` trailers to commits and PR descriptions. This PR eliminates that at multiple levels.

## What Changed

- **`scripts/strip-ai-trailers.sh`** — new `commit-msg` hook that strips `Co-authored-by:` trailers from Cursor and GitHub Copilot while leaving human and dependabot co-authors untouched
- **`scripts/polyscope-rollout.py`** — `ensure_commit_msg_hook()` added; Polyscope now symlinks the hook into every managed worktree during provisioning
- **`setup-hooks.sh`** — installs the `commit-msg` hook for all SecPal repos in the local dev environment setup; uses `git rev-parse --git-path hooks` to resolve the correct hooks directory in linked worktrees
- **`.github/copilot-instructions.md`** — explicit no-AI-attribution rule added with reference to the enforcement hook
- **`scripts/validate-copilot-instructions.sh`** — `detect_repo_type()` now checks for `workflow-templates/` before the openapi-in-`package.json` check, so the `.github` org repo is correctly identified as `org` instead of `contracts`
- **Cursor CLI config** (`~/.cursor/cli-config.json`) — `attributeCommitsToAgent` and `attributePRsToAgent` set to `false` at the source (applied locally, not tracked in repo)

## TDD / Validate-First Evidence

- Failing proof before implementation: `git log` in the api repo showed repeated `Co-authored-by: Cursor <cursoragent@cursor.com>` trailers on Polyscope-provisioned worktree commits
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` passes; `bash tests/validate-copilot-instructions.sh` passes; smoke tests confirm AI trailers are removed while human co-authors (`Alice <alice@example.com>`) are preserved, and middle blank lines in commit bodies are not collapsed
