### PR TITLE
Codify required-check sync automation

### DIFF
--- a/.github/workflows/pull-request-english.yml
+++ b/.github/workflows/pull-request-english.yml
@@ -13,6 +13,7 @@ on:
       - edited
       - reopened
       - ready_for_review
+      - synchronize
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-05 - Codify Required Branch Protection Checks
+
+**Added:**
+
+- added `scripts/sync-required-checks.sh` so the SecPal application repositories and `GuardGuide` now have a single manifest-backed way to print or apply the intended required status-check payloads instead of relying on ad hoc GitHub API calls
+- added `tests/sync-required-checks.sh` and hooked it into `scripts/preflight.sh` so required-check drift is caught locally before branch-protection guidance or workflow names change again
+- updated `docs/ghas-setup.md` and `scripts/README.md` so the documented branch-protection path now points at the repo-specific sync flow rather than the stale one-size-fits-all `CodeQL` example
+
+---
+
 ## 2026-06-04 - Seed GuardGuide During Polyscope Preview Setup
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Added:**
 
-- added `scripts/sync-required-checks.sh` so the SecPal application repositories and `GuardGuide` now have a single manifest-backed way to print or apply the intended required status-check payloads instead of relying on ad hoc GitHub API calls
+- added `scripts/sync-required-checks.sh` so the SecPal application repositories, the org defaults repository itself, and `GuardGuide` now have a single manifest-backed way to print or apply the intended required status-check payloads instead of relying on ad hoc GitHub API calls
 - added `tests/sync-required-checks.sh` and hooked it into `scripts/preflight.sh` so required-check drift is caught locally before branch-protection guidance or workflow names change again
 - updated `docs/ghas-setup.md` and `scripts/README.md` so the documented branch-protection path now points at the repo-specific sync flow rather than the stale one-size-fits-all `CodeQL` example
 

--- a/docs/ghas-setup.md
+++ b/docs/ghas-setup.md
@@ -146,23 +146,28 @@ updates:
 
 ## 🎯 Branch Protection (recommended)
 
-For `main` branch in each repository:
+Required status checks are repo-specific. Do not rely on the stale one-size-fits-all
+`["CodeQL"]` example for application repositories.
+
+Use the sync script in this repository to keep the live branch-protection payloads
+aligned with the meaningful CI gates per repository:
 
 ```bash
-# Via GitHub CLI:
-gh api repos/SecPal/{REPO_NAME}/branches/main/protection \
-  --method PUT \
-  --field required_status_checks='{"strict":true,"contexts":["CodeQL"]}' \
-  --field enforce_admins=true \
-  --field required_pull_request_reviews='{"required_approving_review_count":0}' \
-  --field restrictions=null
+# Inspect one payload before applying it
+bash scripts/sync-required-checks.sh --repo api --print-payload | jq
+
+# Apply one repository's required-check payload
+bash scripts/sync-required-checks.sh --repo api --apply
+
+# Apply the full managed SecPal application baseline
+bash scripts/sync-required-checks.sh --apply
 ```
 
 **Note:**
 
 - `enforce_admins=true`: Non-negotiable - even admins must follow rules
 - `required_approving_review_count=0`: Single maintainer project, automated checks provide quality gates
-- Required status checks: Adjust based on repository type (CodeQL for JS/TS only, not for PHP)
+- Required status checks: Keep them aligned with the real lint, test, build, analysis, and governance gates each repository actually runs
 
 ### Copilot Review Ruleset
 

--- a/docs/ghas-setup.md
+++ b/docs/ghas-setup.md
@@ -159,7 +159,7 @@ bash scripts/sync-required-checks.sh --repo api --print-payload | jq
 # Apply one repository's required-check payload
 bash scripts/sync-required-checks.sh --repo api --apply
 
-# Apply the full managed SecPal application baseline
+# Apply the full managed SecPal repository baseline
 bash scripts/sync-required-checks.sh --apply
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -164,6 +164,46 @@ The script automatically detects repository type:
 - **website**: Astro landing page (has `astro.config.mjs`)
 - **contracts**: OpenAPI contracts (has `package.json` with `openapi` or `docs/openapi.yaml`)
 
+### `sync-required-checks.sh`
+
+Builds and applies the repository-specific required status-check payloads for
+the SecPal application repositories.
+
+**Usage:**
+
+```bash
+# Inspect the payload for one repository without writing to GitHub
+bash scripts/sync-required-checks.sh --repo GuardGuide --print-payload | jq
+
+# Apply the configured payload to one repository
+bash scripts/sync-required-checks.sh --repo api --apply
+
+# Apply the configured payloads to every managed repository
+bash scripts/sync-required-checks.sh --apply
+```
+
+**Managed Repositories:**
+
+- `api`
+- `changelog`
+- `frontend`
+- `contracts`
+- `android`
+- `secpal.app`
+- `GuardGuide`
+
+**What It Does:**
+
+1. Defines the required status-check contexts per repository in one manifest
+2. Builds the exact JSON payload GitHub expects for branch protection updates
+3. Applies the payload through `gh api` using `--input` so booleans and arrays stay typed correctly
+4. Keeps the live branch-protection baseline repeatable after workflow or context drift
+
+**Exit Codes:**
+
+- `0`: Payload printed or sync applied successfully
+- `2`: Usage error, unknown repository, or missing dependency
+
 ## Adding New Scripts
 
 When adding new scripts:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -184,6 +184,7 @@ bash scripts/sync-required-checks.sh --apply
 
 **Managed Repositories:**
 
+- `.github`
 - `api`
 - `changelog`
 - `frontend`

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -197,6 +197,15 @@ if [ -f tests/validate-copilot-instructions.sh ]; then
   }
 fi
 
+if [ -f tests/sync-required-checks.sh ]; then
+  bash tests/sync-required-checks.sh || {
+    echo "" >&2
+    echo "❌ Required-check sync regression test failed!" >&2
+    echo "Fix scripts/sync-required-checks.sh before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/polyscope-rollout.sh ]; then
   bash tests/polyscope-rollout.sh || {
     echo "" >&2

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -173,7 +173,7 @@ apply_repository() {
   local payload_file
 
   ensure_known_repository "$repo"
-  payload_file="$(mktemp "${TMPDIR:-/tmp}/sync-required-checks.${repo//[^A-Za-z0-9]/_}.XXXXXX.json")"
+  payload_file="$(mktemp "${TMPDIR:-/tmp}/sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX")"
   build_payload "$repo" > "$payload_file"
 
   gh api "repos/SecPal/$repo/branches/main/protection/required_status_checks" \
@@ -224,6 +224,8 @@ if [[ -z "$mode" ]]; then
   exit 2
 fi
 
+require_command jq
+
 if [[ "$mode" == "print-payload" ]]; then
   if [[ -z "$repo" ]]; then
     echo "--print-payload requires --repo <name>" >&2
@@ -236,7 +238,6 @@ if [[ "$mode" == "print-payload" ]]; then
 fi
 
 require_command gh
-require_command jq
 
 if [[ -n "$repo" ]]; then
   apply_repository "$repo"

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -6,6 +6,19 @@ set -euo pipefail
 
 REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
 {
+  ".github": [
+    "Check REUSE Compliance",
+    "Check License Compatibility",
+    "Check Code Formatting",
+    "Lint Markdown Files",
+    "Check PR Size / Check PR Size",
+    "conflict-markers / Detect Git Conflict Markers",
+    "Lint GitHub Actions Workflows",
+    "CodeQL",
+    "Validate PR Evidence",
+    "Validate PR Title And Body Language",
+    "Validate Signed PR Commits"
+  ],
   "GuardGuide": [
     "check-conflicts / Detect Git Conflict Markers",
     "Check PR Size / Check PR Size",

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
+{
+  "GuardGuide": [
+    "check-conflicts / Detect Git Conflict Markers",
+    "Check PR Size / Check PR Size",
+    "Detect repository manifests",
+    "Copilot Instructions / Validate Copilot Instructions",
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Detect JavaScript manifest",
+    "Detect PHP manifest",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "Markdown Lint / Lint Markdown Files",
+    "ESLint / Run Linter",
+    "TypeScript Check / Build Project",
+    "Vitest Tests / Build Project",
+    "Laravel Pint / Check Code Style",
+    "PHPStan / Static Analysis",
+    "Pest Tests (PostgreSQL)",
+    "Pest Tests (MariaDB)",
+    "CodeQL"
+  ],
+  "android": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "check-conflicts / Detect Git Conflict Markers",
+    "ESLint / Run Linter",
+    "TypeScript Check / Build Project",
+    "Vitest Tests",
+    "Analyze with CodeQL (javascript-typescript)",
+    "Check PR Size / Check PR Size",
+    "Copilot Instructions / Validate Copilot Instructions",
+    "Markdown Lint / Lint Markdown Files"
+  ],
+  "api": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Laravel Pint / Check Code Style",
+    "PHPStan / Static Analysis",
+    "Formatting Check / Check Code Formatting",
+    "Markdown Lint / Lint Markdown Files",
+    "Check PR Size / Check PR Size",
+    "PEST Tests",
+    "check-conflicts / Detect Git Conflict Markers",
+    "Copilot Instructions / Validate Copilot Instructions"
+  ],
+  "changelog": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "Markdown Lint / Lint Markdown Files",
+    "ESLint / Run Linter",
+    "Next.js Build / Build Project",
+    "Check PR Size / Check PR Size",
+    "check-conflicts / Detect Git Conflict Markers",
+    "TypeScript Check / Build Project",
+    "CodeQL",
+    "Copilot Instructions / Validate Copilot Instructions"
+  ],
+  "contracts": [
+    "REUSE Compliance / Check REUSE Compliance",
+    "Prettier Formatting / Check Code Formatting",
+    "OpenAPI Lint / Validate OpenAPI Specification",
+    "Actionlint / Lint GitHub Actions Workflows",
+    "pr-size / Check PR Size",
+    "License Compatibility / Check License Compatibility",
+    "Markdown Lint / Lint Markdown Files",
+    "check-conflicts / Detect Git Conflict Markers",
+    "Copilot Instructions / Validate Copilot Instructions"
+  ],
+  "frontend": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "ESLint / Run Linter",
+    "TypeScript Check / Build Project",
+    "CodeQL",
+    "Markdown Lint / Lint Markdown Files",
+    "Check PR Size / Check PR Size",
+    "Vitest Tests",
+    "check-conflicts / Detect Git Conflict Markers",
+    "Copilot Instructions / Validate Copilot Instructions"
+  ],
+  "secpal.app": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "Markdown Lint / Lint Markdown Files",
+    "ESLint / Run Linter",
+    "Astro TypeScript Check / Build Project",
+    "Astro Build / Build Project",
+    "Check PR Size / Check PR Size",
+    "check-conflicts / Detect Git Conflict Markers",
+    "CodeQL",
+    "Copilot Instructions / Validate Copilot Instructions",
+    "Node Tests / Run Tests"
+  ]
+}
+EOF
+)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/sync-required-checks.sh --repo <name> --print-payload
+  bash scripts/sync-required-checks.sh [--repo <name>] --apply
+
+Options:
+  --repo <name>      Restrict output or apply mode to a single repository.
+  --print-payload    Print the GitHub API JSON payload for one repository.
+  --apply            Apply the configured required-check payload via gh api.
+  -h, --help         Show this help text.
+EOF
+}
+
+known_repositories() {
+  jq -r 'keys[]' <<<"$REQUIRED_CONTEXTS_JSON"
+}
+
+ensure_known_repository() {
+  local repo="$1"
+
+  if ! jq -e --arg repo "$repo" 'has($repo)' <<<"$REQUIRED_CONTEXTS_JSON" >/dev/null; then
+    echo "Unknown repository: $repo" >&2
+    echo "Known repositories:" >&2
+    known_repositories | sed 's/^/  - /' >&2
+    exit 2
+  fi
+}
+
+build_payload() {
+  local repo="$1"
+
+  ensure_known_repository "$repo"
+
+  jq -n \
+    --arg repo "$repo" \
+    --argjson config "$REQUIRED_CONTEXTS_JSON" \
+    '{strict: true, checks: ($config[$repo] | map({context: ., app_id: -1}))}'
+}
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 2
+  fi
+}
+
+apply_repository() {
+  local repo="$1"
+  local payload_file
+
+  ensure_known_repository "$repo"
+  payload_file="$(mktemp "${TMPDIR:-/tmp}/sync-required-checks.${repo//[^A-Za-z0-9]/_}.XXXXXX.json")"
+  build_payload "$repo" > "$payload_file"
+
+  gh api "repos/SecPal/$repo/branches/main/protection/required_status_checks" \
+    -X PATCH \
+    --input "$payload_file" >/dev/null
+
+  rm -f "$payload_file"
+  echo "Synced required checks for SecPal/$repo"
+}
+
+repo=""
+mode=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --repo" >&2
+        usage >&2
+        exit 2
+      fi
+      repo="$2"
+      shift 2
+      ;;
+    --print-payload)
+      mode="print-payload"
+      shift
+      ;;
+    --apply)
+      mode="apply"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  echo "Select either --print-payload or --apply" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ "$mode" == "print-payload" ]]; then
+  if [[ -z "$repo" ]]; then
+    echo "--print-payload requires --repo <name>" >&2
+    usage >&2
+    exit 2
+  fi
+
+  build_payload "$repo"
+  exit 0
+fi
+
+require_command gh
+require_command jq
+
+if [[ -n "$repo" ]]; then
+  apply_repository "$repo"
+  exit 0
+fi
+
+while IFS= read -r configured_repo; do
+  apply_repository "$configured_repo"
+done < <(known_repositories)

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -37,7 +37,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "PHPStan / Static Analysis",
     "Pest Tests (PostgreSQL)",
     "Pest Tests (MariaDB)",
-    "CodeQL"
+    "Analyze with CodeQL (javascript-typescript)"
   ],
   "android": [
     "Check REUSE Compliance / Check REUSE Compliance",
@@ -74,7 +74,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Check PR Size / Check PR Size",
     "check-conflicts / Detect Git Conflict Markers",
     "TypeScript Check / Build Project",
-    "CodeQL",
+    "Analyze Code (javascript-typescript)",
     "Copilot Instructions / Validate Copilot Instructions"
   ],
   "contracts": [
@@ -111,7 +111,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Astro Build / Build Project",
     "Check PR Size / Check PR Size",
     "check-conflicts / Detect Git Conflict Markers",
-    "CodeQL",
+    "Analyze Code (javascript-typescript)",
     "Copilot Instructions / Validate Copilot Instructions",
     "Node Tests / Run Tests"
   ]

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -94,7 +94,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Formatting Check / Check Code Formatting",
     "ESLint / Run Linter",
     "TypeScript Check / Build Project",
-    "CodeQL",
+    "Analyze with CodeQL (javascript-typescript)",
     "Markdown Lint / Lint Markdown Files",
     "Check PR Size / Check PR Size",
     "Vitest Tests",
@@ -170,17 +170,27 @@ require_command() {
 
 apply_repository() {
   local repo="$1"
-  local payload_file
 
   ensure_known_repository "$repo"
-  payload_file="$(mktemp "${TMPDIR:-/tmp}/sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX")"
-  build_payload "$repo" > "$payload_file"
 
-  gh api "repos/SecPal/$repo/branches/main/protection/required_status_checks" \
-    -X PATCH \
-    --input "$payload_file" >/dev/null
+  # Subshell scopes both the temp file and its EXIT trap so the payload is
+  # always removed, even if build_payload or `gh api` fail under `set -e`.
+  (
+    payload_file="$(mktemp "${TMPDIR:-/tmp}/sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX")"
+    trap 'rm -f "$payload_file"' EXIT
 
-  rm -f "$payload_file"
+    build_payload "$repo" > "$payload_file"
+
+    if ! gh api "repos/SecPal/$repo/branches/main/protection/required_status_checks" \
+      -X PATCH \
+      --input "$payload_file" >/dev/null; then
+      echo "Failed to update required_status_checks for SecPal/$repo." >&2
+      echo "Hint: this PATCH endpoint only updates an existing branch protection rule; GitHub returns 404 if 'main' is not yet protected." >&2
+      echo "      Initialize base branch protection first (see docs/ghas-setup.md), then rerun --apply." >&2
+      exit 1
+    fi
+  )
+
   echo "Synced required checks for SecPal/$repo"
 }
 

--- a/tests/pull-request-english.sh
+++ b/tests/pull-request-english.sh
@@ -83,6 +83,11 @@ if ! grep -Fq 'edited' "$WORKFLOW"; then
   exit 1
 fi
 
+if ! grep -Fq 'synchronize' "$WORKFLOW"; then
+  echo "Workflow must rerun on 'synchronize' so the required check reports against every new PR head SHA." >&2
+  exit 1
+fi
+
 if ! grep -Fq 'CI blocks obvious German PR title/body markers.' "$QUICK_REFERENCE"; then
   echo "Quick reference must document that obvious German PR title/body markers are CI-blocked." >&2
   exit 1

--- a/tests/pull-request-english.sh
+++ b/tests/pull-request-english.sh
@@ -83,7 +83,7 @@ if ! grep -Fq 'edited' "$WORKFLOW"; then
   exit 1
 fi
 
-if ! grep -Fq 'synchronize' "$WORKFLOW"; then
+if ! grep -Eq '^\s*-\s*synchronize\s*$' "$WORKFLOW"; then
   echo "Workflow must rerun on 'synchronize' so the required check reports against every new PR head SHA." >&2
   exit 1
 fi

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYNC_SCRIPT="$REPO_ROOT/scripts/sync-required-checks.sh"
 SHELL_BIN="${BASH:-$(command -v bash)}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Missing required command: jq" >&2
+  echo "Install jq before running tests/sync-required-checks.sh (preflight wires this test in)." >&2
+  exit 2
+fi
+
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sync-required-checks.XXXXXX")"
 
 cleanup() {
@@ -59,6 +66,16 @@ assert_payload_has_context "$guardguide_payload" "CodeQL"
 secpal_app_payload="$(bash "$SYNC_SCRIPT" --repo secpal.app --print-payload)"
 assert_payload_has_context "$secpal_app_payload" "Node Tests / Run Tests"
 assert_payload_has_context "$secpal_app_payload" "CodeQL"
+
+frontend_payload="$(bash "$SYNC_SCRIPT" --repo frontend --print-payload)"
+assert_payload_has_context "$frontend_payload" "Analyze with CodeQL (javascript-typescript)"
+assert_payload_has_context "$frontend_payload" "Vitest Tests"
+
+if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$frontend_payload"; then
+  echo "frontend manifest must not require the bare 'CodeQL' context (frontend's CodeQL workflow emits 'Analyze with CodeQL (<language>)')." >&2
+  echo "$frontend_payload" >&2
+  exit 1
+fi
 
 github_payload="$(bash "$SYNC_SCRIPT" --repo .github --print-payload)"
 assert_payload_has_context "$github_payload" "Validate PR Evidence"

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -42,6 +42,11 @@ secpal_app_payload="$(bash "$SYNC_SCRIPT" --repo secpal.app --print-payload)"
 assert_payload_has_context "$secpal_app_payload" "Node Tests / Run Tests"
 assert_payload_has_context "$secpal_app_payload" "CodeQL"
 
+github_payload="$(bash "$SYNC_SCRIPT" --repo .github --print-payload)"
+assert_payload_has_context "$github_payload" "Validate PR Evidence"
+assert_payload_has_context "$github_payload" "Validate PR Title And Body Language"
+assert_payload_has_context "$github_payload" "Validate Signed PR Commits"
+
 set +e
 unknown_output="$(bash "$SYNC_SCRIPT" --repo does-not-exist --print-payload 2>&1)"
 unknown_status=$?

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYNC_SCRIPT="$REPO_ROOT/scripts/sync-required-checks.sh"
+SHELL_BIN="${BASH:-$(command -v bash)}"
 
 assert_payload_has_context() {
   local payload="$1"
@@ -21,6 +22,16 @@ assert_payload_has_context() {
 
 if [[ ! -x "$SYNC_SCRIPT" ]]; then
   echo "Expected executable sync script at $SYNC_SCRIPT" >&2
+  exit 1
+fi
+
+if grep -Fq 'XXXXXX.json' "$SYNC_SCRIPT"; then
+  echo "Sync script uses a BSD-incompatible mktemp template with a suffix after the X placeholder." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX' "$SYNC_SCRIPT"; then
+  echo "Sync script must use a portable mktemp template whose X placeholder is at the end." >&2
   exit 1
 fi
 
@@ -60,5 +71,29 @@ fi
 if [[ "$unknown_output" != *"Unknown repository"* ]]; then
   echo "Expected unknown repo error to mention 'Unknown repository'" >&2
   echo "$unknown_output" >&2
+  exit 1
+fi
+
+missing_jq_bin="/tmp/sync-required-checks-missing-jq.$$"
+rm -rf "$missing_jq_bin"
+mkdir -p "$missing_jq_bin"
+ln -s "$(command -v cat)" "$missing_jq_bin/cat"
+
+set +e
+missing_jq_output="$(PATH="$missing_jq_bin" "$SHELL_BIN" "$SYNC_SCRIPT" --repo api --print-payload 2>&1)"
+missing_jq_status=$?
+set -e
+
+rm -rf "$missing_jq_bin"
+
+if [[ $missing_jq_status -ne 2 ]]; then
+  echo "Expected --print-payload without jq to exit with status 2" >&2
+  echo "$missing_jq_output" >&2
+  exit 1
+fi
+
+if [[ "$missing_jq_output" != *"Missing required command: jq"* ]]; then
+  echo "Expected --print-payload without jq to report the missing jq dependency" >&2
+  echo "$missing_jq_output" >&2
   exit 1
 fi

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -75,11 +75,15 @@ frontend_payload="$(bash "$SYNC_SCRIPT" --repo frontend --print-payload)"
 assert_payload_has_context "$frontend_payload" "Analyze with CodeQL (javascript-typescript)"
 assert_payload_has_context "$frontend_payload" "Vitest Tests"
 
+contracts_payload="$(bash "$SYNC_SCRIPT" --repo contracts --print-payload)"
+assert_payload_has_context "$contracts_payload" "OpenAPI Lint / Validate OpenAPI Specification"
+assert_payload_has_context "$contracts_payload" "Copilot Instructions / Validate Copilot Instructions"
+
 # The bare 'CodeQL' context is only emitted by .github (its CodeQL Applicability
 # Guardrail workflow names its job exactly 'CodeQL'). For every other repo the
 # CodeQL workflow names a different job (e.g. 'Analyze with CodeQL' / 'Analyze
 # Code'), so requiring bare 'CodeQL' there would block PRs forever.
-for non_github_payload in "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$frontend_payload"; do
+for non_github_payload in "$api_payload" "$android_payload" "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$frontend_payload" "$contracts_payload"; do
   if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$non_github_payload"; then
     echo "Only the '.github' manifest entry may require the bare 'CodeQL' context; other repos must require their actual CodeQL job context (e.g. 'Analyze with CodeQL (<language>)' or 'Analyze Code (<language>)')." >&2
     echo "$non_github_payload" >&2

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYNC_SCRIPT="$REPO_ROOT/scripts/sync-required-checks.sh"
 SHELL_BIN="${BASH:-$(command -v bash)}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sync-required-checks.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
 
 assert_payload_has_context() {
   local payload="$1"
@@ -74,8 +81,7 @@ if [[ "$unknown_output" != *"Unknown repository"* ]]; then
   exit 1
 fi
 
-missing_jq_bin="/tmp/sync-required-checks-missing-jq.$$"
-rm -rf "$missing_jq_bin"
+missing_jq_bin="$TMP_DIR/missing-jq-bin"
 mkdir -p "$missing_jq_bin"
 ln -s "$(command -v cat)" "$missing_jq_bin/cat"
 
@@ -83,8 +89,6 @@ set +e
 missing_jq_output="$(PATH="$missing_jq_bin" "$SHELL_BIN" "$SYNC_SCRIPT" --repo api --print-payload 2>&1)"
 missing_jq_status=$?
 set -e
-
-rm -rf "$missing_jq_bin"
 
 if [[ $missing_jq_status -ne 2 ]]; then
   echo "Expected --print-payload without jq to exit with status 2" >&2

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SYNC_SCRIPT="$REPO_ROOT/scripts/sync-required-checks.sh"
+
+assert_payload_has_context() {
+  local payload="$1"
+  local expected="$2"
+
+  if ! jq -e --arg expected "$expected" '.strict == true and (.checks | any(.context == $expected))' >/dev/null <<<"$payload"; then
+    echo "Expected payload to require '$expected'" >&2
+    echo "$payload" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "$SYNC_SCRIPT" ]]; then
+  echo "Expected executable sync script at $SYNC_SCRIPT" >&2
+  exit 1
+fi
+
+api_payload="$(bash "$SYNC_SCRIPT" --repo api --print-payload)"
+assert_payload_has_context "$api_payload" "Copilot Instructions / Validate Copilot Instructions"
+assert_payload_has_context "$api_payload" "PEST Tests"
+
+android_payload="$(bash "$SYNC_SCRIPT" --repo android --print-payload)"
+assert_payload_has_context "$android_payload" "Check PR Size / Check PR Size"
+assert_payload_has_context "$android_payload" "Markdown Lint / Lint Markdown Files"
+assert_payload_has_context "$android_payload" "Copilot Instructions / Validate Copilot Instructions"
+
+guardguide_payload="$(bash "$SYNC_SCRIPT" --repo GuardGuide --print-payload)"
+assert_payload_has_context "$guardguide_payload" "Pest Tests (PostgreSQL)"
+assert_payload_has_context "$guardguide_payload" "Pest Tests (MariaDB)"
+assert_payload_has_context "$guardguide_payload" "CodeQL"
+
+secpal_app_payload="$(bash "$SYNC_SCRIPT" --repo secpal.app --print-payload)"
+assert_payload_has_context "$secpal_app_payload" "Node Tests / Run Tests"
+assert_payload_has_context "$secpal_app_payload" "CodeQL"
+
+set +e
+unknown_output="$(bash "$SYNC_SCRIPT" --repo does-not-exist --print-payload 2>&1)"
+unknown_status=$?
+set -e
+
+if [[ $unknown_status -eq 0 ]]; then
+  echo "Expected unknown repo lookup to fail" >&2
+  exit 1
+fi
+
+if [[ "$unknown_output" != *"Unknown repository"* ]]; then
+  echo "Expected unknown repo error to mention 'Unknown repository'" >&2
+  echo "$unknown_output" >&2
+  exit 1
+fi

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -61,21 +61,31 @@ assert_payload_has_context "$android_payload" "Copilot Instructions / Validate C
 guardguide_payload="$(bash "$SYNC_SCRIPT" --repo GuardGuide --print-payload)"
 assert_payload_has_context "$guardguide_payload" "Pest Tests (PostgreSQL)"
 assert_payload_has_context "$guardguide_payload" "Pest Tests (MariaDB)"
-assert_payload_has_context "$guardguide_payload" "CodeQL"
+assert_payload_has_context "$guardguide_payload" "Analyze with CodeQL (javascript-typescript)"
 
 secpal_app_payload="$(bash "$SYNC_SCRIPT" --repo secpal.app --print-payload)"
 assert_payload_has_context "$secpal_app_payload" "Node Tests / Run Tests"
-assert_payload_has_context "$secpal_app_payload" "CodeQL"
+assert_payload_has_context "$secpal_app_payload" "Analyze Code (javascript-typescript)"
+
+changelog_payload="$(bash "$SYNC_SCRIPT" --repo changelog --print-payload)"
+assert_payload_has_context "$changelog_payload" "Analyze Code (javascript-typescript)"
+assert_payload_has_context "$changelog_payload" "Next.js Build / Build Project"
 
 frontend_payload="$(bash "$SYNC_SCRIPT" --repo frontend --print-payload)"
 assert_payload_has_context "$frontend_payload" "Analyze with CodeQL (javascript-typescript)"
 assert_payload_has_context "$frontend_payload" "Vitest Tests"
 
-if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$frontend_payload"; then
-  echo "frontend manifest must not require the bare 'CodeQL' context (frontend's CodeQL workflow emits 'Analyze with CodeQL (<language>)')." >&2
-  echo "$frontend_payload" >&2
-  exit 1
-fi
+# The bare 'CodeQL' context is only emitted by .github (its CodeQL Applicability
+# Guardrail workflow names its job exactly 'CodeQL'). For every other repo the
+# CodeQL workflow names a different job (e.g. 'Analyze with CodeQL' / 'Analyze
+# Code'), so requiring bare 'CodeQL' there would block PRs forever.
+for non_github_payload in "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$frontend_payload"; do
+  if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$non_github_payload"; then
+    echo "Only the '.github' manifest entry may require the bare 'CodeQL' context; other repos must require their actual CodeQL job context (e.g. 'Analyze with CodeQL (<language>)' or 'Analyze Code (<language>)')." >&2
+    echo "$non_github_payload" >&2
+    exit 1
+  fi
+done
 
 github_payload="$(bash "$SYNC_SCRIPT" --repo .github --print-payload)"
 assert_payload_has_context "$github_payload" "Validate PR Evidence"


### PR DESCRIPTION
## Summary
- add a manifest-backed `scripts/sync-required-checks.sh` helper to print or apply the intended required status checks for the managed SecPal repositories, the org defaults repository itself, and `GuardGuide`
- add a focused regression test and preflight hook so branch-protection drift is caught locally
- update the branch-protection documentation away from the stale one-size-fits-all `CodeQL` example

## Validation
- `bash tests/sync-required-checks.sh`
- `./scripts/preflight.sh`

## Live follow-up already applied
- tightened the current required checks on `api`, `changelog`, `frontend`, `contracts`, `android`, `secpal.app`, `GuardGuide`, and `.github`

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/sync-required-checks.sh` was authored before `scripts/sync-required-checks.sh`; running it without the helper exits non-zero with `Expected executable sync script at <repo>/scripts/sync-required-checks.sh`, and the per-repo `assert_payload_has_context` calls (e.g. `Validate PR Evidence` for `.github`, `Pest Tests (PostgreSQL)` for `GuardGuide`) cannot be satisfied until the manifest is in place.
- Passing proof after implementation: `bash tests/sync-required-checks.sh` exits 0 on this branch (covers per-repo contexts, unknown-repo handling, missing `jq`, and portable `mktemp` usage).
- Validate-first exception reference: N/A
- No executable change reason: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `--apply` PATCHes live branch protection on eight repos; wrong check names can block merges until fixed, though print mode and regression tests reduce drift risk.
> 
> **Overview**
> Introduces **manifest-backed branch protection** for SecPal repos via `scripts/sync-required-checks.sh`, which can **print** or **apply** per-repo required status-check payloads through the GitHub API instead of ad hoc `gh api` calls.
> 
> Adds **`tests/sync-required-checks.sh`** (per-repo contexts, CodeQL naming rules, portable `mktemp`, unknown-repo / missing-`jq` handling) and wires it into **`scripts/preflight.sh`**. Updates **`docs/ghas-setup.md`** and **`scripts/README.md`** to document the sync flow and drop the stale universal `CodeQL`-only example.
> 
> The **Pull Request English** workflow now runs on **`synchronize`** so the language check stays tied to each new PR head SHA; **`tests/pull-request-english.sh`** enforces that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55ed72e54ca3bfacb14f28a3a632798337291e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

