### PR TITLE
docs(workflows): align gh pr create examples with body-file policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-14 - Harden `gh pr create` examples with tmpfile trap
+
+**Changed:**
+
+- replaced bare `rm -f "$tmpfile"` after `gh pr create` with `trap 'rm -f "$tmpfile"' EXIT`
+  in the workflow documentation snippets (`README.md`, `docs/workflows/PROJECT_AUTOMATION.md`,
+  `docs/workflows/QUICK_REFERENCE.md` including the signed-commit remediation block,
+  `docs/workflows/ROLLOUT_GUIDE.md`) so the temp file is cleaned up even when the command
+  fails or the shell is interrupted
+- switched inline `--body` on `gh pr create` to `--body-file` for programmatic examples,
+  matching Issue And PR Discipline in `.github/copilot-instructions.md`
+- tracked as [#441](https://github.com/SecPal/.github/issues/441)
+
+---
+
 ## 2026-05-14 - Allow ODbL-1.0 in Reusable License Compatibility
 
 **Changed:**

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ gh issue create --label "core-feature" --title "..."
 gh issue create --label "priority: blocker" --title "..."
 
 # Draft PR workflow (recommended)
-gh pr create --draft --body "Closes #123"  # → In Progress
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+printf '%s\n' "Closes #123" > "$tmpfile"
+gh pr create --draft --body-file "$tmpfile"  # → In Progress
 gh pr ready <PR>                            # → In Review
 gh pr ready --undo <PR>                     # → In Progress (changes needed)
 gh pr merge <PR> --squash                   # → Done (auto-closes issue)

--- a/docs/workflows/PROJECT_AUTOMATION.md
+++ b/docs/workflows/PROJECT_AUTOMATION.md
@@ -98,9 +98,12 @@ For incremental development and self-review:
 
 ```bash
 # 1. Start work - create draft PR
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+printf '%s\n' "Closes #123" > "$tmpfile"
 gh pr create --draft \
   --title "WIP: Implement feature X" \
-  --body "Closes #123"
+  --body-file "$tmpfile"
 # → Issue #123 status: 🚧 In Progress
 
 # 2. Ready for review (or Copilot review)

--- a/docs/workflows/QUICK_REFERENCE.md
+++ b/docs/workflows/QUICK_REFERENCE.md
@@ -48,9 +48,12 @@ gh issue create \
 
 ```bash
 # 1. Create draft PR (→ In Progress)
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+printf '%s\n' "Closes #123" > "$tmpfile"
 gh pr create --draft \
   --title "WIP: Feature X" \
-  --body "Closes #123"
+  --body-file "$tmpfile"
 
 # 2. Mark ready (→ In Review)
 gh pr ready 456
@@ -147,9 +150,9 @@ git switch -c replacement/topic
 git cherry-pick -x -S <commit-from-blocked-branch>
 git push -u origin replacement/topic
 tmpfile=$(mktemp "${TMPDIR:-/tmp}/replacement-pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
 printf '%s\n' '## Description' '' 'Replacement PR for blocked unsigned history.' '' '## Related Pull Requests' '' 'Supersedes PR #123' > "$tmpfile"
 gh pr create --draft --title "replacement title" --body-file "$tmpfile"
-rm -f "$tmpfile"
 ```
 
 If the old branch contains mixed signed and unsigned history, re-commit the intended change on the fresh branch instead of merging the blocked branch forward.
@@ -273,7 +276,10 @@ When working alone:
 gh issue create --label "core-feature" --title "..."
 
 # 2. Start work (draft PR)
-gh pr create --draft --body "Closes #123"
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+printf '%s\n' "Closes #123" > "$tmpfile"
+gh pr create --draft --body-file "$tmpfile"
 # → Issue: 🚧 In Progress
 
 # 3. Self-review ready
@@ -305,7 +311,7 @@ alias gh-feature='gh issue create --label "core-feature"'
 # Create blocker issue
 alias gh-blocker='gh issue create --label "priority: blocker"'
 
-# Create draft PR
+# Create draft PR (interactive; opens editor for body — not for scripted PR creation)
 alias gh-draft='gh pr create --draft'
 
 # Mark PR ready

--- a/docs/workflows/ROLLOUT_GUIDE.md
+++ b/docs/workflows/ROLLOUT_GUIDE.md
@@ -146,11 +146,14 @@ git add test.txt
 git commit -m "test: Automation"
 git push -u origin test-automation
 
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/test-pr-body.XXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+printf 'Closes #%s\n' "$ISSUE" > "$tmpfile"
 gh pr create \
   --repo SecPal/api \
   --draft \
   --title "WIP: Test automation" \
-  --body "Closes #$ISSUE"
+  --body-file "$tmpfile"
 ```
 
 **Verify:**


### PR DESCRIPTION
## Reproduced defect / policy gap

There is no failing compiler test for copy-paste documentation. The defect is **policy drift against Issue And PR Discipline** (`.github/copilot-instructions.md`): programmatic PR creation must use `--body-file`, while several workflow docs still showed `gh pr create ... --body "..."`, which contradicts that rule and encourages unsafe shell quoting for multi-line bodies.

## What this PR changes

- Replace inline `--body` examples with `mktemp` + `printf` + `--body-file`, plus `trap ... EXIT` so temp files are removed when `gh` fails or the shell is interrupted.
- Align the signed-commit replacement PR snippet in `docs/workflows/QUICK_REFERENCE.md` with the same pattern.
- Label the `gh-draft` shell alias as interactive-only (not for scripted PR creation).
- Record the change in `CHANGELOG.md` and link [#441](https://github.com/SecPal/.github/issues/441).

## Validations run locally

- `./scripts/preflight.sh` (Prettier, markdownlint-cli2, REUSE, domain policy, conflict markers, polyscope rollout harness exercises, license-compatibility regression script, `npm test` / OpenAPI verified-endpoint presence) — **passed** on branch `docs-gh-pr-body-file` before push.

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A
- Passing proof after implementation: N/A
- Validate-first exception reference: N/A
- No executable change reason: Documentation-only change; no executable behavior or validation logic changed.

## Follow-up before marking ready

- Wait for GitHub Actions on this PR to finish; resolve anything that fails.
- Perform the final self-review in the GitHub PR view and only then mark the PR ready for review (per repository instructions).

## Workspace

- Changes were prepared and pushed from the Polyscope-managed clone at `/home/secpal/.polyscope/clones/be3b4299/lucky-owl` (remote `SecPal/.github`, branch `docs-gh-pr-body-file`).

Closes #441.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that standardize CLI examples; no runtime code, automation, or security-sensitive logic is modified.
> 
> **Overview**
> Aligns all scripted `gh pr create` documentation examples to use `mktemp` + `--body-file` instead of inline `--body`, matching the documented Issue/PR discipline policy and avoiding fragile shell quoting for multi-line bodies.
> 
> Hardens those snippets by adding `trap 'rm -f "$tmpfile"' EXIT` so temp PR-body files are cleaned up even on failures/interrupts, updates the signed-commit replacement-PR example similarly, and clarifies that the `gh-draft` alias is *interactive-only*. Records the change in `CHANGELOG.md` (tracked as `#441`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a81be4ed4ed898f12245a068bbabf123f49b14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
