### PR TITLE
docs: standardize site terminology for customer locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-21 - Standardize Site Terminology For Customer Locations
+
+**Added:**
+
+- added `docs/brand/terminology.md` to define the approved customer-location domain terminology: English uses `site`/`sites`, German domain copy may use `Objekt`/`Objekte`, and `object` remains reserved for technical contexts
+
+**Changed:**
+
+- linked `docs/brand/naming.md` and `docs/brand/README.md` to the new terminology standard so naming and public-copy guidance point to a single source of truth
+- aligned `docs/feature-requirements.md` to use `site` terminology consistently in English domain copy, while keeping historical issue titles explicitly marked as historical
+- added an editorial note and summary cleanup in `docs/adr/20251126-organizational-structure-hierarchy.md` so preserved historical `object` wording cannot be mistaken for current repository terminology
+
+---
+
 ## 2026-06-18 - Fix Linked Polyscope Preview URLs
 
 **Fixed:**

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -1068,12 +1068,12 @@ DB::transaction(function () use ($unit, $newParent) {
 2. **Customer Organization Structure** (`customers`)
    - External customer hierarchy (Corporate → Regional → Local)
    - For **customer users only** (Client role)
-   - Access control via `customer_user_accesses` + `customer_user_object_accesses`
+   - Access control via `customer_user_accesses` + site-specific access mappings (`customer_user_object_accesses`)
    - Read-only access, limited scope
 
 **Key Insight:** A customer (e.g., "Rewe Group") is **managed by** an internal organizational unit (e.g., "Niederlassung Berlin"), but the two hierarchies remain completely separate. Internal employees see both hierarchies (for management), customer users see only their own structure (for access control).
 
-**RBAC Infrastructure:** Both internal employees AND customer users share the **same technical RBAC system** (Spatie Laravel-Permission, Sanctum guard, hierarchical scopes). The difference is in **assigned permissions**: internal roles have CRUD capabilities (`guard_book.create`, `object.update`), while customer roles typically have read-only access (`guard_book.read`, `reports.export`).
+**RBAC Infrastructure:** Both internal employees AND customer users share the **same technical RBAC system** (Spatie Laravel-Permission, Sanctum guard, hierarchical scopes). The difference is in **assigned permissions**: internal roles have CRUD capabilities (`guard_book.create`, `site.update`), while customer roles typically have read-only access (`guard_book.read`, `reports.export`).
 
 ---
 

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC0-1.0
 
 **Date:** 2025-11-26
 
-**Last Updated:** 2025-12-21 (ADR-009 Integration: Inheritance Blocking & Leadership Levels)
+**Last Updated:** 2026-06-21 (Terminology editorial alignment)
 
 **Deciders:** @kevalyq
 
@@ -27,7 +27,7 @@ This ADR defines the architecture for flexible, unlimited-depth organizational h
 
 2. **Customer Structure** (`customers`): External customer organizations (Corporate → Regional → Local)
    - For **customer users** (Client role)
-   - Access control via `customer_user_accesses` + site-specific access mappings
+   - Access control via `customer_user_accesses` + site-specific access mappings (`customer_user_object_accesses`)
    - Read-only access, completely independent from internal structure
 
 **Key Technology:** Closure Table Pattern enables unlimited hierarchy depth, fast queries (O(1) for descendants), and seamless RBAC integration.

--- a/docs/adr/20251126-organizational-structure-hierarchy.md
+++ b/docs/adr/20251126-organizational-structure-hierarchy.md
@@ -13,6 +13,8 @@ SPDX-License-Identifier: CC0-1.0
 
 **Deciders:** @kevalyq
 
+**Editorial Note:** This ADR preserves parts of the original ADR-007 proposal for historical context. Where older sections use `object` or `objects` for customer locations, the current implementation and repository terminology standardize on `site` and `sites`. See [Terminology](../brand/terminology.md).
+
 ## Summary
 
 This ADR defines the architecture for flexible, unlimited-depth organizational hierarchies in SecPal. **Two independent hierarchical systems** are implemented:
@@ -21,11 +23,11 @@ This ADR defines the architecture for flexible, unlimited-depth organizational h
 
    - For **internal employees** (Guards, Managers, explicitly scoped operators)
    - Access control via `user_internal_organizational_scopes`
-   - Fine-grained RBAC: From branch-wide access down to specific object areas
+   - Fine-grained RBAC: From branch-wide access down to specific site areas
 
 2. **Customer Structure** (`customers`): External customer organizations (Corporate → Regional → Local)
    - For **customer users** (Client role)
-   - Access control via `customer_user_accesses` + `customer_user_object_accesses`
+   - Access control via `customer_user_accesses` + site-specific access mappings
    - Read-only access, completely independent from internal structure
 
 **Key Technology:** Closure Table Pattern enables unlimited hierarchy depth, fast queries (O(1) for descendants), and seamless RBAC integration.
@@ -43,7 +45,7 @@ SecPal targets the German private security service industry, which encompasses o
 Security service companies have diverse organizational structures:
 
 1. **Flat structures:** Small businesses where customers are managed directly without intermediate organizational layers
-2. **Branch structures:** Regional branches managing local customers and objects
+2. **Branch structures:** Regional branches managing local customers and sites
 3. **Regional structures:** Multiple branches grouped into regions
 4. **Holding structures:** Multiple subsidiaries (e.g., "ProSec Nord GmbH", "ProSec Süd GmbH") under a parent holding company
 5. **Division structures:** Large companies with separate business units (e.g., "Aviation Security", "Event Security", "Industrial Security")
@@ -55,7 +57,7 @@ Security service companies have diverse organizational structures:
 3. **Dynamic Growth:** Small companies should be able to start simple and add organizational layers as they grow
 4. **Access Control Integration:** RBAC must respect organizational boundaries (e.g., "Regional Manager" sees all branches in their region)
 5. **Customer Hierarchies:** Support for national customers with regional/local contact persons
-6. **Object Segmentation:** Large objects (e.g., airports, industrial sites) need to be divided into areas with separate guard books
+6. **Site Segmentation:** Large sites (e.g., airports, industrial complexes) may need to be divided into areas with separate guard books
 
 ### Real-World Scenarios
 

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -33,6 +33,7 @@ Current brand standards live under this directory:
 - `docs/brand/README.md` - section entry point and scope boundary
 - `docs/brand/brand-architecture.md` - SecPal and product-family hierarchy
 - `docs/brand/naming.md` - public names, capitalization, and terminology rules
+- `docs/brand/terminology.md` - approved domain terminology and translations
 - `docs/brand/slogans.md` - approved slogan strings and punctuation rules
 - `docs/brand/footer-wording.md` - approved compact footer strings
 - `docs/brand/logo-usage.md` - logo usage rules and asset ownership boundaries

--- a/docs/brand/naming.md
+++ b/docs/brand/naming.md
@@ -20,6 +20,7 @@ Use these names exactly in public and contributor-facing materials.
 - Use `SecPal` for the platform or suite.
 - Use `GuardGuide by SecPal` for the standalone product within the SecPal family.
 - After the full product name appears once in the same document or screen, `GuardGuide` is acceptable where the SecPal relationship is already clear.
+- Follow domain terminology rules from `docs/brand/terminology.md` for concepts such as customer locations and role names.
 - Keep repository names, package names, domains, and code identifiers in their technical form when documenting commands or file paths.
 - Do not invent campaign names, editions, or abbreviations unless a brand document adds them explicitly.
 

--- a/docs/brand/terminology.md
+++ b/docs/brand/terminology.md
@@ -1,0 +1,37 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Terminology
+
+Use these domain terms consistently in product, documentation, and contributor-facing copy.
+
+## Customer Locations
+
+| Context                                                                 | Use       | Do not use |
+| ----------------------------------------------------------------------- | --------- | ---------- |
+| English domain term for a customer location where services are provided | `site`    | `object`   |
+| English plural                                                          | `sites`   | `objects`  |
+| German domain term for a customer building/location                     | `Objekt`  | `Object`   |
+| German plural                                                           | `Objekte` | `Objects`  |
+
+## Rule
+
+- A customer location, building, campus, or service area is a `site` in English.
+- In German domain language, the same concept may be called `Objekt` or `Objekte`.
+- Do not translate German `Objekt` to English `object` when the meaning is a customer location.
+- Reserve `object` for technical contexts such as programming, schemas, or license text like `object code`.
+
+## Related Terms
+
+| Context                                       | Use                                                |
+| --------------------------------------------- | -------------------------------------------------- |
+| Optional subdivision of a site                | `site area`                                        |
+| German optional subdivision of a site         | `Objektbereich` or `Bereich`                       |
+| Person responsible for a site in English copy | `Site Manager`                                     |
+| Person responsible for a site in German copy  | `Objektleiter` or repository-specific role wording |
+
+## Rationale
+
+`Site` is the correct English domain term for the place where security services are delivered. It is clearer internationally and avoids confusion with the programming term `object`.

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -70,8 +70,8 @@ Security companies have different organizational structures and job titles:
    | System Settings         | ✗      | ✓    | ✓      | ✗      | ✗      |
 
 4. **Scope-Based Permissions:**
-   - **Organization-wide:** Access all locations/clients
-   - **Location-specific:** Only specific sites
+   - **Organization-wide:** Access all sites/clients
+   - **Site-specific:** Only specific sites
    - **Team-specific:** Only own team members
    - **Self-only:** Own data only (guards)
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -71,7 +71,7 @@ Security companies have different organizational structures and job titles:
 
 4. **Scope-Based Permissions:**
    - **Organization-wide:** Access all locations/clients
-   - **Location-specific:** Only specific objects/sites
+   - **Location-specific:** Only specific sites
    - **Team-specific:** Only own team members
    - **Self-only:** Own data only (guards)
 
@@ -633,7 +633,7 @@ SecPal targets the German private security service industry, which encompasses o
 Security service companies have diverse organizational structures that cannot be modeled with fixed, hardcoded hierarchy levels:
 
 1. **Flat structures:** Small businesses where customers are managed directly without intermediate organizational layers
-2. **Branch structures:** Regional branches managing local customers and objects
+2. **Branch structures:** Regional branches managing local customers and sites
 3. **Regional structures:** Multiple branches grouped into regions
 4. **Holding structures:** Multiple subsidiaries (e.g., "ProSec Nord GmbH", "ProSec Süd GmbH") under a parent holding company
 5. **Division structures:** Large companies with separate business units (e.g., "Aviation Security", "Event Security", "Industrial Security")
@@ -644,7 +644,7 @@ Security service companies have diverse organizational structures that cannot be
 - Enable dynamic growth: Small companies can start simple and add organizational layers as they grow
 - Provide granular access control based on organizational position
 - Support customer hierarchies (national customers with regional/local structures)
-- Allow segmentation of large objects into areas with separate guard books
+- Allow segmentation of large sites into areas with separate guard books
 
 ### User Stories
 
@@ -652,12 +652,12 @@ Security service companies have diverse organizational structures that cannot be
 
 ```
 As a Regional Manager,
-I want to see all objects and guard books managed by branches in my region,
+I want to see all sites and guard books managed by branches in my region,
 So that I can oversee operations and ensure quality standards across all locations.
 
 Acceptance Criteria:
 - Regional Manager can view all branches in assigned region
-- Access includes all customers and objects managed by those branches
+- Access includes all customers and sites managed by those branches
 - Access automatically extends to newly created branches in region
 - No manual permission updates needed when organizational structure changes
 - Can generate regional reports combining data from all branches
@@ -667,7 +667,7 @@ Acceptance Criteria:
 
 ```
 As a Branch Manager,
-I want to manage only my branch's customers and objects,
+I want to manage only my branch's customers and sites,
 So that I focus on my operational area without confusion from other branches' data.
 
 Acceptance Criteria:
@@ -682,13 +682,13 @@ Acceptance Criteria:
 
 ```
 As a Guard,
-I want to access only the objects I'm assigned to,
+I want to access only the sites I'm assigned to,
 So that I can complete my shifts without seeing irrelevant data.
 
 Acceptance Criteria:
 - Guard can only access own current and upcoming shifts
-- Can read/write guard book entries only for assigned objects
-- Cannot see other guards' shifts or unassigned objects
+- Can read/write guard book entries only for assigned sites
+- Cannot see other guards' shifts or unassigned sites
 - Mobile-optimized view for on-site work
 - Offline mode for areas with poor connectivity
 ```
@@ -767,22 +767,22 @@ Acceptance Criteria:
 - Can link customer users to appropriate hierarchy level
 - Customer hierarchies are independent from our internal structure
 - Can assign different access levels (corporate-wide, regional, local)
-- Can grant fine-grained object access when needed
+- Can grant fine-grained site access when needed
 - Visual tree view of customer hierarchy
 ```
 
-#### Story 9: Object Area Segmentation
+#### Story 9: Site Area Segmentation
 
 ```
 As an Operations Manager,
-I want to divide large objects into separate areas with individual guard books,
+I want to divide large sites into separate areas with individual guard books,
 So that guard book entries remain organized and relevant per area.
 
 Acceptance Criteria:
-- Can define multiple areas per object (e.g., Terminal 1, Terminal 2, Apron)
+- Can define multiple areas per site (e.g., Terminal 1, Terminal 2, Apron)
 - Each area can have separate guard book
 - Guards assigned to specific area only access that area's guard book
-- Can generate reports per area or combined for entire object
+- Can generate reports per area or combined for entire site
 - Optional GPS boundaries for geofencing (future enhancement)
 - Clear visual distinction between areas in UI
 ```
@@ -854,31 +854,31 @@ Acceptance Criteria:
 
 3. **Hierarchical Customer Access:**
 
-   - Corporate customer user can access all descendant customers' objects
+   - Corporate customer user can access all descendant customers' sites
    - Regional customer user limited to own region
-   - Local customer user limited to specific objects
+   - Local customer user limited to specific sites
    - Access inheritance follows customer hierarchy, not internal structure
 
-4. **Fine-Grained Object Permissions:**
-   - Customer users can have object-specific permissions
+4. **Fine-Grained Site Permissions:**
+   - Customer users can have site-specific permissions
    - Allowed actions: ["read_guard_book", "read_reports", "export_reports"]
    - Cannot override read-only restriction at entry level
-   - Object permissions can be more restrictive than hierarchy access
+   - Site permissions can be more restrictive than hierarchy access
 
-#### Object Area Segmentation Rules
+#### Site Area Segmentation Rules
 
 1. **Optional Segmentation:**
 
-   - Small objects: Single guard book for entire object (default)
-   - Large objects: Multiple areas with separate guard books (optional)
-   - Decision made per object based on operational needs
+   - Small sites: Single guard book for entire site (default)
+   - Large sites: Multiple areas with separate guard books (optional)
+   - Decision made per site based on operational needs
 
 2. **Area-Specific Guard Books:**
 
    - Each area can require separate guard book (configurable)
    - Guards assigned to area only access that area's guard book
-   - Parent object must exist before areas can be created
-   - Deleting object cascades to all areas and their guard books
+   - Parent site must exist before areas can be created
+   - Deleting a site cascades to all areas and their guard books
 
 3. **Area Boundaries:**
    - Areas are logical divisions (e.g., "Terminal 1", "Warehouse")
@@ -936,7 +936,7 @@ Acceptance Criteria:
 - **Mobile-First:** Guard book access optimized for mobile devices (iOS/Android)
 - **Internationalization:** Support German (primary) and English
 - **Accessibility:** WCAG 2.1 Level AA compliance for all UI components
-- **Offline Mode:** Guards can view assigned shifts and objects offline
+- **Offline Mode:** Guards can view assigned shifts and sites offline
 
 #### Maintainability
 
@@ -969,13 +969,13 @@ SecPal uses the **Closure Table Pattern** for storing and querying hierarchical 
 2. **Customer Structure** (`customers`):
    - External customer hierarchy (Corporate → Regional → Local)
    - For customer users (Client role)
-   - Access control via `customer_user_accesses` + `customer_user_object_accesses`
+   - Access control via `customer_user_accesses` + site-specific access mappings
 
 **RBAC Integration:**
 
 - **Hierarchical Scopes:** Users granted access to organizational unit or customer
 - **Include Descendants:** Configurable flag to include all child units/customers
-- **Fine-Grained Permissions:** Object-level and action-level permissions
+- **Fine-Grained Permissions:** Site-level and action-level permissions
 - **Policy Enforcement:** Laravel policies check both permissions and scopes
 
 **Implementation Reference:**
@@ -991,8 +991,8 @@ SecPal/api#228 - Epic: Flexible Organizational Structure & Multi-Level Hierarchi
 - SecPal/api#229: Database Migrations: Organizational Units & Closure Tables
 - SecPal/api#230: Database Migrations: Customer Hierarchies & Access Control
 - SecPal/api#231: Eloquent Models: Organizational Units with Hierarchical Relationships
-- SecPal/api#232: Eloquent Models: Customers, Objects, and Object Areas
-- SecPal/api#233: Guard Books: Event Stream Implementation & Object Area Segmentation
+- SecPal/api#232: Eloquent Models: Customers, Objects, and Object Areas (historical issue title)
+- SecPal/api#233: Guard Books: Event Stream Implementation & Object Area Segmentation (historical issue title)
 - SecPal/api#234: RBAC: Hierarchical Access Control for Internal Employees
 - SecPal/api#235: RBAC: Customer User Access Control (Read-Only Scopes)
 - SecPal/api#236: API: REST Endpoints for Organizational Structure & Customer Hierarchies
@@ -2002,7 +2002,7 @@ Objektbezogene Dienstanweisungen (Site-Specific):
   - Zugangskontrollen (Access Control)
   - Rundgangspläne (Patrol Routes)
   - Besondere Gefahren (Specific Hazards)
-  - Ansprechpartner Objekt (Client Contacts)
+  - Ansprechpartner am Objekt (Client Contacts)
 
 Sicherheitstechnische Anweisungen (Safety):
   - Brandschutz (Fire Safety)
@@ -2037,7 +2037,7 @@ Schema::create('work_instructions', function (Blueprint $table) {
     $table->foreignUuid('organization_id');
     $table->foreignUuid('template_id')->nullable(); // If created from template
 
-    $table->string('title'); // "Dienstanweisung Objekt A"
+    $table->string('title'); // "Dienstanweisung Site A"
     $table->string('instruction_number')->unique(); // "DA-2025-001"
     $table->integer('version')->default(1); // Version control
 
@@ -2422,12 +2422,12 @@ Schema::create('shift_plan_periods', function (Blueprint $table) {
 **Define recurring shift patterns:**
 
 ```yaml
-Shift Template: "Nachtschicht Objekt A"
+Shift Template: "Nachtschicht Site A"
   Time: 22:00 - 06:00
   Required Staff:
     - 2x Security Guard (§34a)
     - 1x First Aid Certified
-  Location: "Objekt A, Berlin Mitte"
+  Location: "Site A, Berlin Mitte"
   Recurrence: Mo-Fr (weekly)
 ```
 
@@ -2577,11 +2577,11 @@ class CheckShiftCoverage extends Command {
 ┌─────────────────────────────────────────────────────┐
 │ ⚠️ Unterbesetzte Schichten (nächste 14 Tage)       │
 ├─────────────────────────────────────────────────────┤
-│ 🚨 Mo, 28.10. 22:00-06:00 Objekt A                 │
+│ 🚨 Mo, 28.10. 22:00-06:00 Site A                   │
 │    2/3 Mitarbeiter eingeteilt                       │
 │    [Mitarbeiter hinzufügen]                         │
 │                                                     │
-│ ⚠️ Di, 29.10. 06:00-14:00 Objekt B                 │
+│ ⚠️ Di, 29.10. 06:00-14:00 Site B                   │
 │    4/5 Mitarbeiter eingeteilt                       │
 │    [Mitarbeiter hinzufügen]                         │
 └─────────────────────────────────────────────────────┘
@@ -2711,9 +2711,9 @@ Hallo Max,
 Dein Dienstplan für November 2025 ist jetzt verfügbar.
 
 Deine Schichten:
-- Mo, 04.11.2025, 22:00-06:00, Objekt A Berlin
-- Mi, 06.11.2025, 22:00-06:00, Objekt A Berlin
-- Fr, 08.11.2025, 22:00-06:00, Objekt A Berlin
+- Mo, 04.11.2025, 22:00-06:00, Site A Berlin
+- Mi, 06.11.2025, 22:00-06:00, Site A Berlin
+- Fr, 08.11.2025, 22:00-06:00, Site A Berlin
 ... (12 weitere Schichten)
 
 Gesamt: 15 Schichten, 120 Stunden
@@ -2895,7 +2895,7 @@ Clients want to see what happens on their premises:
   "shift": {
     "date": "2025-10-27",
     "time": "22:00 - 06:00",
-    "location": "Objekt A",
+    "location": "Site A",
     "guards": [
       {
         "guard_id": "G-1234", // Pseudonym
@@ -3182,7 +3182,7 @@ Schema::create('registered_devices', function (Blueprint $table) {
 ```php
 Schema::create('locations', function (Blueprint $table) {
     $table->uuid('id')->primary();
-    $table->string('name'); // "Objekt A"
+    $table->string('name'); // "Site A"
     $table->jsonb('gps_center'); // { lat: 52.520, lon: 13.405 }
     $table->integer('geofence_radius_meters')->default(100); // 100m tolerance
     $table->boolean('require_geofence_check')->default(true);
@@ -3208,7 +3208,7 @@ class ClockInService {
 
             if ($distance > $location->geofence_radius_meters) {
                 throw new GeofenceViolationException(
-                    "Sie sind {$distance}m vom Objekt entfernt. Maximal {$location->geofence_radius_meters}m erlaubt."
+                    "Sie sind {$distance}m vom Einsatzort entfernt. Maximal {$location->geofence_radius_meters}m erlaubt."
                 );
             }
         }

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -969,7 +969,7 @@ SecPal uses the **Closure Table Pattern** for storing and querying hierarchical 
 2. **Customer Structure** (`customers`):
    - External customer hierarchy (Corporate → Regional → Local)
    - For customer users (Client role)
-   - Access control via `customer_user_accesses` + site-specific access mappings
+   - Access control via `customer_user_accesses` + site-specific access mappings (`customer_user_object_accesses`)
 
 **RBAC Integration:**
 
@@ -2037,7 +2037,7 @@ Schema::create('work_instructions', function (Blueprint $table) {
     $table->foreignUuid('organization_id');
     $table->foreignUuid('template_id')->nullable(); // If created from template
 
-    $table->string('title'); // "Dienstanweisung Site A"
+    $table->string('title'); // "Dienstanweisung Objekt A"
     $table->string('instruction_number')->unique(); // "DA-2025-001"
     $table->integer('version')->default(1); // Version control
 
@@ -2422,12 +2422,12 @@ Schema::create('shift_plan_periods', function (Blueprint $table) {
 **Define recurring shift patterns:**
 
 ```yaml
-Shift Template: "Nachtschicht Site A"
+Shift Template: "Nachtschicht Objekt A"
   Time: 22:00 - 06:00
   Required Staff:
     - 2x Security Guard (§34a)
     - 1x First Aid Certified
-  Location: "Site A, Berlin Mitte"
+  Location: "Objekt A, Berlin Mitte"
   Recurrence: Mo-Fr (weekly)
 ```
 
@@ -2577,11 +2577,11 @@ class CheckShiftCoverage extends Command {
 ┌─────────────────────────────────────────────────────┐
 │ ⚠️ Unterbesetzte Schichten (nächste 14 Tage)       │
 ├─────────────────────────────────────────────────────┤
-│ 🚨 Mo, 28.10. 22:00-06:00 Site A                   │
+│ 🚨 Mo, 28.10. 22:00-06:00 Objekt A                 │
 │    2/3 Mitarbeiter eingeteilt                       │
 │    [Mitarbeiter hinzufügen]                         │
 │                                                     │
-│ ⚠️ Di, 29.10. 06:00-14:00 Site B                   │
+│ ⚠️ Di, 29.10. 06:00-14:00 Objekt B                 │
 │    4/5 Mitarbeiter eingeteilt                       │
 │    [Mitarbeiter hinzufügen]                         │
 └─────────────────────────────────────────────────────┘
@@ -2711,9 +2711,9 @@ Hallo Max,
 Dein Dienstplan für November 2025 ist jetzt verfügbar.
 
 Deine Schichten:
-- Mo, 04.11.2025, 22:00-06:00, Site A Berlin
-- Mi, 06.11.2025, 22:00-06:00, Site A Berlin
-- Fr, 08.11.2025, 22:00-06:00, Site A Berlin
+- Mo, 04.11.2025, 22:00-06:00, Objekt A Berlin
+- Mi, 06.11.2025, 22:00-06:00, Objekt A Berlin
+- Fr, 08.11.2025, 22:00-06:00, Objekt A Berlin
 ... (12 weitere Schichten)
 
 Gesamt: 15 Schichten, 120 Stunden
@@ -2895,7 +2895,7 @@ Clients want to see what happens on their premises:
   "shift": {
     "date": "2025-10-27",
     "time": "22:00 - 06:00",
-    "location": "Site A",
+    "location": "Objekt A",
     "guards": [
       {
         "guard_id": "G-1234", // Pseudonym


### PR DESCRIPTION
## Reproduced defect

- `docs/feature-requirements.md` mixed `objects/sites` wording and several English `object` references for customer locations while `docs/adr/20251126-organizational-structure-hierarchy.md` already states the implemented terminology is `site`/`sites`. That left contradictory guidance for contributors, translators, and future copy updates.

## Current change

- add `docs/brand/terminology.md` as the single source of truth for customer-location terminology and the German `Objekt` to English `site` mapping
- link `docs/brand/README.md` and `docs/brand/naming.md` to the new terminology guidance
- align `docs/feature-requirements.md` with `site` terminology in English domain copy and mark historical issue titles explicitly as historical where they still use older wording
- add an editorial note plus top-level terminology cleanup in `docs/adr/20251126-organizational-structure-hierarchy.md` so preserved historical proposal text is not mistaken for the current standard
- document the change in `CHANGELOG.md`

## Validation

- `git diff --check`
- `npx prettier --check CHANGELOG.md docs/brand/README.md docs/brand/naming.md docs/brand/terminology.md docs/feature-requirements.md docs/adr/20251126-organizational-structure-hierarchy.md`
- local 4-pass self-review of the touched scope found no issues

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A
- Passing proof after implementation: N/A
- Validate-first exception reference: N/A
- No executable change reason: Documentation-only change; no executable behavior, automation, or validation logic changed.

## Follow-up before ready

- no linked workspaces for this change
- GitHub Actions checks still need to complete
- final self-review in the PR view is still required before marking this draft ready
