### PR TITLE
fix: align GuardGuide rollout with current monolith surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-04 - Align GuardGuide Polyscope Rollout With The Laravel Monolith
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so GuardGuide now emits the current shadcn/ui instruction path, check-only validation commands, a preview `APP_URL` rewrite during setup, a required frontend build step, and the real current run actions (`Pest`, `Typecheck`, `Build`, `Vite Dev`) instead of stale Catalyst/Vitest-era commands
+- fixed the GuardGuide preview environment helper to generate a worktree-safe inline Python command without leading indentation, preventing `--provision-worktrees` from failing with `IndentationError` while rewriting `.env`
+- extended `tests/polyscope-rollout.sh` so the rollout regression suite now proves the renamed GuardGuide instruction file, current validation/run command surface, preview `APP_URL` rewrite, and successful GuardGuide worktree provisioning
+
+---
+
 ## 2026-06-03 - Continue Polyscope Provisioning After Workspace Failures
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -539,6 +539,33 @@ def build_frontend_preview_build_watch_command() -> str:
     return f"python3 -c {shlex.quote(script)}"
 
 
+def build_guardguide_preview_env_setup_command() -> str:
+    script = "\n".join(
+        [
+            "from pathlib import Path",
+            "import os",
+            "import re",
+            "",
+            'workspace = os.environ["POLYSCOPE_WORKSPACE"]',
+            'env_path = Path(".env")',
+            'text = env_path.read_text() if env_path.exists() else ""',
+            'pattern = re.compile(r"^APP_URL=.*$", re.MULTILINE)',
+            'replacement = f"APP_URL=https://guardguide-{workspace}.preview.secpal.dev"',
+            "",
+            "if pattern.search(text):",
+            "    text = pattern.sub(replacement, text)",
+            "else:",
+            '    if text and not text.endswith("\\n"):',
+            '        text += "\\n"',
+            '    text += replacement + "\\n"',
+            "",
+            "env_path.write_text(text)",
+        ]
+    )
+
+    return f'POLYSCOPE_WORKSPACE="${{PWD##*/}}" python3 -c {shlex.quote(script)}'
+
+
 def build_api_preview_seed_command(migration_command: str = "php artisan migrate --force") -> str:
     tinker_script = textwrap.dedent(
         r"""
@@ -576,7 +603,7 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
     commands = {
         "api": "php artisan test && vendor/bin/pint --dirty && vendor/bin/phpstan analyse --no-progress",
         "frontend": "npm run lint && npm run typecheck && npm run test:run:all && npm run build",
-        "GuardGuide": "npm run format:check && npm run lint && npm run typecheck && npm run test && composer run lint && composer run analyse && composer run test",
+        "GuardGuide": "npm run format:check && npm run lint:check && npm run typecheck && npm run test && composer run lint:check && composer run analyse && composer run test",
         "contracts": "npm run validate && npm run lint && npm run format:check",
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
@@ -758,10 +785,10 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "focus_instruction_paths": [
             ".github/instructions/org-shared.instructions.md",
             ".github/instructions/php-laravel.instructions.md",
-            ".github/instructions/react-catalyst.instructions.md",
+            ".github/instructions/react-shadcn.instructions.md",
         ],
         "preview_prefix": "guardguide",
-        "review_focus": "Laravel 13 monolith boundaries, Pest plus Vitest coverage, Catalyst-only UI patterns, Lingui localization, application-layer encryption for person-related data, and standalone-first acknowledgement flows.",
+        "review_focus": "Laravel 13 monolith boundaries, Pest coverage plus frontend build and typecheck validation, shadcn/ui-aligned UI patterns, Lingui localization, application-layer encryption for person-related data, and standalone-first acknowledgement flows.",
         "link_names": [],
         "local_config": {
             "copyGitignored": True,
@@ -772,24 +799,27 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     "test -d vendor || composer install",
                     "test -d node_modules || npm ci",
                     "test -f .env || cp .env.example .env",
+                    build_guardguide_preview_env_setup_command(),
                     "test -f database/database.sqlite || touch database/database.sqlite",
                     "grep -Eq '^APP_KEY=.+$' .env || php artisan key:generate --force",
                     "php artisan migrate --force",
+                    "npm run build",
                 ],
                 "run": [
                     {"label": "Pest", "command": "php artisan test", "runMode": "preserve"},
-                    {"label": "Vitest", "command": "npm run test:watch", "runMode": "replace"},
-                    {"label": "Vite", "command": "npm run start", "runMode": "replace"},
+                    {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
+                    {"label": "Build", "command": "npm run build", "runMode": "preserve"},
+                    {"label": "Vite Dev", "command": "npm run dev", "runMode": "replace"},
                 ],
             },
             "tasks": [
                 {
                     "label": "Review monolith boundary",
-                    "prompt": "Review the changed GuardGuide flow for Laravel monolith boundary drift, Catalyst UI regressions, localization gaps, encryption-at-rest constraints, and missing Pest or Vitest coverage. Keep the change scoped to one GuardGuide issue.",
+                    "prompt": "Review the changed GuardGuide flow for Laravel monolith boundary drift, shadcn/ui regressions, localization gaps, encryption-at-rest constraints, and missing Pest coverage or frontend validation. Keep the change scoped to one GuardGuide issue.",
                 },
                 {
                     "label": "Triage GuardGuide validation",
-                    "prompt": "Reproduce the failing GuardGuide behavior, add or update the smallest relevant Pest or Vitest coverage first when possible, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
+                    "prompt": "Reproduce the failing GuardGuide behavior, add or update the smallest relevant Pest coverage first when possible, then implement the minimal fix and rerun the touched validation. Use typecheck or build validation when the touched slice is frontend-only. Keep the change scoped to one issue.",
                 },
             ],
         },

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -84,12 +84,11 @@ workspace_root = Path(sys.argv[1])
 package_scripts = {
     "GuardGuide": {
         "build": "tsc --noEmit && vite build",
+        "dev": "vite",
         "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
-        "lint": "eslint .",
-        "start": "vite",
-        "test:watch": "vitest",
+        "lint:check": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "vitest run",
+        "test": "npm run build",
     },
     "frontend": {
         "build": "vite build",
@@ -137,6 +136,7 @@ guardguide_composer = {
     "scripts": {
         "analyse": ["./vendor/bin/phpstan analyse"],
         "lint": ["./vendor/bin/pint --test"],
+        "lint:check": ["./vendor/bin/pint --test"],
         "test": ["@php artisan test"],
     }
 }
@@ -345,16 +345,16 @@ create_repo "GuardGuide" "$common_header
 - Treat AI findings and AI-generated fix proposals as hints, not proof.
 - Before merge, prove a claimed defect with a failing test, a reproducible defect, or an explicit invariant.
 - Green CI alone is not enough for AI-generated changes.
-" "react-catalyst.instructions.md" "---
-name: React Catalyst Rules
+" "react-shadcn.instructions.md" "---
+name: React shadcn Rules
 applyTo: 'resources/js/**/*.tsx'
 ---
 
-# React Catalyst Rules
+# React shadcn Rules
 
 - Use React 19 with strict TypeScript.
 - Keep English source text and German translation in Lingui catalogs from the start.
-- Catalyst is the exclusive UI system.
+- shadcn/ui is the exclusive UI baseline.
 "
 
 printf '%s\n' "---
@@ -679,10 +679,38 @@ grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polysc
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
-grep -q 'react-catalyst.instructions.md before taking action' "$workspace_root/GuardGuide/polyscope.local.json"
-grep -qF '"command": "npm run format:check && npm run lint && npm run typecheck && npm run test && composer run lint && composer run analyse && composer run test"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -q 'react-shadcn.instructions.md before taking action' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -q 'POLYSCOPE_WORKSPACE=.*python3 -c' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -q 'APP_URL=https://guardguide-{workspace}\.preview\.secpal\.dev' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "npm run format:check && npm run lint:check && npm run typecheck && npm run test && composer run lint:check && composer run analyse && composer run test"' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"label": "Typecheck"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "npm run typecheck"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"label": "Build"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "npm run build"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"label": "Vite Dev"' "$workspace_root/GuardGuide/polyscope.local.json"
+grep -qF '"command": "npm run dev"' "$workspace_root/GuardGuide/polyscope.local.json"
+
+if grep -q 'react-catalyst.instructions.md' "$workspace_root/GuardGuide/polyscope.local.json"; then
+    echo "GuardGuide Polyscope config must not reference the legacy Catalyst instruction path" >&2
+    exit 1
+fi
+
+if grep -q 'Catalyst' "$workspace_root/GuardGuide/polyscope.local.json"; then
+    echo "GuardGuide Polyscope config must not reference Catalyst wording after the shadcn reset" >&2
+    exit 1
+fi
+
+if grep -qF '"command": "npm run start"' "$workspace_root/GuardGuide/polyscope.local.json"; then
+    echo "GuardGuide Polyscope config must not reference the removed npm run start command" >&2
+    exit 1
+fi
+
+if grep -qF '"command": "npm run test:watch"' "$workspace_root/GuardGuide/polyscope.local.json"; then
+    echo "GuardGuide Polyscope config must not reference the removed npm run test:watch command" >&2
+    exit 1
+fi
 
 if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not reference node_modules" >&2


### PR DESCRIPTION
## Summary
- align the GuardGuide Polyscope rollout source with the current Laravel monolith and shadcn/ui stack
- cover the renamed GuardGuide instruction path, preview APP_URL rewrite, current validation commands, and current run actions in the rollout regression
- fix the GuardGuide inline preview env helper so worktree provisioning stays executable

## TDD / Validate-First Evidence
- Failing proof before implementation: bash /home/secpal/code/SecPal/.github/tests/polyscope-rollout.sh first failed on stale GuardGuide npm/composer command references and legacy instruction-path assertions; the live rollout regeneration also failed with GuardGuide polyscope config references missing composer script 'analyse'; GuardGuide worktree provisioning also failed with IndentationError in the preview APP_URL rewrite helper.
- Passing proof after implementation: bash /home/secpal/code/SecPal/.github/tests/polyscope-rollout.sh passed, and python3 /home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal --repo-state-file /tmp/secpal-polyscope-repo-state.json --skip-db-sync --nginx-output /tmp/secpal-preview.nginx.conf --summary-output /tmp/secpal-polyscope-summary.json completed successfully.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation
- bash /home/secpal/code/SecPal/.github/tests/polyscope-rollout.sh
- python3 /home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal --repo-state-file /tmp/secpal-polyscope-repo-state.json --skip-db-sync --nginx-output /tmp/secpal-preview.nginx.conf --summary-output /tmp/secpal-polyscope-summary.json

Closes #468
Part of SecPal/.github#467
