### PR TITLE
fix(workflows): gate Dependabot auto-merge on PR author, not actor

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependabot Auto-Merge Workflow (.github repository)
@@ -28,7 +28,11 @@ concurrency:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Gate on the PR author rather than the event actor so maintainer-triggered
+    # `reopened` and `ready_for_review` events on Dependabot-authored PRs do not
+    # skip auto-merge enrollment. See:
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -43,7 +43,11 @@ jobs:
   check-eligibility:
     name: Check Auto-Merge Eligibility
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Gate on the PR author rather than the event actor so maintainer-triggered
+    # `reopened` and `ready_for_review` events on Dependabot-authored PRs do not
+    # skip auto-merge enrollment. See:
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     timeout-minutes: 10
     outputs:
       should-auto-merge: ${{ steps.check.outputs.should-auto-merge }}
@@ -238,7 +242,7 @@ jobs:
     name: Skip Auto-Merge
     runs-on: ubuntu-latest
     needs: check-eligibility
-    if: needs.check-eligibility.outputs.should-auto-merge != 'true' && github.actor == 'dependabot[bot]'
+    if: needs.check-eligibility.outputs.should-auto-merge != 'true' && github.event.pull_request.user.login == 'dependabot[bot]'
     timeout-minutes: 10
     steps:
       - name: Add comment for manual review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-13 - Fix Dependabot Auto-Merge Gating To Use PR Author
+
+**Fixed:**
+
+- updated `.github/workflows/dependabot-auto-merge.yml` and `.github/workflows/reusable-dependabot-auto-merge.yml` to gate on `github.event.pull_request.user.login == 'dependabot[bot]'` instead of `github.actor`, so maintainer-triggered `reopened` and `ready_for_review` events on Dependabot-authored PRs no longer skip auto-merge enrollment
+- extended `tests/dependabot-auto-merge.sh` to assert the PR-author-based invariant across both the caller and reusable workflows and to fail loudly if either workflow regresses to the brittle `github.actor` gate
+
+---
+
 ## 2026-06-13 - Fix GuardGuide Polyscope Preview Routing
 
 **Fixed:**

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -50,8 +50,11 @@ grep -q "^    if: github.event.pull_request.user.login == 'dependabot\\[bot\\]'$
 
 # Defensive guard against regression: the brittle actor-based gate must not
 # come back, because it silently skips auto-merge enrollment whenever a
-# maintainer reopens or marks a Dependabot PR as ready for review.
-if grep -q "github.actor == 'dependabot\\[bot\\]'" "$CALLER_WORKFLOW"; then
+# maintainer reopens or marks a Dependabot PR as ready for review. The
+# pattern is anchored to real YAML `if:` lines so explanatory comments or
+# documentation that mention the old `github.actor` pattern do not trip the
+# check.
+if grep -qE "^[[:space:]]+if:.*github\.actor == 'dependabot\[bot\]'" "$CALLER_WORKFLOW"; then
   echo "Dependabot caller workflow must not gate on github.actor; use github.event.pull_request.user.login instead so maintainer-triggered events on Dependabot PRs are not skipped." >&2
   exit 1
 fi
@@ -74,7 +77,10 @@ grep -q "needs.check-eligibility.outputs.should-auto-merge != 'true' && github.e
   exit 1
 }
 
-if grep -q "github.actor == 'dependabot\\[bot\\]'" "$REUSABLE_WORKFLOW"; then
+# Same anchoring as the caller guard: only flag actual YAML `if:` lines so
+# explanatory comments or documentation mentioning the old `github.actor`
+# pattern do not trip the regression check.
+if grep -qE "^[[:space:]]+if:.*github\.actor == 'dependabot\[bot\]'" "$REUSABLE_WORKFLOW"; then
   echo "Reusable Dependabot workflow must not gate on github.actor; use github.event.pull_request.user.login instead so maintainer-triggered events on Dependabot PRs are not skipped." >&2
   exit 1
 fi

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -2,45 +2,81 @@
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 #
-# Regression tests for the .github repository's Dependabot caller workflow.
-# Verifies the caller explicitly grants the write permissions required by the
-# reusable workflow and only invokes it for Dependabot-authored PRs so regular
-# pull requests do not fail during workflow startup.
+# Regression tests for the .github repository's Dependabot caller and reusable
+# workflows. Verifies the caller explicitly grants the write permissions
+# required by the reusable workflow and that both workflows gate on the PR
+# author rather than the event actor so maintainer-triggered `reopened` and
+# `ready_for_review` events on Dependabot-authored PRs still enroll in
+# auto-merge.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
+CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
+REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
 
-if [ ! -f "$WORKFLOW" ]; then
-  echo "Expected workflow was not found: $WORKFLOW" >&2
-  exit 1
-fi
+for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
+  if [ ! -f "$workflow" ]; then
+    echo "Expected workflow was not found: $workflow" >&2
+    exit 1
+  fi
+done
 
-grep -q '^permissions:$' "$WORKFLOW" || {
+grep -q '^permissions:$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must declare explicit permissions." >&2
   exit 1
 }
 
-grep -q '^  contents: write$' "$WORKFLOW" || {
+grep -q '^  contents: write$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must grant contents: write." >&2
   exit 1
 }
 
-grep -q '^  pull-requests: write$' "$WORKFLOW" || {
+grep -q '^  pull-requests: write$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must grant pull-requests: write." >&2
   exit 1
 }
 
-grep -q "^    if: github.actor == 'dependabot\\[bot\\]'$" "$WORKFLOW" || {
-  echo "Dependabot caller workflow must skip non-Dependabot PRs before invoking the reusable workflow." >&2
+# Gate on the PR author (github.event.pull_request.user.login) rather than the
+# event actor (github.actor). The actor is the user who triggered the latest
+# event, which for `reopened` / `ready_for_review` is often a maintainer rather
+# than Dependabot itself. Gating on the author preserves the Dependabot-only
+# scope while still enrolling maintainer-triggered events on Dependabot PRs.
+grep -q "^    if: github.event.pull_request.user.login == 'dependabot\\[bot\\]'$" "$CALLER_WORKFLOW" || {
+  echo "Dependabot caller workflow must gate on github.event.pull_request.user.login so maintainer-triggered reopened / ready_for_review events on Dependabot PRs are not skipped." >&2
   exit 1
 }
 
-grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$WORKFLOW" || {
+# Defensive guard against regression: the brittle actor-based gate must not
+# come back, because it silently skips auto-merge enrollment whenever a
+# maintainer reopens or marks a Dependabot PR as ready for review.
+if grep -q "github.actor == 'dependabot\\[bot\\]'" "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must not gate on github.actor; use github.event.pull_request.user.login instead so maintainer-triggered events on Dependabot PRs are not skipped." >&2
+  exit 1
+fi
+
+grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must keep the reusable workflow uses line pinned to @v1." >&2
   exit 1
 }
+
+# The reusable workflow's check-eligibility and skip-auto-merge jobs must also
+# gate on the PR author so the same maintainer-triggered events are not
+# skipped when other repositories invoke this reusable workflow directly.
+grep -q "^    if: github.event.pull_request.user.login == 'dependabot\\[bot\\]'$" "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must gate check-eligibility on github.event.pull_request.user.login so maintainer-triggered reopened / ready_for_review events on Dependabot PRs are not skipped." >&2
+  exit 1
+}
+
+grep -q "needs.check-eligibility.outputs.should-auto-merge != 'true' && github.event.pull_request.user.login == 'dependabot\\[bot\\]'" "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must gate skip-auto-merge on github.event.pull_request.user.login so maintainer-triggered events on Dependabot PRs still receive the manual-review comment." >&2
+  exit 1
+}
+
+if grep -q "github.actor == 'dependabot\\[bot\\]'" "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must not gate on github.actor; use github.event.pull_request.user.login instead so maintainer-triggered events on Dependabot PRs are not skipped." >&2
+  exit 1
+fi
 
 echo "✓ dependabot auto-merge workflow regression checks passed"


### PR DESCRIPTION
## Description

### Failing proof first

Re-running `tests/dependabot-auto-merge.sh` against the prior `main` workflows
fails because the caller and reusable workflows gated auto-merge on
`github.actor == 'dependabot[bot]'`:

```
Dependabot caller workflow must gate on github.event.pull_request.user.login so maintainer-triggered reopened / ready_for_review events on Dependabot PRs are not skipped.
```

That reproduces the defect from #479: `github.actor` is the user who triggered
the most recent `pull_request` event, so a maintainer who clicks "Reopen" or
"Ready for review" on a Dependabot PR silently bypasses auto-merge enrollment
even though `github.event.pull_request.user.login` is still `dependabot[bot]`.

### Change in this PR

- `.github/workflows/dependabot-auto-merge.yml`: caller job now gates on
  `github.event.pull_request.user.login == 'dependabot[bot]'`, with an inline
  comment linking to GitHub's Dependabot auto-merge documentation.
- `.github/workflows/reusable-dependabot-auto-merge.yml`: both the
  `check-eligibility` job and the `skip-auto-merge` guard switch to the same
  PR-author check so downstream callers benefit from the same fix.
- `tests/dependabot-auto-merge.sh`: the existing regression test now covers
  both workflows. It asserts the PR-author-based invariant in the caller, the
  reusable `check-eligibility` job, and the reusable `skip-auto-merge` guard,
  and adds an explicit anti-regression guard that fails if either workflow
  reverts to `github.actor == 'dependabot[bot]'`.
- `CHANGELOG.md`: dated entry under today's date describing the fix.
- SPDX header on `.github/workflows/dependabot-auto-merge.yml` bumped to
  `2025-2026 SecPal` to reflect the current edit.

Permissions, the reusable workflow pin (`@v1`), `timeout-minutes`, and the
concurrency group are all unchanged, so the security and scheduling surface
stays identical — only the gating condition changes.

### Validations already run

- `bash tests/dependabot-auto-merge.sh` — passes on this branch.
- Verified the new anti-regression guard by temporarily reverting the caller
  to `github.actor == 'dependabot[bot]'`; the test failed with the expected
  message, then was restored.
- `reuse lint` — green (163 / 163 files).
- `bash scripts/preflight.sh` — green (`Preflight OK · Changed lines: 0`
  after exclusions; all governance regression suites including the Dependabot
  auto-merge one passed).

### Linked workspaces and follow-ups

- No linked workspaces.
- No unresolved checks or out-of-scope findings; nothing needs a follow-up
  issue before this PR is marked ready.

## Related Issues

Closes #479

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

The regression test in `tests/dependabot-auto-merge.sh` is the unit-level
proof. Manual verification: reverted the caller `if:` to the actor-based gate
and re-ran the test to confirm it fails, then restored.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/dependabot-auto-merge.sh`
  exits 1 against the pre-change workflows with
  `Dependabot caller workflow must gate on github.event.pull_request.user.login ...`.
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`
  exits 0 with `✓ dependabot auto-merge workflow regression checks passed`,
  and `bash scripts/preflight.sh` exits 0 with `Preflight OK`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow condition-only change with regression tests; permissions, merge policy, and concurrency are unchanged.
> 
> **Overview**
> Fixes **Dependabot auto-merge** silently skipping when a maintainer triggers `reopened` or `ready_for_review` on a Dependabot PR. Jobs previously used `github.actor`, which reflects whoever fired the event—not the PR author.
> 
> The caller workflow (`.github/workflows/dependabot-auto-merge.yml`) and reusable workflow (`.github/workflows/reusable-dependabot-auto-merge.yml`) now gate `auto-merge`, `check-eligibility`, and `skip-auto-merge` on `github.event.pull_request.user.login == 'dependabot[bot]'`, with inline comments pointing at GitHub’s Dependabot automation docs.
> 
> `tests/dependabot-auto-merge.sh` now asserts that invariant on **both** workflows and fails if any job `if:` line regresses to `github.actor`. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708e64271dd89509b0c31fafc84a6086baee9bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->