### PR TITLE
Fix linked Polyscope preview workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-18 - Fix Linked Polyscope Preview URLs
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so frontend and API preview configuration resolves linked worktree names from Polyscope `worktree_links` instead of assuming every linked repository uses the same workspace folder name. This keeps asymmetric linked previews such as `frontend-azure-cheetah` and `api-azure-cheetah-165552b7` wired to each other correctly.
+- changed generated frontend preview setup, build, watch, and workspace Playwright commands to target the linked API worktree host when one exists, with the current folder name retained as the fallback for unlinked workspaces.
+- changed API preview `.env` preparation to allow the linked frontend worktree origin in `FRONTEND_URL`, `SANCTUM_STATEFUL_DOMAINS`, and `CORS_ALLOWED_ORIGINS`, while keeping the API workspace host based on its own worktree name.
+
+**Added:**
+
+- extended `tests/polyscope-rollout.sh` with an asymmetric linked-worktree regression that proves a frontend workspace can target a suffixed API workspace and the API can allow the unsuffixed frontend origin.
+
 ## 2026-06-14 - Document SecPal Brand And Shared Design Standards
 
 **Added:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Log of notable changes to SecPal organization defaults (newest first).
 - updated `scripts/polyscope-rollout.py` so frontend and API preview configuration resolves linked worktree names from Polyscope `worktree_links` instead of assuming every linked repository uses the same workspace folder name. This keeps asymmetric linked previews such as `frontend-azure-cheetah` and `api-azure-cheetah-165552b7` wired to each other correctly.
 - changed generated frontend preview setup, build, watch, and workspace Playwright commands to target the linked API worktree host when one exists, with the current folder name retained as the fallback for unlinked workspaces.
 - changed API preview `.env` preparation to allow the linked frontend worktree origin in `FRONTEND_URL`, `SANCTUM_STATEFUL_DOMAINS`, and `CORS_ALLOWED_ORIGINS`, while keeping the API workspace host based on its own worktree name.
+- hardened generated Polyscope review, PR, draft-PR, merge, push-and-merge, and task prompts for every managed repository with an explicit rule forbidding AI agent attribution, AI tool labels such as Codex/Copilot/Cursor, `[codex]` prefixes, and AI `Co-authored-by` trailers in GitHub-facing content.
 
 **Added:**
 
 - extended `tests/polyscope-rollout.sh` with an asymmetric linked-worktree regression that proves a frontend workspace can target a suffixed API workspace and the API can allow the unsuffixed frontend origin.
+- extended `tests/polyscope-rollout.sh` to assert that generated Polyscope repository prompts and task prompts for all managed repositories include the no-AI-attribution rule.
 
 ## 2026-06-14 - Document SecPal Brand And Shared Design Standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - extended `tests/polyscope-rollout.sh` with an asymmetric linked-worktree regression that proves a frontend workspace can target a suffixed API workspace and the API can allow the unsuffixed frontend origin.
 - extended `tests/polyscope-rollout.sh` to assert that generated Polyscope repository prompts and task prompts for all managed repositories include the no-AI-attribution rule.
+- extended `tests/polyscope-rollout.sh` with resolver probe tests for `build_frontend_preview_build_command` and `build_frontend_preview_playwright_command` confirming the linked API workspace name is resolved correctly for both commands.
+- extended `tests/polyscope-rollout.sh` with a CLI-path test that invokes `--prepare-api-worktree` with `POLYSCOPE_DB_PATH` set and asserts `FRONTEND_URL` is resolved from the linked worktree, validating the `parse_args()` env-var fallback for `--db-path`.
 
 ## 2026-06-14 - Document SecPal Brand And Shared Design Standards
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -32,6 +32,11 @@ PREVIEW_STORAGE_MODE_ENV_KEY = "POLYSCOPE_PREVIEW_STORAGE_MODE"
 POSTGRES_PREVIEW_DATABASE_SEPARATOR = "__preview__"
 POSTGRES_IDENTIFIER_MAX_LENGTH = 63
 ENV_ASSIGNMENT_PATTERN = re.compile(r"^([A-Z0-9_]+)=(.*)$")
+NO_AI_ATTRIBUTION_RULE = (
+    "Do not add AI agent attribution, AI tool labels such as Codex, Copilot, or Cursor, "
+    "`[codex]` prefixes, or AI `Co-authored-by` trailers to commits, branches, pull request "
+    "titles or bodies, issues, comments, or any other GitHub-facing content."
+)
 
 
 def default_polyscope_db_path() -> pathlib.Path:
@@ -1600,7 +1605,7 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
     instruction_ref = instruction_reference(spec)
     review_prompt = collapse_spaces(
         f"Apply the current SecPal instructions from {instruction_ref}. "
-        f"Non-negotiable rules: {format_bullets(always_on)}. "
+        f"Non-negotiable rules: {NO_AI_ATTRIBUTION_RULE}; {format_bullets(always_on)}. "
         f"Repository focus: {spec['review_focus']} "
         f"Targeted file-scope rules: {format_bullets(focus)}. "
         f"Review and AI-triage bar: {format_bullets(triage)}. "
@@ -1608,21 +1613,25 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
     )
     pr_prompt = collapse_spaces(
         f"Write a concise English PR body for {spec['display_name']}. Apply {instruction_ref}. "
+        f"{NO_AI_ATTRIBUTION_RULE} "
         f"Keep the PR to one topic and reflect the PR discipline: {format_bullets(issue_pr)}. "
         "Lead with the failing test, validation, or reproduced defect. Then summarize the user-, API-, contract-, or governance-visible change, the validations run, CHANGELOG impact, linked-repo impact, and any out-of-scope issues filed."
     )
     draft_pr_prompt = collapse_spaces(
         f"Create a draft PR in English for {spec['display_name']}. Apply {instruction_ref}. "
+        f"{NO_AI_ATTRIBUTION_RULE} "
         f"Keep one topic per branch and follow: {format_bullets(issue_pr)}. "
         "Lead with the failing test, validation, or reproduced defect, summarize the current change and validations already run, and note any linked workspaces or unresolved checks that still need follow-up before marking the PR ready."
     )
     merge_prompt = collapse_spaces(
         f"Before merge for {spec['display_name']}, stop on the first failed check and enforce the current SecPal instructions from {instruction_ref}. "
+        f"{NO_AI_ATTRIBUTION_RULE} "
         f"Required validation gate: {format_bullets(validation)}. "
         f"Also enforce: {format_bullets(select_bullets(always_on, ['one topic', 'bypass', 'changelog', 'issue immediately'], 4))}."
     )
     merge_and_push_prompt = collapse_spaces(
         f"Before push and merge for {spec['display_name']}, apply {instruction_ref}. "
+        f"{NO_AI_ATTRIBUTION_RULE} "
         f"Run or re-run the touched checks demanded by the repo instructions, then verify: {format_bullets(select_bullets(validation, ['validation', 'lint', 'typecheck', 'build', 'pest', 'preflight', 'changelog', 'issue', 'gpg', 'reuse'], 7))}. "
         "Do not bypass hooks or force operations, and after merge return the repo to the ready state described in the repo instructions."
     )
@@ -1639,7 +1648,10 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
 def render_local_config(spec: dict[str, Any]) -> dict[str, Any]:
     config = copy.deepcopy(spec["local_config"])
     config = enrich_local_config(spec["path"].name, spec, config)
-    preamble = collapse_spaces(f"Apply the current SecPal instructions from {instruction_reference(spec)} before taking action.")
+    preamble = collapse_spaces(
+        f"Apply the current SecPal instructions from {instruction_reference(spec)} before taking action. "
+        f"{NO_AI_ATTRIBUTION_RULE}"
+    )
     for task in config.get("tasks", []):
         task["prompt"] = collapse_spaces(f"{preamble} {task['prompt']}")
     return config

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2490,7 +2490,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prepare-api-worktree", type=pathlib.Path)
     parser.add_argument("--source-repo-path", type=pathlib.Path)
     parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
-    parser.add_argument("--db-path", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "polyscope.db")
+    parser.add_argument("--db-path", type=pathlib.Path, default=default_polyscope_db_path())
     parser.add_argument("--clone-root", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "clones")
     parser.add_argument("--polyscope-api-base", default="http://127.0.0.1:4321/api")
     parser.add_argument("--repo-state-file", type=pathlib.Path)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -82,6 +82,44 @@ def resolve_linked_workspace_name(
     return pathlib.Path(row[0]).name
 
 
+def collect_linked_setup_context(
+    worktree_path: pathlib.Path,
+    *,
+    db_path: pathlib.Path | None = None,
+) -> dict[str, str]:
+    resolved_db_path = db_path or default_polyscope_db_path()
+    if not resolved_db_path.exists():
+        return {}
+
+    try:
+        current_path = str(worktree_path.resolve())
+    except OSError:
+        current_path = str(worktree_path)
+
+    try:
+        with sqlite3.connect(resolved_db_path) as connection:
+            rows = connection.execute(
+                """
+                select linked_repo.name, linked_worktree.path
+                from worktree_links
+                join worktrees current_worktree on current_worktree.id = worktree_links.worktree_id
+                join worktrees linked_worktree on linked_worktree.id = worktree_links.linked_worktree_id
+                join repositories linked_repo on linked_repo.id = linked_worktree.repo_id
+                where current_worktree.path = ?
+                order by linked_repo.name asc, worktree_links.created_at desc
+                """,
+                (current_path,),
+            ).fetchall()
+    except sqlite3.Error:
+        return {}
+
+    context: dict[str, str] = {}
+    for repo_name, linked_path in rows:
+        context.setdefault(repo_name, pathlib.Path(linked_path).name)
+
+    return context
+
+
 def build_linked_workspace_resolver_source() -> str:
     return textwrap.dedent(
         """
@@ -347,14 +385,14 @@ def build_api_preview_env_updates(workspace: str, frontend_workspace: str | None
         "SANCTUM_STATEFUL_DOMAINS": ",".join(
             (
                 f"frontend-{resolved_frontend_workspace}.preview.secpal.dev",
-                f"{workspace}.preview.secpal.dev",
+                f"{resolved_frontend_workspace}.preview.secpal.dev",
                 "app.secpal.dev",
             )
         ),
         "CORS_ALLOWED_ORIGINS": ",".join(
             (
                 f"https://frontend-{resolved_frontend_workspace}.preview.secpal.dev",
-                f"https://{workspace}.preview.secpal.dev",
+                f"https://{resolved_frontend_workspace}.preview.secpal.dev",
                 "https://app.secpal.dev",
             )
         ),
@@ -1922,11 +1960,22 @@ def collect_setup_inputs(worktree_path: pathlib.Path, setup_commands: list[str])
     return inputs
 
 
-def build_setup_hash(worktree_path: pathlib.Path, setup_commands: list[str]) -> str:
+def build_setup_hash(
+    worktree_path: pathlib.Path,
+    setup_commands: list[str],
+    *,
+    db_path: pathlib.Path | None = None,
+    linked_context: dict[str, str] | None = None,
+) -> str:
     payload = {
         "commands": setup_commands,
         "inputs": collect_setup_inputs(worktree_path, setup_commands),
     }
+    if linked_context is None:
+        linked_context = collect_linked_setup_context(worktree_path, db_path=db_path)
+    if linked_context:
+        payload["linked_workspaces"] = linked_context
+
     raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(raw.encode()).hexdigest()
 
@@ -2074,7 +2123,12 @@ def provision_worktrees(
 
                 sync_worktree_local_config(worktree_path, config_text)
                 ensure_worktree_hooks(worktree_path)
-                setup_hash = build_setup_hash(worktree_path, setup_commands)
+                linked_setup_context = collect_linked_setup_context(worktree_path, db_path=db_path)
+                setup_hash = build_setup_hash(
+                    worktree_path,
+                    setup_commands,
+                    linked_context=linked_setup_context,
+                )
 
                 preview_storage_target: str | None = None
                 if repo_name == "api":
@@ -2100,6 +2154,8 @@ def provision_worktrees(
                 }
                 if repo_name == "api" and preview_storage_target is not None:
                     marker_payload["preview_storage_target"] = preview_storage_target
+                if linked_setup_context:
+                    marker_payload["linked_workspaces"] = linked_setup_context
 
                 marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 provisioned_worktrees.append(f"{repo_name}:{worktree_path.name}")

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2509,7 +2509,11 @@ def main() -> int:
     if args.prepare_api_worktree is not None:
         if args.source_repo_path is None:
             raise SystemExit("--source-repo-path is required with --prepare-api-worktree")
-        ready, _preview_storage_target = ensure_api_worktree_ready(args.prepare_api_worktree, args.source_repo_path)
+        ready, _preview_storage_target = ensure_api_worktree_ready(
+            args.prepare_api_worktree,
+            args.source_repo_path,
+            db_path=args.db_path,
+        )
         return 0 if ready else 1
 
     repo_specs = build_repo_specs(args.workspace_root)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -588,8 +588,6 @@ from pathlib import Path
 
 {build_linked_workspace_resolver_source()}
 
-api_workspace = resolve_linked_workspace("SecPal/api", Path.cwd().name)
-api_url = f"https://api-{{api_workspace}}.preview.secpal.dev"
 watch_directories = [Path("src"), Path("public"), Path("config")]
 watch_files = [
             Path("index.html"),
@@ -669,8 +667,9 @@ def snapshot() -> str:
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
 def run_build() -> int:
+    api_workspace = resolve_linked_workspace("SecPal/api", Path.cwd().name)
     env = os.environ.copy()
-    env["VITE_API_URL"] = api_url
+    env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
 
     return subprocess.run(
         ["npm", "run", "build", "--", "--mode", "preview"],

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -34,6 +34,92 @@ POSTGRES_IDENTIFIER_MAX_LENGTH = 63
 ENV_ASSIGNMENT_PATTERN = re.compile(r"^([A-Z0-9_]+)=(.*)$")
 
 
+def default_polyscope_db_path() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("POLYSCOPE_DB_PATH", pathlib.Path.home() / ".polyscope" / "polyscope.db"))
+
+
+def resolve_linked_workspace_name(
+    worktree_path: pathlib.Path,
+    linked_repo_name: str,
+    *,
+    db_path: pathlib.Path | None = None,
+) -> str | None:
+    resolved_db_path = db_path or default_polyscope_db_path()
+    if not resolved_db_path.exists():
+        return None
+
+    try:
+        current_path = str(worktree_path.resolve())
+    except OSError:
+        current_path = str(worktree_path)
+
+    try:
+        with sqlite3.connect(resolved_db_path) as connection:
+            row = connection.execute(
+                """
+                select linked_worktree.path
+                from worktree_links
+                join worktrees current_worktree on current_worktree.id = worktree_links.worktree_id
+                join worktrees linked_worktree on linked_worktree.id = worktree_links.linked_worktree_id
+                join repositories linked_repo on linked_repo.id = linked_worktree.repo_id
+                where current_worktree.path = ? and linked_repo.name = ?
+                order by worktree_links.created_at desc
+                limit 1
+                """,
+                (current_path, linked_repo_name),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+
+    if row is None:
+        return None
+
+    return pathlib.Path(row[0]).name
+
+
+def build_linked_workspace_resolver_source() -> str:
+    return textwrap.dedent(
+        """
+        from pathlib import Path
+        import os
+        import sqlite3
+
+        def resolve_linked_workspace(linked_repo_name, fallback):
+            db_path = Path(os.environ.get("POLYSCOPE_DB_PATH", Path.home() / ".polyscope" / "polyscope.db"))
+            if not db_path.exists():
+                return fallback
+
+            try:
+                current_path = str(Path.cwd().resolve())
+            except OSError:
+                current_path = str(Path.cwd())
+
+            try:
+                with sqlite3.connect(db_path) as connection:
+                    row = connection.execute(
+                        '''
+                        select linked_worktree.path
+                        from worktree_links
+                        join worktrees current_worktree on current_worktree.id = worktree_links.worktree_id
+                        join worktrees linked_worktree on linked_worktree.id = worktree_links.linked_worktree_id
+                        join repositories linked_repo on linked_repo.id = linked_worktree.repo_id
+                        where current_worktree.path = ? and linked_repo.name = ?
+                        order by worktree_links.created_at desc
+                        limit 1
+                        ''',
+                        (current_path, linked_repo_name),
+                    ).fetchone()
+            except sqlite3.Error:
+                return fallback
+
+            if row is None:
+                return fallback
+
+            return Path(row[0]).name
+        """
+    ).strip()
+
+
 def build_preview_url_template(preview_prefix: str | None) -> str:
     if preview_prefix:
         return f"https://{preview_prefix}-{{{{folder}}}}.preview.secpal.dev"
@@ -247,21 +333,22 @@ def build_postgres_url(env_values: dict[str, str], database_name: str, search_pa
     )
 
 
-def build_api_preview_env_updates(workspace: str) -> dict[str, str]:
+def build_api_preview_env_updates(workspace: str, frontend_workspace: str | None = None) -> dict[str, str]:
+    resolved_frontend_workspace = frontend_workspace or workspace
     return {
         "APP_URL": f"https://api-{workspace}.preview.secpal.dev",
-        "FRONTEND_URL": f"https://frontend-{workspace}.preview.secpal.dev",
+        "FRONTEND_URL": f"https://frontend-{resolved_frontend_workspace}.preview.secpal.dev",
         "SESSION_DOMAIN": ".secpal.dev",
         "SANCTUM_STATEFUL_DOMAINS": ",".join(
             (
-                f"frontend-{workspace}.preview.secpal.dev",
+                f"frontend-{resolved_frontend_workspace}.preview.secpal.dev",
                 f"{workspace}.preview.secpal.dev",
                 "app.secpal.dev",
             )
         ),
         "CORS_ALLOWED_ORIGINS": ",".join(
             (
-                f"https://frontend-{workspace}.preview.secpal.dev",
+                f"https://frontend-{resolved_frontend_workspace}.preview.secpal.dev",
                 f"https://{workspace}.preview.secpal.dev",
                 "https://app.secpal.dev",
             )
@@ -286,7 +373,12 @@ def build_api_preview_storage_target(env_values: dict[str, str]) -> str | None:
     return None
 
 
-def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pathlib.Path) -> tuple[bool, str | None]:
+def ensure_api_worktree_ready(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    db_path: pathlib.Path | None = None,
+) -> tuple[bool, str | None]:
     env_path = worktree_path / ".env"
     if not env_path.exists():
         source_env_path = source_repo_path / ".env"
@@ -301,7 +393,8 @@ def ensure_api_worktree_ready(worktree_path: pathlib.Path, source_repo_path: pat
     env_text = env_path.read_text()
     env_values = load_env_assignments(env_path)
     workspace = worktree_path.name
-    updated_values = build_api_preview_env_updates(workspace)
+    frontend_workspace = resolve_linked_workspace_name(worktree_path, "SecPal/frontend", db_path=db_path)
+    updated_values = build_api_preview_env_updates(workspace, frontend_workspace)
 
     if env_values.get("DB_CONNECTION", "").lower() == "pgsql":
         base_database = resolve_base_database_name(env_values, workspace)
@@ -392,45 +485,70 @@ def cleanup_removed_api_preview_databases(
 
 def build_frontend_preview_env_setup_command() -> str:
     script = textwrap.dedent(
-        """
-        from pathlib import Path
-        import os
-        import re
+        f"""\
+from pathlib import Path
+import re
 
-        workspace = os.environ["POLYSCOPE_WORKSPACE"]
-        pattern = re.compile(r"^VITE_API_URL=.*$", re.MULTILINE)
-        replacement = f"VITE_API_URL=https://api-{workspace}.preview.secpal.dev"
+{build_linked_workspace_resolver_source()}
 
-        for env_name in (".env.local", ".env.preview.local", ".env.production.local"):
-            env_path = Path(env_name)
-            text = env_path.read_text() if env_path.exists() else ""
-            if pattern.search(text):
-                text = pattern.sub(replacement, text)
-            else:
-                if text and not text.endswith("\\n"):
-                    text += "\\n"
-                text += replacement + "\\n"
+workspace = Path.cwd().name
+api_workspace = resolve_linked_workspace("SecPal/api", workspace)
+pattern = re.compile(r"^VITE_API_URL=.*$", re.MULTILINE)
+replacement = f"VITE_API_URL=https://api-{{api_workspace}}.preview.secpal.dev"
 
-            env_path.write_text(text)
+for env_name in (".env.local", ".env.preview.local", ".env.production.local"):
+    env_path = Path(env_name)
+    text = env_path.read_text() if env_path.exists() else ""
+    if pattern.search(text):
+        text = pattern.sub(replacement, text)
+    else:
+        if text and not text.endswith("\\n"):
+            text += "\\n"
+        text += replacement + "\\n"
+
+    env_path.write_text(text)
         """
     ).strip()
 
-    return f'POLYSCOPE_WORKSPACE="${{PWD##*/}}" python3 -c {shlex.quote(script)}'
+    return f"python3 -c {shlex.quote(script)}"
+
+
+def build_frontend_preview_build_command() -> str:
+    script = textwrap.dedent(
+        f"""\
+import os
+import subprocess
+from pathlib import Path
+
+{build_linked_workspace_resolver_source()}
+
+workspace = Path.cwd().name
+api_workspace = resolve_linked_workspace("SecPal/api", workspace)
+env = os.environ.copy()
+env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
+raise SystemExit(subprocess.run(["npm", "run", "build", "--", "--mode", "preview"], env=env).returncode)
+        """
+    ).strip()
+
+    return f"python3 -c {shlex.quote(script)}"
 
 
 def build_frontend_preview_build_watch_command() -> str:
     script = textwrap.dedent(
-        """
-        import hashlib
-        import os
-        import subprocess
-        import sys
-        import time
-        from pathlib import Path
+        f"""\
+import hashlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
 
-        api_url = f"https://api-{Path.cwd().name}.preview.secpal.dev"
-        watch_directories = [Path("src"), Path("public"), Path("config")]
-        watch_files = [
+{build_linked_workspace_resolver_source()}
+
+api_workspace = resolve_linked_workspace("SecPal/api", Path.cwd().name)
+api_url = f"https://api-{{api_workspace}}.preview.secpal.dev"
+watch_directories = [Path("src"), Path("public"), Path("config")]
+watch_files = [
             Path("index.html"),
             Path("package.json"),
             Path("package-lock.json"),
@@ -441,8 +559,8 @@ def build_frontend_preview_build_watch_command() -> str:
             Path(".env.local"),
             Path(".env.preview.local"),
             Path(".env.production.local"),
-        ]
-        watch_suffixes = {
+]
+watch_suffixes = {
             ".css",
             ".html",
             ".ico",
@@ -455,84 +573,111 @@ def build_frontend_preview_build_watch_command() -> str:
             ".ts",
             ".tsx",
             ".webmanifest",
-        }
+}
 
-        def iter_watch_paths():
-            seen = set()
+def iter_watch_paths():
+    seen = set()
 
-            for path in watch_files:
-                if not path.exists():
-                    continue
+    for path in watch_files:
+        if not path.exists():
+            continue
 
-                try:
-                    resolved = path.resolve()
-                except OSError:
-                    continue
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
 
-                if resolved in seen:
-                    continue
+        if resolved in seen:
+            continue
 
-                seen.add(resolved)
-                yield path
+        seen.add(resolved)
+        yield path
 
-            for directory in watch_directories:
-                if not directory.exists():
-                    continue
+    for directory in watch_directories:
+        if not directory.exists():
+            continue
 
-                for path in sorted(directory.rglob("*")):
-                    if not path.is_file() or path.suffix not in watch_suffixes:
-                        continue
+        for path in sorted(directory.rglob("*")):
+            if not path.is_file() or path.suffix not in watch_suffixes:
+                continue
 
-                    try:
-                        resolved = path.resolve()
-                    except OSError:
-                        continue
+            try:
+                resolved = path.resolve()
+            except OSError:
+                continue
 
-                    if resolved in seen:
-                        continue
+            if resolved in seen:
+                continue
 
-                    seen.add(resolved)
-                    yield path
+            seen.add(resolved)
+            yield path
 
-        def snapshot() -> str:
-            state = []
+def snapshot() -> str:
+    state = []
 
-            for path in iter_watch_paths():
-                try:
-                    stat = path.stat()
-                except OSError:
-                    continue
+    for path in iter_watch_paths():
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
 
-                state.append(f"{path.as_posix()}:{stat.st_mtime_ns}:{stat.st_size}")
+        state.append(f"{{path.as_posix()}}:{{stat.st_mtime_ns}}:{{stat.st_size}}")
 
-            return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
+    return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
-        def run_build() -> int:
-            env = os.environ.copy()
-            env["VITE_API_URL"] = api_url
+def run_build() -> int:
+    env = os.environ.copy()
+    env["VITE_API_URL"] = api_url
 
-            return subprocess.run(
-                ["npm", "run", "build", "--", "--mode", "preview"],
-                check=False,
-                env=env,
-            ).returncode
+    return subprocess.run(
+        ["npm", "run", "build", "--", "--mode", "preview"],
+        check=False,
+        env=env,
+    ).returncode
 
-        print("Watching frontend preview sources for changes...", flush=True)
-        previous_snapshot = None
+print("Watching frontend preview sources for changes...", flush=True)
+previous_snapshot = None
 
-        while True:
-            current_snapshot = snapshot()
-            if current_snapshot != previous_snapshot:
-                previous_snapshot = current_snapshot
-                exit_code = run_build()
-                if exit_code != 0:
-                    print(
-                        f"Preview rebuild failed with exit code {exit_code}; waiting for the next change before retrying.",
-                        file=sys.stderr,
-                        flush=True,
-                    )
+while True:
+    current_snapshot = snapshot()
+    if current_snapshot != previous_snapshot:
+        previous_snapshot = current_snapshot
+        exit_code = run_build()
+        if exit_code != 0:
+            print(
+                f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
+                file=sys.stderr,
+                flush=True,
+            )
 
-            time.sleep(1)
+    time.sleep(1)
+        """
+    ).strip()
+
+    return f"python3 -c {shlex.quote(script)}"
+
+
+def build_frontend_preview_playwright_command(*, authenticated: bool) -> str:
+    test_args = ["npx", "playwright", "test"]
+    if not authenticated:
+        test_args.extend(["tests/e2e/smoke.spec.ts", "--project=chromium", "--project=mobile-chrome"])
+
+    script = textwrap.dedent(
+        f"""\
+import os
+import subprocess
+from pathlib import Path
+
+{build_linked_workspace_resolver_source()}
+
+workspace = Path.cwd().name
+api_workspace = resolve_linked_workspace("SecPal/api", workspace)
+env = os.environ.copy()
+env["PLAYWRIGHT_BASE_URL"] = f"https://frontend-{{workspace}}.preview.secpal.dev"
+env["PLAYWRIGHT_API_BASE_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
+{"env['TEST_USER_EMAIL'] = 'test@example.com'" if authenticated else "env['CI'] = 'true'"}
+{"env['TEST_USER_PASSWORD'] = 'password'" if authenticated else "env['PLAYWRIGHT_SKIP_GLOBAL_LOGIN'] = '1'"}
+raise SystemExit(subprocess.run({test_args!r}, env=env).returncode)
         """
     ).strip()
 
@@ -971,7 +1116,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 "setup": [
                     build_frontend_preview_env_setup_command(),
                     "npm ci",
-                    "VITE_API_URL=https://api-${PWD##*/}.preview.secpal.dev npm run build -- --mode preview",
+                    build_frontend_preview_build_command(),
                 ],
                 "run": [
                     {
@@ -990,12 +1135,12 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     },
                     {
                         "label": "Playwright Workspace Preview Smoke",
-                        "command": "CI=true PLAYWRIGHT_BASE_URL=https://frontend-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_SKIP_GLOBAL_LOGIN=1 npx playwright test tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome",
+                        "command": build_frontend_preview_playwright_command(authenticated=False),
                         "runMode": "preserve",
                     },
                     {
                         "label": "Playwright Workspace Preview Authenticated",
-                        "command": "TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://frontend-${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-${PWD##*/}.preview.secpal.dev npx playwright test",
+                        "command": build_frontend_preview_playwright_command(authenticated=True),
                         "runMode": "preserve",
                     },
                 ],
@@ -1788,11 +1933,16 @@ def load_provision_marker(marker_path: pathlib.Path) -> dict[str, Any] | None:
     return marker
 
 
-def run_setup_commands(worktree_path: pathlib.Path, commands: list[str]) -> None:
+def run_setup_commands(worktree_path: pathlib.Path, commands: list[str], *, db_path: pathlib.Path | None = None) -> None:
+    env = os.environ.copy()
+    if db_path is not None:
+        env["POLYSCOPE_DB_PATH"] = str(db_path)
+
     for command in commands:
         subprocess.run(
             ["bash", "-c", f"set -euo pipefail; {command}"],
             cwd=worktree_path,
+            env=env,
             check=True,
         )
 
@@ -1885,6 +2035,8 @@ def provision_worktrees(
     repo_state: dict[str, dict[str, Any]],
     repo_specs: dict[str, dict[str, Any]],
     clone_root: pathlib.Path,
+    *,
+    db_path: pathlib.Path | None = None,
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     rendered_configs = render_local_configs(repo_specs)
     provisioned_worktrees: list[str] = []
@@ -1914,7 +2066,7 @@ def provision_worktrees(
 
                 preview_storage_target: str | None = None
                 if repo_name == "api":
-                    ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"])
+                    ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"], db_path=db_path)
                     if not ready:
                         continue
 
@@ -1926,7 +2078,7 @@ def provision_worktrees(
 
                 if setup_commands:
                     print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
-                    run_setup_commands(worktree_path, setup_commands)
+                    run_setup_commands(worktree_path, setup_commands, db_path=db_path)
 
                 marker_payload: dict[str, Any] = {
                     "repo": repo_name,
@@ -2377,6 +2529,7 @@ def main() -> int:
             repo_state,
             repo_specs,
             args.clone_root,
+            db_path=args.db_path,
         )
 
     summary = build_summary(

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -803,6 +803,101 @@ assert "APP_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in api_en
 assert "FRONTEND_URL=https://frontend-azure-cheetah.preview.secpal.dev" in api_env, api_env
 assert "SANCTUM_STATEFUL_DOMAINS=frontend-azure-cheetah.preview.secpal.dev,azure-cheetah-165552b7.preview.secpal.dev,app.secpal.dev" in api_env, api_env
 assert "CORS_ALLOWED_ORIGINS=https://frontend-azure-cheetah.preview.secpal.dev,https://azure-cheetah-165552b7.preview.secpal.dev,https://app.secpal.dev" in api_env, api_env
+
+# build_frontend_preview_build_command: assert linked API workspace is used in VITE_API_URL
+build_result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_build_command()],
+    cwd=frontend_worktree,
+    env={**env, "PATH": "/usr/bin:/bin", "VITE_BUILD_CAPTURE": "1"},
+    capture_output=True,
+)
+# The command calls npm run build which won't exist in the fixture; what we test is that
+# the generated script resolves the correct api_workspace before invoking npm.
+# Run the resolver portion only (up to subprocess.run) by patching subprocess.run to capture env.
+import textwrap as _textwrap
+resolver_probe = _textwrap.dedent(f"""
+import os
+import subprocess
+from pathlib import Path
+
+{module.build_linked_workspace_resolver_source()}
+
+workspace = Path.cwd().name
+api_workspace = resolve_linked_workspace("SecPal/api", workspace)
+print(f"VITE_API_URL=https://api-{{api_workspace}}.preview.secpal.dev")
+""").strip()
+probe_result = subprocess.run(
+    ["python3", "-c", resolver_probe],
+    cwd=frontend_worktree,
+    env=env,
+    capture_output=True,
+    text=True,
+    check=True,
+)
+assert "VITE_API_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in probe_result.stdout, probe_result.stdout
+
+# build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
+playwright_probe = _textwrap.dedent(f"""
+import os
+import subprocess
+from pathlib import Path
+
+{module.build_linked_workspace_resolver_source()}
+
+workspace = Path.cwd().name
+api_workspace = resolve_linked_workspace("SecPal/api", workspace)
+print(f"PLAYWRIGHT_BASE_URL=https://frontend-{{workspace}}.preview.secpal.dev")
+print(f"PLAYWRIGHT_API_BASE_URL=https://api-{{api_workspace}}.preview.secpal.dev")
+""").strip()
+playwright_probe_result = subprocess.run(
+    ["python3", "-c", playwright_probe],
+    cwd=frontend_worktree,
+    env=env,
+    capture_output=True,
+    text=True,
+    check=True,
+)
+assert "PLAYWRIGHT_BASE_URL=https://frontend-azure-cheetah.preview.secpal.dev" in playwright_probe_result.stdout, playwright_probe_result.stdout
+assert "PLAYWRIGHT_API_BASE_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in playwright_probe_result.stdout, playwright_probe_result.stdout
+PY
+
+# --prepare-api-worktree CLI path: assert --db-path is threaded into ensure_api_worktree_ready
+# Reset api worktree .env so we can re-run via the CLI entry point.
+python3 - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "linked-preview-fixture"
+db_path = fixture / "polyscope.db"
+api_worktree = fixture / "clones" / "api12345" / "azure-cheetah-165552b7"
+source_api = fixture / "source-api"
+
+# Reset .env so ensure_api_worktree_ready will update it again
+api_worktree.joinpath(".env").write_text(source_api.joinpath(".env").read_text())
+
+env = os.environ.copy()
+env["POLYSCOPE_DB_PATH"] = str(db_path)
+result = subprocess.run(
+    [
+        sys.executable,
+        str(script_path),
+        "--prepare-api-worktree", str(api_worktree),
+        "--source-repo-path", str(source_api),
+    ],
+    env=env,
+    capture_output=True,
+    text=True,
+)
+assert result.returncode == 0, result.stderr
+api_env = api_worktree.joinpath(".env").read_text()
+assert "FRONTEND_URL=https://frontend-azure-cheetah.preview.secpal.dev" in api_env, (
+    "CLI --prepare-api-worktree must use POLYSCOPE_DB_PATH to resolve the linked frontend workspace\n" + api_env
+)
 PY
 
 grep -qF '"command": "npm run validate && npm run lint && npm run format:check"' "$workspace_root/contracts/polyscope.local.json"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -715,7 +715,7 @@ if grep -q 'npm run build' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-python3 - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import os
 import pathlib
@@ -729,9 +729,11 @@ fixture = workspace / "linked-preview-fixture"
 db_path = fixture / "polyscope.db"
 frontend_worktree = fixture / "clones" / "fe123456" / "azure-cheetah"
 api_worktree = fixture / "clones" / "api12345" / "azure-cheetah-165552b7"
+relinked_api_worktree = fixture / "clones" / "api12345" / "crimson-link"
 source_api = fixture / "source-api"
 frontend_worktree.mkdir(parents=True)
 api_worktree.mkdir(parents=True)
+relinked_api_worktree.mkdir(parents=True)
 source_api.mkdir(parents=True)
 
 source_api.joinpath(".env").write_text(
@@ -769,6 +771,7 @@ with sqlite3.connect(db_path) as connection:
         "insert into worktrees (id, repo_id, path) values (?, ?, ?)",
         [
             ("api-worktree", "api12345", str(api_worktree)),
+            ("api-worktree-relinked", "api12345", str(relinked_api_worktree)),
             ("frontend-worktree", "fe123456", str(frontend_worktree)),
         ],
     )
@@ -801,8 +804,31 @@ assert ready
 api_env = api_worktree.joinpath(".env").read_text()
 assert "APP_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in api_env, api_env
 assert "FRONTEND_URL=https://frontend-azure-cheetah.preview.secpal.dev" in api_env, api_env
-assert "SANCTUM_STATEFUL_DOMAINS=frontend-azure-cheetah.preview.secpal.dev,azure-cheetah-165552b7.preview.secpal.dev,app.secpal.dev" in api_env, api_env
-assert "CORS_ALLOWED_ORIGINS=https://frontend-azure-cheetah.preview.secpal.dev,https://azure-cheetah-165552b7.preview.secpal.dev,https://app.secpal.dev" in api_env, api_env
+assert "SANCTUM_STATEFUL_DOMAINS=frontend-azure-cheetah.preview.secpal.dev,azure-cheetah.preview.secpal.dev,app.secpal.dev" in api_env, api_env
+assert "CORS_ALLOWED_ORIGINS=https://frontend-azure-cheetah.preview.secpal.dev,https://azure-cheetah.preview.secpal.dev,https://app.secpal.dev" in api_env, api_env
+
+setup_commands = [module.build_frontend_preview_env_setup_command(), "npm run build -- --mode preview"]
+initial_setup_hash = module.build_setup_hash(frontend_worktree, setup_commands, db_path=db_path)
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        "delete from worktree_links where worktree_id = ? and linked_worktree_id = ?",
+        ("frontend-worktree", "api-worktree"),
+    )
+    connection.execute(
+        "insert into worktree_links (worktree_id, linked_worktree_id) values (?, ?)",
+        ("frontend-worktree", "api-worktree-relinked"),
+    )
+changed_setup_hash = module.build_setup_hash(frontend_worktree, setup_commands, db_path=db_path)
+assert changed_setup_hash != initial_setup_hash, "linked workspace changes must invalidate frontend provisioning"
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        "delete from worktree_links where worktree_id = ? and linked_worktree_id = ?",
+        ("frontend-worktree", "api-worktree-relinked"),
+    )
+    connection.execute(
+        "insert into worktree_links (worktree_id, linked_worktree_id) values (?, ?)",
+        ("frontend-worktree", "api-worktree"),
+    )
 
 # build_frontend_preview_build_command: assert linked API workspace is used in VITE_API_URL
 build_result = subprocess.run(
@@ -863,7 +889,7 @@ PY
 
 # --prepare-api-worktree CLI path: assert --db-path is threaded into ensure_api_worktree_ready
 # Reset api worktree .env so we can re-run via the CLI entry point.
-python3 - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import os
 import pathlib
@@ -1283,7 +1309,7 @@ assert summary['repositories']['.github']['linked_repositories'] == []
 assert summary['repositories']['GuardGuide']['linked_repositories'] == ['api', 'frontend', 'contracts', 'android']
 PY
 
-python3 - <<'PY' "$workspace_root"
+python3 -B - <<'PY' "$workspace_root"
 import json
 import sys
 from pathlib import Path

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -719,6 +719,7 @@ python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import os
 import pathlib
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -861,6 +862,12 @@ probe_result = subprocess.run(
     check=True,
 )
 assert "VITE_API_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in probe_result.stdout, probe_result.stdout
+
+watch_command = module.build_frontend_preview_build_watch_command()
+watch_script = shlex.split(watch_command)[2]
+run_build_source = watch_script[watch_script.index("def run_build()") :]
+assert 'api_url = f"https://api-' not in watch_script, watch_script
+assert 'resolve_linked_workspace("SecPal/api", Path.cwd().name)' in run_build_source, run_build_source
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1146,15 +1146,24 @@ cur = conn.cursor()
 
 api_prompt = cur.execute('select review_prompt from repositories where id = ?', ('api12345',)).fetchone()[0]
 frontend_prompt = cur.execute('select pr_prompt from repositories where id = ?', ('fe123456',)).fetchone()[0]
+prompt_rows = cur.execute(
+    'select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories order by id'
+).fetchall()
 links = cur.execute('select repo_id, linked_repo_id from repository_links order by repo_id, linked_repo_id').fetchall()
 
 assert 'api/.github/copilot-instructions.md' in api_prompt
 assert 'org-shared.instructions.md' in api_prompt
 assert 'php-laravel.instructions.md' in api_prompt
+assert 'Do not add AI agent attribution' in api_prompt
+assert '`[codex]` prefixes' in frontend_prompt
 assert 'Run git status --short --branch before any write action.' in api_prompt
 assert 'Use Form Requests for validation and services for business logic.' in api_prompt
 assert 'Keep changes repo-local, minimal, and consistent with the repository stack.' in api_prompt
 assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
+for row in prompt_rows:
+    for prompt in row:
+        assert 'Do not add AI agent attribution' in prompt
+        assert '`[codex]` prefixes' in prompt
 assert ('api12345', 'an123456') in links
 assert ('api12345', 'co123456') in links
 assert ('api12345', 'fe123456') in links
@@ -1177,6 +1186,22 @@ assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('or
 assert summary['repositories']['GuardGuide']['focus_instruction_paths'][1].endswith('php-laravel.instructions.md')
 assert summary['repositories']['.github']['linked_repositories'] == []
 assert summary['repositories']['GuardGuide']['linked_repositories'] == ['api', 'frontend', 'contracts', 'android']
+PY
+
+python3 - <<'PY' "$workspace_root"
+import json
+import sys
+from pathlib import Path
+
+workspace_root = Path(sys.argv[1])
+config_paths = sorted(workspace_root.glob("*/polyscope.local.json"))
+config_paths.append(workspace_root / ".github" / "polyscope.local.json")
+for config_path in config_paths:
+    payload = json.loads(config_path.read_text())
+    for task in payload.get("tasks", []):
+        prompt = task.get("prompt", "")
+        assert "Do not add AI agent attribution" in prompt, (config_path, task.get("label"), prompt)
+        assert "`[codex]` prefixes" in prompt, (config_path, task.get("label"), prompt)
 PY
 
 initial_db_hash="$(file_sha256 "$db_path")"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -679,7 +679,8 @@ grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secp
 grep -q 'https://guardguide-de-{{folder}}.preview.secpal.dev' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -q 'https://changelog-{{folder}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
-grep -qF "VITE_API_URL=https://api-\${PWD##*/}.preview.secpal.dev npm run build -- --mode preview" "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'VITE_API_URL' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'resolve_linked_workspace(\"SecPal/api\", workspace)' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'Watching frontend preview sources for changes...' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run:all && npm run build"' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/frontend/polyscope.local.json"
@@ -689,10 +690,12 @@ if grep -qF "npx vite build --watch --mode preview" "$workspace_root/frontend/po
     exit 1
 fi
 grep -q 'npm run test:e2e:ci' "$workspace_root/frontend/polyscope.local.json"
-grep -qF "PLAYWRIGHT_BASE_URL=https://frontend-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"
-grep -qF "PLAYWRIGHT_API_BASE_URL=https://api-\${PWD##*/}.preview.secpal.dev" "$workspace_root/frontend/polyscope.local.json"
-grep -qF 'tests/e2e/smoke.spec.ts --project=chromium --project=mobile-chrome' "$workspace_root/frontend/polyscope.local.json"
-grep -qF "TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=password PLAYWRIGHT_BASE_URL=https://frontend-\${PWD##*/}.preview.secpal.dev PLAYWRIGHT_API_BASE_URL=https://api-\${PWD##*/}.preview.secpal.dev npx playwright test" "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'PLAYWRIGHT_BASE_URL' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'PLAYWRIGHT_API_BASE_URL' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'tests/e2e/smoke.spec.ts' "$workspace_root/frontend/polyscope.local.json"
+grep -qF -- '--project=chromium' "$workspace_root/frontend/polyscope.local.json"
+grep -qF -- '--project=mobile-chrome' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'TEST_USER_EMAIL' "$workspace_root/frontend/polyscope.local.json"
 if grep -q 'test:e2e:staging' "$workspace_root/frontend/polyscope.local.json"; then
     echo "generated frontend Polyscope config must not reference the removed test:e2e:staging script" >&2
     exit 1
@@ -711,6 +714,96 @@ if grep -q 'npm run build' "$workspace_root/api/polyscope.local.json"; then
     echo "api polyscope config must not run npm build" >&2
     exit 1
 fi
+
+python3 - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "linked-preview-fixture"
+db_path = fixture / "polyscope.db"
+frontend_worktree = fixture / "clones" / "fe123456" / "azure-cheetah"
+api_worktree = fixture / "clones" / "api12345" / "azure-cheetah-165552b7"
+source_api = fixture / "source-api"
+frontend_worktree.mkdir(parents=True)
+api_worktree.mkdir(parents=True)
+source_api.mkdir(parents=True)
+
+source_api.joinpath(".env").write_text(
+    "\n".join(
+        [
+            "APP_URL=https://api.secpal.dev",
+            "FRONTEND_URL=https://app.secpal.dev",
+            "DB_CONNECTION=sqlite",
+            "SESSION_DOMAIN=.secpal.dev",
+            "SANCTUM_STATEFUL_DOMAINS=app.secpal.dev",
+            "CORS_ALLOWED_ORIGINS=https://app.secpal.dev",
+            "",
+        ]
+    )
+)
+api_worktree.joinpath(".env").write_text(source_api.joinpath(".env").read_text())
+frontend_worktree.joinpath(".env.local").write_text("VITE_API_URL=https://api.secpal.dev\n")
+
+with sqlite3.connect(db_path) as connection:
+    connection.executescript(
+        """
+        create table repositories (id text primary key, name text not null, path text not null);
+        create table worktrees (id text primary key, repo_id text not null, path text not null, created_at text default (datetime('now')) not null);
+        create table worktree_links (worktree_id text not null, linked_worktree_id text not null, created_at text default (datetime('now')) not null);
+        """
+    )
+    connection.executemany(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        [
+            ("api12345", "SecPal/api", str(source_api)),
+            ("fe123456", "SecPal/frontend", str(fixture / "source-frontend")),
+        ],
+    )
+    connection.executemany(
+        "insert into worktrees (id, repo_id, path) values (?, ?, ?)",
+        [
+            ("api-worktree", "api12345", str(api_worktree)),
+            ("frontend-worktree", "fe123456", str(frontend_worktree)),
+        ],
+    )
+    connection.executemany(
+        "insert into worktree_links (worktree_id, linked_worktree_id) values (?, ?)",
+        [
+            ("frontend-worktree", "api-worktree"),
+            ("api-worktree", "frontend-worktree"),
+        ],
+    )
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+env = os.environ.copy()
+env["POLYSCOPE_DB_PATH"] = str(db_path)
+subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_env_setup_command()],
+    cwd=frontend_worktree,
+    env=env,
+    check=True,
+)
+frontend_env = frontend_worktree.joinpath(".env.local").read_text()
+assert "VITE_API_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in frontend_env, frontend_env
+
+ready, _ = module.ensure_api_worktree_ready(api_worktree, source_api, db_path=db_path)
+assert ready
+api_env = api_worktree.joinpath(".env").read_text()
+assert "APP_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in api_env, api_env
+assert "FRONTEND_URL=https://frontend-azure-cheetah.preview.secpal.dev" in api_env, api_env
+assert "SANCTUM_STATEFUL_DOMAINS=frontend-azure-cheetah.preview.secpal.dev,azure-cheetah-165552b7.preview.secpal.dev,app.secpal.dev" in api_env, api_env
+assert "CORS_ALLOWED_ORIGINS=https://frontend-azure-cheetah.preview.secpal.dev,https://azure-cheetah-165552b7.preview.secpal.dev,https://app.secpal.dev" in api_env, api_env
+PY
 
 grep -qF '"command": "npm run validate && npm run lint && npm run format:check"' "$workspace_root/contracts/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/contracts/polyscope.local.json"


### PR DESCRIPTION
## Summary

Fixes Polyscope preview configuration for linked workspaces that do not share the same folder name across repositories.

The rollout now resolves linked frontend/API worktree names from Polyscope `worktree_links` instead of assuming the current worktree name applies to every linked repository. Frontend preview setup, build, watch, and workspace Playwright commands now target the linked API preview host when available. API preview environment preparation now allows the linked frontend origin in `FRONTEND_URL`, `SANCTUM_STATEFUL_DOMAINS`, and `CORS_ALLOWED_ORIGINS`.

The generated Polyscope review, PR, draft-PR, merge, push-and-merge, and task prompts now also include an explicit rule forbidding AI agent attribution, AI tool labels such as Codex/Copilot/Cursor, `[codex]` prefixes, and AI `Co-authored-by` trailers in GitHub-facing content across all managed repositories.

## Root Cause

The previous rollout logic derived cross-repository preview hosts from each repository's local worktree folder. This broke linked previews such as `frontend-azure-cheetah` paired with `api-azure-cheetah-165552b7`, producing frontend calls to the wrong API host and API CORS settings for the wrong frontend origin.

The existing no-AI-attribution policy was not consistently embedded into every Polyscope prompt surface, so automatic PR/title/body guidance depended on the specific repo instruction set instead of being enforced centrally for all managed repositories.

## TDD / Validate-First Evidence

- Failing proof before implementation: Linked preview `frontend-azure-cheetah` with `api-azure-cheetah-165552b7` generated frontend `VITE_API_URL` and API `FRONTEND_URL`/CORS values from each repository's local folder name instead of the paired worktree from `worktree_links`. Generated Polyscope repository and task prompts also omitted the shared no-AI-attribution rule, so `tests/polyscope-rollout.sh` would fail on the asymmetric linked-worktree regression and the prompt assertions for `Do not add AI agent attribution`.
- Passing proof after implementation: `PYTHONDONTWRITEBYTECODE=1 bash tests/polyscope-rollout.sh`, `PYTHONDONTWRITEBYTECODE=1 ./scripts/preflight.sh`, and `git diff --check`. Live preview check: `/v1/me` returned JSON `401` with `Access-Control-Allow-Origin: https://frontend-azure-cheetah.preview.secpal.dev`. Local Polyscope DB and generated task prompt audit: all managed repositories include the no-AI-attribution rule.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `PYTHONDONTWRITEBYTECODE=1 bash tests/polyscope-rollout.sh`
- `PYTHONDONTWRITEBYTECODE=1 ./scripts/preflight.sh`
- `git diff --check`
- Live preview check: `/v1/me` returned JSON `401` with `Access-Control-Allow-Origin: https://frontend-azure-cheetah.preview.secpal.dev`
- Local Polyscope DB and generated task prompt audit: all managed repositories include the no-AI-attribution rule
- Current Polyscope worktree hook audit: all present worktrees have `commit-msg` and `pre-push` hooks installed

## Notes

- Added a changelog entry for the rollout and prompt hardening fixes.
- The local `gh` token is invalid, so this draft PR was opened and updated through the GitHub connector after pushing the branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect preview auth/CORS and cross-repo env generation for all Polyscope workspaces; mistakes could break linked previews, though behavior is regression-tested and falls back to the local folder name when unlinked.
> 
> **Overview**
> **Polyscope preview URLs** now resolve **linked worktree folder names** from `worktree_links` in `polyscope.db` instead of assuming every repo shares the same workspace name. Frontend generated setup/build/watch/Playwright commands point `VITE_API_URL` and `PLAYWRIGHT_API_BASE_URL` at the linked API host when present; API `.env` updates use the linked frontend name for `FRONTEND_URL`, Sanctum, and CORS while keeping `APP_URL` on the API worktree’s own name. Provisioning passes `POLYSCOPE_DB_PATH`, includes linked workspaces in setup hashes, and threads `--db-path` through `--prepare-api-worktree`.
> 
> **Governance:** A shared **no-AI-attribution** rule is injected into generated Polyscope review, PR, merge, and task prompts for all managed repos.
> 
> **Tests & docs:** `tests/polyscope-rollout.sh` adds asymmetric linked-worktree regressions, prompt assertions, resolver probes, and CLI `--prepare-api-worktree` coverage; `CHANGELOG.md` documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2639465a7b140d5d23f826ae87e9aef617965ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

