### PR TITLE
fix(polyscope): make repository metadata sync idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-16 - Make Polyscope Metadata Sync Idempotent
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so `sync_repository_metadata()` now compares the desired repository prompts and managed `repository_links` against the current `polyscope.db` state before taking a backup or writing any rows
+- skipped both `backup_db()` and SQLite writes when the repository metadata is already up to date, eliminating the `polyscope-worktree-provision.path` feedback loop that was caused by no-op DB rewrites triggering fresh inotify activations
+- extended `tests/polyscope-rollout.sh` to prove a repeated identical metadata sync leaves `polyscope.db` unchanged and reports `db_backup: null` on the second run
+- tracked as [#453](https://github.com/SecPal/.github/issues/453)
+
+---
+
 ## 2026-05-16 - Restore DB Sync For Polyscope Worktree Provisioning
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1447,12 +1447,16 @@ def ensure_repositories_registered(api_base: str, repo_specs: dict[str, dict[str
 
 
 def backup_db(db_path: pathlib.Path) -> pathlib.Path:
-    if not db_path.exists():
-        raise SystemExit(f"Polyscope DB not found at {db_path}; start Polyscope at least once so the DB is created before running this script")
+    ensure_polyscope_db_exists(db_path)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_path = db_path.parent / f"{db_path.name}.backup-{timestamp}"
     shutil.copy2(db_path, backup_path)
     return backup_path
+
+
+def ensure_polyscope_db_exists(db_path: pathlib.Path) -> None:
+    if not db_path.exists():
+        raise SystemExit(f"Polyscope DB not found at {db_path}; start Polyscope at least once so the DB is created before running this script")
 
 
 def build_desired_repository_metadata(
@@ -1504,6 +1508,7 @@ def sync_repository_metadata(
 ) -> pathlib.Path | None:
     managed_repo_ids = [repo_state[name]["id"] for name in REPO_SETTINGS]
     desired_links, desired_prompts = build_desired_repository_metadata(repo_state, repo_specs)
+    ensure_polyscope_db_exists(db_path)
 
     conn = sqlite3.connect(db_path)
     current_links, current_prompts = read_current_repository_metadata(conn, managed_repo_ids)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1530,7 +1530,7 @@ def sync_repository_metadata(
                 (repo_id, repo_state[linked_name]["id"]),
             )
 
-        prompts = build_prompt_bundle(spec)
+        prompt_values = desired_prompts[repo_id]
         cur.execute(
             """
             update repositories
@@ -1541,14 +1541,7 @@ def sync_repository_metadata(
                 merge_and_push_prompt = ?
             where id = ?
             """,
-            (
-                prompts["review_prompt"],
-                prompts["pr_prompt"],
-                prompts["draft_pr_prompt"],
-                prompts["merge_prompt"],
-                prompts["merge_and_push_prompt"],
-                repo_id,
-            ),
+            (*prompt_values, repo_id),
         )
 
     conn.commit()

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1455,12 +1455,67 @@ def backup_db(db_path: pathlib.Path) -> pathlib.Path:
     return backup_path
 
 
-def sync_repository_metadata(db_path: pathlib.Path, repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]]) -> pathlib.Path:
+def build_desired_repository_metadata(
+    repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]]
+) -> tuple[set[tuple[str, str]], dict[str, tuple[str, str, str, str, str]]]:
+    desired_links: set[tuple[str, str]] = set()
+    desired_prompts: dict[str, tuple[str, str, str, str, str]] = {}
+
+    for repo_name, spec in repo_specs.items():
+        repo_id = repo_state[repo_name]["id"]
+        for linked_name in spec["link_names"]:
+            desired_links.add((repo_id, repo_state[linked_name]["id"]))
+
+        prompts = build_prompt_bundle(spec)
+        desired_prompts[repo_id] = (
+            prompts["review_prompt"],
+            prompts["pr_prompt"],
+            prompts["draft_pr_prompt"],
+            prompts["merge_prompt"],
+            prompts["merge_and_push_prompt"],
+        )
+
+    return desired_links, desired_prompts
+
+
+def read_current_repository_metadata(
+    conn: sqlite3.Connection, managed_repo_ids: list[str]
+) -> tuple[set[tuple[str, str]], dict[str, tuple[str, str, str, str, str]]]:
+    cur = conn.cursor()
+    placeholders = ", ".join("?" for _ in managed_repo_ids)
+    current_links = set(
+        cur.execute(
+            f"select repo_id, linked_repo_id from repository_links where repo_id in ({placeholders}) or linked_repo_id in ({placeholders})",
+            managed_repo_ids + managed_repo_ids,
+        ).fetchall()
+    )
+    current_prompts = {
+        row[0]: row[1:]
+        for row in cur.execute(
+            f"select id, review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id in ({placeholders})",
+            managed_repo_ids,
+        ).fetchall()
+    }
+    return current_links, current_prompts
+
+
+def sync_repository_metadata(
+    db_path: pathlib.Path, repo_state: dict[str, dict[str, Any]], repo_specs: dict[str, dict[str, Any]]
+) -> pathlib.Path | None:
+    managed_repo_ids = [repo_state[name]["id"] for name in REPO_SETTINGS]
+    desired_links, desired_prompts = build_desired_repository_metadata(repo_state, repo_specs)
+
+    conn = sqlite3.connect(db_path)
+    current_links, current_prompts = read_current_repository_metadata(conn, managed_repo_ids)
+    conn.close()
+
+    if current_links == desired_links and current_prompts == desired_prompts:
+        return None
+
     backup_path = backup_db(db_path)
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
 
-    managed_repo_ids = [repo_state[name]["id"] for name in REPO_SETTINGS]
     placeholders = ", ".join("?" for _ in managed_repo_ids)
     cur.execute(
         f"delete from repository_links where repo_id in ({placeholders}) or linked_repo_id in ({placeholders})",

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -18,6 +18,20 @@ if [[ ! -x "$PRETTIER_BIN" ]]; then
     exit 1
 fi
 
+file_sha256() {
+    python3 - "$1" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+digest = hashlib.sha256()
+with Path(sys.argv[1]).open("rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+}
+
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-rollout.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
@@ -637,7 +651,7 @@ assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('or
 assert summary['repositories']['.github']['linked_repositories'] == []
 PY
 
-initial_db_hash="$(sha256sum "$db_path" | cut -d' ' -f1)"
+initial_db_hash="$(file_sha256 "$db_path")"
 initial_backup_count="$(find "$workspace" -maxdepth 1 -name 'polyscope.db.backup-*' | wc -l)"
 
 python3 "$PYTHON_SCRIPT" \
@@ -648,7 +662,7 @@ python3 "$PYTHON_SCRIPT" \
     --summary-output "$repeat_summary_output" \
     > /dev/null
 
-repeat_db_hash="$(sha256sum "$db_path" | cut -d' ' -f1)"
+repeat_db_hash="$(file_sha256 "$db_path")"
 repeat_backup_count="$(find "$workspace" -maxdepth 1 -name 'polyscope.db.backup-*' | wc -l)"
 
 if [ "$repeat_backup_count" -ne "$initial_backup_count" ]; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -461,6 +461,7 @@ db_path="$workspace/polyscope.db"
 repos_json="$workspace/repos.json"
 nginx_output="$workspace/preview.secpal.dev.conf"
 summary_output="$workspace/summary.json"
+repeat_summary_output="$workspace/repeat-summary.json"
 
 python3 - <<'PY' "$db_path" "$repos_json" "$workspace_root"
 import json
@@ -626,6 +627,7 @@ assert ('api12345', 'fe123456') in links
 assert ('sa123456', 'ch123456') in links
 
 summary = json.loads(summary_path.read_text())
+assert summary['db_backup'] is not None
 assert summary['repositories']['api']['preview_prefix'] == 'api'
 assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
 assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
@@ -633,6 +635,39 @@ assert summary['repositories']['changelog']['preview_prefix'] == 'changelog'
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
 assert summary['repositories']['.github']['linked_repositories'] == []
+PY
+
+initial_db_hash="$(sha256sum "$db_path" | cut -d' ' -f1)"
+initial_backup_count="$(find "$workspace" -maxdepth 1 -name 'polyscope.db.backup-*' | wc -l)"
+
+python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --db-path "$db_path" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$repeat_summary_output" \
+    > /dev/null
+
+repeat_db_hash="$(sha256sum "$db_path" | cut -d' ' -f1)"
+repeat_backup_count="$(find "$workspace" -maxdepth 1 -name 'polyscope.db.backup-*' | wc -l)"
+
+if [ "$repeat_backup_count" -ne "$initial_backup_count" ]; then
+    echo "repeat metadata sync must not create another DB backup when repository metadata is unchanged" >&2
+    exit 1
+fi
+
+if [ "$repeat_db_hash" != "$initial_db_hash" ]; then
+    echo "repeat metadata sync must leave polyscope.db unchanged when repository metadata is already up to date" >&2
+    exit 1
+fi
+
+python3 - <<'PY' "$repeat_summary_output"
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text())
+assert summary['db_backup'] is None
 PY
 
 provision_log="$workspace/provision.log"


### PR DESCRIPTION
Fixes #453

## Summary
- make `sync_repository_metadata()` compare desired prompts and managed repository links before taking a DB backup or writing SQLite rows
- skip backup creation and metadata writes entirely when `polyscope.db` is already up to date
- add regression coverage proving a second identical rollout run leaves `polyscope.db` unchanged and reports `db_backup: null`
- document the fix in `CHANGELOG.md`

## Problem
`polyscope-worktree-provision.path` watches `polyscope.db`, but `sync_repository_metadata()` rewrote the database on every run even when the prompt and link metadata already matched. That no-op write path kept retriggering provisioning through inotify and could loop until systemd rate-limited the service.

## Validation
- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash tests/polyscope-rollout.sh` exited non-zero with `repeat metadata sync must not create another DB backup when repository metadata is unchanged` after adding the repeated-run assertions
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` exited with `0` and `./scripts/preflight.sh` exited with `0`
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the Polyscope SQLite sync path to conditionally skip backups and writes, which could affect prompt/link updates if the comparison logic is wrong. Risk is limited to local Polyscope provisioning metadata but impacts automation behavior (inotify/systemd loops).
> 
> **Overview**
> Prevents no-op rewrites of `polyscope.db` during Polyscope rollout by making `sync_repository_metadata()` *idempotent*: it now computes desired prompts/managed `repository_links`, reads the current DB state, and **skips both DB backup and SQLite writes when nothing would change** (returning `None` for `db_backup`).
> 
> Adds regression coverage in `tests/polyscope-rollout.sh` to rerun the rollout twice and assert the second run leaves the DB byte-identical, creates no additional `polyscope.db.backup-*`, and reports `db_backup: null`; documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd9fc8f9d8d54e307a79cda8e14677259a146de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->