### PR TITLE
[codex] Document guardguide.de in required-checks tooling

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,7 +173,7 @@ the SecPal application repositories.
 
 ```bash
 # Inspect the payload for one repository without writing to GitHub
-bash scripts/sync-required-checks.sh --repo GuardGuide --print-payload | jq
+bash scripts/sync-required-checks.sh --repo guardguide.de --print-payload | jq
 
 # Apply the configured payload to one repository
 bash scripts/sync-required-checks.sh --repo api --apply
@@ -192,6 +192,7 @@ bash scripts/sync-required-checks.sh --apply
 - `android`
 - `secpal.app`
 - `GuardGuide`
+- `guardguide.de`
 
 **What It Does:**
 


### PR DESCRIPTION
## Summary
- document `guardguide.de` as a managed repository in `scripts/sync-required-checks.sh` usage docs
- align the example command with the new public-site repository
- keep the central required-check governance docs consistent with the live repository set

## Why
During a cross-repository branch-protection audit, `guardguide.de` was already governed correctly in the central manifest and live GitHub settings, but the script README still omitted it. That left the operational documentation behind the actual managed state.

## Validation
- `bash tests/sync-required-checks.sh`
- live required-check drift audit across `.github`, `contracts`, `frontend`, `api`, `android`, `secpal.app`, `changelog`, `GuardGuide`, and `guardguide.de`
- synced live required-checks back to the central manifest for `frontend`, `secpal.app`, `changelog`, and `GuardGuide`

## Operational outcome
The following repositories now match the central required-check manifest again:
- `frontend`
- `secpal.app`
- `changelog`
- `GuardGuide`

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A
- Passing proof after implementation: N/A
- Validate-first exception reference: N/A
- No executable change reason: Documentation-only update to `scripts/README.md` adding `guardguide.de` to the managed repositories list and the print-payload example. No script logic, workflow, or branch-protection behavior changes.