### PR TITLE
Allow ODbL-1.0 in reusable license compatibility

### DIFF
--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -66,7 +66,7 @@ jobs:
             "CC0-1.0"
             "ISC"
             "OFL-1.1"
-            "ODbL-1.0"   # Open Database License: bundled upstream license texts and SPDX on data/fixture files and metadata only — not for relicensing application source under ODbL
+            "ODbL-1.0"   # Open Database License: accepted for bundled geo-data, reference datasets, and similar data-only artifacts (e.g. OpenPLZ); appropriate file-level usage is a code-review concern — this check only verifies AGPL compatibility
             "LicenseRef-TailwindPlus"
           )
 

--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -12,6 +12,9 @@ on:
         type: string
         default: "3.x"
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     name: Check License Compatibility
@@ -63,6 +66,7 @@ jobs:
             "CC0-1.0"
             "ISC"
             "OFL-1.1"
+            "ODbL-1.0"   # Open Database License: bundled upstream license texts and SPDX on data/fixture files and metadata only — not for relicensing application source under ODbL
             "LicenseRef-TailwindPlus"
           )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-14 - Allow ODbL-1.0 in Reusable License Compatibility
+
+**Changed:**
+
+- allowed `ODbL-1.0` in `reusable-license-compatibility.yml` so `reuse spdx` output that includes the Open
+  Database License (bundled upstream license texts, SPDX on data or fixture files, and related metadata)
+  passes the centralized compatibility job; scope is documented inline and does not endorse ODbL as the
+  default license for application source
+- set `permissions: contents: read` on the reusable workflow (least privilege for `workflow_call`)
+- tracked as [#449](https://github.com/SecPal/.github/issues/449)
+
+---
+
 ## 2026-05-09 - Harden API Preview Runtime Recovery
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Log of notable changes to SecPal organization defaults (newest first).
   passes the centralized compatibility job; scope is documented inline and does not endorse ODbL as the
   default license for application source
 - set `permissions: contents: read` on the reusable workflow (least privilege for `workflow_call`)
+- clarified the ODbL-1.0 inline comment to truthfully state that the check verifies AGPL compatibility only
+  and that file-level usage appropriateness is a code-review concern, resolving the mismatch flagged by
+  Copilot review (comment previously implied path-aware enforcement that CI did not implement)
+- added `tests/license-compatibility.sh` with positive and negative regression fixtures for the allowlist,
+  wired into `scripts/preflight.sh` so future edits to the compatible-licenses array are caught locally
 - tracked as [#449](https://github.com/SecPal/.github/issues/449)
 
 ---

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -206,6 +206,15 @@ if [ -f tests/polyscope-rollout.sh ]; then
   }
 fi
 
+if [ -f tests/license-compatibility.sh ]; then
+  bash tests/license-compatibility.sh || {
+    echo "" >&2
+    echo "❌ License-compatibility allowlist regression test failed!" >&2
+    echo "Restore the ODbL-1.0 entry or fix the incompatible-license check in .github/workflows/reusable-license-compatibility.yml before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/tests/license-compatibility.sh
+++ b/tests/license-compatibility.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+#
+# Regression tests for the reusable license-compatibility allowlist.
+# Verifies the allowlist accepts explicitly-approved identifiers and
+# rejects clearly-incompatible ones so future edits cannot silently
+# widen or narrow the policy without preflight catching the change.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/reusable-license-compatibility.yml"
+
+failures=()
+
+# ---------------------------------------------------------------------------
+# Helper: extract the compatible_licenses array lines from the workflow YAML.
+# Returns the raw YAML lines between the array open/close.
+# ---------------------------------------------------------------------------
+extract_allowlist() {
+  awk '/compatible_licenses=\(/{found=1; next} found && /^[[:space:]]*\)[[:space:]]*$/{exit} found{print}' "$WORKFLOW"
+}
+
+# ---------------------------------------------------------------------------
+# positive_case LABEL LICENSE
+#   Assert that LICENSE appears in the compatible_licenses array.
+# ---------------------------------------------------------------------------
+positive_case() {
+  local label="$1"
+  local license="$2"
+  if ! extract_allowlist | grep -qF "\"$license\""; then
+    failures+=("FAIL [$label]: expected '$license' to be in compatible_licenses but it was not found")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# negative_case LABEL LICENSE
+#   Assert that LICENSE does NOT appear in the compatible_licenses array.
+# ---------------------------------------------------------------------------
+negative_case() {
+  local label="$1"
+  local license="$2"
+  if extract_allowlist | grep -qF "\"$license\""; then
+    failures+=("FAIL [$label]: '$license' must NOT be in compatible_licenses but it was found")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Core AGPL-family / permissive licenses must stay in the allowlist.
+positive_case "core AGPL license accepted"        "AGPL-3.0-or-later"
+positive_case "CC0-1.0 accepted"                  "CC0-1.0"
+positive_case "MIT accepted"                      "MIT"
+positive_case "Apache-2.0 accepted"               "Apache-2.0"
+positive_case "OFL-1.1 accepted"                  "OFL-1.1"
+positive_case "LicenseRef-TailwindPlus accepted"  "LicenseRef-TailwindPlus"
+
+# ODbL-1.0 must be in the allowlist (OpenPLZ geo-data and similar datasets).
+positive_case "ODbL-1.0 accepted for data files" "ODbL-1.0"
+
+# Incompatible / copyleft-only licenses must never appear in the allowlist.
+negative_case "GPL-2.0-only rejected"  "GPL-2.0-only"
+negative_case "GPL-2.0-or-later rejected" "GPL-2.0-or-later"
+negative_case "SSPL-1.0 rejected"      "SSPL-1.0"
+negative_case "BUSL-1.1 rejected"      "BUSL-1.1"
+negative_case "proprietary rejected"   "LicenseRef-Proprietary"
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo "❌ license-compatibility allowlist regression failures:" >&2
+  for f in "${failures[@]}"; do
+    echo "  $f" >&2
+  done
+  exit 1
+fi
+
+echo "✓ license-compatibility allowlist regression tests passed ($(extract_allowlist | grep -c '"' || true) entries checked)"


### PR DESCRIPTION
## Description

The reusable license compatibility workflow now accepts SPDX identifier `ODbL-1.0`, with an inline comment limiting intent to bundled upstream license texts and SPDX on data, fixture files, and metadata (not as the default license for application source). The reusable workflow declares `permissions: contents: read`.

`CHANGELOG.md` is updated accordingly.

## Related Issues

Closes #449

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change
- [ ] Other (see above)

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] Manual testing performed

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A (policy allowlist change; existing CI was failing downstream on ODbL-1.0 per issue)
- Passing proof after implementation: `pre-commit run --files .github/workflows/reusable-license-compatibility.yml CHANGELOG.md`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: ODbL-1.0 SPDX identifier appended to the compatible-licenses array in reusable-license-compatibility.yml; no executable control flow or logic changed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the organization-wide license allowlist, which can change what downstream repos’ CI accepts; impact is limited to a simple identifier allowlist plus least-privilege workflow permissions and a new regression test.
> 
> **Overview**
> Updates the reusable license-compatibility workflow to treat `ODbL-1.0` as AGPL-compatible (with clarified inline intent) and sets explicit `permissions: contents: read` for least privilege.
> 
> Adds a local regression guard (`tests/license-compatibility.sh`) and wires it into `scripts/preflight.sh` to catch future allowlist drift; `CHANGELOG.md` records the policy/testing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879b1fc91158c3df2f26262f77d577fe94b11064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->