### PR TITLE
fix(check-domains): align banner with secpal.* scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Added:**
 
-- added `tests/check-domains.sh` regression test that locks in the banner/README scope language, exercises a synthetic workspace to prove `guardguide.de` references pass cleanly, and proves an unapproved `secpal.*` host (e.g. `secpal.xyz`) still fails the gate, and wired it into `scripts/preflight.sh` so the contradiction surfaced on SecPal/.github#483 (resolved as out of scope and tracked in SecPal/.github#484) cannot return unnoticed.
+- added `tests/check-domains.sh` regression test that locks in the banner/README scope language, exercises a synthetic workspace to prove `guardguide.de` references pass cleanly, and proves an unapproved `secpal.*` host (one is staged inside the test's own temporary workspace, never in the repo) still fails the gate, and wired it into `scripts/preflight.sh` so the contradiction surfaced on SecPal/.github#483 (resolved as out of scope and tracked in SecPal/.github#484) cannot return unnoticed.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-14 - Align `check-domains.sh` Banner With Its `secpal.*` Scope
+
+**Changed:**
+
+- rewrote the banner and on-failure Policy block in `scripts/check-domains.sh` so the help text matches the script's actual `secpal\.[A-Za-z0-9.-]+` match regex: the gate explicitly documents that it only enforces the `secpal.*` namespace split, drops the misleading "ANY other" claim in favour of "any other unapproved `secpal.*` host", and points readers at the owning repository's policy guards for non-`secpal` SecPal hosts such as `guardguide.de` (introduced in SecPal/.github#483).
+- documented `scripts/check-domains.sh` in `scripts/README.md` with an explicit "Scope (intentional limit)" section so contributors discover the boundary alongside the other validation scripts and stop expecting the org-wide gate to police every external SecPal domain.
+
+**Added:**
+
+- added `tests/check-domains.sh` regression test that locks in the banner/README scope language, exercises a synthetic workspace to prove `guardguide.de` references pass cleanly, and proves an unapproved `secpal.*` host (e.g. `secpal.xyz`) still fails the gate, and wired it into `scripts/preflight.sh` so the contradiction surfaced on SecPal/.github#483 (resolved as out of scope and tracked in SecPal/.github#484) cannot return unnoticed.
+
+---
+
 ## 2026-06-14 - Soft-Warn Missing Repos In `setup-hooks.sh`
 
 **Changed:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,39 @@ This directory contains utility scripts for SecPal development.
 
 ## Validation Scripts
 
+### `check-domains.sh`
+
+Enforces the SecPal `secpal.*` namespace split. The script scans tracked text
+files for any `secpal.<something>` substring and flags entries that fall
+outside the approved set (`secpal.app`, `changelog.secpal.app`,
+`apk.secpal.app`, `secpal.dev`, `api.secpal.dev`, `app.secpal.dev`, plus
+arbitrary `*.preview.secpal.dev` previews). It also surfaces the deprecated
+`.app` web host (the `api.secpal.app` deprecated web host) so callers cannot
+reintroduce it as an active host.
+
+**Scope (intentional limit):**
+
+- The match regex is `secpal\.[A-Za-z0-9.-]+`, so only `secpal.*` strings are
+  ever inspected. Non-`secpal` domains are out of scope by design — even when
+  they belong to SecPal (e.g. `guardguide.de`).
+- SecPal-owned external hosts such as `guardguide.de` (managed via
+  SecPal/.github#483) are governed by their own repository policy guards and
+  are not first-class entries here. Adding them to this allowlist would be
+  inert because the matcher never sees them.
+- Treat the banner's "Forbidden" list as "forbidden `secpal.*` variants",
+  not "every non-SecPal domain on the internet".
+
+**Usage:**
+
+```bash
+bash scripts/check-domains.sh
+```
+
+**Exit Codes:**
+
+- `0`: No forbidden `secpal.*` variants or deprecated `.app` web-host usages
+- `1`: One or more violations found
+
 ### `audit-closed-epics.sh`
 
 Audits Epic issues and reports checklist drift, such as closed child issues

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,13 +11,14 @@ This directory contains utility scripts for SecPal development.
 
 ### `check-domains.sh`
 
-Enforces the SecPal `secpal.*` namespace split. The script scans tracked text
-files for any `secpal.<something>` substring and flags entries that fall
-outside the approved set (`secpal.app`, `changelog.secpal.app`,
-`apk.secpal.app`, `secpal.dev`, `api.secpal.dev`, `app.secpal.dev`, plus
-arbitrary `*.preview.secpal.dev` previews). It also surfaces the deprecated
-`.app` web host (the `api.secpal.app` deprecated web host) so callers cannot
-reintroduce it as an active host.
+Enforces the SecPal `secpal.*` namespace split. The script greps text files
+in the working tree (via `grep -r --include=...`, so untracked files matching
+the include patterns are inspected too) for any `secpal.<something>`
+substring and flags entries that fall outside the approved set
+(`secpal.app`, `changelog.secpal.app`, `apk.secpal.app`, `secpal.dev`,
+`api.secpal.dev`, `app.secpal.dev`, plus arbitrary `*.preview.secpal.dev`
+previews). It also surfaces `api.secpal.app`, the deprecated `.app` web
+host, so callers cannot reintroduce it as an active host.
 
 **Scope (intentional limit):**
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,6 +16,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
+echo "Scope: enforces the secpal.* namespace split only (match regex: secpal\\.[A-Za-z0-9.-]+)."
+echo "Out of scope: non-secpal SecPal-owned hosts such as guardguide.de are governed by"
+echo "their own repository policy guards and are intentionally not inspected here."
 echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Public changelog site: changelog.secpal.app"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
@@ -23,7 +26,8 @@ echo "Android artifact host: apk.secpal.app"
 echo "Human-facing Android landing page: secpal.app/android"
 echo "Identifier-only: app.secpal (Android application ID)"
 echo "Deprecated web hosts: api.secpal.app"
-echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, app.secpal.app, ANY other"
+echo "Forbidden secpal.* variants: secpal.com, secpal.org, secpal.net, secpal.io,"
+echo "  secpal.example, app.secpal.app, and any other unapproved secpal.* host."
 echo ""
 
 matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
@@ -106,7 +110,7 @@ else
         echo "$deprecated_web_hosts"
         echo ""
     fi
-    echo -e "${YELLOW}Policy:${NC}"
+    echo -e "${YELLOW}Policy (scope: secpal.* namespace split only):${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
     echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact/download host"
@@ -116,7 +120,8 @@ else
     echo "  - app.secpal: Android application identifier only"
     echo "  - secpal.app/android: human-facing Android landing page"
     echo "  - DEPRECATED as web hosts: api.secpal.app"
-    echo "  - FORBIDDEN: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, app.secpal.app"
+    echo "  - FORBIDDEN secpal.* variants: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, app.secpal.app"
+    echo "  - Non-secpal SecPal hosts (e.g. guardguide.de) are out of scope; enforce them in the owning repository."
     echo ""
     echo "Fix these violations before committing."
     exit 1

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: MIT
 
 # Domain Policy Enforcement Script
-# Validates that only approved SecPal domains and identifiers are used
-# ZERO TOLERANCE for other domains or deprecated .app web hosts
+# Scope: enforces the secpal.* namespace split only (match regex:
+#   secpal\.[A-Za-z0-9.-]+). Non-secpal SecPal-owned hosts (e.g.
+#   guardguide.de) are intentionally out of scope here and are governed by
+#   their owning repository's policy guard.
+# ZERO TOLERANCE for unapproved secpal.* hosts or deprecated .app web hosts.
 
 set -euo pipefail
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -79,6 +79,15 @@ if [ -f scripts/check-domains.sh ]; then
   }
 fi
 
+if [ -f tests/check-domains.sh ]; then
+  bash tests/check-domains.sh || {
+    echo "" >&2
+    echo "❌ Domain policy scope regression test failed!" >&2
+    echo "Keep scripts/check-domains.sh and scripts/README.md aligned on the secpal.* namespace scope (see SecPal/.github#484) before continuing." >&2
+    exit 1
+  }
+fi
+
 # Conflict Marker Check (prevents accidental commits of broken code)
 if [ -f scripts/check-conflict-markers.sh ]; then
   bash scripts/check-conflict-markers.sh || {

--- a/tests/check-domains.sh
+++ b/tests/check-domains.sh
@@ -2,18 +2,30 @@
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
-# Regression test for scripts/check-domains.sh covering SecPal/.github#484.
+# Regression test for scripts/check-domains.sh covering SecPal/.github#484
+# plus the PR #488 Copilot review findings.
 #
 # The script is intentionally scoped to enforcing the secpal.* namespace
 # split. SecPal-external hosts (e.g. guardguide.de) are governed by their
 # own repository policy guards and must NOT be flagged here. This test
-# locks in three guarantees so the banner can never drift back to claiming
-# the gate covers "any other" domain:
+# locks in the following guarantees so neither the banner nor any of the
+# surrounding documentation can drift back to claiming the gate covers
+# "any other" domain:
 #
-#   1. The banner and the failure-mode Policy block document the scope limit
-#      (so the help text and the regex agree).
-#   2. scripts/README.md documents the same intentional scope.
-#   3. Behaviour matches the documented scope: guardguide.de references in
+#   1. The banner and the failure-mode Policy block document the scope
+#      limit (so the help text and the regex agree).
+#   2. The script's top-of-file header comment documents the same scope
+#      instead of the legacy "ZERO TOLERANCE for other domains" wording
+#      that contradicted the matcher.
+#   3. scripts/README.md documents the same intentional scope and does not
+#      claim the script only scans tracked files (it greps the working
+#      tree, untracked files included) so contributors do not develop the
+#      wrong mental model.
+#   4. CHANGELOG.md does not contain a literal unapproved secpal.* host
+#      such as secpal.xyz, even when describing the regression fixture;
+#      such hosts only ever live inside the test's own temporary workspace
+#      so the prose cannot accidentally trip the gate after a reword.
+#   5. Behaviour matches the documented scope: guardguide.de references in
 #      a workspace pass cleanly, while an unapproved secpal.* host still
 #      fails the gate.
 
@@ -23,6 +35,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/check-domains.sh"
 README="$REPO_ROOT/scripts/README.md"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 
 if [ ! -f "$SCRIPT" ]; then
   echo "Missing scripts/check-domains.sh" >&2
@@ -31,6 +44,11 @@ fi
 
 if [ ! -f "$README" ]; then
   echo "Missing scripts/README.md" >&2
+  exit 1
+fi
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "Missing CHANGELOG.md" >&2
   exit 1
 fi
 
@@ -56,6 +74,18 @@ if ! grep -Fq 'Non-secpal SecPal hosts' "$SCRIPT"; then
   exit 1
 fi
 
+# 2b. Header comment documents the scope and does not contradict it
+# (PR #488 review thread on scripts/check-domains.sh:7).
+if ! grep -Fq '# Scope: enforces the secpal.* namespace split only' "$SCRIPT"; then
+  echo "scripts/check-domains.sh header comment must declare the secpal.* namespace scope" >&2
+  exit 1
+fi
+
+if grep -Fq 'ZERO TOLERANCE for other domains' "$SCRIPT"; then
+  echo "scripts/check-domains.sh header comment must not reuse the contradicting 'ZERO TOLERANCE for other domains' wording" >&2
+  exit 1
+fi
+
 # 3. README documents the intentional scope.
 if ! grep -Fq 'Scope (intentional limit)' "$README"; then
   echo "scripts/README.md must document the check-domains.sh scope limit" >&2
@@ -67,7 +97,29 @@ if ! grep -Fq 'guardguide.de' "$README"; then
   exit 1
 fi
 
-# 4. Behavioural check: guardguide.de references pass, unapproved secpal.* fails.
+# 3b. README accurately describes the scan target (working tree, not just
+# tracked files) so contributors do not develop the wrong mental model
+# (PR #488 review thread on scripts/README.md:20).
+if grep -Fq 'scans tracked text files' "$README"; then
+  echo "scripts/README.md must not claim check-domains.sh scans only tracked files; it greps the working tree" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'working tree' "$README"; then
+  echo "scripts/README.md must describe the scan target as the working tree" >&2
+  exit 1
+fi
+
+# 4. CHANGELOG.md must not contain a literal unapproved secpal.* host even
+# in its prose. The regression fixture lives in the test's own temporary
+# workspace so the changelog entry cannot accidentally trip the gate after
+# a reword (PR #488 review thread on CHANGELOG.md:21).
+if grep -Fq 'secpal.xyz' "$CHANGELOG"; then
+  echo "CHANGELOG.md must not contain literal unapproved secpal.* hosts (e.g. secpal.xyz); keep such fixtures inside tests/check-domains.sh" >&2
+  exit 1
+fi
+
+# 5. Behavioural check: guardguide.de references pass, unapproved secpal.* fails.
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/check-domains.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 

--- a/tests/check-domains.sh
+++ b/tests/check-domains.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+# Regression test for scripts/check-domains.sh covering SecPal/.github#484.
+#
+# The script is intentionally scoped to enforcing the secpal.* namespace
+# split. SecPal-external hosts (e.g. guardguide.de) are governed by their
+# own repository policy guards and must NOT be flagged here. This test
+# locks in three guarantees so the banner can never drift back to claiming
+# the gate covers "any other" domain:
+#
+#   1. The banner and the failure-mode Policy block document the scope limit
+#      (so the help text and the regex agree).
+#   2. scripts/README.md documents the same intentional scope.
+#   3. Behaviour matches the documented scope: guardguide.de references in
+#      a workspace pass cleanly, while an unapproved secpal.* host still
+#      fails the gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-domains.sh"
+README="$REPO_ROOT/scripts/README.md"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "Missing scripts/check-domains.sh" >&2
+  exit 1
+fi
+
+if [ ! -f "$README" ]; then
+  echo "Missing scripts/README.md" >&2
+  exit 1
+fi
+
+# 1. Banner documents the intentional scope limit.
+if ! grep -Fq 'Scope: enforces the secpal.* namespace split only' "$SCRIPT"; then
+  echo "scripts/check-domains.sh banner must declare the secpal.* namespace scope" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'guardguide.de' "$SCRIPT"; then
+  echo "scripts/check-domains.sh must call out guardguide.de as out of scope" >&2
+  exit 1
+fi
+
+# 2. Failure-mode Policy block also documents the scope.
+if ! grep -Fq 'scope: secpal.* namespace split only' "$SCRIPT"; then
+  echo "scripts/check-domains.sh Policy block must repeat the scope limit on failure" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Non-secpal SecPal hosts' "$SCRIPT"; then
+  echo "scripts/check-domains.sh Policy block must point readers at owning-repo guards" >&2
+  exit 1
+fi
+
+# 3. README documents the intentional scope.
+if ! grep -Fq 'Scope (intentional limit)' "$README"; then
+  echo "scripts/README.md must document the check-domains.sh scope limit" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'guardguide.de' "$README"; then
+  echo "scripts/README.md must mention guardguide.de as the canonical out-of-scope example" >&2
+  exit 1
+fi
+
+# 4. Behavioural check: guardguide.de references pass, unapproved secpal.* fails.
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/check-domains.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/scripts"
+cp "$SCRIPT" "$workspace/scripts/check-domains.sh"
+
+cat >"$workspace/guardguide.md" <<'EOF'
+# GuardGuide notes
+
+Production homepage: https://guardguide.de
+Marketing redirect: https://www.guardguide.de
+
+Approved SecPal hosts used in examples:
+- https://secpal.app
+- https://changelog.secpal.app
+- https://apk.secpal.app
+- https://api.secpal.dev
+- https://app.secpal.dev
+- https://feature-branch.preview.secpal.dev
+EOF
+
+(
+  cd "$workspace"
+  bash scripts/check-domains.sh >output.txt 2>&1
+)
+
+if ! grep -Fq 'Domain Policy Check PASSED' "$workspace/output.txt"; then
+  cat "$workspace/output.txt"
+  echo "check-domains.sh should pass when only guardguide.de + approved secpal.* hosts are present" >&2
+  exit 1
+fi
+
+if grep -F 'guardguide' "$workspace/output.txt" | grep -qiv 'out of scope\|governed by\|namespace'; then
+  cat "$workspace/output.txt"
+  echo "check-domains.sh must not flag guardguide.de as a violation" >&2
+  exit 1
+fi
+
+# Now confirm an unapproved secpal.* host still fails the gate so the scope
+# limit is not a free pass for actual namespace violations.
+cat >"$workspace/regression.md" <<'EOF'
+# Regression fixture
+
+This file intentionally references an unapproved secpal.xyz host so the
+gate has something to fail on.
+
+Bad: https://secpal.xyz
+EOF
+
+set +e
+(
+  cd "$workspace"
+  bash scripts/check-domains.sh >output.txt 2>&1
+)
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+  cat "$workspace/output.txt"
+  echo "check-domains.sh must still fail when an unapproved secpal.* host is present" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'secpal.xyz' "$workspace/output.txt"; then
+  cat "$workspace/output.txt"
+  echo "check-domains.sh must surface the unapproved secpal.xyz host in its output" >&2
+  exit 1
+fi
+
+echo "tests/check-domains.sh: ok"


### PR DESCRIPTION
## Description

`scripts/check-domains.sh` is intentionally scoped to the SecPal `secpal.*`
namespace split — its match regex is `secpal\.[A-Za-z0-9.-]+`, so non-`secpal`
strings are never inspected. The banner, however, advertised:

```
Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, app.secpal.app, ANY other
```

After SecPal/.github#483 bootstrapped `guardguide.de` as a managed static
site, an automated reviewer surfaced that the "ANY other" claim contradicts
the regex: the gate cannot (and intentionally does not) enforce anything
against non-`secpal.*` hosts such as `guardguide.de`; those are governed
by their owning repository's policy guard.

Per option 1 of #484, this PR clarifies the documented scope rather than
extending the allowlist with inert non-`secpal` entries (adding e.g.
`guardguide.de` would never reach the matcher and would only deepen the
confusion).

### Failing proof before implementation

`tests/check-domains.sh` is the executable failing-proof for #484:

- Against the previous banner it would have failed at the
  `'Scope: enforces the secpal.* namespace split only'` assertion.
- Against an unchanged `scripts/README.md` it would have failed at the
  `'Scope (intentional limit)'` and `guardguide.de` assertions.
- The behavioural section (workspace fixture with `guardguide.de`
  references) locks in that the gate keeps passing on out-of-scope hosts,
  and the second fixture (`secpal.xyz`) proves the scope limit is **not**
  a free pass for actual `secpal.*` namespace violations.

### Passing proof after implementation

```
$ bash tests/check-domains.sh
tests/check-domains.sh: ok

$ bash scripts/check-domains.sh
=== Domain Policy Check ===
Scope: enforces the secpal.* namespace split only (match regex: secpal\.[A-Za-z0-9.-]+).
Out of scope: non-secpal SecPal-owned hosts such as guardguide.de are governed by
their own repository policy guards and are intentionally not inspected here.
...
✅ Domain Policy Check PASSED

$ bash ./scripts/preflight.sh
... (all gates green) ...
Preflight OK · Changed lines: 559
```

## Summary of changes

- `scripts/check-domains.sh` — banner now opens with an explicit scope
  statement (regex included), names `guardguide.de` as the canonical
  out-of-scope example, and renames the misleading "ANY other" suffix to
  "any other unapproved `secpal.*` host". The on-failure Policy block
  repeats the scope limit so users hitting the gate see it again.
- `scripts/README.md` — new `check-domains.sh` section with a dedicated
  "Scope (intentional limit)" subsection covering the regex, the
  `guardguide.de` example, and the "forbidden = forbidden `secpal.*`
  variants" framing.
- `tests/check-domains.sh` — new regression test asserting the banner +
  README scope language, exercising a synthetic workspace to prove
  `guardguide.de` passes cleanly, and confirming an unapproved `secpal.*`
  host (`secpal.xyz`) still fails the gate.
- `scripts/preflight.sh` — wires `tests/check-domains.sh` in next to the
  existing `check-domains.sh` invocation so the contract cannot silently
  regress.
- `CHANGELOG.md` — new `2026-06-14 - Align check-domains.sh Banner With
  Its secpal.* Scope` entry.

## Related Issues

Closes #484
Refs #483

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manual testing performed

Manual checks performed locally:

- `bash scripts/check-domains.sh` — passes (banner edits do not self-flag).
- `bash tests/check-domains.sh` — passes; also verified it fails as
  expected when the `secpal.xyz` fixture is staged, so the second guard
  is genuine.
- `bash ./scripts/preflight.sh` — full governance preflight green
  (prettier, markdownlint, REUSE, check-domains, conflict markers,
  reusable workflow timeouts, CodeQL applicability, epic audit, PR
  template/evidence/English/commit-signature checks, project board
  helper, mktemp portability, prettier version alignment, Copilot
  instructions validator, required-checks sync, Polyscope state audit,
  Polyscope rollout, license compatibility, Dependabot auto-merge,
  setup-hooks, OpenAPI verified-endpoint presence). PR size 559 changed
  lines (under the 600 cap).
- `shellcheck`, `reuse lint` — clean (164 / 164 REUSE compliant).

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/check-domains.sh` —
  exercises the synthetic `guardguide.de` workspace and asserts the new
  banner / README scope language; would have failed against the prior
  banner and the prior `scripts/README.md`.
- Passing proof after implementation: `bash tests/check-domains.sh` →
  `tests/check-domains.sh: ok`; `bash scripts/check-domains.sh` →
  `✅ Domain Policy Check PASSED`; `bash ./scripts/preflight.sh` →
  `Preflight OK · Changed lines: 559`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## Follow-ups / unresolved checks

- None. No new out-of-scope findings emerged; the original out-of-scope
  reference on SecPal/.github#483 (review thread `r3409427183`) is the
  one this PR closes via #484.
- Local CI proxy is `bash ./scripts/preflight.sh` (green). Branch
  protection on `SecPal/.github` will run the same suite plus
  Copilot/CodeQL/REUSE workflows on push of this PR; if any of those
  surface a genuine issue I will fix it before marking ready.
- No linked workspaces required beyond this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression-test changes only; domain enforcement logic is unchanged aside from clearer messaging.
> 
> **Overview**
> **Documentation fix for a misleading domain gate banner** — the script’s matcher was always `secpal\.[A-Za-z0-9.-]+`, but help text implied it blocked “ANY other” domain, which confused contributors after `guardguide.de` landed.
> 
> `scripts/check-domains.sh` now states scope up front (banner, header comment, and failure **Policy** block): only unapproved **`secpal.*`** hosts and deprecated `.app` web usage are enforced; non-`secpal` SecPal hosts such as **`guardguide.de`** are explicitly out of scope and owned by repo-level guards. The forbidden list is reframed as **forbidden `secpal.*` variants**, not global domain policing. **Grep/allowlist behavior is unchanged.**
> 
> `scripts/README.md` gains a **`check-domains.sh`** section with a **Scope (intentional limit)** subsection and notes that scans use the **working tree** (including untracked matches), not tracked-only files.
> 
> **`tests/check-domains.sh`** locks banner/README/CHANGELOG wording, forbids literal `secpal.xyz` in `CHANGELOG.md`, and runs temp-workspace checks that `guardguide.de` passes while unapproved `secpal.*` still fails. **`scripts/preflight.sh`** runs that test after the domain check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3069113ba8ff7991e10fce6dcb7e238be5c8f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->