### PR TITLE
Add Polyscope state audit guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-06 - Add Local Polyscope State Audit Guard
+
+**Added:**
+
+- added `scripts/audit-polyscope-state.py` to audit the local Polyscope runtime for clone-root drift, unregistered Git worktrees, invalid stub directories, clone-local config hygiene, and over-retained `polyscope.db` backups
+- added `tests/polyscope-state-audit.sh` plus a `scripts/preflight.sh` hook so the local Polyscope audit stays regression-tested with fixture-backed SQLite and filesystem coverage
+- documented the new audit script in `scripts/README.md` so the operational cleanup path no longer depends on ad hoc one-off shell commands
+
+---
+
 ## 2026-06-05 - Codify Required Branch Protection Checks
 
 **Added:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -205,6 +205,37 @@ bash scripts/sync-required-checks.sh --apply
 - `0`: Payload printed or sync applied successfully
 - `2`: Usage error, unknown repository, or missing dependency
 
+### `audit-polyscope-state.py`
+
+Audits the local Polyscope runtime state for repository/clone drift, stale
+worktree directories, clone-local config hygiene, and over-retained SQLite
+backups.
+
+**Usage:**
+
+```bash
+# Audit the real local Polyscope state
+python3 scripts/audit-polyscope-state.py
+
+# Audit a custom Polyscope home and print JSON findings
+python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --json
+```
+
+**What It Checks:**
+
+1. Repository IDs in `polyscope.db` that do not have a matching clone root
+2. Clone roots that no longer belong to any registered repository
+3. Clone subdirectories that are not valid Git worktrees
+4. Valid Git worktrees that are not registered in the `worktrees` table
+5. Registered worktrees missing clone-local `polyscope.local.json`, drifting from the repo-root config, or missing `.git/info/exclude` coverage
+6. `polyscope.db.backup-*` files beyond the configured retention count
+
+**Exit Codes:**
+
+- `0`: No findings
+- `1`: One or more findings detected
+- `2`: Usage error or missing dependency/state
+
 ## Adding New Scripts
 
 When adding new scripts:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -229,7 +229,7 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 4. Valid Git worktrees that are not registered in the `worktrees` table
 5. Registered worktrees whose on-disk path no longer exists
 6. Worktree rows referencing a `repo_id` that is missing from `repositories`
-7. Registered worktrees missing clone-local `polyscope.local.json`, drifting from the repo-root config, or missing `polyscope.local.json` coverage in the worktree's `info/exclude` (resolved via the per-worktree gitdir so linked worktrees are handled)
+7. Registered worktrees missing clone-local `polyscope.local.json`, drifting from the repo-root config, or where Git would still track `polyscope.local.json` (the check uses `git check-ignore` so commented (`#`), negated (`!`), or look-alike (`.bak`) entries in `info/exclude` are not mistaken for effective coverage, and per-worktree gitdirs of linked worktrees are followed automatically)
 8. `polyscope.db.backup-*` files beyond the configured retention count
 
 **Exit Codes:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -227,8 +227,10 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 2. Clone roots that no longer belong to any registered repository
 3. Clone subdirectories that are not valid Git worktrees
 4. Valid Git worktrees that are not registered in the `worktrees` table
-5. Registered worktrees missing clone-local `polyscope.local.json`, drifting from the repo-root config, or missing `.git/info/exclude` coverage
-6. `polyscope.db.backup-*` files beyond the configured retention count
+5. Registered worktrees whose on-disk path no longer exists
+6. Worktree rows referencing a `repo_id` that is missing from `repositories`
+7. Registered worktrees missing clone-local `polyscope.local.json`, drifting from the repo-root config, or missing `polyscope.local.json` coverage in the worktree's `info/exclude` (resolved via the per-worktree gitdir so linked worktrees are handled)
+8. `polyscope.db.backup-*` files beyond the configured retention count
 
 **Exit Codes:**
 

--- a/scripts/audit-polyscope-state.py
+++ b/scripts/audit-polyscope-state.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit local Polyscope state for drift and stale data.")
+    parser.add_argument(
+        "--polyscope-home",
+        default=str(Path.home() / ".polyscope"),
+        help="Path to the Polyscope home directory. Defaults to ~/.polyscope.",
+    )
+    parser.add_argument(
+        "--backup-retention",
+        type=int,
+        default=8,
+        help="How many newest polyscope.db backups to keep before older ones are reported as excess.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print findings as JSON.")
+    return parser.parse_args()
+
+
+def ensure_dependencies(polyscope_home: Path, backup_retention: int) -> Path:
+    if backup_retention < 0:
+        raise SystemExit("--backup-retention must be >= 0")
+
+    if shutil.which("git") is None:
+        raise SystemExit("git is required to audit Polyscope worktrees")
+
+    db_path = polyscope_home / "polyscope.db"
+    if not db_path.exists():
+        raise SystemExit(f"Polyscope DB not found at {db_path}")
+    return db_path
+
+
+def is_git_worktree(path: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def load_state(db_path: Path) -> tuple[dict[str, dict[str, str]], list[dict[str, str]]]:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    repositories = {
+        repo_id: {"name": name, "path": path}
+        for repo_id, name, path in cur.execute("SELECT id, name, path FROM repositories ORDER BY name")
+    }
+    worktrees = [
+        {
+            "repo_id": repo_id,
+            "branch": branch,
+            "path": path,
+            "status": status,
+        }
+        for repo_id, branch, path, status in cur.execute(
+            "SELECT repo_id, branch, path, status FROM worktrees ORDER BY repo_id, path"
+        )
+    ]
+    conn.close()
+    return repositories, worktrees
+
+
+def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[Any]]:
+    db_path = ensure_dependencies(polyscope_home, backup_retention)
+    repositories, worktrees = load_state(db_path)
+
+    clone_root = polyscope_home / "clones"
+    clone_root.mkdir(parents=True, exist_ok=True)
+
+    repo_ids = set(repositories)
+    clone_roots = sorted(path for path in clone_root.iterdir() if path.is_dir())
+    registered_worktree_paths = {Path(entry["path"]).resolve(): entry for entry in worktrees}
+
+    findings: dict[str, list[Any]] = {
+        "orphan_clone_roots": [],
+        "repos_missing_clone_roots": [],
+        "invalid_clone_worktrees": [],
+        "unregistered_git_worktrees": [],
+        "missing_registered_worktrees": [],
+        "missing_clone_local_configs": [],
+        "worktree_config_mismatches": [],
+        "missing_worktree_excludes": [],
+        "excess_db_backups": [],
+    }
+
+    for repo_id, repo in sorted(repositories.items(), key=lambda item: item[1]["name"]):
+        expected_clone_root = clone_root / repo_id
+        if not expected_clone_root.is_dir():
+            findings["repos_missing_clone_roots"].append(
+                {
+                    "repo_id": repo_id,
+                    "repo_name": repo["name"],
+                    "repo_path": repo["path"],
+                    "clone_root": str(expected_clone_root),
+                }
+            )
+
+    for root in clone_roots:
+        if root.name not in repo_ids:
+            findings["orphan_clone_roots"].append(str(root))
+
+        for child in sorted(path for path in root.iterdir() if path.is_dir()):
+            child_resolved = child.resolve()
+            if is_git_worktree(child):
+                if child_resolved not in registered_worktree_paths:
+                    findings["unregistered_git_worktrees"].append(str(child))
+            else:
+                findings["invalid_clone_worktrees"].append(str(child))
+
+    for worktree in worktrees:
+        worktree_path = Path(worktree["path"])
+        if not worktree_path.exists():
+            findings["missing_registered_worktrees"].append(worktree)
+            continue
+
+        repo_root = Path(repositories[worktree["repo_id"]]["path"])
+        repo_config = repo_root / "polyscope.local.json"
+        worktree_config = worktree_path / "polyscope.local.json"
+        if repo_config.exists():
+            if not worktree_config.exists():
+                findings["missing_clone_local_configs"].append(str(worktree_path))
+            elif repo_config.read_text() != worktree_config.read_text():
+                findings["worktree_config_mismatches"].append(str(worktree_path))
+
+            exclude_path = worktree_path / ".git" / "info" / "exclude"
+            if not exclude_path.exists() or "polyscope.local.json" not in exclude_path.read_text():
+                findings["missing_worktree_excludes"].append(str(worktree_path))
+
+    backups = sorted(polyscope_home.glob("polyscope.db.backup-*"))
+    if backup_retention == 0:
+        findings["excess_db_backups"] = [str(path) for path in backups]
+    elif backup_retention < len(backups):
+        findings["excess_db_backups"] = [str(path) for path in backups[:-backup_retention]]
+
+    return findings
+
+
+def print_human(findings: dict[str, list[Any]]) -> None:
+    labels = {
+        "orphan_clone_roots": "Orphan clone roots",
+        "repos_missing_clone_roots": "Repositories missing clone roots",
+        "invalid_clone_worktrees": "Invalid clone worktrees",
+        "unregistered_git_worktrees": "Unregistered git worktrees",
+        "missing_registered_worktrees": "Missing registered worktrees",
+        "missing_clone_local_configs": "Missing clone-local configs",
+        "worktree_config_mismatches": "Clone-local config mismatches",
+        "missing_worktree_excludes": "Missing worktree exclude entries",
+        "excess_db_backups": "Excess DB backups",
+    }
+    any_findings = False
+    for key, label in labels.items():
+        values = findings[key]
+        if not values:
+            continue
+        any_findings = True
+        print(f"{label}:")
+        for value in values:
+            if isinstance(value, dict):
+                print(f"  - {json.dumps(value, sort_keys=True)}")
+            else:
+                print(f"  - {value}")
+    if not any_findings:
+        print("Polyscope state audit passed with no findings.")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        findings = audit_state(Path(args.polyscope_home), args.backup_retention)
+    except SystemExit as exc:
+        message = str(exc)
+        if message:
+            print(message, file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(findings, indent=2, sort_keys=True))
+    else:
+        print_human(findings)
+
+    return 1 if any(findings.values()) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-polyscope-state.py
+++ b/scripts/audit-polyscope-state.py
@@ -54,25 +54,20 @@ def is_git_worktree(path: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
-def resolve_git_dir(worktree_path: Path) -> Path:
-    # Linked worktrees store .git as a file pointing at <main>/.git/worktrees/<name>,
-    # which is where per-worktree info/exclude lives; resolve it via git so the
-    # audit reads the correct location instead of <worktree>/.git/info/exclude.
+def worktree_ignores_polyscope_config(worktree_path: Path) -> bool:
+    # Ask Git itself whether polyscope.local.json is effectively ignored.
+    # A substring scan of info/exclude would accept commented (`# polyscope.local.json`),
+    # negated (`!polyscope.local.json`), or look-alike (`polyscope.local.json.bak`)
+    # entries even though Git would still pick the file up via `git add`.
+    # `git check-ignore` also transparently follows the per-worktree gitdir, so
+    # linked worktrees (.git as a file) are handled without manual resolution.
     result = subprocess.run(
-        ["git", "-C", str(worktree_path), "rev-parse", "--absolute-git-dir"],
+        ["git", "-C", str(worktree_path), "check-ignore", "-q", "--", "polyscope.local.json"],
         check=False,
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0:
-        return worktree_path / ".git"
-    return Path(result.stdout.strip())
-
-
-def has_exclude_entry(exclude_path: Path, entry: str) -> bool:
-    if not exclude_path.exists():
-        return False
-    return any(line.strip() == entry for line in exclude_path.read_text().splitlines())
+    return result.returncode == 0
 
 
 def load_state(db_path: Path) -> tuple[dict[str, dict[str, str]], list[dict[str, str]]]:
@@ -166,8 +161,7 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
             elif repo_config.read_text() != worktree_config.read_text():
                 findings["worktree_config_mismatches"].append(str(worktree_path))
 
-            exclude_path = resolve_git_dir(worktree_path) / "info" / "exclude"
-            if not has_exclude_entry(exclude_path, "polyscope.local.json"):
+            if not worktree_ignores_polyscope_config(worktree_path):
                 findings["missing_worktree_excludes"].append(str(worktree_path))
 
     backups = sorted(polyscope_home.glob("polyscope.db.backup-*"))

--- a/scripts/audit-polyscope-state.py
+++ b/scripts/audit-polyscope-state.py
@@ -69,6 +69,12 @@ def resolve_git_dir(worktree_path: Path) -> Path:
     return Path(result.stdout.strip())
 
 
+def has_exclude_entry(exclude_path: Path, entry: str) -> bool:
+    if not exclude_path.exists():
+        return False
+    return any(line.strip() == entry for line in exclude_path.read_text().splitlines())
+
+
 def load_state(db_path: Path) -> tuple[dict[str, dict[str, str]], list[dict[str, str]]]:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
@@ -161,7 +167,7 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
                 findings["worktree_config_mismatches"].append(str(worktree_path))
 
             exclude_path = resolve_git_dir(worktree_path) / "info" / "exclude"
-            if not exclude_path.exists() or "polyscope.local.json" not in exclude_path.read_text():
+            if not has_exclude_entry(exclude_path, "polyscope.local.json"):
                 findings["missing_worktree_excludes"].append(str(worktree_path))
 
     backups = sorted(polyscope_home.glob("polyscope.db.backup-*"))

--- a/scripts/audit-polyscope-state.py
+++ b/scripts/audit-polyscope-state.py
@@ -94,6 +94,7 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
         "invalid_clone_worktrees": [],
         "unregistered_git_worktrees": [],
         "missing_registered_worktrees": [],
+        "worktrees_missing_repositories": [],
         "missing_clone_local_configs": [],
         "worktree_config_mismatches": [],
         "missing_worktree_excludes": [],
@@ -130,7 +131,12 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
             findings["missing_registered_worktrees"].append(worktree)
             continue
 
-        repo_root = Path(repositories[worktree["repo_id"]]["path"])
+        repo = repositories.get(worktree["repo_id"])
+        if repo is None:
+            findings["worktrees_missing_repositories"].append(worktree)
+            continue
+
+        repo_root = Path(repo["path"])
         repo_config = repo_root / "polyscope.local.json"
         worktree_config = worktree_path / "polyscope.local.json"
         if repo_config.exists():
@@ -159,6 +165,7 @@ def print_human(findings: dict[str, list[Any]]) -> None:
         "invalid_clone_worktrees": "Invalid clone worktrees",
         "unregistered_git_worktrees": "Unregistered git worktrees",
         "missing_registered_worktrees": "Missing registered worktrees",
+        "worktrees_missing_repositories": "Worktrees missing repositories",
         "missing_clone_local_configs": "Missing clone-local configs",
         "worktree_config_mismatches": "Clone-local config mismatches",
         "missing_worktree_excludes": "Missing worktree exclude entries",

--- a/scripts/audit-polyscope-state.py
+++ b/scripts/audit-polyscope-state.py
@@ -54,6 +54,21 @@ def is_git_worktree(path: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
+def resolve_git_dir(worktree_path: Path) -> Path:
+    # Linked worktrees store .git as a file pointing at <main>/.git/worktrees/<name>,
+    # which is where per-worktree info/exclude lives; resolve it via git so the
+    # audit reads the correct location instead of <worktree>/.git/info/exclude.
+    result = subprocess.run(
+        ["git", "-C", str(worktree_path), "rev-parse", "--absolute-git-dir"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return worktree_path / ".git"
+    return Path(result.stdout.strip())
+
+
 def load_state(db_path: Path) -> tuple[dict[str, dict[str, str]], list[dict[str, str]]]:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
@@ -82,10 +97,10 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
     repositories, worktrees = load_state(db_path)
 
     clone_root = polyscope_home / "clones"
-    clone_root.mkdir(parents=True, exist_ok=True)
-
     repo_ids = set(repositories)
-    clone_roots = sorted(path for path in clone_root.iterdir() if path.is_dir())
+    # Audit is read-only: if clones/ has not been provisioned yet, treat it as empty
+    # rather than creating it (would mutate user state on a fresh Polyscope home).
+    clone_roots = sorted(path for path in clone_root.iterdir() if path.is_dir()) if clone_root.is_dir() else []
     registered_worktree_paths = {Path(entry["path"]).resolve(): entry for entry in worktrees}
 
     findings: dict[str, list[Any]] = {
@@ -145,7 +160,7 @@ def audit_state(polyscope_home: Path, backup_retention: int) -> dict[str, list[A
             elif repo_config.read_text() != worktree_config.read_text():
                 findings["worktree_config_mismatches"].append(str(worktree_path))
 
-            exclude_path = worktree_path / ".git" / "info" / "exclude"
+            exclude_path = resolve_git_dir(worktree_path) / "info" / "exclude"
             if not exclude_path.exists() or "polyscope.local.json" not in exclude_path.read_text():
                 findings["missing_worktree_excludes"].append(str(worktree_path))
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -206,6 +206,15 @@ if [ -f tests/sync-required-checks.sh ]; then
   }
 fi
 
+if [ -f tests/polyscope-state-audit.sh ]; then
+  bash tests/polyscope-state-audit.sh || {
+    echo "" >&2
+    echo "❌ Polyscope state audit regression test failed!" >&2
+    echo "Fix scripts/audit-polyscope-state.py before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/polyscope-rollout.sh ]; then
   bash tests/polyscope-rollout.sh || {
     echo "" >&2

--- a/tests/polyscope-state-audit.sh
+++ b/tests/polyscope-state-audit.sh
@@ -280,6 +280,8 @@ entries = [
     ('wt-no-cfg',    'feature/no-cfg',    clone_root / 'no-config'),
     ('wt-drift',     'feature/drift',     clone_root / 'drift'),
     ('wt-no-excl',   'feature/no-excl',   clone_root / 'no-exclude'),
+    ('wt-comment',   'feature/comment',   clone_root / 'commented-exclude'),
+    ('wt-negated',   'feature/negated',   clone_root / 'negated-exclude'),
     ('wt-linked',    'feature/linked',    clone_root / 'linked'),
 ]
 cur.executemany(
@@ -308,17 +310,29 @@ git init -q "$poly2_home/clones/api22222/no-exclude"
 cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/no-exclude/polyscope.local.json"
 printf '# polyscope.local.json\n' > "$poly2_home/clones/api22222/no-exclude/.git/info/exclude"
 
-# wt-linked: real linked worktree (.git is a file) - proves gitdir is resolved
-# before reading info/exclude. The linked gitdir lives outside the clones tree
-# so the clone-scan loop does not see it as a clone subdir.
+# wt-comment: exclude line is a Git comment (`#`), audit must NOT accept it
+git init -q "$poly2_home/clones/api22222/commented-exclude"
+cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/commented-exclude/polyscope.local.json"
+printf '# polyscope.local.json\n' > "$poly2_home/clones/api22222/commented-exclude/.git/info/exclude"
+
+# wt-negated: exclude has the entry plus a later negation; Git tracks the file again
+git init -q "$poly2_home/clones/api22222/negated-exclude"
+cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/negated-exclude/polyscope.local.json"
+printf 'polyscope.local.json\n!polyscope.local.json\n' > "$poly2_home/clones/api22222/negated-exclude/.git/info/exclude"
+
+# wt-linked: real linked worktree (.git is a file) - proves that exclude
+# resolution follows Git semantics. For linked worktrees Git reads
+# info/exclude from the common gitdir (not the per-worktree gitdir), and
+# `git check-ignore` honours that automatically. The main repo lives outside
+# the clones tree so the clone-scan loop does not see it as a clone subdir.
 main_repo="$workspace/poly2/main-repo"
 git init -q "$main_repo"
 git -C "$main_repo" -c user.email=t@example.com -c user.name=tester commit -q --allow-empty -m bootstrap
 git -C "$main_repo" worktree add --quiet -b feature/linked "$poly2_home/clones/api22222/linked"
 cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/linked/polyscope.local.json"
-linked_gitdir="$(git -C "$poly2_home/clones/api22222/linked" rev-parse --absolute-git-dir)"
-mkdir -p "$linked_gitdir/info"
-printf 'polyscope.local.json\n' > "$linked_gitdir/info/exclude"
+linked_common_gitdir="$(git -C "$poly2_home/clones/api22222/linked" rev-parse --git-common-dir)"
+mkdir -p "$linked_common_gitdir/info"
+printf 'polyscope.local.json\n' > "$linked_common_gitdir/info/exclude"
 
 set +e
 worktree_findings_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$poly2_home" --backup-retention 10 --json 2>&1)"
@@ -347,6 +361,8 @@ assert [wt['path']   for wt in report['missing_registered_worktrees']] == [str(c
 assert sorted(report['missing_clone_local_configs']) == [str(clones / 'no-config')]
 assert sorted(report['worktree_config_mismatches'])  == [str(clones / 'drift')]
 assert sorted(report['missing_worktree_excludes'])   == sorted([
+    str(clones / 'commented-exclude'),
+    str(clones / 'negated-exclude'),
     str(clones / 'no-config'),
     str(clones / 'no-exclude'),
 ])

--- a/tests/polyscope-state-audit.sh
+++ b/tests/polyscope-state-audit.sh
@@ -122,6 +122,7 @@ assert report['repos_missing_clone_roots'] == [
     }
 ]
 assert report['missing_registered_worktrees'] == []
+assert report['worktrees_missing_repositories'] == []
 assert report['missing_clone_local_configs'] == []
 assert report['worktree_config_mismatches'] == []
 assert report['missing_worktree_excludes'] == []
@@ -172,5 +173,54 @@ assert report['excess_db_backups'] == [
         str(polyscope_home / 'polyscope.db.backup-20260603T000000Z'),
         str(polyscope_home / 'polyscope.db.backup-20260604T000000Z'),
         str(polyscope_home / 'polyscope.db.backup-20260605T000000Z'),
+]
+PY
+
+broken_worktree="$workspace/missing-repo-worktree"
+mkdir -p "$broken_worktree"
+
+python3 - <<'PY' "$polyscope_home" "$broken_worktree"
+import sqlite3
+import sys
+from pathlib import Path
+
+polyscope_home = Path(sys.argv[1])
+broken_worktree = Path(sys.argv[2])
+conn = sqlite3.connect(polyscope_home / 'polyscope.db')
+cur = conn.cursor()
+cur.execute(
+    'INSERT INTO worktrees (id, repo_id, branch, path, status) VALUES (?, ?, ?, ?, ?)',
+    ('wt-missing-repo', 'missing99', 'feature/missing-repo', str(broken_worktree), 'active'),
+)
+conn.commit()
+conn.close()
+PY
+
+set +e
+missing_repo_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$polyscope_home" --backup-retention 10 --json 2>&1)"
+missing_repo_status=$?
+set -e
+
+if [[ $missing_repo_status -ne 1 ]]; then
+    echo "Expected missing-repo audit to exit with status 1, got $missing_repo_status" >&2
+    echo "$missing_repo_output" >&2
+    exit 1
+fi
+
+python3 - <<'PY' "$missing_repo_output" "$broken_worktree"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+broken_worktree = Path(sys.argv[2])
+
+assert report['worktrees_missing_repositories'] == [
+    {
+        'repo_id': 'missing99',
+        'branch': 'feature/missing-repo',
+        'path': str(broken_worktree),
+        'status': 'active',
+    }
 ]
 PY

--- a/tests/polyscope-state-audit.sh
+++ b/tests/polyscope-state-audit.sh
@@ -302,10 +302,11 @@ git init -q "$poly2_home/clones/api22222/drift"
 printf '{"preview":{"url":"https://drift.preview.secpal.dev"}}\n' > "$poly2_home/clones/api22222/drift/polyscope.local.json"
 printf 'polyscope.local.json\n' > "$poly2_home/clones/api22222/drift/.git/info/exclude"
 
-# wt-no-excl: config matches but exclude entry missing -> missing_worktree_excludes
+# wt-no-excl: config matches but exclude only has a commented entry ->
+# missing_worktree_excludes
 git init -q "$poly2_home/clones/api22222/no-exclude"
 cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/no-exclude/polyscope.local.json"
-printf 'unrelated-entry\n' > "$poly2_home/clones/api22222/no-exclude/.git/info/exclude"
+printf '# polyscope.local.json\n' > "$poly2_home/clones/api22222/no-exclude/.git/info/exclude"
 
 # wt-linked: real linked worktree (.git is a file) - proves gitdir is resolved
 # before reading info/exclude. The linked gitdir lives outside the clones tree

--- a/tests/polyscope-state-audit.sh
+++ b/tests/polyscope-state-audit.sh
@@ -224,3 +224,136 @@ assert report['worktrees_missing_repositories'] == [
     }
 ]
 PY
+
+# === Scenario: worktree-level findings ===
+# Covers missing_registered_worktrees, missing_clone_local_configs,
+# worktree_config_mismatches, missing_worktree_excludes plus proves
+# that exclude resolution follows the gitdir pointer for linked worktrees.
+
+poly2_home="$workspace/poly2/.polyscope"
+poly2_workspace="$workspace/poly2/SecPal"
+mkdir -p "$poly2_home/clones/api22222" "$poly2_workspace/api"
+
+printf '{"preview":{"url":"https://api-{{folder}}.preview.secpal.dev"}}\n' > "$poly2_workspace/api/polyscope.local.json"
+
+python3 - <<'PY' "$poly2_home" "$poly2_workspace"
+import sqlite3
+import sys
+from pathlib import Path
+
+poly2_home = Path(sys.argv[1])
+poly2_workspace = Path(sys.argv[2])
+db_path = poly2_home / 'polyscope.db'
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+
+cur.executescript(
+    '''
+    CREATE TABLE repositories (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        base_branch TEXT DEFAULT 'main' NOT NULL
+    );
+
+    CREATE TABLE worktrees (
+        id TEXT PRIMARY KEY NOT NULL,
+        repo_id TEXT NOT NULL,
+        branch TEXT NOT NULL,
+        path TEXT NOT NULL,
+        status TEXT DEFAULT 'active' NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        FOREIGN KEY (repo_id) REFERENCES repositories(id)
+    );
+    '''
+)
+
+cur.execute(
+    'INSERT INTO repositories (id, name, path, base_branch) VALUES (?, ?, ?, ?)',
+    ('api22222', 'SecPal/api', str(poly2_workspace / 'api'), 'main'),
+)
+
+clone_root = poly2_home / 'clones' / 'api22222'
+entries = [
+    ('wt-disappear', 'feature/disappear', clone_root / 'disappeared'),
+    ('wt-no-cfg',    'feature/no-cfg',    clone_root / 'no-config'),
+    ('wt-drift',     'feature/drift',     clone_root / 'drift'),
+    ('wt-no-excl',   'feature/no-excl',   clone_root / 'no-exclude'),
+    ('wt-linked',    'feature/linked',    clone_root / 'linked'),
+]
+cur.executemany(
+    'INSERT INTO worktrees (id, repo_id, branch, path, status) VALUES (?, ?, ?, ?, ?)',
+    [(wid, 'api22222', branch, str(path), 'active') for wid, branch, path in entries],
+)
+
+conn.commit()
+conn.close()
+PY
+
+# wt-disappear: intentionally not created on disk -> missing_registered_worktrees
+
+# wt-no-cfg: dir + git init, no polyscope.local.json copied -> missing_clone_local_configs
+# (audit then short-circuits exclude check because worktree_config branch already failed)
+git init -q "$poly2_home/clones/api22222/no-config"
+
+# wt-drift: config differs from repo config -> worktree_config_mismatches; exclude is fine
+git init -q "$poly2_home/clones/api22222/drift"
+printf '{"preview":{"url":"https://drift.preview.secpal.dev"}}\n' > "$poly2_home/clones/api22222/drift/polyscope.local.json"
+printf 'polyscope.local.json\n' > "$poly2_home/clones/api22222/drift/.git/info/exclude"
+
+# wt-no-excl: config matches but exclude entry missing -> missing_worktree_excludes
+git init -q "$poly2_home/clones/api22222/no-exclude"
+cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/no-exclude/polyscope.local.json"
+printf 'unrelated-entry\n' > "$poly2_home/clones/api22222/no-exclude/.git/info/exclude"
+
+# wt-linked: real linked worktree (.git is a file) - proves gitdir is resolved
+# before reading info/exclude. The linked gitdir lives outside the clones tree
+# so the clone-scan loop does not see it as a clone subdir.
+main_repo="$workspace/poly2/main-repo"
+git init -q "$main_repo"
+git -C "$main_repo" -c user.email=t@example.com -c user.name=tester commit -q --allow-empty -m bootstrap
+git -C "$main_repo" worktree add --quiet -b feature/linked "$poly2_home/clones/api22222/linked"
+cp "$poly2_workspace/api/polyscope.local.json" "$poly2_home/clones/api22222/linked/polyscope.local.json"
+linked_gitdir="$(git -C "$poly2_home/clones/api22222/linked" rev-parse --absolute-git-dir)"
+mkdir -p "$linked_gitdir/info"
+printf 'polyscope.local.json\n' > "$linked_gitdir/info/exclude"
+
+set +e
+worktree_findings_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$poly2_home" --backup-retention 10 --json 2>&1)"
+worktree_findings_status=$?
+set -e
+
+if [[ $worktree_findings_status -ne 1 ]]; then
+    echo "Expected worktree-findings scenario to exit with status 1, got $worktree_findings_status" >&2
+    echo "$worktree_findings_output" >&2
+    exit 1
+fi
+
+python3 - <<'PY' "$worktree_findings_output" "$poly2_home"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+clones = Path(sys.argv[2]) / 'clones' / 'api22222'
+
+linked_path = str(clones / 'linked')
+
+assert [wt['branch'] for wt in report['missing_registered_worktrees']] == ['feature/disappear']
+assert [wt['path']   for wt in report['missing_registered_worktrees']] == [str(clones / 'disappeared')]
+
+assert sorted(report['missing_clone_local_configs']) == [str(clones / 'no-config')]
+assert sorted(report['worktree_config_mismatches'])  == [str(clones / 'drift')]
+assert sorted(report['missing_worktree_excludes'])   == sorted([
+    str(clones / 'no-config'),
+    str(clones / 'no-exclude'),
+])
+
+# Linked worktree must NOT show up in any worktree-level finding: that proves
+# audit resolves the gitdir before reading info/exclude.
+for key in ('missing_clone_local_configs', 'worktree_config_mismatches', 'missing_worktree_excludes'):
+    assert linked_path not in report[key], (key, report[key])
+
+assert report['worktrees_missing_repositories'] == []
+PY

--- a/tests/polyscope-state-audit.sh
+++ b/tests/polyscope-state-audit.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AUDIT_SCRIPT="$REPO_ROOT/scripts/audit-polyscope-state.py"
+
+if [[ ! -x "$AUDIT_SCRIPT" ]]; then
+  echo "Expected executable audit script at $AUDIT_SCRIPT" >&2
+  exit 1
+fi
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-state-audit.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+polyscope_home="$workspace/.polyscope"
+workspace_root="$workspace/SecPal"
+mkdir -p "$polyscope_home/clones" "$workspace_root/api" "$workspace_root/frontend"
+
+printf '{"preview":{"url":"https://api-{{folder}}.preview.secpal.dev"}}\n' > "$workspace_root/api/polyscope.local.json"
+printf '{"preview":{"url":"https://frontend-{{folder}}.preview.secpal.dev"}}\n' > "$workspace_root/frontend/polyscope.local.json"
+
+python3 - <<'PY' "$polyscope_home" "$workspace_root"
+import sqlite3
+import sys
+from pathlib import Path
+
+polyscope_home = Path(sys.argv[1])
+workspace_root = Path(sys.argv[2])
+db_path = polyscope_home / 'polyscope.db'
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+
+cur.executescript(
+    '''
+    CREATE TABLE repositories (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        base_branch TEXT DEFAULT 'main' NOT NULL
+    );
+
+    CREATE TABLE worktrees (
+        id TEXT PRIMARY KEY NOT NULL,
+        repo_id TEXT NOT NULL,
+        branch TEXT NOT NULL,
+        path TEXT NOT NULL,
+        status TEXT DEFAULT 'active' NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        FOREIGN KEY (repo_id) REFERENCES repositories(id)
+    );
+    '''
+)
+
+cur.executemany(
+    'INSERT INTO repositories (id, name, path, base_branch) VALUES (?, ?, ?, ?)',
+    [
+        ('api11111', 'SecPal/api', str(workspace_root / 'api'), 'main'),
+        ('frontend2', 'SecPal/frontend', str(workspace_root / 'frontend'), 'main'),
+    ],
+)
+
+tracked = polyscope_home / 'clones' / 'api11111' / 'tracked-worktree'
+tracked.mkdir(parents=True)
+cur.execute(
+    'INSERT INTO worktrees (id, repo_id, branch, path, status) VALUES (?, ?, ?, ?, ?)',
+    ('wt1', 'api11111', 'feature/tracked', str(tracked), 'active'),
+)
+
+conn.commit()
+conn.close()
+PY
+
+git init -q "$polyscope_home/clones/api11111/tracked-worktree"
+cp "$workspace_root/api/polyscope.local.json" "$polyscope_home/clones/api11111/tracked-worktree/polyscope.local.json"
+mkdir -p "$polyscope_home/clones/api11111/tracked-worktree/.git/info"
+printf 'polyscope.local.json\n' > "$polyscope_home/clones/api11111/tracked-worktree/.git/info/exclude"
+
+mkdir -p "$polyscope_home/clones/api11111/unregistered-worktree"
+git init -q "$polyscope_home/clones/api11111/unregistered-worktree"
+
+mkdir -p "$polyscope_home/clones/orphan9999/invalid-stub"
+
+printf 'backup one\n' > "$polyscope_home/polyscope.db.backup-20260601T000000Z"
+printf 'backup two\n' > "$polyscope_home/polyscope.db.backup-20260602T000000Z"
+printf 'backup three\n' > "$polyscope_home/polyscope.db.backup-20260603T000000Z"
+
+set +e
+dirty_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$polyscope_home" --backup-retention 2 --json 2>&1)"
+dirty_status=$?
+set -e
+
+if [[ $dirty_status -ne 1 ]]; then
+  echo "Expected dirty Polyscope fixture to exit with status 1, got $dirty_status" >&2
+  echo "$dirty_output" >&2
+  exit 1
+fi
+
+python3 - <<'PY' "$dirty_output" "$polyscope_home" "$workspace_root"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+polyscope_home = Path(sys.argv[2])
+workspace_root = Path(sys.argv[3])
+
+assert report['orphan_clone_roots'] == [str(polyscope_home / 'clones' / 'orphan9999')]
+assert report['invalid_clone_worktrees'] == [str(polyscope_home / 'clones' / 'orphan9999' / 'invalid-stub')]
+assert report['unregistered_git_worktrees'] == [str(polyscope_home / 'clones' / 'api11111' / 'unregistered-worktree')]
+assert report['excess_db_backups'] == [str(polyscope_home / 'polyscope.db.backup-20260601T000000Z')]
+assert report['repos_missing_clone_roots'] == [
+    {
+        'repo_id': 'frontend2',
+        'repo_name': 'SecPal/frontend',
+        'repo_path': str(workspace_root / 'frontend'),
+        'clone_root': str(polyscope_home / 'clones' / 'frontend2'),
+    }
+]
+assert report['missing_registered_worktrees'] == []
+assert report['missing_clone_local_configs'] == []
+assert report['worktree_config_mismatches'] == []
+assert report['missing_worktree_excludes'] == []
+PY
+
+mkdir -p "$polyscope_home/clones/frontend2"
+rm -rf "$polyscope_home/clones/orphan9999"
+rm -rf "$polyscope_home/clones/api11111/unregistered-worktree"
+rm -f "$polyscope_home/polyscope.db.backup-20260601T000000Z"
+
+clean_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$polyscope_home" --backup-retention 2 --json)"
+
+python3 - <<'PY' "$clean_output"
+import json
+import sys
+
+report = json.loads(sys.argv[1])
+
+for key, value in report.items():
+    if isinstance(value, list):
+        assert value == [], (key, value)
+PY
+
+printf 'backup four\n' > "$polyscope_home/polyscope.db.backup-20260604T000000Z"
+printf 'backup five\n' > "$polyscope_home/polyscope.db.backup-20260605T000000Z"
+
+set +e
+zero_retention_output="$(python3 "$AUDIT_SCRIPT" --polyscope-home "$polyscope_home" --backup-retention 0 --json 2>&1)"
+zero_retention_status=$?
+set -e
+
+if [[ $zero_retention_status -ne 1 ]]; then
+    echo "Expected zero-retention backup audit to exit with status 1, got $zero_retention_status" >&2
+    echo "$zero_retention_output" >&2
+    exit 1
+fi
+
+python3 - <<'PY' "$zero_retention_output" "$polyscope_home"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+polyscope_home = Path(sys.argv[2])
+
+assert report['excess_db_backups'] == [
+        str(polyscope_home / 'polyscope.db.backup-20260602T000000Z'),
+        str(polyscope_home / 'polyscope.db.backup-20260603T000000Z'),
+        str(polyscope_home / 'polyscope.db.backup-20260604T000000Z'),
+        str(polyscope_home / 'polyscope.db.backup-20260605T000000Z'),
+]
+PY


### PR DESCRIPTION
## Summary
- add `scripts/audit-polyscope-state.py` to audit local Polyscope clone-root, worktree, config, and backup drift
- add `tests/polyscope-state-audit.sh` covering orphan clones, invalid stubs, unregistered worktrees, missing clone roots, and zero-retention backup handling
- wire the new audit into `scripts/preflight.sh` and document it in `scripts/README.md` and `CHANGELOG.md`

## Validation
- bash tests/polyscope-state-audit.sh
- python3 scripts/audit-polyscope-state.py --json
- ./scripts/preflight.sh

## TDD / Validate-First Evidence

- Failing proof before implementation: ran `tests/polyscope-state-audit.sh` after staging the pre-feature script (`git checkout 8f8c905 -- scripts/audit-polyscope-state.py`) — test failed with `KeyError: 'worktrees_missing_repositories'` (exit 1), confirming the new missing-repo assertion was red before the fix in `ede2b58`
- Passing proof after implementation: re-ran `bash tests/polyscope-state-audit.sh` against HEAD — exit 0, all assertions (orphan clones, invalid stubs, unregistered worktrees, missing clone roots, zero-retention backups, worktrees pointing at missing repositories) pass
- Validate-first exception reference: N/A
- No executable change reason: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only local tooling and fixture-backed tests in the org defaults repo; no production runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **read-only local Polyscope state audit** so developers can detect `~/.polyscope` drift without ad hoc shell one-liners.
> 
> **`scripts/audit-polyscope-state.py`** reads `polyscope.db` and the `clones/` tree, reports eight finding types (orphan clone roots, missing clone roots, invalid stubs, unregistered Git worktrees, missing DB worktrees, worktrees with missing repos, clone-local `polyscope.local.json` hygiene, and excess `polyscope.db.backup-*` files), and exits `1` when anything is wrong. Config checks use **`git check-ignore`** (not `info/exclude` substring matching) so commented, negated, or look-alike exclude lines are not treated as effective; linked worktrees are covered via Git’s gitdir resolution. **`--polyscope-home`**, **`--backup-retention`**, and **`--json`** are supported.
> 
> **`tests/polyscope-state-audit.sh`** builds fixture SQLite + filesystem layouts and asserts dirty/clean runs, zero-retention backups, missing-repo worktrees, and worktree-level config/exclude edge cases (including real linked worktrees). **`scripts/preflight.sh`** runs that test; **`scripts/README.md`** and **`CHANGELOG.md`** document the operational entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56b191b8b25f13ba755c46b17a43fb7217095af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

