### PR TITLE
fix(polyscope): resolve system ssh agent socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - updated `scripts/install-polyscope-rollout.sh` so the system-scope `polyscope-server.service` override resolves `SSH_AUTH_SOCK` to the actual service user's runtime directory instead of writing the broken literal `%U` placeholder that expands to `/run/user/0/openssh_agent` at runtime
-- extended `tests/polyscope-rollout.sh` so the installer regression suite now proves the generated system drop-in uses the resolved numeric runtime socket path for the target server user, preventing future regressions in API-driven worktree creation
+- extended `tests/polyscope-rollout.sh` so the installer regression suite now proves both the resolved numeric runtime socket path for an explicit system service user and the root fallback when the unit omits `User=`, preventing future regressions in API-driven worktree creation
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-03 - Fix Polyscope Server SSH Agent Socket For Worktree Creation
+
+**Fixed:**
+
+- updated `scripts/install-polyscope-rollout.sh` so the system-scope `polyscope-server.service` override resolves `SSH_AUTH_SOCK` to the actual service user's runtime directory instead of writing the broken literal `%U` placeholder that expands to `/run/user/0/openssh_agent` at runtime
+- extended `tests/polyscope-rollout.sh` so the installer regression suite now proves the generated system drop-in uses the resolved numeric runtime socket path for the target server user, preventing future regressions in API-driven worktree creation
+
+---
+
 ## 2026-06-03 - Register GuardGuide In Polyscope Rollout
 
 **Changed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -78,8 +78,29 @@ detect_system_server_fragment_path() {
     "$SYSTEMCTL_BIN" show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
 }
 
+detect_system_server_user() {
+    "$SYSTEMCTL_BIN" show -p User --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
+}
+
 detect_user_server_fragment_path() {
     "$SYSTEMCTL_BIN" --user show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
+}
+
+resolve_system_server_ssh_auth_sock() {
+    local system_server_user system_server_uid
+
+    system_server_user="$(detect_system_server_user)"
+    if [[ -z "$system_server_user" ]]; then
+        printf '/run/user/%s/openssh_agent\n' "$(id -u)"
+        return
+    fi
+
+    if ! system_server_uid="$(id -u "$system_server_user" 2>/dev/null)"; then
+        echo "Error: could not resolve uid for system server user '$system_server_user'." >&2
+        exit 1
+    fi
+
+    printf '/run/user/%s/openssh_agent\n' "$system_server_uid"
 }
 
 resolve_server_scope() {
@@ -164,6 +185,11 @@ done
 
 server_scope="$(resolve_server_scope)"
 system_server_fragment_path="$(detect_system_server_fragment_path)"
+system_server_ssh_auth_sock=""
+
+if [[ "$server_scope" == "system" ]]; then
+    system_server_ssh_auth_sock="$(resolve_system_server_ssh_auth_sock)"
+fi
 
 if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]]; then
     echo "Error: --polyscope-server-scope system was requested but no system $POLYSCOPE_SYSTEM_SERVER_UNIT unit was found." >&2
@@ -239,7 +265,7 @@ ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
 ExecStartPost=
 ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
 Environment=PATH=$SERVICE_PATH
-Environment=SSH_AUTH_SOCK=/run/user/%U/openssh_agent
+Environment=SSH_AUTH_SOCK=$system_server_ssh_auth_sock
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 EOF
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -91,7 +91,7 @@ resolve_system_server_ssh_auth_sock() {
 
     system_server_user="$(detect_system_server_user)"
     if [[ -z "$system_server_user" ]]; then
-        printf '/run/user/%s/openssh_agent\n' "$(id -u)"
+        printf '/run/user/0/openssh_agent\n'
         return
     fi
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1628,7 +1628,7 @@ env HOME="$system_home_dir" \
     SUDO_BIN="$fake_sudo_dir/sudo" \
     SUDO_LOG="$system_sudo_log" \
     FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
-    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="$(id -un)" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="" \
     POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$system_dropin_dir" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
@@ -1639,7 +1639,7 @@ test -f "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q "Environment=PATH=$system_polyscope_git_dir:$system_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
-grep -q "Environment=SSH_AUTH_SOCK=/run/user/$(id -u)/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q 'Environment=SSH_AUTH_SOCK=/run/user/0/openssh_agent' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
 grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1505,6 +1505,10 @@ if [[ "${1:-}" == "show" && "${2:-}" == "-p" && "${3:-}" == "FragmentPath" && "$
         printf '%s\n' "${FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT:-}"
     fi
 fi
+
+if [[ "${1:-}" == "show" && "${2:-}" == "-p" && "${3:-}" == "User" && "${4:-}" == "--value" && "${5:-}" == "polyscope-server.service" ]]; then
+    printf '%s\n' "${FAKE_SYSTEM_POLYSCOPE_SERVER_USER:-}"
+fi
 exit 0
 STUB
 chmod +x "$fake_systemctl_dir/systemctl"
@@ -1624,6 +1628,7 @@ env HOME="$system_home_dir" \
     SUDO_BIN="$fake_sudo_dir/sudo" \
     SUDO_LOG="$system_sudo_log" \
     FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="$(id -un)" \
     POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$system_dropin_dir" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
@@ -1634,7 +1639,7 @@ test -f "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q "Environment=PATH=$system_polyscope_git_dir:$system_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
-grep -q "Environment=SSH_AUTH_SOCK=/run/user/%U/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q "Environment=SSH_AUTH_SOCK=/run/user/$(id -u)/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
 grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1611,6 +1611,8 @@ system_systemctl_log="$workspace/system-systemctl.log"
 system_sudo_log="$workspace/system-sudo.log"
 system_fragment_dir="$workspace/system-fragments"
 system_fragment_path="$system_fragment_dir/polyscope-server.service"
+system_server_user="$(id -un)"
+system_server_uid="$(id -u)"
 mkdir -p "$system_bin_dir" "$system_user_unit_dir" "$system_polyscope_bin_dir" "$system_polyscope_git_dir" "$system_fragment_dir"
 printf '[Unit]\nDescription=Polyscope Server\n' > "$system_fragment_path"
 
@@ -1628,7 +1630,7 @@ env HOME="$system_home_dir" \
     SUDO_BIN="$fake_sudo_dir/sudo" \
     SUDO_LOG="$system_sudo_log" \
     FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
-    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="$system_server_user" \
     POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$system_dropin_dir" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
@@ -1639,7 +1641,7 @@ test -f "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q "Environment=PATH=$system_polyscope_git_dir:$system_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
-grep -q 'Environment=SSH_AUTH_SOCK=/run/user/0/openssh_agent' "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q "Environment=SSH_AUTH_SOCK=/run/user/$system_server_uid/openssh_agent" "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
 grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"
@@ -1652,6 +1654,24 @@ grep -q '^--user enable --now polyscope-rollout-sync.path$' "$system_systemctl_l
 grep -q '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
 grep -q '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log"
 grep -q '^--user start polyscope-worktree-provision.service$' "$system_systemctl_log"
+
+system_fallback_dropin_dir="$workspace/system-fallback-service-units/polyscope-server.service.d"
+mkdir -p "$system_fallback_dropin_dir"
+
+env HOME="$system_home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$system_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$system_sudo_log" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="" \
+    POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$system_fallback_dropin_dir" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$system_bin_dir" --unit-dir "$system_user_unit_dir" --polyscope-server-bin "$fake_server_bin"
+
+grep -q 'Environment=SSH_AUTH_SOCK=/run/user/0/openssh_agent' "$system_fallback_dropin_dir/zz-secpal-runtime.conf"
 
 grep -q 'ExecStart=.*/polyscope-server serve --host 127.0.0.1 --port 4321' "$fake_unit_dir/polyscope-server.service"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.service"


### PR DESCRIPTION
## Summary
- resolve the system-scope `polyscope-server.service` SSH agent socket to the actual service user runtime directory instead of the broken `%U` placeholder
- regression-test the generated system drop-in so future installer runs keep emitting a real runtime socket path
- document the fix in `CHANGELOG.md`

## Testing
- `bash ./tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence
- Failing proof before implementation: the generated system-scope drop-in still emitted `Environment=SSH_AUTH_SOCK=/run/user/%U/openssh_agent`, and the live `polyscope-server.service` process showed `SSH_AUTH_SOCK=/run/user/0/openssh_agent` before the runtime correction.
- Passing proof after implementation: `bash ./tests/polyscope-rollout.sh` now proves the installer resolves the numeric runtime socket path in the system drop-in, and `./scripts/preflight.sh` passed on the PR branch.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Tracking
- Closes #466
- Related: #460 was resolved live by correcting GuardGuide remote protocol drift to HTTPS
- Parent #463

## Deployment note
- No immediate live rollout is required for #460 anymore; this PR preserves the systemd hardening in source so future installer runs cannot regress the socket path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches systemd runtime for Polyscope server and SSH/git signing used by worktree provisioning; wrong UID would break signed commits until reinstall, but scope is limited to the installer drop-in and is regression-tested.
> 
> **Overview**
> **Fixes system Polyscope server SSH agent path** so API-driven worktree/git operations can use the real service user’s agent instead of a broken `/run/user/0/openssh_agent` socket.
> 
> The installer now reads `polyscope-server.service`’s `User=`, resolves that account’s UID, and writes `Environment=SSH_AUTH_SOCK=/run/user/<uid>/openssh_agent` into the system drop-in (with `/run/user/0/...` when no `User=` is set). It no longer emits the literal `%U` placeholder, which systemd does not expand in that context.
> 
> **Regression coverage** in `tests/polyscope-rollout.sh` asserts the resolved path for an explicit system user and the root fallback; **CHANGELOG** documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b5d5495afea55060b407310e25bd1b76d77194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->