### PR TITLE
feat(polyscope): register GuardGuide rollout support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-03 - Register GuardGuide In Polyscope Rollout
+
+**Changed:**
+
+- added `GuardGuide` to `scripts/polyscope-rollout.py` so the rollout generator now manages its repository prompts, local Polyscope config, and preview URL alongside the existing SecPal repos
+- configured GuardGuide as a Laravel monolith with React/Catalyst guidance, combined repo-local validation commands, and a prefixed preview host at `guardguide-<workspace>.preview.secpal.dev`
+- extended the generated preview nginx mapping and `tests/polyscope-rollout.sh` so GuardGuide registration, local config rendering, and prefixed preview routing stay regression-covered
+
+---
+
 ## 2026-05-16 - Add Polyscope Run Controls For Checks And Findings
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1213,13 +1213,37 @@ def load_package_scripts(repo_path: pathlib.Path) -> set[str]:
     return {str(script_name) for script_name in scripts}
 
 
-def validate_local_config_command(repo_name: str, repo_path: pathlib.Path, package_scripts: set[str], command: str) -> None:
+def load_composer_scripts(repo_path: pathlib.Path) -> set[str]:
+    composer_json_path = repo_path / "composer.json"
+    if not composer_json_path.exists():
+        return set()
+
+    raw_text = composer_json_path.read_text()
+    try:
+        composer_data = json.loads(raw_text)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"invalid composer.json for rollout validation ({composer_json_path}): {error}") from error
+
+    scripts = composer_data.get("scripts", {})
+    if not isinstance(scripts, dict):
+        raise SystemExit(f"invalid composer.json for rollout validation ({composer_json_path}): scripts must be an object")
+
+    return {str(script_name) for script_name in scripts}
+
+
+def validate_local_config_command(
+    repo_name: str,
+    repo_path: pathlib.Path,
+    package_scripts: set[str],
+    composer_scripts: set[str],
+    command: str,
+) -> None:
     package_json_path = repo_path / "package.json"
     package_lock_path = repo_path / "package-lock.json"
     composer_json_path = repo_path / "composer.json"
     artisan_path = repo_path / "artisan"
 
-    if re.search(r"\bcomposer\s+install\b", command) and not composer_json_path.exists():
+    if re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command) and not composer_json_path.exists():
         raise SystemExit(f"{repo_name} polyscope config references composer without a composer.json at the repo root")
 
     if re.search(r"\bphp\s+artisan\b", command) and not artisan_path.exists():
@@ -1238,6 +1262,10 @@ def validate_local_config_command(repo_name: str, repo_path: pathlib.Path, packa
     for script_name in re.findall(r"\bnpm\s+run\s+([A-Za-z0-9:_-]+)\b", command):
         if script_name not in package_scripts:
             raise SystemExit(f"{repo_name} polyscope config references missing npm script '{script_name}'")
+
+    for script_name in re.findall(r"\bcomposer\s+(?:run|run-script)\s+([A-Za-z0-9:_-]+)\b", command):
+        if script_name not in composer_scripts:
+            raise SystemExit(f"{repo_name} polyscope config references missing composer script '{script_name}'")
 
     try:
         tokens = shlex.split(command)
@@ -1272,14 +1300,15 @@ def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
         repo_path = pathlib.Path(spec["path"])
         config = render_local_config(spec)
         package_scripts = load_package_scripts(repo_path)
+        composer_scripts = load_composer_scripts(repo_path)
 
         for command in config.get("scripts", {}).get("setup", []):
-            validate_local_config_command(repo_name, repo_path, package_scripts, command)
+            validate_local_config_command(repo_name, repo_path, package_scripts, composer_scripts, command)
 
         for item in config.get("scripts", {}).get("run", []):
             command = item.get("command")
             if isinstance(command, str):
-                validate_local_config_command(repo_name, repo_path, package_scripts, command)
+                validate_local_config_command(repo_name, repo_path, package_scripts, composer_scripts, command)
 
 
 def is_provisionable_worktree(
@@ -1307,9 +1336,10 @@ def is_provisionable_worktree(
         return skip(f"missing required repo file {copilot_instructions_rel}")
 
     package_scripts = load_package_scripts(worktree_path)
+    composer_scripts = load_composer_scripts(worktree_path)
     try:
         for command in validation_commands:
-            validate_local_config_command(repo_name, worktree_path, package_scripts, command)
+            validate_local_config_command(repo_name, worktree_path, package_scripts, composer_scripts, command)
     except SystemExit as error:
         return skip(str(error))
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -565,6 +565,7 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
     commands = {
         "api": "php artisan test && vendor/bin/pint --dirty && vendor/bin/phpstan analyse --no-progress",
         "frontend": "npm run lint && npm run typecheck && npm run test:run:all && npm run build",
+        "GuardGuide": "npm run format:check && npm run lint && npm run typecheck && npm run test && composer run lint && composer run analyse && composer run test",
         "contracts": "npm run validate && npm run lint && npm run format:check",
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
@@ -735,6 +736,49 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 {
                     "label": "Triage failing Vitest",
                     "prompt": "Reproduce the failing behavior, add or update the smallest relevant test first, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "GuardGuide": {
+        "display_name": "SecPal/GuardGuide",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/php-laravel.instructions.md",
+            ".github/instructions/react-catalyst.instructions.md",
+        ],
+        "preview_prefix": "guardguide",
+        "review_focus": "Laravel 13 monolith boundaries, Pest plus Vitest coverage, Catalyst-only UI patterns, Lingui localization, application-layer encryption for person-related data, and standalone-first acknowledgement flows.",
+        "link_names": [],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": build_preview_url_template("guardguide")},
+            "scripts": {
+                "setup": [
+                    "test -d vendor || composer install",
+                    "test -d node_modules || npm ci",
+                    "test -f .env || cp .env.example .env",
+                    "test -f database/database.sqlite || touch database/database.sqlite",
+                    "grep -Eq '^APP_KEY=.+$' .env || php artisan key:generate --force",
+                    "php artisan migrate --force",
+                ],
+                "run": [
+                    {"label": "Pest", "command": "php artisan test", "runMode": "preserve"},
+                    {"label": "Vitest", "command": "npm run test:watch", "runMode": "replace"},
+                    {"label": "Vite", "command": "npm run start", "runMode": "replace"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review monolith boundary",
+                    "prompt": "Review the changed GuardGuide flow for Laravel monolith boundary drift, Catalyst UI regressions, localization gaps, encryption-at-rest constraints, and missing Pest or Vitest coverage. Keep the change scoped to one GuardGuide issue.",
+                },
+                {
+                    "label": "Triage GuardGuide validation",
+                    "prompt": "Reproduce the failing GuardGuide behavior, add or update the smallest relevant Pest or Vitest coverage first when possible, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
                 },
             ],
         },
@@ -1649,9 +1693,10 @@ def sync_repository_metadata(
 def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
     api_id = repo_state["api"]["id"]
     frontend_id = repo_state["frontend"]["id"]
+    guardguide_id = repo_state["GuardGuide"]["id"]
     secpal_app_id = repo_state["secpal.app"]["id"]
     changelog_id = repo_state["changelog"]["id"]
-    # NOTE: workspace names starting with api-, frontend-, secpal-app-, or changelog- are
+    # NOTE: workspace names starting with api-, frontend-, guardguide-, secpal-app-, or changelog- are
     # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
     # Generic workspaces must not use those prefixes; the regex will treat them as legacy
     # hosts and route them to the wrong backend.
@@ -1660,7 +1705,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -1672,7 +1717,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
-            server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -1689,11 +1734,14 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $api_public $api_root/public;
             set $frontend_root /home/secpal/.polyscope/clones/{frontend_id}/$workspace;
             set $frontend_dist $frontend_root/dist;
+            set $guardguide_root /home/secpal/.polyscope/clones/{guardguide_id}/$workspace;
+            set $guardguide_public $guardguide_root/public;
             set $secpal_app_root /home/secpal/.polyscope/clones/{secpal_app_id}/$workspace;
             set $secpal_app_dist $secpal_app_root/dist;
             set $changelog_root /home/secpal/.polyscope/clones/{changelog_id}/$workspace;
             set $changelog_out $changelog_root/out;
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
+            set $php_root $api_public;
             set $route_mode static;
 
             if (-f $api_public/index.php) {{
@@ -1731,8 +1779,15 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 set $route_mode static;
             }}
 
+            if ($repo = guardguide) {{
+                set $preview_docroot $guardguide_public;
+                set $php_root $guardguide_public;
+                set $route_mode api;
+            }}
+
             if ($repo = api) {{
                 set $preview_docroot $api_public;
+                set $php_root $api_public;
                 set $route_mode api;
             }}
 
@@ -1769,14 +1824,14 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             }}
 
             location = /index.php {{
-                if (!-f $api_public/index.php) {{
+                if (!-f $php_root/index.php) {{
                     return 404;
                 }}
 
                 include snippets/fastcgi-php.conf;
                 fastcgi_pass unix:/run/php/php8.4-fpm-secpal-api.sock;
-                fastcgi_param SCRIPT_FILENAME $api_public/index.php;
-                fastcgi_param DOCUMENT_ROOT $api_public;
+                fastcgi_param SCRIPT_FILENAME $php_root/index.php;
+                fastcgi_param DOCUMENT_ROOT $php_root;
                 fastcgi_param HTTP_HOST $host;
             }}
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -75,10 +75,22 @@ workspace_root = Path(sys.argv[1])
 (workspace_root / "api" / "scripts").mkdir(parents=True, exist_ok=True)
 (workspace_root / "api" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
 
+(workspace_root / "GuardGuide" / "composer.json").write_text("{}\n")
+(workspace_root / "GuardGuide" / "artisan").write_text("#!/usr/bin/env php\n")
+
 (workspace_root / ".github" / "scripts").mkdir(parents=True, exist_ok=True)
 (workspace_root / ".github" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
 
 package_scripts = {
+    "GuardGuide": {
+        "build": "tsc --noEmit && vite build",
+        "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
+        "lint": "eslint .",
+        "start": "vite",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "test": "vitest run",
+    },
     "frontend": {
         "build": "vite build",
         "lint": "eslint .",
@@ -297,6 +309,57 @@ applyTo: 'src/**/*.tsx'
 - Keep load, action, and destructive-flow error state separate.
 "
 
+create_repo "GuardGuide" "$common_header
+
+# GuardGuide Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- TDD is mandatory for behavior and code changes.
+- Keep one topic per branch and pull request.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- the branch still covers exactly one topic
+- TDD happened for behavior changes
+- the smallest relevant validation passed for the touched area
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix proposals as hints, not proof.
+- Before merge, prove a claimed defect with a failing test, a reproducible defect, or an explicit invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "react-catalyst.instructions.md" "---
+name: React Catalyst Rules
+applyTo: 'resources/js/**/*.tsx'
+---
+
+# React Catalyst Rules
+
+- Use React 19 with strict TypeScript.
+- Keep English source text and German translation in Lingui catalogs from the start.
+- Catalyst is the exclusive UI system.
+"
+
+printf '%s\n' "---
+name: Laravel PHP Rules
+applyTo: '**/*.php'
+---
+
+# Laravel PHP Rules
+
+- Use Form Requests for validation and services for business logic.
+- Add or update the smallest relevant Pest test for each PHP change, then run the affected tests.
+- Use vendor/bin/pint --dirty after changes.
+" > "$workspace_root/GuardGuide/.github/instructions/php-laravel.instructions.md"
+
 create_repo "contracts" "$common_header
 
 # Contracts Instructions
@@ -509,6 +572,7 @@ repo_state = {
     'android': {'id': 'an123456', 'name': 'SecPal/android', 'path': str(workspace_root / 'android')},
     'secpal.app': {'id': 'sa123456', 'name': 'SecPal/secpal.app', 'path': str(workspace_root / 'secpal.app')},
     'changelog': {'id': 'ch123456', 'name': 'SecPal/changelog', 'path': str(workspace_root / 'changelog')},
+    'GuardGuide': {'id': 'gg123456', 'name': 'SecPal/GuardGuide', 'path': str(workspace_root / 'GuardGuide')},
     '.github': {'id': 'gh123456', 'name': 'SecPal/.github', 'path': str(workspace_root / '.github')},
 }
 
@@ -552,6 +616,7 @@ if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api
 fi
 grep -q 'react-typescript.instructions.md before taking action' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://frontend-{{folder}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
+grep -q 'https://guardguide-{{folder}}.preview.secpal.dev' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
 grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
@@ -599,16 +664,27 @@ grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polysc
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
+grep -q 'react-catalyst.instructions.md before taking action' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "npm run format:check && npm run lint && npm run typecheck && npm run test && composer run lint && composer run analyse && composer run test"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/GuardGuide/polyscope.local.json"
 
 if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not reference node_modules" >&2
     exit 1
 fi
 
-grep -q 'server_name ~^(?:(?<repo>api|frontend|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
+grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
+grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
+grep -qF "if (\$repo = guardguide) {" "$nginx_output"
+grep -qF "set \$php_root \$api_public;" "$nginx_output"
+grep -qF "set \$php_root \$guardguide_public;" "$nginx_output"
 grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
+grep -qF "if (!-f \$php_root/index.php) {" "$nginx_output"
+grep -qF "fastcgi_param SCRIPT_FILENAME \$php_root/index.php;" "$nginx_output"
+grep -qF "fastcgi_param DOCUMENT_ROOT \$php_root;" "$nginx_output"
 
 if grep -qF "try_files \$uri \$uri/ @preview_router;" "$nginx_output"; then
     echo "preview nginx config must not treat a missing workspace docroot as a directory hit" >&2
@@ -640,6 +716,7 @@ fi
     "$workspace_root/frontend/polyscope.local.json" \
     "$workspace_root/contracts/polyscope.local.json" \
     "$workspace_root/android/polyscope.local.json" \
+    "$workspace_root/GuardGuide/polyscope.local.json" \
     "$workspace_root/secpal.app/polyscope.local.json" \
     "$workspace_root/changelog/polyscope.local.json" \
     "$workspace_root/.github/polyscope.local.json" \
@@ -677,11 +754,14 @@ summary = json.loads(summary_path.read_text())
 assert summary['db_backup'] is not None
 assert summary['repositories']['api']['preview_prefix'] == 'api'
 assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
+assert summary['repositories']['GuardGuide']['preview_prefix'] == 'guardguide'
 assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
 assert summary['repositories']['changelog']['preview_prefix'] == 'changelog'
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
+assert summary['repositories']['GuardGuide']['focus_instruction_paths'][1].endswith('php-laravel.instructions.md')
 assert summary['repositories']['.github']['linked_repositories'] == []
+assert summary['repositories']['GuardGuide']['linked_repositories'] == []
 PY
 
 initial_db_hash="$(file_sha256 "$db_path")"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -133,6 +133,15 @@ package_scripts = {
     },
 }
 
+guardguide_composer = {
+    "scripts": {
+        "analyse": ["./vendor/bin/phpstan analyse"],
+        "lint": ["./vendor/bin/pint --test"],
+        "test": ["@php artisan test"],
+    }
+}
+(workspace_root / "GuardGuide" / "composer.json").write_text(json.dumps(guardguide_composer, indent=2) + "\n")
+
 for repo_name, scripts in package_scripts.items():
     repo_dir = workspace_root / repo_name
     (repo_dir / "scripts").mkdir(parents=True, exist_ok=True)
@@ -591,6 +600,12 @@ python3 "$PYTHON_SCRIPT" \
     --nginx-output "$nginx_output" \
     --summary-output "$summary_output" \
     > /dev/null
+
+assert_rollout_rejects_invalid_local_config \
+    "$PYTHON_SCRIPT" \
+    'composer run analyse' \
+    'composer run missing-script' \
+    "GuardGuide polyscope config references missing composer script 'missing-script'"
 
 grep -q 'https://api-{{folder}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"


### PR DESCRIPTION
## Summary
- register `GuardGuide` in `scripts/polyscope-rollout.py` so Polyscope now manages its prompts, local config, run actions, and preview URL alongside the existing SecPal repos
- add GuardGuide rollout regression coverage and preview nginx routing, including the dynamic PHP docroot handling required for prefixed Laravel previews
- prove the new repo works live by creating the first GuardGuide workspace (`calm-otter`) and verifying `https://guardguide-calm-otter.preview.secpal.dev/` returns `200 OK`

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash ./tests/polyscope-rollout.sh` failed because `GuardGuide/polyscope.local.json` was not generated at all, and after the first rollout wiring it still exposed the hard-coded API PHP handler (`if (!-f $api_public/index.php)`) instead of a GuardGuide-aware path.
- Passing proof after implementation: `bash ./tests/polyscope-rollout.sh`; `./scripts/preflight.sh`; `curl -skS -D - https://guardguide-calm-otter.preview.secpal.dev/ -o /tmp/guardguide-calm-otter.body` returned `HTTP/1.1 200 OK` with body `GuardGuide backend baseline`.
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

## Self-review
- Findings: none. The final diff is limited to the rollout generator, its regression test, and the `.github` changelog. Out-of-scope follow-up issues were filed as `#460` and `#461` instead of widening this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared preview nginx PHP routing and rollout validation; mistakes could misroute Laravel previews, but behavior is covered by expanded polyscope-rollout tests.
> 
> **Overview**
> Registers **GuardGuide** in the Polyscope rollout generator so it gets the same treatment as other SecPal repos: generated `polyscope.local.json`, review tasks, **All Checks** / **Preflight** / **Fix current findings**, and preview URL `https://guardguide-<workspace>.preview.secpal.dev`.
> 
> The new repo profile targets a **Laravel + React/Catalyst** monolith (combined npm + `composer run` validation, SQLite-oriented setup, Pest/Vite run actions, org + PHP + Catalyst instruction paths).
> 
> Preview **nginx** now recognizes the `guardguide-` host prefix and routes PHP through a shared **`$php_root`** (API vs GuardGuide `public/`) instead of hard-coding only the API docroot.
> 
> Rollout validation now loads **`composer.json` scripts** and fails fast on missing `composer run` targets; **`tests/polyscope-rollout.sh`** covers GuardGuide config, composer-script rejection, and nginx assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694197917846644c82ed58c319f1a54e8e99fcba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->