### PR TITLE
fix(setup-hooks): soft-warn missing managed repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-14 - Soft-Warn Missing Repos In `setup-hooks.sh`
+
+**Changed:**
+
+- reworked `setup-hooks.sh` so a missing managed repository directory is reported as a warning (`Skipped (missing directory)` summary line) instead of being added to `FAILED_REPOS`, and the script now exits `0` when every present repo's pre-push, pre-commit, and commit-msg hooks installed cleanly — only real installation step failures still exit `1`. The summary now points users at `.github/scripts/install-polyscope-rollout.sh`, matching the actual workspace layout, and still treats non-directory managed paths as hard failures so corrupted workspaces do not slip through as success.
+- documented the new soft-warn contract and the rollout sync command in `scripts/README.md` so the `setup-hooks.sh` and `install-polyscope-rollout.sh` flows are discoverable side-by-side.
+
+**Added:**
+
+- expanded `tests/setup-hooks.sh` from a single happy-path assertion into four regression scenarios — happy path, warning path (missing managed repo still exits `0` with the correct rollout hint), corrupt-path failure path (managed repo path exists but is not a directory), and failure path (broken `setup-pre-push.sh` still exits `1`) — and wired the test into `scripts/preflight.sh` so the soft-warn contract from SecPal/.github#485 cannot regress unnoticed.
+
+---
+
 ## 2026-06-14 - Bootstrap guardguide.de Rollout
 
 **Added:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -238,6 +238,46 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 - `1`: One or more findings detected
 - `2`: Usage error or missing dependency/state
 
+### `install-polyscope-rollout.sh`
+
+Installs the SecPal Polyscope rollout systemd units that keep workspace clones,
+prompts, and preview config in sync. Run this from the workspace root when
+`setup-hooks.sh` reports a managed repo as **skipped (missing directory)** so
+the rollout-managed workspace can sync back to the expected repository set.
+
+**Usage:**
+
+```bash
+bash .github/scripts/install-polyscope-rollout.sh
+```
+
+After installation, the user-level `polyscope-rollout-sync.service` and
+`polyscope-worktree-provision.service` units take care of provisioning new
+managed repositories automatically when the canonical repo list changes.
+
+### `setup-hooks.sh`
+
+Installs pre-push, pre-commit, and commit-msg hooks across every managed
+SecPal repo discovered next to the `.github` checkout.
+
+**Behavior:**
+
+- Repos that are **missing on disk** are surfaced as a soft warning (separate
+  summary line) and the script still exits `0` when every other repo's hooks
+  installed cleanly. Run `.github/scripts/install-polyscope-rollout.sh` (or
+  sync via Polyscope) to recover the rollout-managed workspace state.
+- Managed repo paths that exist but are **not directories** are treated as real
+  failures because they indicate a corrupted workspace layout, not a repo that
+  simply has not been synced yet.
+- Real failures in `setup-pre-push.sh`, `setup-pre-commit.sh`, or the
+  commit-msg symlink still mark the repo as failed and exit `1`.
+
+**Usage:**
+
+```bash
+bash .github/setup-hooks.sh
+```
+
 ## Adding New Scripts
 
 When adding new scripts:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -242,6 +242,15 @@ if [ -f tests/dependabot-auto-merge.sh ]; then
   }
 fi
 
+if [ -f tests/setup-hooks.sh ]; then
+  bash tests/setup-hooks.sh || {
+    echo "" >&2
+    echo "❌ setup-hooks.sh regression test failed!" >&2
+    echo "Restore the soft-warn-on-missing-repo contract in setup-hooks.sh (see SecPal/.github#485) before continuing." >&2
+    exit 1
+  }
+fi
+
 # 1) PHP / Laravel
 if [ -f composer.json ]; then
   if ! command -v composer >/dev/null 2>&1; then

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -13,8 +13,10 @@ WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$WORKSPACE_ROOT"
 
 REPOS=("api" "frontend" "contracts" "android" "secpal.app" "guardguide.de" "changelog" ".github")
+ROLLOUT_HINT="Run .github/scripts/install-polyscope-rollout.sh (or sync via Polyscope) to provision missing SecPal repositories."
 SUCCESS_COUNT=0
 FAILED_REPOS=()
+MISSING_REPOS=()
 
 # Check if pre-commit is installed
 if ! command -v pre-commit &>/dev/null; then
@@ -26,10 +28,19 @@ if ! command -v pre-commit &>/dev/null; then
 fi
 
 for repo in "${REPOS[@]}"; do
+	if [ ! -e "$repo" ]; then
+		# Missing managed repos are a soft warning, not a failure: workspaces that
+		# have not yet synced the latest REPOS list (or are otherwise incomplete)
+		# should still install hooks for whatever is present and exit 0.
+		echo "  ⚠ Directory not found: $repo (skipping)"
+		MISSING_REPOS+=("$repo")
+		continue
+	fi
+
 	if [ ! -d "$repo" ]; then
-                echo "  ✗ Directory not found: $repo"
-                FAILED_REPOS+=("$repo (directory not found)")
-                continue
+		echo "  ✗ Path is not a directory: $repo"
+		FAILED_REPOS+=("$repo (path is not a directory)")
+		continue
 	fi
 
 	echo "────────────────────────────────────────"
@@ -108,25 +119,34 @@ else
 	echo "  • Optional direct install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
 fi
 
+if [ ${#MISSING_REPOS[@]} -gt 0 ]; then
+	echo "Skipped (missing directory): ${#MISSING_REPOS[@]} repositories"
+	for missing in "${MISSING_REPOS[@]}"; do
+		echo "  ⚠ $missing"
+	done
+	echo ""
+	echo "💡 $ROLLOUT_HINT"
+fi
+
 if [ ${#FAILED_REPOS[@]} -gt 0 ]; then
 	echo "Failed: ${#FAILED_REPOS[@]} repositories"
 	for failed in "${FAILED_REPOS[@]}"; do
 		echo "  ✗ $failed"
 	done
 	exit 1
-else
-	echo ""
-	echo "✅ All Git hooks have been successfully installed!"
-	echo ""
-	echo "📝 What's installed:"
-	echo "  • Pre-commit hooks: Formatting, linting, REUSE compliance"
-	echo "  • Pre-push hooks: Comprehensive quality checks (via scripts/preflight.sh)"
-	echo "  • Commit-msg hooks: Strip AI agent attribution trailers (Cursor, Copilot)"
-	echo ""
-	echo "💡 Usage:"
-	echo "  • Hooks run automatically on commit/push"
-	echo "  • Test manually: cd <repo> && ./scripts/preflight.sh"
-	echo "  • Manual workflow lint: pre-commit run actionlint --all-files"
-	echo "  • Bypass (emergencies only): git push --no-verify"
-	echo ""
 fi
+
+echo ""
+echo "✅ All Git hooks have been successfully installed!"
+echo ""
+echo "📝 What's installed:"
+echo "  • Pre-commit hooks: Formatting, linting, REUSE compliance"
+echo "  • Pre-push hooks: Comprehensive quality checks (via scripts/preflight.sh)"
+echo "  • Commit-msg hooks: Strip AI agent attribution trailers (Cursor, Copilot)"
+echo ""
+echo "💡 Usage:"
+echo "  • Hooks run automatically on commit/push"
+echo "  • Test manually: cd <repo> && ./scripts/preflight.sh"
+echo "  • Manual workflow lint: pre-commit run actionlint --all-files"
+echo "  • Bypass (emergencies only): git push --no-verify"
+echo ""

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -7,23 +7,49 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-workspace="$(mktemp -d "${TMPDIR:-/tmp}/setup-hooks.XXXXXX")"
-trap 'rm -rf "$workspace"' EXIT
+ALL_REPOS=(api frontend contracts android secpal.app guardguide.de changelog .github)
 
-mkdir -p "$workspace/.github"
-cp "$REPO_ROOT/setup-hooks.sh" "$workspace/.github/setup-hooks.sh"
+# Single portable mktemp invocation (matches the regression guard in
+# tests/mktemp-portability.sh); each scenario gets its own subdirectory below.
+sandbox="$(mktemp -d "${TMPDIR:-/tmp}/setup-hooks.XXXXXX")"
+trap 'rm -rf "$sandbox"' EXIT
 
-mkdir -p "$workspace/bin"
-cat >"$workspace/bin/pre-commit" <<'STUB'
+happy_workspace="$sandbox/happy"
+warning_workspace="$sandbox/warning"
+corrupt_workspace="$sandbox/corrupt"
+failure_workspace="$sandbox/failure"
+mkdir -p "$happy_workspace" "$warning_workspace" "$corrupt_workspace" "$failure_workspace"
+
+setup_workspace() {
+  local workspace="$1"
+  shift
+  local repos=("$@")
+
+  mkdir -p "$workspace/.github/scripts"
+  cp "$REPO_ROOT/setup-hooks.sh" "$workspace/.github/setup-hooks.sh"
+  cp "$REPO_ROOT/scripts/strip-ai-trailers.sh" "$workspace/.github/scripts/strip-ai-trailers.sh"
+  chmod +x "$workspace/.github/scripts/strip-ai-trailers.sh"
+
+  mkdir -p "$workspace/bin"
+  cat >"$workspace/bin/pre-commit" <<'STUB'
 #!/usr/bin/env bash
 exit 0
 STUB
-chmod +x "$workspace/bin/pre-commit"
+  chmod +x "$workspace/bin/pre-commit"
+
+  for repo in "${repos[@]}"; do
+    create_repo "$workspace" "$repo"
+  done
+}
 
 create_repo() {
-  local repo="$1"
+  local workspace="$1"
+  local repo="$2"
 
   mkdir -p "$workspace/$repo/scripts"
+  # Initialize a real git repo so `git rev-parse --git-path hooks` works for the
+  # commit-msg symlink installation.
+  git -C "$workspace/$repo" init -q
 
   cat >"$workspace/$repo/scripts/setup-pre-push.sh" <<'STUB'
 #!/usr/bin/env bash
@@ -38,20 +64,112 @@ STUB
   chmod +x "$workspace/$repo/scripts/setup-pre-push.sh" "$workspace/$repo/scripts/setup-pre-commit.sh"
 }
 
-repos=(api frontend contracts android secpal.app guardguide.de changelog .github)
-expected_hook_count=$(( ${#repos[@]} * 2 ))
+run_setup_hooks() {
+  local workspace="$1"
+  local output_file="$2"
+  local rc=0
 
-for repo in "${repos[@]}"; do
-  create_repo "$repo"
-done
+  set +e
+  PATH="$workspace/bin:$PATH" bash "$workspace/.github/setup-hooks.sh" >"$output_file" 2>&1
+  rc=$?
+  set -e
+  return "$rc"
+}
 
-output_file="$workspace/output.txt"
+# ─── Happy path: every documented repo is present ────────────────────────────
+setup_workspace "$happy_workspace" "${ALL_REPOS[@]}"
 
-if ! PATH="$workspace/bin:$PATH" bash "$workspace/.github/setup-hooks.sh" >"$output_file" 2>&1; then
-  cat "$output_file"
-  echo "setup-hooks.sh unexpectedly failed" >&2
+happy_output="$happy_workspace/output.txt"
+if ! run_setup_hooks "$happy_workspace" "$happy_output"; then
+  cat "$happy_output"
+  echo "happy-path setup-hooks.sh unexpectedly failed" >&2
   exit 1
 fi
 
-grep -q "Successfully installed: ${expected_hook_count} hooks" "$output_file"
-grep -q 'All Git hooks have been successfully installed' "$output_file"
+happy_expected_hooks=$(( ${#ALL_REPOS[@]} * 3 ))
+grep -q "Successfully installed: ${happy_expected_hooks} hooks" "$happy_output"
+grep -q 'All Git hooks have been successfully installed' "$happy_output"
+if grep -q 'Skipped (missing directory)' "$happy_output"; then
+  cat "$happy_output"
+  echo "happy-path output should not report skipped repositories" >&2
+  exit 1
+fi
+if grep -q '^Failed: ' "$happy_output"; then
+  cat "$happy_output"
+  echo "happy-path output should not report failed repositories" >&2
+  exit 1
+fi
+
+# ─── Warning path: a managed repo directory is missing ───────────────────────
+# The expectation is documented in SecPal/.github#485: missing managed repos
+# must surface as a warning so workspaces that have not synced the latest REPOS
+# list (for example after a fresh repo is added) still install hooks for the
+# repos they do have, instead of failing the whole script.
+warning_present_repos=(api frontend contracts android secpal.app changelog .github)
+setup_workspace "$warning_workspace" "${warning_present_repos[@]}"
+
+warning_output="$warning_workspace/output.txt"
+if ! run_setup_hooks "$warning_workspace" "$warning_output"; then
+  cat "$warning_output"
+  echo "warning-path setup-hooks.sh unexpectedly failed (missing repo must be a warning, not an error)" >&2
+  exit 1
+fi
+
+grep -q 'Directory not found: guardguide.de' "$warning_output"
+grep -q 'Skipped (missing directory): 1 repositories' "$warning_output"
+grep -q '.github/scripts/install-polyscope-rollout.sh' "$warning_output"
+grep -q 'All Git hooks have been successfully installed' "$warning_output"
+
+warning_expected_hooks=$(( ${#warning_present_repos[@]} * 3 ))
+grep -q "Successfully installed: ${warning_expected_hooks} hooks" "$warning_output"
+
+if grep -q '^Failed: ' "$warning_output"; then
+  cat "$warning_output"
+  echo "warning-path output must not report Failed repositories for missing directories" >&2
+  exit 1
+fi
+
+# ─── Corrupt path: managed repo path exists but is not a directory ───────────
+# Only a truly missing repo should soft-warn. If the path exists as a regular
+# file, the workspace is corrupted and setup-hooks.sh must fail loudly.
+corrupt_present_repos=(api frontend contracts android secpal.app changelog .github)
+setup_workspace "$corrupt_workspace" "${corrupt_present_repos[@]}"
+printf 'not a directory\n' >"$corrupt_workspace/guardguide.de"
+
+corrupt_output="$corrupt_workspace/output.txt"
+if run_setup_hooks "$corrupt_workspace" "$corrupt_output"; then
+  cat "$corrupt_output"
+  echo "corrupt-path setup-hooks.sh unexpectedly succeeded (non-directory managed path must fail)" >&2
+  exit 1
+fi
+
+grep -q '^Failed: 1 repositories' "$corrupt_output"
+grep -q 'guardguide.de (path is not a directory)' "$corrupt_output"
+if grep -q '^Skipped (missing directory): ' "$corrupt_output"; then
+  cat "$corrupt_output"
+  echo "corrupt-path output must not treat a regular file as a missing directory" >&2
+  exit 1
+fi
+
+# ─── Failure path: a real installation step fails ────────────────────────────
+# Even with the soft-warn change, breakage in a hook installation step (e.g.
+# setup-pre-push.sh exits non-zero) must still fail the script with exit 1.
+setup_workspace "$failure_workspace" "${ALL_REPOS[@]}"
+cat >"$failure_workspace/api/scripts/setup-pre-push.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$failure_workspace/api/scripts/setup-pre-push.sh"
+
+failure_output="$failure_workspace/output.txt"
+if run_setup_hooks "$failure_workspace" "$failure_output"; then
+  cat "$failure_output"
+  echo "failure-path setup-hooks.sh unexpectedly succeeded (broken pre-push install must exit non-zero)" >&2
+  exit 1
+fi
+
+grep -q 'Pre-push hook installation failed' "$failure_output"
+grep -q '^Failed: 1 repositories' "$failure_output"
+grep -q 'api (pre-push)' "$failure_output"
+
+echo "tests/setup-hooks.sh: happy, warning, corrupt-path, and failure paths verified."

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -87,9 +87,9 @@ if ! run_setup_hooks "$happy_workspace" "$happy_output"; then
 fi
 
 happy_expected_hooks=$(( ${#ALL_REPOS[@]} * 3 ))
-grep -q "Successfully installed: ${happy_expected_hooks} hooks" "$happy_output"
-grep -q 'All Git hooks have been successfully installed' "$happy_output"
-if grep -q 'Skipped (missing directory)' "$happy_output"; then
+grep -Fq "Successfully installed: ${happy_expected_hooks} hooks" "$happy_output"
+grep -Fq 'All Git hooks have been successfully installed' "$happy_output"
+if grep -Fq 'Skipped (missing directory)' "$happy_output"; then
   cat "$happy_output"
   echo "happy-path output should not report skipped repositories" >&2
   exit 1
@@ -115,13 +115,13 @@ if ! run_setup_hooks "$warning_workspace" "$warning_output"; then
   exit 1
 fi
 
-grep -q 'Directory not found: guardguide.de' "$warning_output"
-grep -q 'Skipped (missing directory): 1 repositories' "$warning_output"
-grep -q '.github/scripts/install-polyscope-rollout.sh' "$warning_output"
-grep -q 'All Git hooks have been successfully installed' "$warning_output"
+grep -Fq 'Directory not found: guardguide.de' "$warning_output"
+grep -Fq 'Skipped (missing directory): 1 repositories' "$warning_output"
+grep -Fq '.github/scripts/install-polyscope-rollout.sh' "$warning_output"
+grep -Fq 'All Git hooks have been successfully installed' "$warning_output"
 
 warning_expected_hooks=$(( ${#warning_present_repos[@]} * 3 ))
-grep -q "Successfully installed: ${warning_expected_hooks} hooks" "$warning_output"
+grep -Fq "Successfully installed: ${warning_expected_hooks} hooks" "$warning_output"
 
 if grep -q '^Failed: ' "$warning_output"; then
   cat "$warning_output"
@@ -144,7 +144,7 @@ if run_setup_hooks "$corrupt_workspace" "$corrupt_output"; then
 fi
 
 grep -q '^Failed: 1 repositories' "$corrupt_output"
-grep -q 'guardguide.de (path is not a directory)' "$corrupt_output"
+grep -Fq 'guardguide.de (path is not a directory)' "$corrupt_output"
 if grep -q '^Skipped (missing directory): ' "$corrupt_output"; then
   cat "$corrupt_output"
   echo "corrupt-path output must not treat a regular file as a missing directory" >&2
@@ -168,8 +168,8 @@ if run_setup_hooks "$failure_workspace" "$failure_output"; then
   exit 1
 fi
 
-grep -q 'Pre-push hook installation failed' "$failure_output"
+grep -Fq 'Pre-push hook installation failed' "$failure_output"
 grep -q '^Failed: 1 repositories' "$failure_output"
-grep -q 'api (pre-push)' "$failure_output"
+grep -Fq 'api (pre-push)' "$failure_output"
 
 echo "tests/setup-hooks.sh: happy, warning, corrupt-path, and failure paths verified."


### PR DESCRIPTION
## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/setup-hooks.sh` against `origin/main` reproduced #485 by exiting `1` when a managed repository directory was missing.
- Passing proof after implementation: `bash tests/setup-hooks.sh`; `bash tests/mktemp-portability.sh`; `shellcheck setup-hooks.sh tests/setup-hooks.sh scripts/preflight.sh`; `bash -n setup-hooks.sh tests/setup-hooks.sh scripts/preflight.sh`; `pre-commit run --files CHANGELOG.md scripts/README.md scripts/preflight.sh setup-hooks.sh tests/setup-hooks.sh`; `reuse lint`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary of the change

- `setup-hooks.sh` (`setup-hooks.sh:30-44`, `:122-129`): missing managed
  repository directories now surface as a soft warning (`Skipped (missing
  directory)` summary line, separate `MISSING_REPOS` counter) and the script
  exits `0` when every present repo's hooks installed cleanly. Managed paths
  that exist but are not directories are still treated as a hard failure
  because that indicates a corrupted workspace, not an unsynced repo.
- The summary now points users at `.github/scripts/install-polyscope-rollout.sh`
  (or Polyscope rollout sync) so out-of-sync workspaces know how to provision
  missing repos. `scripts/README.md` documents `install-polyscope-rollout.sh`
  and the new soft-warn contract for `setup-hooks.sh` side-by-side.
- `tests/setup-hooks.sh` is rewritten as four regression scenarios — happy
  path (every repo present, all hooks installed), warning path (missing repo
  still exits `0` with the rollout hint), corrupt-path (managed path exists
  but is not a directory, still exits `1`), and failure path (broken
  `setup-pre-push.sh` still exits `1`). It is wired into
  `scripts/preflight.sh:236-249` so the contract cannot regress unnoticed.
- `CHANGELOG.md` records the behavior change under a dedicated 2026-06-14
  entry.

## Validations already run

- `bash tests/setup-hooks.sh` — happy, warning, corrupt-path, and failure
  paths all green.
- `bash tests/mktemp-portability.sh` — single
  `mktemp -d "${TMPDIR:-/tmp}/setup-hooks.XXXXXX"` invocation in the test
  keeps the existing portability guard untouched.
- `shellcheck setup-hooks.sh tests/setup-hooks.sh scripts/preflight.sh` —
  clean.
- `bash -n setup-hooks.sh tests/setup-hooks.sh scripts/preflight.sh` —
  syntax OK.
- `pre-commit run --files CHANGELOG.md scripts/README.md scripts/preflight.sh setup-hooks.sh tests/setup-hooks.sh` — `reuse lint`,
  Prettier, markdownlint, shellcheck, large-file/merge-conflict/EOL guards
  all pass.
- `reuse lint` — repository remains REUSE compliant.

## Acceptance criteria from #485

- [x] `setup-hooks.sh` skips missing repos with a warning and still exits `0`
      when no real installation step failed.
- [x] `tests/setup-hooks.sh` regression covers the warning path (missing
      repo) and the failure path (broken install). The four-scenario suite
      adds happy-path and corrupt-path coverage on top.
- [x] `setup-hooks.sh` output and `scripts/README.md` point users at the
      rollout sync command for missing repos.
- [x] `CHANGELOG.md` records the behavior change.

## Linked workspaces and follow-ups

No untracked follow-ups identified. The pre-existing tab/space indentation
inconsistency in `setup-hooks.sh:60-105` (introduced in `6bc71c1` together
with the commit-msg hook) is out of scope for this PR; if cleanup is desired,
file a dedicated style-only issue rather than mixing it into this behavior
change. No cross-repo workspace coordination required — the change is fully
contained inside `SecPal/.github`.

Closes #485.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local workspace bootstrap and hook-install scripting only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **`setup-hooks.sh`** no longer treats absent managed repo directories as failures. Those repos are listed under **Skipped (missing directory)** with a hint to run **`install-polyscope-rollout.sh`** (or Polyscope sync), and the script **exits 0** when hooks install cleanly everywhere else. Paths that exist but are not directories still count as hard failures, and broken hook installs still **exit 1**.
> 
> **`tests/setup-hooks.sh`** now covers four cases (all present, missing repo, corrupt path, failed install), and **`scripts/preflight.sh`** runs that test so the contract cannot regress. **`scripts/README.md`** and **`CHANGELOG.md`** document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9380116f43c4337df79b6ff2813350a796b6224f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

