### PR TITLE
fix(polyscope): harden api preview runtime recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-09 - Harden API Preview Runtime Recovery
+
+**Changed:**
+
+- updated `scripts/polyscope-rollout.py` so generated API preview `Queue Worker` commands now run
+  `php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600`
+  instead of `queue:listen`, keeping default mail jobs and forensics jobs on one explicit worker path that
+  can satisfy the readiness heartbeat checks consistently across preview workspaces
+- updated the generated API preview `Preview Only: Refresh DB + E2E User` command to rerun the same
+  hardened `config:clear`, migration, `db:seed`, and canonical `test@example.com` normalization flow as
+  initial setup instead of relying on raw `migrate:fresh --seed`, so missing tenant keys and the standard
+  preview login are restored together after preview DB resets
+- extended `tests/polyscope-rollout.sh` to prove API preview configs emit the combined `queue:work`
+  command, reject the old `queue:listen` worker, and use the hardened reseed flow for preview DB refreshes
+
 ## 2026-05-09 - Replace Fragile Frontend Preview Watch Builds With Full Rebuild Watcher
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -504,7 +504,7 @@ def build_frontend_preview_build_watch_command() -> str:
     return f"python3 -c {shlex.quote(script)}"
 
 
-def build_api_preview_seed_command() -> str:
+def build_api_preview_seed_command(migration_command: str = "php artisan migrate --force") -> str:
     tinker_script = textwrap.dedent(
         r"""
         $canonical = \App\Models\User::where('email', 'test@example.com')->first();
@@ -531,7 +531,7 @@ def build_api_preview_seed_command() -> str:
 
     return (
         "php artisan config:clear && "
-        "php artisan migrate --force && "
+        f"{migration_command} && "
         "php artisan db:seed --force && "
         f"php artisan tinker --execute={shlex.quote(tinker_script)}"
     )
@@ -559,13 +559,13 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     build_api_preview_seed_command(),
                 ],
                 "run": [
-                    {"label": "Queue Worker", "command": "php artisan queue:listen --tries=1", "runMode": "replace"},
+                    {"label": "Queue Worker", "command": "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600", "runMode": "replace"},
                     {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
                     # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.
                     # It intentionally reseeds the canonical E2E login `test@example.com` / `password` and must never target production.
                     {
                         "label": "Preview Only: Refresh DB + E2E User",
-                        "command": "php artisan migrate:fresh --seed",
+                        "command": build_api_preview_seed_command("php artisan migrate:fresh --force"),
                         "runMode": "preserve",
                     },
                     {"label": "Pest", "command": "php artisan test", "runMode": "preserve"},

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -508,8 +508,18 @@ grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polys
 grep -q 'org-shared.instructions.md' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF 'php artisan config:clear && php artisan migrate --force && php artisan db:seed --force && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
+grep -qF 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600' "$workspace_root/api/polyscope.local.json"
+if grep -qF 'php artisan queue:listen --tries=1' "$workspace_root/api/polyscope.local.json"; then
+    echo "preview API queue worker must use combined queue:work and not queue:listen" >&2
+    exit 1
+fi
 grep -qF "test@example.com" "$workspace_root/api/polyscope.local.json"
 grep -qF 'Preview Only: Refresh DB + E2E User' "$workspace_root/api/polyscope.local.json"
+grep -qF 'php artisan migrate:fresh --force && php artisan db:seed --force && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
+if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api/polyscope.local.json"; then
+    echo "preview API refresh command must use the hardened reseed flow and not raw migrate:fresh --seed" >&2
+    exit 1
+fi
 grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://frontend-{{folder}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"


### PR DESCRIPTION
## Reproduced defect
- preview API workspaces could fall back to a fragile queue worker command that left default-queue jobs unprocessed and `/health/ready` flapping to `not_ready`
- preview DB refresh flows could leave tenant keys and the canonical `test@example.com` login unrecovered, which broke the standard preview login after reset or drift

## TDD / Validate-First Evidence
- Failing proof before implementation: reproduced the broken preview state in `grumpy-lynx`, where API readiness regressed to `not_ready` after preview drift/reset and the canonical `test@example.com` login no longer worked until tenant keys and the hardened reseed flow were restored
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary
- switch generated API preview queue workers to one explicit `queue:work` command covering `activity-hash-chain`, `merkle`, `opentimestamp`, and `default`
- reuse the hardened API preview seed-and-normalize flow for `Preview Only: Refresh DB + E2E User` so tenant keys and the canonical preview login are restored together after `migrate:fresh`
- extend rollout regression coverage for both the queue worker command and the hardened preview refresh command

## Validation
- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## CHANGELOG
- updated `CHANGELOG.md` in the same change set
