### PR TITLE
fix(polyscope): restore db sync for worktree provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - removed `--skip-db-sync` from the generated `polyscope-worktree-provision.service` so automatic Polyscope provisioning now reapplies repository prompt and review metadata instead of leaving AI instruction settings drifted after repo deletion or re-registration
 - kept `--skip-local-configs` in place so the background provisioner still avoids rewriting repo-local workspace config during its repair pass
+- added `StartLimitIntervalSec=300` / `StartLimitBurst=3` to the provisioner service unit to bound the self-trigger feedback loop (DB sync writes to `polyscope.db` which the path unit watches)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-16 - Restore DB Sync For Polyscope Worktree Provisioning
+
+**Changed:**
+
+- removed `--skip-db-sync` from the generated `polyscope-worktree-provision.service` so automatic Polyscope provisioning now reapplies repository prompt and review metadata instead of leaving AI instruction settings drifted after repo deletion or re-registration
+- kept `--skip-local-configs` in place so the background provisioner still avoids rewriting repo-local workspace config during its repair pass
+
+---
+
 ## 2026-05-14 - Harden `gh pr create` examples with tmpfile trap
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -304,7 +304,7 @@ WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --skip-db-sync --provision-worktrees
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --provision-worktrees
 EOF
 
 cat >"$PROVISION_PATH_UNIT" <<EOF

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -297,6 +297,12 @@ cat >"$PROVISION_SERVICE_UNIT" <<EOF
 [Unit]
 Description=Provision SecPal Polyscope worktrees automatically
 After=polyscope-rollout-sync.service
+# Bound the self-trigger feedback loop: DB sync writes to polyscope.db which is
+# watched by the paired path unit; without a burst cap this can re-trigger the
+# service until systemd rate-limits the unit.  Three starts per five minutes is
+# enough to handle normal provisioning while preventing runaway activation.
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
 Type=oneshot

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1423,6 +1423,8 @@ grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-
 grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'StartLimitIntervalSec=300' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'StartLimitBurst=3' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1423,7 +1423,7 @@ grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-
 grep -q '/api/.github/copilot-instructions.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
-grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"


### PR DESCRIPTION
## Summary
- remove `--skip-db-sync` from the generated `polyscope-worktree-provision.service`
- add `StartLimitIntervalSec=300` / `StartLimitBurst=3` to bound the self-trigger feedback loop
  (DB sync writes to `polyscope.db` which the path unit watches)
- keep `--skip-local-configs` so background provisioning still avoids rewriting repo-local workspace config
- document the repair in `CHANGELOG.md`

## Problem
The automatic Polyscope worktree provisioner skipped DB sync, so repository prompt and review metadata could stay drifted after repo deletion or re-registration.

## Feedback Loop Concern (Copilot + Codex review)
DB sync calls `sync_repository_metadata()` which always writes to `polyscope.db`.  The paired
path unit watches that same file.  Without a burst cap the service could retrigger itself
repeatedly.  `StartLimitIntervalSec=300` / `StartLimitBurst=3` bounds this to at most three
activations per five-minute window, ensuring metadata is repaired while capping runaway
activation.  A follow-up issue will implement an idempotent DB sync check to eliminate the
loop entirely.

## Validation
- updated `tests/polyscope-rollout.sh` expectation first and confirmed it failed before the installer change
- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash tests/polyscope-rollout.sh` exited with `1` after updating the expected `polyscope-worktree-provision.service` command line to require DB sync.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` exited with `0`, and `./scripts/preflight.sh` passed after removing `--skip-db-sync` and adding the start-limit directives to the generated provisioner unit.
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`
