### PR TITLE
fix(polyscope): reprovision drifted preview targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-16 - Reprovision Drifted Polyscope API Preview Targets
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so API worktree provisioning normalizes the preview `.env` before honoring the provision marker, instead of treating a matching `setup_hash` as sufficient even when the worktree's preview target has drifted
+- stored the API preview storage target in `.polyscope-secpal-provisioned.json`, which makes older markers trigger a one-time re-provision pass and prevents stale markers from suppressing schema/database recovery for a renamed or drifted worktree
+- extended `tests/polyscope-rollout.sh` with a schema-mode regression that mutates an existing API worktree back to a sibling preview schema and proves the next provisioning run repairs the `.env` and reruns the API setup commands
+- tracked as [#455](https://github.com/SecPal/.github/issues/455)
+
+---
+
 ## 2026-05-16 - Make Polyscope Metadata Sync Idempotent
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1404,9 +1404,6 @@ def provision_worktrees(
                 if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
                     continue
 
-            if repo_name == "api" and preview_storage_target is None:
-                continue
-
             if setup_commands:
                 print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
                 run_setup_commands(worktree_path, setup_commands)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -269,7 +269,24 @@ def build_api_preview_env_updates(workspace: str) -> dict[str, str]:
     }
 
 
-def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> bool:
+def build_api_preview_storage_target(env_values: dict[str, str]) -> str | None:
+    storage_mode = env_values.get(PREVIEW_STORAGE_MODE_ENV_KEY, "").strip().lower()
+
+    if storage_mode == "database":
+        preview_database = env_values.get("DB_DATABASE", "").strip()
+        if preview_database:
+            return f"database:{preview_database}"
+
+    if storage_mode == "schema":
+        base_database = env_values.get(PREVIEW_DATABASE_BASE_ENV_KEY, env_values.get("DB_DATABASE", "")).strip()
+        preview_schema = env_values.get(PREVIEW_SCHEMA_ENV_KEY, "").strip()
+        if base_database and preview_schema:
+            return f"schema:{base_database}:{preview_schema}"
+
+    return None
+
+
+def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> tuple[bool, str | None]:
     env_path = worktree_path / ".env"
     if not env_path.exists():
         source_env_path = source_repo_path / ".env"
@@ -278,9 +295,10 @@ def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pat
                 f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
                 f".env missing and source preview env not found at {source_env_path}"
             )
-            return False
+            return False, None
         shutil.copy2(source_env_path, env_path)
 
+    env_text = env_path.read_text()
     env_values = load_env_assignments(env_path)
     workspace = worktree_path.name
     updated_values = build_api_preview_env_updates(workspace)
@@ -304,8 +322,14 @@ def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pat
             updated_values[PREVIEW_SCHEMA_ENV_KEY] = preview_target
         updated_values[PREVIEW_DATABASE_BASE_ENV_KEY] = base_database
 
-    env_path.write_text(upsert_env_assignments(env_path.read_text(), updated_values))
-    return True
+    updated_env_text = upsert_env_assignments(env_text, updated_values)
+    if updated_env_text != env_text:
+        env_path.write_text(updated_env_text)
+
+    final_env_values = env_values.copy()
+    final_env_values.update(updated_values)
+
+    return True, build_api_preview_storage_target(final_env_values)
 
 
 def cleanup_removed_api_preview_databases(
@@ -1368,31 +1392,35 @@ def provision_worktrees(
             sync_worktree_local_config(worktree_path, config_text)
             ensure_worktree_hooks(worktree_path)
 
+            preview_storage_target: str | None = None
+            if repo_name == "api":
+                ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"])
+                if not ready:
+                    continue
+
             marker_path = worktree_path / PROVISION_MARKER_FILENAME
             marker = load_provision_marker(marker_path)
             if marker is not None and marker.get("setup_hash") == setup_hash:
-                continue
-
-            if repo_name == "api":
-                if not ensure_api_worktree_ready(worktree_path, spec["path"]):
+                if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
                     continue
+
+            if repo_name == "api" and preview_storage_target is None:
+                continue
 
             if setup_commands:
                 print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
                 run_setup_commands(worktree_path, setup_commands)
 
-            marker_path.write_text(
-                json.dumps(
-                    {
-                        "repo": repo_name,
-                        "workspace": worktree_path.name,
-                        "setup_hash": setup_hash,
-                        "provisioned_at": datetime.now(timezone.utc).isoformat(),
-                    },
-                    indent=2,
-                )
-                + "\n"
-            )
+            marker_payload: dict[str, Any] = {
+                "repo": repo_name,
+                "workspace": worktree_path.name,
+                "setup_hash": setup_hash,
+                "provisioned_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if repo_name == "api" and preview_storage_target is not None:
+                marker_payload["preview_storage_target"] = preview_storage_target
+
+            marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
             provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
 
     return provisioned_worktrees, cleaned_preview_storage_targets
@@ -1758,7 +1786,8 @@ def main() -> int:
     if args.prepare_api_worktree is not None:
         if args.source_repo_path is None:
             raise SystemExit("--source-repo-path is required with --prepare-api-worktree")
-        return 0 if ensure_api_worktree_ready(args.prepare_api_worktree, args.source_repo_path) else 1
+        ready, _preview_storage_target = ensure_api_worktree_ready(args.prepare_api_worktree, args.source_repo_path)
+        return 0 if ready else 1
 
     repo_specs = build_repo_specs(args.workspace_root)
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1227,6 +1227,70 @@ assert state['databases'] == ['secpal'], state['databases']
 assert 'secpal__preview__schema_badger' in state['schemas'], state['schemas']
 PY
 
+python3 - <<'PY' "$schema_api_clone/.polyscope-secpal-provisioned.json"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+marker = json.loads(path.read_text())
+marker.pop('preview_storage_target', None)
+path.write_text(json.dumps(marker, indent=2) + "\n")
+PY
+
+cat >"$schema_api_clone/.env" <<'EOF'
+APP_URL=https://api-daring-mouse.preview.secpal.dev
+FRONTEND_URL=https://frontend-daring-mouse.preview.secpal.dev
+DB_CONNECTION=pgsql
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_DATABASE=secpal
+DB_URL=postgresql://secpal@127.0.0.1:5432/secpal?search_path=secpal__preview__daring_mouse
+DB_USERNAME=secpal
+DB_PASSWORD=
+SESSION_DOMAIN=.secpal.dev
+SANCTUM_STATEFUL_DOMAINS=frontend-daring-mouse.preview.secpal.dev,daring-mouse.preview.secpal.dev,app.secpal.dev
+CORS_ALLOWED_ORIGINS=https://frontend-daring-mouse.preview.secpal.dev,https://daring-mouse.preview.secpal.dev,https://app.secpal.dev
+POLYSCOPE_BASE_DB_DATABASE=secpal
+POLYSCOPE_PREVIEW_STORAGE_MODE=schema
+POLYSCOPE_PREVIEW_SCHEMA=secpal__preview__daring_mouse
+EOF
+
+schema_recovery_summary_json="$workspace/schema-recovery-summary.json"
+schema_provision_log_lines_before_recovery="$(wc -l < "$provision_log")"
+env HOME="$schema_home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$schema_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$schema_recovery_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - <<'PY' "$schema_recovery_summary_json"
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+assert 'api:schema-badger' in provisioned, provisioned
+PY
+
+test "$schema_provision_log_lines_before_recovery" -lt "$(wc -l < "$provision_log")"
+grep -qF 'APP_URL=https://api-schema-badger.preview.secpal.dev' "$schema_api_clone/.env"
+grep -qF 'FRONTEND_URL=https://frontend-schema-badger.preview.secpal.dev' "$schema_api_clone/.env"
+grep -qF 'DB_URL=postgresql://secpal@127.0.0.1:5432/secpal?search_path=secpal__preview__schema_badger' "$schema_api_clone/.env"
+grep -qF 'POLYSCOPE_PREVIEW_SCHEMA=secpal__preview__schema_badger' "$schema_api_clone/.env"
+
+test "$(grep -cF "php:$schema_api_clone:artisan migrate --force" "$provision_log")" -eq 2
+test "$(grep -cF 'CREATE SCHEMA IF NOT EXISTS "secpal__preview__schema_badger"' "$fake_psql_log")" -eq 2
+
 rm -rf "$schema_api_clone" "$schema_frontend_clone"
 
 env HOME="$schema_home_dir" \


### PR DESCRIPTION
## Summary
- reprovision API worktrees when the same worktree has stale preview storage state or an older marker lacks target metadata
- normalize the API preview `.env` before marker short-circuiting so stale same-worktree schema/database drift is repaired on the next provisioning run
- add a schema-mode regression that proves a sibling-schema drifted worktree is repaired and reprovisioned
- preview domains remain workspace-scoped and ephemeral; the marker field is only used to detect stale state inside a given worktree, not to persist domains across workspaces

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash tests/polyscope-rollout.sh` failed with `AssertionError: []` after the new stale-marker drift regression because the provision marker still short-circuited API reprovisioning for a drifted schema target.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

Closes #455.
