### PR TITLE
fix(polyscope): isolate worktree provision failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-03 - Continue Polyscope Provisioning After Workspace Failures
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so `--provision-worktrees` now isolates expected per-worktree provisioning failures, records them under `failed_provision_worktrees` in the rollout summary, and continues provisioning the remaining managed workspaces instead of aborting the entire run on the first broken clone
+- extended `tests/polyscope-rollout.sh` with a regression where one API workspace setup fails while a fresh GuardGuide workspace must still provision successfully, proving the shared rollout path no longer lets unrelated workspace failures block newer repositories
+
+---
+
 ## 2026-06-03 - Register GuardGuide In Polyscope Rollout
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- updated `scripts/polyscope-rollout.py` so `--provision-worktrees` now isolates expected per-worktree provisioning failures, records them under `failed_provision_worktrees` in the rollout summary, and continues provisioning the remaining managed workspaces instead of aborting the entire run on the first broken clone
-- extended `tests/polyscope-rollout.sh` with a regression where one API workspace setup fails while a fresh GuardGuide workspace must still provision successfully, proving the shared rollout path no longer lets unrelated workspace failures block newer repositories
+- updated `scripts/polyscope-rollout.py` so `--provision-worktrees` now isolates expected per-worktree provisioning failures, records them under `failed_provision_worktrees` in the rollout summary, continues provisioning the remaining managed workspaces instead of aborting the entire run on the first broken clone, and keeps preview database/schema targets for still-present but broken API clones out of cleanup
+- extended `tests/polyscope-rollout.sh` with regressions where one API workspace setup fails, a malformed API clone must still protect its preview storage targets from cleanup, and a fresh GuardGuide workspace must still provision successfully, proving the shared rollout path no longer lets unrelated workspace failures block newer repositories or delete live preview data for broken clones
 
 ---
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1528,10 +1528,10 @@ def provision_worktrees(
         config_text = rendered_configs[repo_name]
 
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
-            if not is_provisionable_worktree(repo_name, worktree_path, validation_commands):
-                continue
-
             try:
+                if not is_provisionable_worktree(repo_name, worktree_path, validation_commands):
+                    continue
+
                 sync_worktree_local_config(worktree_path, config_text)
                 ensure_worktree_hooks(worktree_path)
 
@@ -1562,7 +1562,7 @@ def provision_worktrees(
 
                 marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
-            except (subprocess.CalledProcessError, SystemExit) as error:
+            except (OSError, subprocess.CalledProcessError, SystemExit) as error:
                 error_message = str(error)
                 print(
                     f"Failed to provision {repo_name} worktree {worktree_path.name} at {worktree_path}: {error_message}",

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1999,6 +1999,8 @@ def main() -> int:
     if args.summary_output is not None:
         args.summary_output.write_text(json.dumps(summary, indent=2) + "\n")
     print(json.dumps(summary, indent=2))
+    if failed_provision_worktrees:
+        return 1
     return 0
 
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1508,10 +1508,11 @@ def provision_worktrees(
     repo_state: dict[str, dict[str, Any]],
     repo_specs: dict[str, dict[str, Any]],
     clone_root: pathlib.Path,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[dict[str, str]]]:
     rendered_configs = render_local_configs(repo_specs)
     provisioned_worktrees: list[str] = []
     cleaned_preview_storage_targets = cleanup_removed_api_preview_databases(repo_state, repo_specs, clone_root)
+    failed_provision_worktrees: list[dict[str, str]] = []
 
     for repo_name, spec in repo_specs.items():
         repo_clone_root = clone_root / repo_state[repo_name]["id"]
@@ -1530,38 +1531,53 @@ def provision_worktrees(
             if not is_provisionable_worktree(repo_name, worktree_path, validation_commands):
                 continue
 
-            sync_worktree_local_config(worktree_path, config_text)
-            ensure_worktree_hooks(worktree_path)
+            try:
+                sync_worktree_local_config(worktree_path, config_text)
+                ensure_worktree_hooks(worktree_path)
 
-            preview_storage_target: str | None = None
-            if repo_name == "api":
-                ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"])
-                if not ready:
-                    continue
+                preview_storage_target: str | None = None
+                if repo_name == "api":
+                    ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"])
+                    if not ready:
+                        continue
 
-            marker_path = worktree_path / PROVISION_MARKER_FILENAME
-            marker = load_provision_marker(marker_path)
-            if marker is not None and marker.get("setup_hash") == setup_hash:
-                if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
-                    continue
+                marker_path = worktree_path / PROVISION_MARKER_FILENAME
+                marker = load_provision_marker(marker_path)
+                if marker is not None and marker.get("setup_hash") == setup_hash:
+                    if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
+                        continue
 
-            if setup_commands:
-                print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
-                run_setup_commands(worktree_path, setup_commands)
+                if setup_commands:
+                    print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
+                    run_setup_commands(worktree_path, setup_commands)
 
-            marker_payload: dict[str, Any] = {
-                "repo": repo_name,
-                "workspace": worktree_path.name,
-                "setup_hash": setup_hash,
-                "provisioned_at": datetime.now(timezone.utc).isoformat(),
-            }
-            if repo_name == "api" and preview_storage_target is not None:
-                marker_payload["preview_storage_target"] = preview_storage_target
+                marker_payload: dict[str, Any] = {
+                    "repo": repo_name,
+                    "workspace": worktree_path.name,
+                    "setup_hash": setup_hash,
+                    "provisioned_at": datetime.now(timezone.utc).isoformat(),
+                }
+                if repo_name == "api" and preview_storage_target is not None:
+                    marker_payload["preview_storage_target"] = preview_storage_target
 
-            marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
-            provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
+                marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
+                provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")
+            except (subprocess.CalledProcessError, SystemExit) as error:
+                error_message = str(error)
+                print(
+                    f"Failed to provision {repo_name} worktree {worktree_path.name} at {worktree_path}: {error_message}",
+                    file=sys.stderr,
+                )
+                failed_provision_worktrees.append(
+                    {
+                        "repo": repo_name,
+                        "workspace": worktree_path.name,
+                        "path": str(worktree_path),
+                        "error": error_message,
+                    }
+                )
 
-    return provisioned_worktrees, cleaned_preview_storage_targets
+    return provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees
 
 
 def request_json(api_base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None) -> Any:
@@ -1880,12 +1896,14 @@ def build_summary(
     nginx_output: pathlib.Path,
     provisioned_worktrees: list[str],
     cleaned_preview_storage_targets: list[str],
+    failed_provision_worktrees: list[dict[str, str]],
 ) -> dict[str, Any]:
     summary: dict[str, Any] = {
         "db_backup": str(db_backup) if db_backup is not None else None,
         "rendered_nginx_config": str(nginx_output),
         "provisioned_worktrees": provisioned_worktrees,
         "cleaned_preview_storage_targets": cleaned_preview_storage_targets,
+        "failed_provision_worktrees": failed_provision_worktrees,
         "repositories": {},
     }
     for repo_name, spec in repo_specs.items():
@@ -1961,8 +1979,13 @@ def main() -> int:
 
     provisioned_worktrees: list[str] = []
     cleaned_preview_storage_targets: list[str] = []
+    failed_provision_worktrees: list[dict[str, str]] = []
     if args.provision_worktrees:
-        provisioned_worktrees, cleaned_preview_storage_targets = provision_worktrees(repo_state, repo_specs, args.clone_root)
+        provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
+            repo_state,
+            repo_specs,
+            args.clone_root,
+        )
 
     summary = build_summary(
         repo_state,
@@ -1971,6 +1994,7 @@ def main() -> int:
         args.nginx_output,
         provisioned_worktrees,
         cleaned_preview_storage_targets,
+        failed_provision_worktrees,
     )
     if args.summary_output is not None:
         args.summary_output.write_text(json.dumps(summary, indent=2) + "\n")

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -355,12 +355,18 @@ def cleanup_removed_api_preview_databases(
 
     api_spec = repo_specs["api"]
     api_validation_commands = render_local_config(api_spec).get("scripts", {}).get("setup", [])
-    active_targets = {
-        build_preview_database_name(base_database, worktree_path.name)
-        for worktree_path in api_clone_root.iterdir()
-        if worktree_path.is_dir()
-        if is_provisionable_worktree("api", worktree_path, api_validation_commands, log_skip_reason=False)
-    }
+    active_targets: set[str] = set()
+    for worktree_path in api_clone_root.iterdir():
+        if not worktree_path.is_dir():
+            continue
+
+        try:
+            if not is_provisionable_worktree("api", worktree_path, api_validation_commands, log_skip_reason=False):
+                continue
+        except (OSError, SystemExit):
+            continue
+
+        active_targets.add(build_preview_database_name(base_database, worktree_path.name))
 
     cleaned_databases: list[str] = []
     if postgres_role_can_create_databases(env_values, base_database):

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -361,12 +361,17 @@ def cleanup_removed_api_preview_databases(
             continue
 
         try:
-            if not is_provisionable_worktree("api", worktree_path, api_validation_commands, log_skip_reason=False):
-                continue
+            protects_storage_target = is_provisionable_worktree(
+                "api",
+                worktree_path,
+                api_validation_commands,
+                log_skip_reason=False,
+            )
         except (OSError, SystemExit):
-            continue
+            protects_storage_target = True
 
-        active_targets.add(build_preview_database_name(base_database, worktree_path.name))
+        if protects_storage_target:
+            active_targets.add(build_preview_database_name(base_database, worktree_path.name))
 
     cleaned_databases: list[str] = []
     if postgres_role_can_create_databases(env_values, base_database):

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -844,6 +844,9 @@ chmod +x "$fake_exec_dir/composer"
 cat >"$fake_exec_dir/php" <<'STUB'
 #!/usr/bin/env bash
 printf 'php:%s:%s\n' "$PWD" "$*" >> "$PROVISION_LOG"
+if [[ -n "${FAIL_ON_WORKTREE:-}" && "$PWD" == "$FAIL_ON_WORKTREE" ]]; then
+    exit 23
+fi
 exit 0
 STUB
 chmod +x "$fake_exec_dir/php"
@@ -1263,6 +1266,58 @@ summary = json.loads(open(sys.argv[1]).read())
 assert summary.get('provisioned_worktrees', []) == [], summary.get('provisioned_worktrees', [])
 assert summary.get('cleaned_preview_storage_targets', []) == [], summary.get('cleaned_preview_storage_targets', [])
 PY
+
+failing_api_clone="$home_dir/.polyscope/clones/api12345/abort-hawk"
+guardguide_clone="$home_dir/.polyscope/clones/gg123456/steady-otter"
+failure_isolation_summary_json="$workspace/failure-isolation-summary.json"
+
+mkdir -p "$failing_api_clone/.git/info" "$failing_api_clone/.git/hooks" "$failing_api_clone/scripts"
+mkdir -p "$guardguide_clone/.git/info" "$guardguide_clone/.git/hooks" "$guardguide_clone/database"
+
+seed_api_worktree_files "$failing_api_clone"
+seed_api_worktree_files "$guardguide_clone"
+seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+printf 'APP_KEY=\n' > "$guardguide_clone/.env.example"
+
+env HOME="$home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
+    FAIL_ON_WORKTREE="$failing_api_clone" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$failure_isolation_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - "$failure_isolation_summary_json" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+failed = summary.get('failed_provision_worktrees', [])
+
+assert 'GuardGuide:steady-otter' in provisioned, provisioned
+assert 'api:abort-hawk' not in provisioned, provisioned
+assert any(
+    entry.get('repo') == 'api'
+    and entry.get('workspace') == 'abort-hawk'
+    and 'returned non-zero exit status 23' in entry.get('error', '')
+    for entry in failed
+), failed
+PY
+
+grep -qF "php:$failing_api_clone:artisan config:clear" "$provision_log"
+grep -qF "composer:$guardguide_clone:install" "$provision_log"
+grep -qF "npm:$guardguide_clone:ci" "$provision_log"
+test -f "$guardguide_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$failing_api_clone/.polyscope-secpal-provisioned.json"
 
 schema_home_dir="$workspace/schema-home"
 schema_api_clone="$schema_home_dir/.polyscope/clones/api12345/schema-badger"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1268,21 +1268,25 @@ assert summary.get('cleaned_preview_storage_targets', []) == [], summary.get('cl
 PY
 
 failing_api_clone="$home_dir/.polyscope/clones/api12345/abort-hawk"
+failing_api_cleanup_clone="$home_dir/.polyscope/clones/api12345/broken-mole"
 failing_frontend_manifest_clone="$home_dir/.polyscope/clones/fe123456/broken-ibis"
 failing_frontend_io_clone="$home_dir/.polyscope/clones/fe123456/locked-oryx"
 guardguide_clone="$home_dir/.polyscope/clones/gg123456/steady-otter"
 failure_isolation_summary_json="$workspace/failure-isolation-summary.json"
 
 mkdir -p "$failing_api_clone/.git/info" "$failing_api_clone/.git/hooks" "$failing_api_clone/scripts"
+mkdir -p "$failing_api_cleanup_clone/.git/info" "$failing_api_cleanup_clone/.git/hooks" "$failing_api_cleanup_clone/scripts"
 mkdir -p "$failing_frontend_manifest_clone/.git/info" "$failing_frontend_manifest_clone/.git/hooks" "$failing_frontend_manifest_clone/scripts"
 mkdir -p "$failing_frontend_io_clone/.git/info" "$failing_frontend_io_clone/.git/hooks" "$failing_frontend_io_clone/scripts"
 mkdir -p "$guardguide_clone/.git/info" "$guardguide_clone/.git/hooks" "$guardguide_clone/database"
 
 seed_api_worktree_files "$failing_api_clone"
+seed_api_worktree_files "$failing_api_cleanup_clone"
 seed_node_worktree_files "$failing_frontend_manifest_clone" "frontend-broken-ibis"
 seed_node_worktree_files "$failing_frontend_io_clone" "frontend-locked-oryx"
 seed_api_worktree_files "$guardguide_clone"
 seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+printf '{"scripts": ' > "$failing_api_cleanup_clone/composer.json"
 printf '{"scripts": ' > "$failing_frontend_manifest_clone/package.json"
 rm -rf "$failing_frontend_io_clone/.git/info"
 printf 'not a directory\n' > "$failing_frontend_io_clone/.git/info"
@@ -1316,12 +1320,19 @@ failed = summary.get('failed_provision_worktrees', [])
 
 assert 'GuardGuide:steady-otter' in provisioned, provisioned
 assert 'api:abort-hawk' not in provisioned, provisioned
+assert 'api:broken-mole' not in provisioned, provisioned
 assert 'frontend:broken-ibis' not in provisioned, provisioned
 assert 'frontend:locked-oryx' not in provisioned, provisioned
 assert any(
     entry.get('repo') == 'api'
     and entry.get('workspace') == 'abort-hawk'
     and 'returned non-zero exit status 23' in entry.get('error', '')
+    for entry in failed
+), failed
+assert any(
+    entry.get('repo') == 'api'
+    and entry.get('workspace') == 'broken-mole'
+    and 'invalid composer.json for rollout validation' in entry.get('error', '')
     for entry in failed
 ), failed
 assert any(
@@ -1343,6 +1354,7 @@ grep -qF "composer:$guardguide_clone:install" "$provision_log"
 grep -qF "npm:$guardguide_clone:ci" "$provision_log"
 test -f "$guardguide_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_api_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$failing_api_cleanup_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_frontend_manifest_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_frontend_io_clone/.polyscope-secpal-provisioned.json"
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1292,6 +1292,16 @@ rm -rf "$failing_frontend_io_clone/.git/info"
 printf 'not a directory\n' > "$failing_frontend_io_clone/.git/info"
 printf 'APP_KEY=\n' > "$guardguide_clone/.env.example"
 
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+state['databases'].append('secpal__preview__broken_mole')
+state.setdefault('schemas', []).append('secpal__preview__broken_mole')
+open(sys.argv[1], 'w').write(json.dumps(state))
+PY
+
 env HOME="$home_dir" \
     PATH="$service_path" \
     PROVISION_LOG="$provision_log" \
@@ -1317,12 +1327,14 @@ import sys
 summary = json.loads(open(sys.argv[1]).read())
 provisioned = summary.get('provisioned_worktrees', [])
 failed = summary.get('failed_provision_worktrees', [])
+cleaned = summary.get('cleaned_preview_storage_targets', [])
 
 assert 'GuardGuide:steady-otter' in provisioned, provisioned
 assert 'api:abort-hawk' not in provisioned, provisioned
 assert 'api:broken-mole' not in provisioned, provisioned
 assert 'frontend:broken-ibis' not in provisioned, provisioned
 assert 'frontend:locked-oryx' not in provisioned, provisioned
+assert 'secpal__preview__broken_mole' not in cleaned, cleaned
 assert any(
     entry.get('repo') == 'api'
     and entry.get('workspace') == 'abort-hawk'
@@ -1347,6 +1359,15 @@ assert any(
     and 'File exists' in entry.get('error', '')
     for entry in failed
 ), failed
+PY
+
+python3 - <<'PY' "$fake_pg_state"
+import json
+import sys
+
+state = json.loads(open(sys.argv[1]).read())
+assert 'secpal__preview__broken_mole' in state['databases'], state['databases']
+assert 'secpal__preview__broken_mole' in state.get('schemas', []), state.get('schemas', [])
 PY
 
 grep -qF "php:$failing_api_clone:artisan config:clear" "$provision_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1268,15 +1268,24 @@ assert summary.get('cleaned_preview_storage_targets', []) == [], summary.get('cl
 PY
 
 failing_api_clone="$home_dir/.polyscope/clones/api12345/abort-hawk"
+failing_frontend_manifest_clone="$home_dir/.polyscope/clones/fe123456/broken-ibis"
+failing_frontend_io_clone="$home_dir/.polyscope/clones/fe123456/locked-oryx"
 guardguide_clone="$home_dir/.polyscope/clones/gg123456/steady-otter"
 failure_isolation_summary_json="$workspace/failure-isolation-summary.json"
 
 mkdir -p "$failing_api_clone/.git/info" "$failing_api_clone/.git/hooks" "$failing_api_clone/scripts"
+mkdir -p "$failing_frontend_manifest_clone/.git/info" "$failing_frontend_manifest_clone/.git/hooks" "$failing_frontend_manifest_clone/scripts"
+mkdir -p "$failing_frontend_io_clone/.git/info" "$failing_frontend_io_clone/.git/hooks" "$failing_frontend_io_clone/scripts"
 mkdir -p "$guardguide_clone/.git/info" "$guardguide_clone/.git/hooks" "$guardguide_clone/database"
 
 seed_api_worktree_files "$failing_api_clone"
+seed_node_worktree_files "$failing_frontend_manifest_clone" "frontend-broken-ibis"
+seed_node_worktree_files "$failing_frontend_io_clone" "frontend-locked-oryx"
 seed_api_worktree_files "$guardguide_clone"
 seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+printf '{"scripts": ' > "$failing_frontend_manifest_clone/package.json"
+rm -rf "$failing_frontend_io_clone/.git/info"
+printf 'not a directory\n' > "$failing_frontend_io_clone/.git/info"
 printf 'APP_KEY=\n' > "$guardguide_clone/.env.example"
 
 env HOME="$home_dir" \
@@ -1307,10 +1316,24 @@ failed = summary.get('failed_provision_worktrees', [])
 
 assert 'GuardGuide:steady-otter' in provisioned, provisioned
 assert 'api:abort-hawk' not in provisioned, provisioned
+assert 'frontend:broken-ibis' not in provisioned, provisioned
+assert 'frontend:locked-oryx' not in provisioned, provisioned
 assert any(
     entry.get('repo') == 'api'
     and entry.get('workspace') == 'abort-hawk'
     and 'returned non-zero exit status 23' in entry.get('error', '')
+    for entry in failed
+), failed
+assert any(
+    entry.get('repo') == 'frontend'
+    and entry.get('workspace') == 'broken-ibis'
+    and 'invalid package.json for rollout validation' in entry.get('error', '')
+    for entry in failed
+), failed
+assert any(
+    entry.get('repo') == 'frontend'
+    and entry.get('workspace') == 'locked-oryx'
+    and 'File exists' in entry.get('error', '')
     for entry in failed
 ), failed
 PY
@@ -1320,6 +1343,8 @@ grep -qF "composer:$guardguide_clone:install" "$provision_log"
 grep -qF "npm:$guardguide_clone:ci" "$provision_log"
 test -f "$guardguide_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_api_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$failing_frontend_manifest_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$failing_frontend_io_clone/.polyscope-secpal-provisioned.json"
 
 schema_home_dir="$workspace/schema-home"
 schema_api_clone="$schema_home_dir/.polyscope/clones/api12345/schema-badger"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1293,7 +1293,9 @@ env HOME="$home_dir" \
     --skip-local-configs \
     --skip-db-sync \
     --provision-worktrees \
-    > /dev/null
+    > /dev/null || failure_isolation_exit=$?
+
+test "${failure_isolation_exit:-0}" -eq 1
 
 python3 - "$failure_isolation_summary_json" <<'PY'
 import json


### PR DESCRIPTION
## Summary
- keep `--provision-worktrees` running after expected per-worktree setup failures instead of aborting the whole rollout pass
- record failed worktrees and their errors in the rollout summary for later inspection
- regression-test the case where a broken API workspace must not block a fresh GuardGuide workspace

## Testing
- `bash ./tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence
- Failing proof before implementation: the new rollout regression with failing API workspace `abort-hawk` exited the provisioning run with `subprocess.CalledProcessError` before GuardGuide workspace `steady-otter` could provision.
- Passing proof after implementation: `bash ./tests/polyscope-rollout.sh` now passes with `GuardGuide:steady-otter` in `provisioned_worktrees`, `api:abort-hawk` absent from provisioned results, and the failure recorded in `failed_provision_worktrees`; `./scripts/preflight.sh` also passed.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Tracking
- Closes #461
- Parent #463

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provisioning error handling and preview database cleanup semantics on the Polyscope host; wrong behavior could skip needed cleanup or leave broken workspaces unreported, but scope is rollout automation with new regression tests.
> 
> **Overview**
> **Polyscope worktree provisioning** no longer stops on the first broken clone when `--provision-worktrees` runs. `scripts/polyscope-rollout.py` wraps each worktree in a try/except, logs failures, appends structured entries to **`failed_provision_worktrees`** in the rollout JSON summary, and **`main()` exits 1** if any failures remain so operators still get a signal while other workspaces finish.
> 
> **API preview cleanup** now treats existing worktree directories as protecting their preview DB/schema targets even when validation throws (`OSError` / `SystemExit`), so a malformed API clone is not dropped from the active set and its preview storage is not deleted during cleanup.
> 
> **Tests** in `tests/polyscope-rollout.sh` cover a failing API setup, malformed manifests, and a successful **GuardGuide** provision in the same pass, with changelog notes for the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3f420257804323bb13baf44e240772090fbcc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->