### PR TITLE
fix(polyscope): replace fragile frontend preview watch builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- replaced the frontend Polyscope preview `Build Watch` command with a stable full-rebuild watcher that reruns `npm run build -- --mode preview` after source changes instead of relying on `vite build --watch --mode preview`, which could stop permanently after repeated locale or UI edits with `vite:css-post` / unknown-file failures
+- replaced the frontend Polyscope preview `Build Watch` command with a stable full-rebuild watcher
+  that reruns `npm run build -- --mode preview` after source changes instead of relying on
+  `vite build --watch --mode preview`, which could stop permanently after repeated locale or UI
+  edits with `vite:css-post` / unknown-file failures
 
 ## 2026-05-09 - Pin Preview Frontend Local Env Overrides To Workspace API Hosts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Replace Fragile Frontend Preview Watch Builds With Full Rebuild Watcher
+
+**Fixed:**
+
+- replaced the frontend Polyscope preview `Build Watch` command with a stable full-rebuild watcher that reruns `npm run build -- --mode preview` after source changes instead of relying on `vite build --watch --mode preview`, which could stop permanently after repeated locale or UI edits with `vite:css-post` / unknown-file failures
+
 ## 2026-05-09 - Pin Preview Frontend Local Env Overrides To Workspace API Hosts
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -383,6 +383,115 @@ def build_frontend_preview_env_setup_command() -> str:
     return f'POLYSCOPE_WORKSPACE="${{PWD##*/}}" python3 -c {shlex.quote(script)}'
 
 
+def build_frontend_preview_build_watch_command() -> str:
+    script = textwrap.dedent(
+        """
+        import hashlib
+        import os
+        import subprocess
+        import sys
+        import time
+        from pathlib import Path
+
+        api_url = f"https://api-{Path.cwd().name}.preview.secpal.dev"
+        watch_directories = [Path("src"), Path("public"), Path("config")]
+        watch_files = [
+            Path("index.html"),
+            Path("package.json"),
+            Path("package-lock.json"),
+            Path("tsconfig.json"),
+            Path("vite.config.ts"),
+            Path("lingui.config.cjs"),
+            Path("linguiVitePluginInterop.ts"),
+            Path(".env.local"),
+            Path(".env.preview.local"),
+            Path(".env.production.local"),
+        ]
+        watch_suffixes = {
+            ".css",
+            ".html",
+            ".ico",
+            ".js",
+            ".json",
+            ".mjs",
+            ".png",
+            ".po",
+            ".svg",
+            ".ts",
+            ".tsx",
+            ".webmanifest",
+        }
+
+        def iter_watch_paths():
+            seen = set()
+
+            for path in watch_files:
+                if not path.exists():
+                    continue
+
+                resolved = path.resolve()
+                if resolved in seen:
+                    continue
+
+                seen.add(resolved)
+                yield path
+
+            for directory in watch_directories:
+                if not directory.exists():
+                    continue
+
+                for path in sorted(directory.rglob("*")):
+                    if not path.is_file() or path.suffix not in watch_suffixes:
+                        continue
+
+                    resolved = path.resolve()
+                    if resolved in seen:
+                        continue
+
+                    seen.add(resolved)
+                    yield path
+
+        def snapshot() -> str:
+            state = []
+
+            for path in iter_watch_paths():
+                stat = path.stat()
+                state.append(f"{path.as_posix()}:{stat.st_mtime_ns}:{stat.st_size}")
+
+            return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
+
+        def run_build() -> int:
+            env = os.environ.copy()
+            env["VITE_API_URL"] = api_url
+
+            return subprocess.run(
+                ["npm", "run", "build", "--", "--mode", "preview"],
+                check=False,
+                env=env,
+            ).returncode
+
+        print("Watching frontend preview sources for changes...", flush=True)
+        previous_snapshot = None
+
+        while True:
+            current_snapshot = snapshot()
+            if current_snapshot != previous_snapshot:
+                previous_snapshot = current_snapshot
+                exit_code = run_build()
+                if exit_code != 0:
+                    print(
+                        f"Preview rebuild failed with exit code {exit_code}; waiting for the next change before retrying.",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+
+            time.sleep(1)
+        """
+    ).strip()
+
+    return f"python3 -c {shlex.quote(script)}"
+
+
 def build_api_preview_seed_command() -> str:
     tinker_script = textwrap.dedent(
         r"""
@@ -487,7 +596,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 "run": [
                     {
                         "label": "Build Watch",
-                        "command": "VITE_API_URL=https://api-${PWD##*/}.preview.secpal.dev npx vite build --watch --mode preview",
+                        "command": build_frontend_preview_build_watch_command(),
                         "autostart": True,
                         "runMode": "replace",
                     },

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -429,7 +429,11 @@ def build_frontend_preview_build_watch_command() -> str:
                 if not path.exists():
                     continue
 
-                resolved = path.resolve()
+                try:
+                    resolved = path.resolve()
+                except OSError:
+                    continue
+
                 if resolved in seen:
                     continue
 
@@ -444,7 +448,11 @@ def build_frontend_preview_build_watch_command() -> str:
                     if not path.is_file() or path.suffix not in watch_suffixes:
                         continue
 
-                    resolved = path.resolve()
+                    try:
+                        resolved = path.resolve()
+                    except OSError:
+                        continue
+
                     if resolved in seen:
                         continue
 
@@ -455,7 +463,11 @@ def build_frontend_preview_build_watch_command() -> str:
             state = []
 
             for path in iter_watch_paths():
-                stat = path.stat()
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+
                 state.append(f"{path.as_posix()}:{stat.st_mtime_ns}:{stat.st_size}")
 
             return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -516,7 +516,11 @@ grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secp
 grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
 grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
-grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'Watching frontend preview sources for changes...' "$workspace_root/frontend/polyscope.local.json"
+if grep -qF "npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"; then
+    echo "generated frontend Polyscope config must not rely on Vite watch mode for preview rebuilds" >&2
+    exit 1
+fi
 grep -q 'npm run test:e2e:ci' "$workspace_root/frontend/polyscope.local.json"
 grep -qF "PLAYWRIGHT_BASE_URL=https://frontend-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"
 grep -qF "PLAYWRIGHT_API_BASE_URL=https://api-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"


### PR DESCRIPTION
## Description

Replace the frontend Polyscope preview Build Watch command with a stable full-rebuild watcher that reruns `npm run build -- --mode preview` after source changes instead of relying on `vite build --watch --mode preview`.

## Related Issues

Closes #446

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change

## Testing

- [x] Tested locally
- [x] Added/updated integration tests
- [x] Manual testing performed

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` failed after the regression was updated to reject `npx vite build --watch --mode preview` and require the new stable watcher marker string.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## Screenshots (if applicable)

- N/A
