### PR TITLE
feat(polyscope): add run controls for checks and findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-05-16 - Add Polyscope Run Controls For Checks And Findings
+
+**Changed:**
+
+- updated `scripts/polyscope-rollout.py` so generated `polyscope.local.json` files now expose repo-specific `All Checks` run actions across the SecPal workspace instead of requiring developers to remember the underlying validation commands manually
+- surfaced `Preflight` as a run action wherever a repository ships `scripts/preflight.sh`, making the existing preflight entrypoint available on demand from Polyscope instead of only through hooks or manual shell use
+- added a standard `Fix current findings` Polyscope task that tells the agent to run the current repo's checks, fix repo-local findings, rerun validations, and stop instead of widening the branch into unrelated multi-topic cleanup
+- extended `tests/polyscope-rollout.sh` so the rollout generator must keep emitting those run actions and the fix-findings task for every supported repository
+- tracked as [#457](https://github.com/SecPal/.github/issues/457)
+
+---
+
 ## 2026-05-16 - Reprovision Drifted Polyscope API Preview Targets
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -569,7 +569,7 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
         "changelog": "npm run check && npm run lint && npm run csp:check && npm run build",
-        ".github": "npm test && ./scripts/preflight.sh",
+        ".github": "npm run test && ./scripts/preflight.sh",
     }
     return commands.get(repo_name)
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -561,6 +561,72 @@ def build_api_preview_seed_command(migration_command: str = "php artisan migrate
     )
 
 
+def build_repo_all_checks_command(repo_name: str) -> str | None:
+    commands = {
+        "api": "php artisan test && vendor/bin/pint --dirty && vendor/bin/phpstan analyse --no-progress",
+        "frontend": "npm run lint && npm run typecheck && npm run test:run:all && npm run build",
+        "contracts": "npm run validate && npm run lint && npm run format:check",
+        "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
+        "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
+        "changelog": "npm run check && npm run lint && npm run csp:check && npm run build",
+        ".github": "npm test && ./scripts/preflight.sh",
+    }
+    return commands.get(repo_name)
+
+
+def ensure_run_action(
+    actions: list[dict[str, Any]],
+    *,
+    label: str,
+    command: str,
+    run_mode: str = "preserve",
+    autostart: bool | None = None,
+) -> list[dict[str, Any]]:
+    if any(item.get("label") == label for item in actions):
+        return actions
+
+    action: dict[str, Any] = {"label": label, "command": command, "runMode": run_mode}
+    if autostart is not None:
+        action["autostart"] = autostart
+
+    return [action, *actions]
+
+
+def ensure_task(tasks: list[dict[str, str]], *, label: str, prompt: str) -> list[dict[str, str]]:
+    if any(item.get("label") == label for item in tasks):
+        return tasks
+    return [{"label": label, "prompt": prompt}, *tasks]
+
+
+def enrich_local_config(repo_name: str, spec: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    scripts = config.setdefault("scripts", {})
+    run_actions = [dict(item) for item in scripts.get("run", [])]
+
+    all_checks_command = build_repo_all_checks_command(repo_name)
+    if all_checks_command is not None:
+        run_actions = ensure_run_action(run_actions, label="All Checks", command=all_checks_command)
+
+    preflight_script = pathlib.Path(spec["path"]) / "scripts" / "preflight.sh"
+    if preflight_script.is_file():
+        run_actions = ensure_run_action(run_actions, label="Preflight", command="./scripts/preflight.sh")
+
+    scripts["run"] = run_actions
+
+    tasks = [dict(item) for item in config.get("tasks", [])]
+    tasks = ensure_task(
+        tasks,
+        label="Fix current findings",
+        prompt=(
+            "Run the generated validation actions for this repo, including All Checks and Preflight when available. "
+            "Fix the current findings in this repo only, rerun the touched validations until they are clean, and keep the branch scoped to one issue. "
+            "If the findings expand into unrelated topics or require broader cleanup, stop and track them instead of widening the change."
+        ),
+    )
+    config["tasks"] = tasks
+
+    return config
+
+
 REPO_SETTINGS: dict[str, dict[str, Any]] = {
     "api": {
         "display_name": "SecPal/api",
@@ -1028,6 +1094,7 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
 
 def render_local_config(spec: dict[str, Any]) -> dict[str, Any]:
     config = copy.deepcopy(spec["local_config"])
+    config = enrich_local_config(spec["path"].name, spec, config)
     preamble = collapse_spaces(f"Apply the current SecPal instructions from {instruction_reference(spec)} before taking action.")
     for task in config.get("tasks", []):
         task["prompt"] = collapse_spaces(f"{preamble} {task['prompt']}")

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -569,7 +569,7 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
         "changelog": "npm run check && npm run lint && npm run csp:check && npm run build",
-        ".github": "npm run test && ./scripts/preflight.sh",
+        ".github": "./scripts/preflight.sh",
     }
     return commands.get(repo_name)
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -597,7 +597,7 @@ grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope
 grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF '"command": "npm test && ./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
+grep -qF '"command": "npm run test && ./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
 
 if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -597,7 +597,7 @@ grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope
 grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF '"command": "npm run test && ./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
 
 if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -72,6 +72,8 @@ workspace_root = Path(sys.argv[1])
 
 (workspace_root / "api" / "composer.json").write_text("{}\n")
 (workspace_root / "api" / "artisan").write_text("#!/usr/bin/env php\n")
+(workspace_root / "api" / "scripts").mkdir(parents=True, exist_ok=True)
+(workspace_root / "api" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
 
 (workspace_root / ".github" / "scripts").mkdir(parents=True, exist_ok=True)
 (workspace_root / ".github" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
@@ -80,7 +82,10 @@ package_scripts = {
     "frontend": {
         "build": "vite build",
         "lint": "eslint .",
+        "preflight": "./scripts/preflight.sh",
         "typecheck": "tsc --noEmit",
+        "test:run": "vitest run",
+        "test:run:all": "vitest run --coverage",
         "test:watch": "vitest",
         "test:e2e:ci": "cross-env CI=true playwright test",
         "test:e2e:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev playwright test",
@@ -107,14 +112,19 @@ package_scripts = {
         "check": "tsc --noEmit",
         "lint": "eslint .",
         "csp:check": "node scripts/generate-csp.mjs --check",
+        "preflight": "./scripts/preflight.sh",
     },
     ".github": {
         "copilot:review:scan": "./scripts/copilot-review-tool.sh scan",
+        "test": "npm run test:openapi-verified-presence",
+        "test:openapi-verified-presence": "bash tests/check-openapi-verified-endpoints.sh",
     },
 }
 
 for repo_name, scripts in package_scripts.items():
     repo_dir = workspace_root / repo_name
+    (repo_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (repo_dir / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
     package_json = {
         "name": repo_name.replace(".", "-"),
         "private": True,
@@ -531,6 +541,11 @@ fi
 grep -qF "test@example.com" "$workspace_root/api/polyscope.local.json"
 grep -qF 'Preview Only: Refresh DB + E2E User' "$workspace_root/api/polyscope.local.json"
 grep -qF 'php artisan migrate:fresh --force && php artisan db:seed --force && php artisan tinker --execute=' "$workspace_root/api/polyscope.local.json"
+grep -qF '"label": "All Checks"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"command": "php artisan test && vendor/bin/pint --dirty && vendor/bin/phpstan analyse --no-progress"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"label": "Preflight"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/api/polyscope.local.json"
 if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api/polyscope.local.json"; then
     echo "preview API refresh command must use the hardened reseed flow and not raw migrate:fresh --seed" >&2
     exit 1
@@ -542,6 +557,9 @@ grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/chang
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
 grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'Watching frontend preview sources for changes...' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run:all && npm run build"' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/frontend/polyscope.local.json"
 if grep -qF "npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"; then
     echo "generated frontend Polyscope config must not rely on Vite watch mode for preview rebuilds" >&2
     exit 1
@@ -566,6 +584,21 @@ if grep -q 'npm run build' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not run npm build" >&2
     exit 1
 fi
+
+grep -qF '"command": "npm run validate && npm run lint && npm run format:check"' "$workspace_root/contracts/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/contracts/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/contracts/polyscope.local.json"
+grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify"' "$workspace_root/android/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/android/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/android/polyscope.local.json"
+grep -qF '"command": "npm run check && npm run lint && npm run test && npm run build"' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
+grep -qF '"command": "npm test && ./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
 
 if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not reference node_modules" >&2


### PR DESCRIPTION
## Summary
- add repo-specific `All Checks` run actions to generated `polyscope.local.json` files across the SecPal workspace
- expose `Preflight` as a run action wherever `scripts/preflight.sh` exists
- add a standard `Fix current findings` Polyscope task for guided repo-local remediation after checks fail

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash ./tests/polyscope-rollout.sh` failed after the new regression expectations were added because the generated Polyscope configs still lacked the repo-wide `All Checks`, `Preflight`, and `Fix current findings` actions.
- Passing proof after implementation: `bash ./tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

Closes #457.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generated `polyscope.local.json` run actions/tasks across multiple repos, and incorrect command mappings or ordering could break developer workflows or automated Polyscope provisioning.
> 
> **Overview**
> **Polyscope-generated `polyscope.local.json` now includes richer run controls and guided remediation tasks.** The rollout generator adds a repo-specific `All Checks` run action (mapped per repo), automatically adds a `Preflight` run action when `scripts/preflight.sh` exists, and injects a standard `Fix current findings` task prompt to keep AI-assisted fixes scoped to the current repo.
> 
> **Tests were updated to lock in the new behavior.** `tests/polyscope-rollout.sh` now seeds per-repo `scripts/preflight.sh` and asserts the generated configs contain the new run actions and task across all supported repositories, and `CHANGELOG.md` records the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98a880bf1b79bff6d25217d532412af6a8efc67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->