### PR TITLE
[codex] Reduce Polyscope preview watcher idle CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - replaced the generated GuardGuide Polyscope `Vite Dev` action with an autostarted full-build watcher so nginx-backed previews keep `public/build` current without depending on the Vite dev server or hot-file behavior
 - added matching full-build watchers for the generated `secpal.app` and `changelog` Polyscope configs so static preview hosts rebuild their served output after source changes instead of relying on a one-time setup build
+- excluded generated build output directories from preview watcher snapshots so GuardGuide `public/build` updates do not trigger a continuous rebuild loop
+- reduced preview watcher polling from every second to every two seconds so multiple open Polyscope workspaces spend less CPU while idle
 - extended `tests/polyscope-rollout.sh` to reject GuardGuide `npm run dev` preview actions and to prove the generated static and GuardGuide preview configs include the build watcher commands
 
 ---

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -532,7 +532,7 @@ def build_frontend_preview_build_watch_command() -> str:
                         flush=True,
                     )
 
-            time.sleep(1)
+            time.sleep(2)
         """
     ).strip()
 
@@ -576,7 +576,7 @@ def build_preview_full_rebuild_watch_command(
             seen = set()
 
             for path in watch_files:
-                if not path.exists():
+                if not path.exists() or is_ignored(path):
                     continue
 
                 try:
@@ -598,7 +598,7 @@ def build_preview_full_rebuild_watch_command(
                     continue
 
                 for path in sorted(directory.rglob("*")):
-                    if not path.is_file() or path.suffix not in watch_suffixes:
+                    if not path.is_file() or path.suffix not in watch_suffixes or is_ignored(path):
                         continue
 
                     try:
@@ -646,7 +646,7 @@ def build_preview_full_rebuild_watch_command(
                         flush=True,
                     )
 
-            time.sleep(1)
+            time.sleep(2)
         """
     ).strip()
 


### PR DESCRIPTION
## Summary

- reduce generated Polyscope preview watcher polling from every second to every two seconds
- keep the merged GuardGuide `public/build` ignore behavior intact so nginx-backed preview builds do not trigger themselves
- document the CPU-related watcher follow-up in the existing Polyscope preview watcher changelog section

## Root Cause

The initial GuardGuide Build Watch rollout could run hot when a watcher observed build output. PR #481 now contains the output-directory ignore behavior, but existing and generated preview watchers still poll every second, which compounds idle CPU when several Polyscope workspaces are open.

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- host process check after stopping the runaway GuardGuide watcher showed no remaining `vite build` loop; remaining idle load was from Codex sessions and older already-running frontend watchers

## TDD / Validate-First Evidence

- Failing proof before implementation: host `ps` showed `node .../GuardGuide/.../node_modules/.bin/vite build` consuming about 130% CPU from the GuardGuide preview watcher process group.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh && ./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local Polyscope preview watcher scripts and changelog text; no production auth, data, or API behavior.
> 
> **Overview**
> Generated Polyscope **preview build watchers** now poll every **2 seconds** instead of every second, cutting idle CPU when several workspaces keep watchers open.
> 
> The shared `build_preview_full_rebuild_watch_command` generator also **skips ignored paths earlier** when building file snapshots (including explicit watch files under ignored dirs like GuardGuide `public/build`), so nginx-served build output is less likely to retrigger endless rebuilds. **CHANGELOG** records the polling change and the build-output exclusion in the existing Polyscope preview watcher section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d15b1920a09f73bb108a40d8049f79d2794bcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->