### PR TITLE
[codex] Bootstrap guardguide.de rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - rewrote the `CREATED`, `UPDATED`, and `SKIPPED` counter increments in `scripts/sync-labels.sh` from `((COUNTER++))` to `COUNTER=$((COUNTER + 1))` so label sync no longer exits early under `set -e` when a counter is incremented from `0` (post-increment of `0` returns `0`, which `set -e` treats as a failed command)
+- taught the generic static preview watcher in `scripts/polyscope-rollout.py` to ignore explicit generated files, and configured the `secpal.app` and `guardguide.de` Build Watch commands to skip their generated `public/og-*.svg` and `public/og-*.png` assets so `npm run build` no longer retriggers the watcher indefinitely by rewriting files inside the watched `public/` tree
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-14 - Bootstrap guardguide.de Rollout
+
+**Added:**
+
+- registered `guardguide.de` in `scripts/polyscope-rollout.py` as a static Astro site with its own copilot instructions, preview prefix `guardguide-de`, autostarted Build Watch, and an All Checks command so Polyscope workspaces for the marketing site come up with the same governance and preview tooling as the other managed repositories
+- extended generated nginx preview routing in `scripts/polyscope-rollout.py` to recognize the `guardguide-de` host prefix and serve the built Astro `dist/` output, with the generic preview precedence updated so `changelog > guardguide.de > secpal.app > frontend > api` still resolves deterministically
+- added `guardguide.de` to the managed required-checks baseline in `scripts/sync-required-checks.sh` (Astro check/build plus Node tests), the hook installation coverage in `setup-hooks.sh`, the epic audit repo list in `scripts/audit-closed-epics.sh`, and the Polyscope installer watch list in `scripts/install-polyscope-rollout.sh`
+- extended `tests/polyscope-rollout.sh`, `tests/sync-required-checks.sh`, and `tests/setup-hooks.sh` to prove the generated rollout output, branch-protection payload, and hook installation coverage all include the new repository
+
+**Fixed:**
+
+- rewrote the `CREATED`, `UPDATED`, and `SKIPPED` counter increments in `scripts/sync-labels.sh` from `((COUNTER++))` to `COUNTER=$((COUNTER + 1))` so label sync no longer exits early under `set -e` when a counter is incremented from `0` (post-increment of `0` returns `0`, which `set -e` treats as a failed command)
+
+---
+
 ## 2026-06-13 - Fix Polyscope Preview Build Watchers
 
 **Fixed:**

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -28,7 +28,7 @@ Options:
   --repo REPO  Repository name to inspect. Repeat to scope the audit.
 
 If no repositories are provided, the script audits the active SecPal workspace
-repositories: api, changelog, frontend, contracts, android, secpal.app, .github.
+repositories: api, changelog, frontend, contracts, android, secpal.app, guardguide.de, .github.
 EOF
       exit 0
       ;;
@@ -40,7 +40,7 @@ EOF
 done
 
 if [ ${#repos[@]} -eq 0 ]; then
-  repos=(api changelog frontend contracts android secpal.app .github)
+  repos=(api changelog frontend contracts android secpal.app guardguide.de .github)
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -307,6 +307,8 @@ PathChanged=$WORKSPACE_ROOT/android/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/android/.github/instructions
 PathChanged=$WORKSPACE_ROOT/secpal.app/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/secpal.app/.github/instructions
+PathChanged=$WORKSPACE_ROOT/guardguide.de/.github/copilot-instructions.md
+PathChanged=$WORKSPACE_ROOT/guardguide.de/.github/instructions
 PathChanged=$WORKSPACE_ROOT/changelog/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/changelog/.github/instructions
 PathChanged=$WORKSPACE_ROOT/.github/.github/copilot-instructions.md
@@ -352,6 +354,7 @@ PathChanged=$WORKSPACE_ROOT/frontend/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/android/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/secpal.app/polyscope.local.json
+PathChanged=$WORKSPACE_ROOT/guardguide.de/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/changelog/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/.github/polyscope.local.json
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2087,7 +2087,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -2099,7 +2099,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
-            server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -544,12 +544,14 @@ def build_preview_full_rebuild_watch_command(
     label: str,
     watch_directories: list[str],
     ignored_directories: list[str] | None = None,
+    ignored_paths: list[str] | None = None,
     watch_files: list[str],
     watch_suffixes: list[str],
     build_args: list[str] | None = None,
 ) -> str:
     command = build_args or ["npm", "run", "build"]
     ignored_directories = ignored_directories or []
+    ignored_paths = ignored_paths or []
     script = textwrap.dedent(
         f"""
         import hashlib
@@ -559,7 +561,7 @@ def build_preview_full_rebuild_watch_command(
         from pathlib import Path
 
         watch_directories = [Path(value) for value in {watch_directories!r}]
-        ignored_directories = [Path(value).resolve() for value in {ignored_directories!r}]
+        ignored_entries = [Path(value).resolve() for value in {(ignored_directories + ignored_paths)!r}]
         watch_files = [Path(value) for value in {watch_files!r}]
         watch_suffixes = set({watch_suffixes!r})
         build_args = {command!r}
@@ -570,7 +572,7 @@ def build_preview_full_rebuild_watch_command(
             except OSError:
                 return True
 
-            return any(ignored == resolved or ignored in resolved.parents for ignored in ignored_directories)
+            return any(ignored == resolved or ignored in resolved.parents for ignored in ignored_entries)
 
         def iter_watch_paths():
             seen = set()
@@ -696,10 +698,16 @@ def build_guardguide_preview_build_watch_command() -> str:
     )
 
 
-def build_static_preview_build_watch_command(site_name: str, watch_directories: list[str]) -> str:
+def build_static_preview_build_watch_command(
+    site_name: str,
+    watch_directories: list[str],
+    *,
+    ignored_paths: list[str] | None = None,
+) -> str:
     return build_preview_full_rebuild_watch_command(
         label=f"Watching {site_name} preview sources for changes...",
         watch_directories=watch_directories,
+        ignored_paths=ignored_paths,
         watch_files=[
             "astro.config.mjs",
             "eslint.config.js",
@@ -1148,6 +1156,12 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                         "command": build_static_preview_build_watch_command(
                             "secpal.app",
                             ["public", "scripts", "secpal.app", "src"],
+                            ignored_paths=[
+                                "public/og-default.svg",
+                                "public/og-default.png",
+                                "public/og-de.svg",
+                                "public/og-de.png",
+                            ],
                         ),
                         "autostart": True,
                         "runMode": "replace",
@@ -1192,6 +1206,12 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                         "command": build_static_preview_build_watch_command(
                             "guardguide.de",
                             ["public", "scripts", "src"],
+                            ignored_paths=[
+                                "public/og-default.svg",
+                                "public/og-default.png",
+                                "public/og-de.svg",
+                                "public/og-de.png",
+                            ],
                         ),
                         "autostart": True,
                         "runMode": "replace",

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -838,6 +838,7 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
         "changelog": "npm run check && npm run lint && npm run csp:check && npm run build",
+        "guardguide.de": "npm run check && npm run lint && npm run test && npm run build",
         ".github": "./scripts/preflight.sh",
     }
     return commands.get(repo_name)
@@ -1147,6 +1148,50 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                         "command": build_static_preview_build_watch_command(
                             "secpal.app",
                             ["public", "scripts", "secpal.app", "src"],
+                        ),
+                        "autostart": True,
+                        "runMode": "replace",
+                    },
+                    {"label": "Astro Check", "command": "npm run check", "runMode": "preserve"},
+                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
+                    {"label": "Tests", "command": "npm run test", "runMode": "preserve"},
+                ],
+            },
+            "tasks": [
+                {
+                    "label": "Review site semantics",
+                    "prompt": "Review the marketing-site change for static-build regressions, accessibility drift, semantic HTML changes, and missing test or Astro-check coverage. Keep the work scoped to the touched page or component.",
+                },
+                {
+                    "label": "Triage failing Astro",
+                    "prompt": "Reproduce the failing static-site behavior or Astro check, add or update the smallest relevant validation first, then implement the minimal fix and rerun the touched commands. Keep the change scoped to one issue.",
+                },
+            ],
+        },
+    },
+    "guardguide.de": {
+        "display_name": "SecPal/guardguide.de",
+        "base_branch": "main",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "focus_instruction_paths": [
+            ".github/instructions/org-shared.instructions.md",
+            ".github/instructions/astro-static.instructions.md",
+        ],
+        "preview_prefix": "guardguide-de",
+        "review_focus": "Astro static rendering, minimal client-side JavaScript, semantic HTML, accessible landmarks, and strict TypeScript on the public site.",
+        "link_names": [],
+        "local_config": {
+            "copyGitignored": True,
+            "runMode": "replace",
+            "preview": {"url": build_preview_url_template("guardguide-de")},
+            "scripts": {
+                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "run": [
+                    {
+                        "label": "Build Watch",
+                        "command": build_static_preview_build_watch_command(
+                            "guardguide.de",
+                            ["public", "scripts", "src"],
                         ),
                         "autostart": True,
                         "runMode": "replace",
@@ -2031,8 +2076,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
     frontend_id = repo_state["frontend"]["id"]
     guardguide_id = repo_state["GuardGuide"]["id"]
     secpal_app_id = repo_state["secpal.app"]["id"]
+    guardguide_de_id = repo_state["guardguide.de"]["id"]
     changelog_id = repo_state["changelog"]["id"]
-    # NOTE: workspace names starting with api-, frontend-, guardguide-, secpal-app-, or changelog- are
+    # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-, secpal-app-, or changelog- are
     # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
     # Generic workspaces must not use those prefixes; the regex will treat them as legacy
     # hosts and route them to the wrong backend.
@@ -2041,7 +2087,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -2053,7 +2099,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
-            server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -2074,6 +2120,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $guardguide_public $guardguide_root/public;
             set $secpal_app_root /home/secpal/.polyscope/clones/{secpal_app_id}/$workspace;
             set $secpal_app_dist $secpal_app_root/dist;
+            set $guardguide_de_root /home/secpal/.polyscope/clones/{guardguide_de_id}/$workspace;
+            set $guardguide_de_dist $guardguide_de_root/dist;
             set $changelog_root /home/secpal/.polyscope/clones/{changelog_id}/$workspace;
             set $changelog_out $changelog_root/out;
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
@@ -2095,6 +2143,11 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 set $route_mode static;
             }}
 
+            if (-f $guardguide_de_dist/index.html) {{
+                set $preview_docroot $guardguide_de_dist;
+                set $route_mode static;
+            }}
+
             if (-f $changelog_out/index.html) {{
                 set $preview_docroot $changelog_out;
                 set $route_mode static;
@@ -2107,6 +2160,11 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
 
             if ($repo = secpal-app) {{
                 set $preview_docroot $secpal_app_dist;
+                set $route_mode static;
+            }}
+
+            if ($repo = guardguide-de) {{
+                set $preview_docroot $guardguide_de_dist;
                 set $route_mode static;
             }}
 

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -103,12 +103,12 @@ for label_spec in "${LABELS[@]}"; do
 
     if [ "$CURRENT_COLOR" = "$color" ] && [ "$CURRENT_DESC" = "$description" ]; then
       # Already up to date
-      ((SKIPPED++))
+      SKIPPED=$((SKIPPED + 1))
     else
       # Update needed
       if gh label edit "$name" --repo "$ORG/$REPO" --color "$color" --description "$description" &> /dev/null; then
         echo "🔄 Updated: $name"
-        ((UPDATED++))
+        UPDATED=$((UPDATED + 1))
       else
         echo "❌ Failed to update: $name"
       fi
@@ -117,7 +117,7 @@ for label_spec in "${LABELS[@]}"; do
     # Label doesn't exist, create it
     if gh label create "$name" --repo "$ORG/$REPO" --color "$color" --description "$description" &> /dev/null; then
       echo "✨ Created: $name"
-      ((CREATED++))
+      CREATED=$((CREATED + 1))
     else
       echo "❌ Failed to create: $name"
     fi

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -77,6 +77,20 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Analyze Code (javascript-typescript)",
     "Copilot Instructions / Validate Copilot Instructions"
   ],
+  "guardguide.de": [
+    "Check REUSE Compliance / Check REUSE Compliance",
+    "Check License Compatibility / Check License Compatibility",
+    "Formatting Check / Check Code Formatting",
+    "Markdown Lint / Lint Markdown Files",
+    "ESLint / Run Linter",
+    "Astro TypeScript Check / Build Project",
+    "Astro Build / Build Project",
+    "Check PR Size / Check PR Size",
+    "check-conflicts / Detect Git Conflict Markers",
+    "Analyze Code (javascript-typescript)",
+    "Copilot Instructions / Validate Copilot Instructions",
+    "Node Tests / Run Tests"
+  ],
   "contracts": [
     "REUSE Compliance / Check REUSE Compliance",
     "Prettier Formatting / Check Code Formatting",

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$WORKSPACE_ROOT"
 
-REPOS=("api" "frontend" "contracts" "android" "secpal.app" "changelog" ".github")
+REPOS=("api" "frontend" "contracts" "android" "secpal.app" "guardguide.de" "changelog" ".github")
 SUCCESS_COUNT=0
 FAILED_REPOS=()
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -118,6 +118,12 @@ package_scripts = {
         "lint": "eslint .",
         "test": "node --test tests/**/*.mjs",
     },
+    "guardguide.de": {
+        "build": "astro build",
+        "check": "astro check",
+        "lint": "eslint .",
+        "test": "node --test tests/**/*.mjs",
+    },
     "changelog": {
         "build": "next build",
         "check": "tsc --noEmit",
@@ -478,6 +484,42 @@ applyTo: 'src/**/*.astro'
 - Run formatting, lint, typecheck, and build.
 "
 
+create_repo "guardguide.de" "$common_header
+
+# guardguide.de Instructions
+
+## Always-On Rules
+
+- Run git status --short --branch before any write action.
+- Validate-first.
+
+## Issue And PR Discipline
+
+- The first PR state must be draft.
+
+## Required Validation
+
+- the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
+- CHANGELOG.md was updated for real changes
+- no bypass was used
+
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
+- Green CI alone is not enough for AI-generated changes.
+" "astro-static.instructions.md" "---
+name: Astro Static Site Rules
+applyTo: 'src/**/*.astro'
+---
+
+# Astro Static Site Rules
+
+- Prefer semantic HTML, accessible landmarks, and keyboard-safe interactions.
+- Keep client-side JavaScript minimal.
+- Run formatting, lint, typecheck, and build.
+"
+
 create_repo "changelog" "$common_header
 
 # Changelog Instructions
@@ -580,6 +622,7 @@ repo_state = {
     'contracts': {'id': 'co123456', 'name': 'SecPal/contracts', 'path': str(workspace_root / 'contracts')},
     'android': {'id': 'an123456', 'name': 'SecPal/android', 'path': str(workspace_root / 'android')},
     'secpal.app': {'id': 'sa123456', 'name': 'SecPal/secpal.app', 'path': str(workspace_root / 'secpal.app')},
+    'guardguide.de': {'id': 'gd123456', 'name': 'SecPal/guardguide.de', 'path': str(workspace_root / 'guardguide.de')},
     'changelog': {'id': 'ch123456', 'name': 'SecPal/changelog', 'path': str(workspace_root / 'changelog')},
     'GuardGuide': {'id': 'gg123456', 'name': 'SecPal/GuardGuide', 'path': str(workspace_root / 'GuardGuide')},
     '.github': {'id': 'gh123456', 'name': 'SecPal/.github', 'path': str(workspace_root / '.github')},
@@ -633,6 +676,7 @@ grep -q 'react-typescript.instructions.md before taking action' "$workspace_root
 grep -q 'https://frontend-{{folder}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://guardguide-{{folder}}.preview.secpal.dev' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
+grep -q 'https://guardguide-de-{{folder}}.preview.secpal.dev' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
 grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
@@ -679,6 +723,11 @@ grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/secpal.app/polys
 grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"label": "Build Watch"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF 'Watching secpal.app preview sources for changes...' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF '"command": "npm run check && npm run lint && npm run test && npm run build"' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF '"label": "Fix current findings"' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF '"label": "Build Watch"' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF 'Watching guardguide.de preview sources for changes...' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
@@ -848,7 +897,7 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
+grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
 grep -qF "if (\$repo = guardguide) {" "$nginx_output"
@@ -881,15 +930,17 @@ fi
 api_if_line="$(grep -nF "if (-f \$api_public/index.php) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 frontend_if_line="$(grep -nF "if (-f \$frontend_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 secpal_app_if_line="$(grep -nF "if (-f \$secpal_app_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
+guardguide_de_if_line="$(grep -nF "if (-f \$guardguide_de_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 changelog_if_line="$(grep -nF "if (-f \$changelog_out/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 
 test -n "$api_if_line"
 test -n "$frontend_if_line"
 test -n "$secpal_app_if_line"
+test -n "$guardguide_de_if_line"
 test -n "$changelog_if_line"
 
-if (( api_if_line >= frontend_if_line || frontend_if_line >= secpal_app_if_line || secpal_app_if_line >= changelog_if_line )); then
-    echo "generic preview precedence must prefer changelog > secpal.app > frontend > api" >&2
+if (( api_if_line >= frontend_if_line || frontend_if_line >= secpal_app_if_line || secpal_app_if_line >= guardguide_de_if_line || guardguide_de_if_line >= changelog_if_line )); then
+    echo "generic preview precedence must prefer changelog > guardguide.de > secpal.app > frontend > api" >&2
     exit 1
 fi
 
@@ -900,6 +951,7 @@ fi
     "$workspace_root/android/polyscope.local.json" \
     "$workspace_root/GuardGuide/polyscope.local.json" \
     "$workspace_root/secpal.app/polyscope.local.json" \
+    "$workspace_root/guardguide.de/polyscope.local.json" \
     "$workspace_root/changelog/polyscope.local.json" \
     "$workspace_root/.github/polyscope.local.json" \
     >/dev/null
@@ -942,6 +994,7 @@ assert summary['repositories']['api']['preview_prefix'] == 'api'
 assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
 assert summary['repositories']['GuardGuide']['preview_prefix'] == 'guardguide'
 assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
+assert summary['repositories']['guardguide.de']['preview_prefix'] == 'guardguide-de'
 assert summary['repositories']['changelog']['preview_prefix'] == 'changelog'
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -897,7 +897,7 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide|guardguide-de|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
+grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
 grep -qF "if (\$repo = guardguide) {" "$nginx_output"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -723,11 +723,15 @@ grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/secpal.app/polys
 grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"label": "Build Watch"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF 'Watching secpal.app preview sources for changes...' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF 'public/og-default.svg' "$workspace_root/secpal.app/polyscope.local.json"
+grep -qF 'public/og-de.png' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"command": "npm run check && npm run lint && npm run test && npm run build"' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF '"label": "Build Watch"' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF 'Watching guardguide.de preview sources for changes...' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF 'public/og-default.svg' "$workspace_root/guardguide.de/polyscope.local.json"
+grep -qF 'public/og-de.png' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
@@ -806,6 +810,75 @@ PY
 
 python3 -B - <<'PY' "$PYTHON_SCRIPT"
 import importlib.util
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+script_path = Path(sys.argv[1]).resolve()
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+workspace = Path(tempfile.mkdtemp(prefix="polyscope-build-watch-generated-files-"))
+
+try:
+    (workspace / "public").mkdir()
+    (workspace / "src").mkdir()
+    (workspace / "src" / "input.ts").write_text("seed\n")
+    (workspace / "package.json").write_text("{}\n")
+
+    command = module.build_preview_full_rebuild_watch_command(
+        label="watching",
+        watch_directories=["public", "src"],
+        ignored_paths=["public/generated.svg", "public/generated.png"],
+        watch_files=["package.json"],
+        watch_suffixes=[".json", ".png", ".svg", ".ts"],
+        build_args=[
+            "python3",
+            "-c",
+            (
+                "from pathlib import Path; "
+                "counter = Path('build-count.txt'); "
+                "count = int(counter.read_text()) + 1 if counter.exists() else 1; "
+                "counter.write_text(str(count)); "
+                "Path('public/generated.svg').write_text(f'svg-{count}'); "
+                "Path('public/generated.png').write_text(f'png-{count}')"
+            ),
+        ],
+    )
+
+    process = subprocess.Popen(
+        shlex.split(command),
+        cwd=workspace,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    time.sleep(3.5)
+    process.terminate()
+
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=2)
+
+    build_count = int((workspace / "build-count.txt").read_text())
+    if build_count != 1:
+        raise SystemExit(
+            f"build watcher must ignore generated files inside watched source trees; observed {build_count} builds"
+        )
+finally:
+    shutil.rmtree(workspace)
+PY
+
+python3 -B - <<'PY' "$PYTHON_SCRIPT"
+import importlib.util
 import sys
 from pathlib import Path
 
@@ -815,13 +888,22 @@ module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(module)
 
-command = module.build_static_preview_build_watch_command("changelog", ["public", "src"])
+command = module.build_static_preview_build_watch_command(
+    "changelog",
+    ["public", "src"],
+    ignored_paths=["public/generated.svg"],
+)
 
 for required_suffix in (".avif", ".gif", ".ico", ".jpeg", ".jpg", ".woff2"):
     if required_suffix not in command:
         raise SystemExit(
             f"static preview build watcher must track {required_suffix} assets so preview output stays current"
         )
+
+if "public/generated.svg" not in command:
+    raise SystemExit(
+        "static preview build watcher must support explicitly ignored generated files"
+    )
 PY
 
 python3 -B - <<'PY' "$PYTHON_SCRIPT"

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -38,7 +38,7 @@ STUB
   chmod +x "$workspace/$repo/scripts/setup-pre-push.sh" "$workspace/$repo/scripts/setup-pre-commit.sh"
 }
 
-repos=(api frontend contracts android secpal.app changelog .github)
+repos=(api frontend contracts android secpal.app guardguide.de changelog .github)
 expected_hook_count=$(( ${#repos[@]} * 2 ))
 
 for repo in "${repos[@]}"; do

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -44,6 +44,7 @@ if grep -Fq 'XXXXXX.json' "$SYNC_SCRIPT"; then
   exit 1
 fi
 
+# shellcheck disable=SC2016
 if ! grep -Fq 'sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX' "$SYNC_SCRIPT"; then
   echo "Sync script must use a portable mktemp template whose X placeholder is at the end." >&2
   exit 1
@@ -71,6 +72,10 @@ changelog_payload="$(bash "$SYNC_SCRIPT" --repo changelog --print-payload)"
 assert_payload_has_context "$changelog_payload" "Analyze Code (javascript-typescript)"
 assert_payload_has_context "$changelog_payload" "Next.js Build / Build Project"
 
+guardguide_de_payload="$(bash "$SYNC_SCRIPT" --repo guardguide.de --print-payload)"
+assert_payload_has_context "$guardguide_de_payload" "Node Tests / Run Tests"
+assert_payload_has_context "$guardguide_de_payload" "Astro Build / Build Project"
+
 frontend_payload="$(bash "$SYNC_SCRIPT" --repo frontend --print-payload)"
 assert_payload_has_context "$frontend_payload" "Analyze with CodeQL (javascript-typescript)"
 assert_payload_has_context "$frontend_payload" "Vitest Tests"
@@ -83,7 +88,7 @@ assert_payload_has_context "$contracts_payload" "Copilot Instructions / Validate
 # Guardrail workflow names its job exactly 'CodeQL'). For every other repo the
 # CodeQL workflow names a different job (e.g. 'Analyze with CodeQL' / 'Analyze
 # Code'), so requiring bare 'CodeQL' there would block PRs forever.
-for non_github_payload in "$api_payload" "$android_payload" "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$frontend_payload" "$contracts_payload"; do
+for non_github_payload in "$api_payload" "$android_payload" "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$guardguide_de_payload" "$frontend_payload" "$contracts_payload"; do
   if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$non_github_payload"; then
     echo "Only the '.github' manifest entry may require the bare 'CodeQL' context; other repos must require their actual CodeQL job context (e.g. 'Analyze with CodeQL (<language>)' or 'Analyze Code (<language>)')." >&2
     echo "$non_github_payload" >&2


### PR DESCRIPTION
## Summary
- register `guardguide.de` in the Polyscope rollout and preview nginx generation as a static Astro site
- add the new repository to the managed required-checks baseline, hook installation coverage, and issue-audit repository lists
- fix `sync-labels.sh` so label sync no longer exits early under `set -e` when counters increment from zero

## Validation
- `bash tests/sync-required-checks.sh`
- `bash tests/polyscope-rollout.sh`

## TDD / Validate-First Evidence

- Failing proof before implementation: reverting only the production diff (`scripts/polyscope-rollout.py`, `scripts/sync-required-checks.sh`, `setup-hooks.sh`, `scripts/install-polyscope-rollout.sh`, `scripts/audit-closed-epics.sh`) while keeping the new test assertions makes `bash tests/polyscope-rollout.sh` exit `2` with `grep: /tmp/polyscope-rollout.*/SecPal/guardguide.de/polyscope.local.json: No such file or directory`, and `bash tests/sync-required-checks.sh` exits `2` because the baseline JSON omits `guardguide.de`. Separately, the `sync-labels.sh` bug is reproducible with `bash -c 'set -e; X=0; ((X++)); echo done'` exiting `1` without printing `done` because post-increment of `0` returns `0` and trips `set -e`.
- Passing proof after implementation: with the full PR applied, `bash tests/polyscope-rollout.sh`, `bash tests/sync-required-checks.sh`, and `bash tests/pull-request-evidence.sh` all exit `0`; the `sync-labels.sh` rewrite to `X=$((X + 1))` runs cleanly under `set -e` (`bash -c 'set -e; X=0; X=$((X + 1)); echo done'` prints `done` and exits `0`).
- Validate-first exception reference: N/A
- No executable change reason: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated preview nginx precedence and Polyscope provisioning for a new host prefix; mistakes could misroute previews, but scope is additive org automation with regression tests rather than application auth or data paths.
> 
> **Overview**
> **Adds `guardguide.de` to the managed SecPal workspace** with the same governance hooks as other repos: Polyscope rollout (static Astro site, `guardguide-de` preview prefix, Build Watch, All Checks), nginx preview routing to `dist/`, required branch checks (Astro + Node tests), `setup-hooks.sh`, epic audit defaults, and Polyscope installer path watches.
> 
> **Fixes two operational bugs:** `sync-labels.sh` counter bumps no longer abort under `set -e` when incrementing from zero, and static preview Build Watch commands can **ignore explicit generated paths** (notably `public/og-*.svg/png` on `secpal.app` and `guardguide.de`) so builds do not retrigger in a loop.
> 
> Tests in `polyscope-rollout`, `sync-required-checks`, and `setup-hooks` assert the new repo and watcher behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b785856e619a675a329e7e30bcaff13914ff126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

