### PR TITLE
fix(polyscope): pin preview env overrides to workspace API hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Pin Preview Frontend Local Env Overrides To Workspace API Hosts
+
+**Changed:**
+
+- hardened `scripts/polyscope-rollout.py` so frontend preview provisioning now rewrites `.env.local`, `.env.preview.local`, and `.env.production.local` inside preview worktrees to the workspace-specific preview API host instead of leaving later builds free to fall back to `api.secpal.dev`
+- extended `tests/polyscope-rollout.sh` to prove frontend preview provisioning overwrites live-targeted preview and production local Vite API overrides with the current workspace preview API host
+
 ## 2026-05-09 - Fix AI-Trailer Hook Robustness and Validator Misdetection
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -363,19 +363,20 @@ def build_frontend_preview_env_setup_command() -> str:
         import re
 
         workspace = os.environ["POLYSCOPE_WORKSPACE"]
-        env_path = Path(".env.local")
-
-        text = env_path.read_text() if env_path.exists() else ""
         pattern = re.compile(r"^VITE_API_URL=.*$", re.MULTILINE)
         replacement = f"VITE_API_URL=https://api-{workspace}.preview.secpal.dev"
-        if pattern.search(text):
-            text = pattern.sub(replacement, text)
-        else:
-            if text and not text.endswith("\\n"):
-                text += "\\n"
-            text += replacement + "\\n"
 
-        env_path.write_text(text)
+        for env_name in (".env.local", ".env.preview.local", ".env.production.local"):
+            env_path = Path(env_name)
+            text = env_path.read_text() if env_path.exists() else ""
+            if pattern.search(text):
+                text = pattern.sub(replacement, text)
+            else:
+                if text and not text.endswith("\\n"):
+                    text += "\\n"
+                text += replacement + "\\n"
+
+            env_path.write_text(text)
         """
     ).strip()
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -791,6 +791,14 @@ cat >"$frontend_clone/.env.local" <<'EOF'
 VITE_API_URL=https://api.secpal.dev
 EOF
 
+cat >"$frontend_clone/.env.preview.local" <<'EOF'
+VITE_API_URL=https://api.secpal.dev
+EOF
+
+cat >"$frontend_clone/.env.production.local" <<'EOF'
+VITE_API_URL=https://api.secpal.dev
+EOF
+
 cat >"$frontend_clone/.pre-commit-config.yaml" <<'EOF'
 repos: []
 EOF
@@ -838,6 +846,8 @@ grep -qF 'POLYSCOPE_BASE_DB_DATABASE=secpal' "$api_clone/.env"
 grep -qF 'SANCTUM_STATEFUL_DOMAINS=frontend-auto-hawk.preview.secpal.dev,auto-hawk.preview.secpal.dev,app.secpal.dev' "$api_clone/.env"
 grep -qF 'CORS_ALLOWED_ORIGINS=https://frontend-auto-hawk.preview.secpal.dev,https://auto-hawk.preview.secpal.dev,https://app.secpal.dev' "$api_clone/.env"
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.local"
+grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.preview.local"
+grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.production.local"
 cmp -s "$workspace_root/api/polyscope.local.json" "$api_clone/polyscope.local.json"
 cmp -s "$workspace_root/frontend/polyscope.local.json" "$frontend_clone/polyscope.local.json"
 grep -q '^polyscope.local.json$' "$api_clone/.git/info/exclude"


### PR DESCRIPTION
## Description

Pin frontend preview worktree env overrides to the workspace-specific preview API host across all local Vite env files that can affect later builds.

## Related Issues

Closes #444

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change

## Testing

- [x] Tested locally
- [x] Added/updated integration tests

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` failed after seeding `.env.preview.local` and `.env.production.local` with `VITE_API_URL=https://api.secpal.dev` because preview provisioning only rewrote `.env.local`.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## Screenshots (if applicable)

- N/A
