### PR TITLE
Fix Polyscope lockfile reprovisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-15 - Reprovision Polyscope Worktrees On Lockfile Drift
+
+**Changed:**
+
+- updated `scripts/polyscope-rollout.py` so Node-based managed worktrees now run plain `npm ci` during provisioning instead of `test -d node_modules || npm ci`. Provisioning is already marker-gated, so the old existence check only preserved stale dependency trees after lockfile changes.
+- updated `scripts/polyscope-rollout.py` so the per-worktree provision marker hash now includes dependency manifest inputs (`package.json`, `package-lock.json`, `composer.json`, `composer.lock`) in addition to the setup command list. Together with unconditional `npm ci`, this forces a fresh dependency install when a managed workspace's lockfiles change, closing the drift that left GuardGuide preview worktrees with stale `node_modules` after the new `@fontsource/inter` dependency landed.
+
+**Added:**
+
+- extended `tests/polyscope-rollout.sh` with a regression that mutates a provisioned frontend worktree `package-lock.json` and proves the next provisioning pass reruns setup instead of trusting the previous marker.
+
+---
+
 ## 2026-06-14 - Skip Gitignored Agent Scratch Dir In `check-domains.sh`
 
 **Changed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1030,7 +1030,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "preview": {"url": build_preview_url_template("guardguide")},
             "scripts": {
                 "setup": [
-                    "test -d vendor || composer install",
+                    "composer install",
                     "npm ci",
                     "test -f .env || cp .env.example .env",
                     build_guardguide_preview_env_setup_command(),

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -970,7 +970,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "scripts": {
                 "setup": [
                     build_frontend_preview_env_setup_command(),
-                    "test -d node_modules || npm ci",
+                    "npm ci",
                     "VITE_API_URL=https://api-${PWD##*/}.preview.secpal.dev npm run build -- --mode preview",
                 ],
                 "run": [
@@ -1031,7 +1031,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "scripts": {
                 "setup": [
                     "test -d vendor || composer install",
-                    "test -d node_modules || npm ci",
+                    "npm ci",
                     "test -f .env || cp .env.example .env",
                     build_guardguide_preview_env_setup_command(),
                     "test -f database/database.sqlite || touch database/database.sqlite",
@@ -1079,7 +1079,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "copyGitignored": True,
             "runMode": "replace",
             "scripts": {
-                "setup": ["test -d node_modules || npm ci"],
+                "setup": ["npm ci"],
                 "run": [
                     {"label": "Validate", "command": "npm run validate", "runMode": "preserve"},
                     {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
@@ -1113,7 +1113,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "copyGitignored": True,
             "runMode": "replace",
             "scripts": {
-                "setup": ["test -d node_modules || npm ci"],
+                "setup": ["npm ci"],
                 "run": [
                     {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
                     {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
@@ -1149,7 +1149,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "runMode": "replace",
             "preview": {"url": build_preview_url_template("secpal-app")},
             "scripts": {
-                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "setup": ["npm ci", "npm run build"],
                 "run": [
                     {
                         "label": "Build Watch",
@@ -1199,7 +1199,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "runMode": "replace",
             "preview": {"url": build_preview_url_template("guardguide-de")},
             "scripts": {
-                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "setup": ["npm ci", "npm run build"],
                 "run": [
                     {
                         "label": "Build Watch",
@@ -1249,7 +1249,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "runMode": "replace",
             "preview": {"url": build_preview_url_template("changelog")},
             "scripts": {
-                "setup": ["test -d node_modules || npm ci", "npm run build"],
+                "setup": ["npm ci", "npm run build"],
                 "run": [
                     {
                         "label": "Build Watch",
@@ -1289,7 +1289,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "copyGitignored": True,
             "runMode": "replace",
             "scripts": {
-                "setup": ["test -d node_modules || npm ci"],
+                "setup": ["npm ci"],
                 "run": [
                     {"label": "Preflight", "command": "./scripts/preflight.sh", "runMode": "preserve"},
                     {"label": "Copilot Review Scan", "command": "npm run copilot:review:scan", "runMode": "preserve"},
@@ -1747,9 +1747,31 @@ def render_local_configs(repo_specs: dict[str, dict[str, Any]]) -> dict[str, str
     }
 
 
-def build_setup_hash(setup_commands: list[str]) -> str:
-    payload = json.dumps(setup_commands, separators=(",", ":"), ensure_ascii=True)
-    return hashlib.sha256(payload.encode()).hexdigest()
+def collect_setup_inputs(worktree_path: pathlib.Path, setup_commands: list[str]) -> dict[str, str]:
+    inputs: dict[str, str] = {}
+    command_text = "\n".join(setup_commands)
+
+    candidate_paths: list[pathlib.Path] = []
+    if re.search(r"\bnpm\s+(?:ci|install|run)\b|\bnpx\b", command_text):
+        candidate_paths.extend([worktree_path / "package.json", worktree_path / "package-lock.json"])
+
+    if re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command_text):
+        candidate_paths.extend([worktree_path / "composer.json", worktree_path / "composer.lock"])
+
+    for path in candidate_paths:
+        if path.is_file():
+            inputs[path.name] = path.read_text()
+
+    return inputs
+
+
+def build_setup_hash(worktree_path: pathlib.Path, setup_commands: list[str]) -> str:
+    payload = {
+        "commands": setup_commands,
+        "inputs": collect_setup_inputs(worktree_path, setup_commands),
+    }
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode()).hexdigest()
 
 
 def load_provision_marker(marker_path: pathlib.Path) -> dict[str, Any] | None:
@@ -1879,7 +1901,6 @@ def provision_worktrees(
         setup_commands = validation_commands
         if repo_name == "api":
             setup_commands = setup_commands[1:]
-        setup_hash = build_setup_hash(setup_commands)
         config_text = rendered_configs[repo_name]
 
         for worktree_path in sorted(path for path in repo_clone_root.iterdir() if path.is_dir()):
@@ -1889,6 +1910,7 @@ def provision_worktrees(
 
                 sync_worktree_local_config(worktree_path, config_text)
                 ensure_worktree_hooks(worktree_path)
+                setup_hash = build_setup_hash(worktree_path, setup_commands)
 
                 preview_storage_target: str | None = None
                 if repo_name == "api":

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1843,6 +1843,45 @@ grep -qF 'POLYSCOPE_PREVIEW_SCHEMA=secpal__preview__schema_badger' "$schema_api_
 test "$(grep -cF "php:$schema_api_clone:artisan migrate --force" "$provision_log")" -eq 2
 test "$(grep -cF 'CREATE SCHEMA IF NOT EXISTS "secpal__preview__schema_badger"' "$fake_psql_log")" -eq 2
 
+python3 - <<'PY' "$schema_frontend_clone/package-lock.json"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["packages"][""] = {"name": "frontend-schema-badger", "version": "0.0.2"}
+path.write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+schema_lockfile_summary_json="$workspace/schema-lockfile-summary.json"
+schema_frontend_npm_ci_count_before="$(grep -cF "npm:$schema_frontend_clone:ci" "$provision_log" || true)"
+env HOME="$schema_home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$schema_pg_state" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$schema_lockfile_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null
+
+python3 - <<'PY' "$schema_lockfile_summary_json"
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+assert 'frontend:schema-badger' in provisioned, provisioned
+PY
+
+test "$schema_frontend_npm_ci_count_before" -lt "$(grep -cF "npm:$schema_frontend_clone:ci" "$provision_log")"
+
 rm -rf "$schema_api_clone" "$schema_frontend_clone"
 
 env HOME="$schema_home_dir" \
@@ -1878,7 +1917,7 @@ grep -qF 'DROP SCHEMA IF EXISTS "secpal__preview__schema_badger" CASCADE' "$fake
 assert_rollout_rejects_invalid_local_config \
     "$PYTHON_SCRIPT" \
     '"test -d vendor || composer install",' \
-    '"test -d vendor || composer install",\n                    "test -d node_modules || npm ci",' \
+    '"test -d vendor || composer install",\n                    "npm ci",' \
     "api polyscope config references npm without a package.json at the repo root"
 
 assert_rollout_rejects_invalid_local_config \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1593,6 +1593,7 @@ seed_node_worktree_files "$failing_frontend_manifest_clone" "frontend-broken-ibi
 seed_node_worktree_files "$failing_frontend_io_clone" "frontend-locked-oryx"
 seed_api_worktree_files "$guardguide_clone"
 seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+printf '{\n  "packages": []\n}\n' > "$guardguide_clone/composer.lock"
 printf '{"scripts": ' > "$failing_api_cleanup_clone/composer.json"
 printf '{"scripts": ' > "$failing_frontend_manifest_clone/package.json"
 rm -rf "$failing_frontend_io_clone/.git/info"
@@ -1687,6 +1688,48 @@ test ! -f "$failing_api_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_api_cleanup_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_frontend_manifest_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$failing_frontend_io_clone/.polyscope-secpal-provisioned.json"
+
+python3 - <<'PY' "$guardguide_clone/composer.lock"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["packages"].append({"name": "guardguide/app", "version": "1.0.1"})
+path.write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+guardguide_lockfile_summary_json="$workspace/guardguide-lockfile-summary.json"
+guardguide_composer_install_count_before="$(grep -cF "composer:$guardguide_clone:install" "$provision_log" || true)"
+env HOME="$home_dir" \
+    PATH="$service_path" \
+    PROVISION_LOG="$provision_log" \
+    FAKE_PSQL_LOG="$fake_psql_log" \
+    FAKE_PSQL_STATE="$fake_pg_state" \
+    FAIL_ON_WORKTREE="$failing_api_clone" \
+    python3 "$PYTHON_SCRIPT" \
+    --workspace-root "$workspace_root" \
+    --repo-state-file "$repos_json" \
+    --nginx-output "$nginx_output" \
+    --summary-output "$guardguide_lockfile_summary_json" \
+    --skip-local-configs \
+    --skip-db-sync \
+    --provision-worktrees \
+    > /dev/null || guardguide_lockfile_exit=$?
+
+test "${guardguide_lockfile_exit:-0}" -eq 1
+
+python3 - "$guardguide_lockfile_summary_json" <<'PY'
+import json
+import sys
+
+summary = json.loads(open(sys.argv[1]).read())
+provisioned = summary.get('provisioned_worktrees', [])
+assert 'GuardGuide:steady-otter' in provisioned, provisioned
+PY
+
+test "$guardguide_composer_install_count_before" -lt "$(grep -cF "composer:$guardguide_clone:install" "$provision_log")"
 
 schema_home_dir="$workspace/schema-home"
 schema_api_clone="$schema_home_dir/.polyscope/clones/api12345/schema-badger"


### PR DESCRIPTION
## Summary
- make Node-based Polyscope setup run `npm ci` deterministically during provisioning
- include dependency manifests and lockfiles in the worktree setup fingerprint
- add a regression test that proves lockfile drift triggers reprovisioning

## Root Cause
Polyscope only checked whether `node_modules/` existed before deciding to skip `npm ci`. When a repository added or changed dependencies without changing the generated setup command list, existing workspaces kept stale dependency trees and failed later during build or setup.

## Validation
- `bash tests/polyscope-rollout.sh`
- live reprovisioning pass via `scripts/polyscope-rollout.py --provision-worktrees`

## TDD / Validate-First Evidence

- Failing proof before implementation: with `scripts/polyscope-rollout.py` reverted to `origin/main` (Node setups still using `test -d node_modules || npm ci` and `build_setup_hash` only hashing the command list) and the new regression block in `tests/polyscope-rollout.sh` (the `python3 - <<'PY' "$schema_frontend_clone/package-lock.json"` mutation plus the `test "$schema_frontend_npm_ci_count_before" -lt "$(grep -cF "npm:$schema_frontend_clone:ci" "$provision_log")"` assertion) in place, `bash tests/polyscope-rollout.sh` exits `1` on that assertion because the second `--provision-worktrees` pass short-circuits on the unchanged `setup_hash` and never reruns `npm:$schema_frontend_clone:ci`, so the post-mutation count stays equal to the pre-mutation count.
- Passing proof after implementation: with both diff hunks applied (`scripts/polyscope-rollout.py` running `npm ci` unconditionally for Node setups and `build_setup_hash` mixing `package.json` / `package-lock.json` contents into the per-worktree hash, plus the new test block), `bash tests/polyscope-rollout.sh` runs to completion with exit code `0`; the lockfile mutation triggers a fresh `npm:$schema_frontend_clone:ci` entry in `$provision_log` and the rendered `$schema_lockfile_summary_json` lists `frontend:schema-badger` under `provisioned_worktrees`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Polyscope provisioning behavior for all Node-based preview workspaces; incorrect hashing could cause excess rebuilds or missed reprovisions, but scope is dev tooling only.
> 
> **Overview**
> Polyscope worktree provisioning no longer skips `npm ci` when `node_modules` already exists. **Node-based** managed repos (`frontend`, `GuardGuide`, `contracts`, `android`, static sites, `.github`) now always run **`npm ci`** during setup, because the provision marker already gates full runs— the old `test -d node_modules || npm ci` pattern left **stale trees** after lockfile-only changes (e.g. new `@fontsource/inter` on GuardGuide previews).
> 
> The **setup fingerprint** (`.polyscope-secpal-provisioned.json` `setup_hash`) now hashes **setup commands plus** the contents of `package.json` / `package-lock.json` (and `composer.json` / `composer.lock` when Composer commands appear), computed **per worktree** so a changed lockfile invalidates the marker and triggers reprovisioning.
> 
> `tests/polyscope-rollout.sh` gains a regression that mutates a provisioned frontend `package-lock.json` and asserts a later `--provision-worktrees` pass runs `npm ci` again and lists the worktree in `provisioned_worktrees`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88079bbc9aba30aa2e921529cc10d1067a4ed0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
