### PR TITLE
Harden Polyscope preview publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependencies
@@ -8,6 +8,8 @@ vendor/
 # Build artifacts
 dist/
 build/
+__pycache__/
+*.py[cod]
 
 # Environment & Secrets
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - updated `scripts/polyscope-rollout.py` so staged frontend preview publishes remove stale files from `dist/`, handle file/directory shape changes, and still publish `index.html` last after assets are reconciled
-- rejected symlinked staged preview build output before publishing so preview `dist/` updates cannot copy files from outside the stage directory, and moved stale-file pruning after the `index.html` swap succeeds
-- kept preview nginx HTTP/2 configuration compatible with nginx 1.24 and explicitly denied hidden files and PHP files below immutable asset prefix locations
+- rejected symlinked staged build output and symlinked live preview `dist/` paths before publishing
+- kept preview nginx compatible with nginx 1.24, relaxed preview CSP for static framework output, revalidated `/assets/`, and denied hidden/PHP files below immutable asset prefixes
 - added Python bytecode ignore rules to `.gitignore` so generated `__pycache__/` artifacts do not enter future rollout diffs
-
-**Added:**
-
-- extended `tests/polyscope-rollout.sh` to run the generated frontend preview build command through a fake `npm` and prove linked API env propagation, stale output deletion, and asset path type changes
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-23 - Harden Polyscope Preview Publishing
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so staged frontend preview publishes remove stale files from `dist/`, handle file/directory shape changes, and still publish `index.html` last after assets are reconciled
+- fixed the nginx header regression assertions in `tests/polyscope-rollout.sh` so each immutable asset location block is parsed independently instead of accidentally scanning into following location blocks
+- added Python bytecode ignore rules to `.gitignore` so generated `__pycache__/` artifacts do not enter future rollout diffs
+
+**Added:**
+
+- extended `tests/polyscope-rollout.sh` to run the generated frontend preview build command through a fake `npm` and prove linked API env propagation, stale output deletion, and asset path type changes
+
+---
+
 ## 2026-06-21 - Standardize Site Terminology For Customer Locations
 
 **Added:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - updated `scripts/polyscope-rollout.py` so staged frontend preview publishes remove stale files from `dist/`, handle file/directory shape changes, and still publish `index.html` last after assets are reconciled
 - rejected symlinked staged preview build output before publishing so preview `dist/` updates cannot copy files from outside the stage directory, and moved stale-file pruning after the `index.html` swap succeeds
 - kept preview nginx HTTP/2 configuration compatible with nginx 1.24 and explicitly denied hidden files and PHP files below immutable asset prefix locations
-- fixed the nginx header regression assertions in `tests/polyscope-rollout.sh` so each immutable asset location block is parsed independently instead of accidentally scanning into following location blocks
 - added Python bytecode ignore rules to `.gitignore` so generated `__pycache__/` artifacts do not enter future rollout diffs
 
 **Added:**
 
 - extended `tests/polyscope-rollout.sh` to run the generated frontend preview build command through a fake `npm` and prove linked API env propagation, stale output deletion, and asset path type changes
-- added rollout regression coverage for symlink rejection, index-swap failure behavior, watch-command publish ordering, environment-preserving fake `npm` path setup, and preview nginx immutable asset deny rules
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - updated `scripts/polyscope-rollout.py` so staged frontend preview publishes remove stale files from `dist/`, handle file/directory shape changes, and still publish `index.html` last after assets are reconciled
+- rejected symlinked staged preview build output before publishing so preview `dist/` updates cannot copy files from outside the stage directory, and moved stale-file pruning after the `index.html` swap succeeds
 - fixed the nginx header regression assertions in `tests/polyscope-rollout.sh` so each immutable asset location block is parsed independently instead of accidentally scanning into following location blocks
 - added Python bytecode ignore rules to `.gitignore` so generated `__pycache__/` artifacts do not enter future rollout diffs
 
 **Added:**
 
 - extended `tests/polyscope-rollout.sh` to run the generated frontend preview build command through a fake `npm` and prove linked API env propagation, stale output deletion, and asset path type changes
+- added rollout regression coverage for symlink rejection, index-swap failure behavior, watch-command publish ordering, and environment-preserving fake `npm` path setup
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - updated `scripts/polyscope-rollout.py` so staged frontend preview publishes remove stale files from `dist/`, handle file/directory shape changes, and still publish `index.html` last after assets are reconciled
 - rejected symlinked staged preview build output before publishing so preview `dist/` updates cannot copy files from outside the stage directory, and moved stale-file pruning after the `index.html` swap succeeds
+- kept preview nginx HTTP/2 configuration compatible with nginx 1.24 and explicitly denied hidden files and PHP files below immutable asset prefix locations
 - fixed the nginx header regression assertions in `tests/polyscope-rollout.sh` so each immutable asset location block is parsed independently instead of accidentally scanning into following location blocks
 - added Python bytecode ignore rules to `.gitignore` so generated `__pycache__/` artifacts do not enter future rollout diffs
 
 **Added:**
 
 - extended `tests/polyscope-rollout.sh` to run the generated frontend preview build command through a fake `npm` and prove linked API env propagation, stale output deletion, and asset path type changes
-- added rollout regression coverage for symlink rejection, index-swap failure behavior, watch-command publish ordering, and environment-preserving fake `npm` path setup
+- added rollout regression coverage for symlink rejection, index-swap failure behavior, watch-command publish ordering, environment-preserving fake `npm` path setup, and preview nginx immutable asset deny rules
 
 ---
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -568,6 +568,8 @@ from pathlib import Path
 {build_linked_workspace_resolver_source()}
 
 def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    if src_file.is_symlink():
+        raise RuntimeError(f"staged build output contains symlink: {{src_file}}")
     dest_file.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
@@ -577,6 +579,8 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     os.replace(tmp_path, dest_file)
 
 def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
+    if src_dir.is_symlink():
+        raise RuntimeError(f"staged build output contains symlink: {{src_dir}}")
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -595,6 +599,8 @@ def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[
             continue
 
         relative = child.relative_to(stage_dir)
+        if child.is_symlink():
+            raise RuntimeError(f"staged build output contains symlink: {{relative}}")
         if child.is_dir():
             stage_dirs.add(relative)
         else:
@@ -771,6 +777,8 @@ def snapshot() -> str:
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
 def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    if src_file.is_symlink():
+        raise RuntimeError(f"staged build output contains symlink: {{src_file}}")
     dest_file.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
@@ -780,6 +788,8 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     os.replace(tmp_path, dest_file)
 
 def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
+    if src_dir.is_symlink():
+        raise RuntimeError(f"staged build output contains symlink: {{src_dir}}")
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -798,6 +808,8 @@ def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[
             continue
 
         relative = child.relative_to(stage_dir)
+        if child.is_symlink():
+            raise RuntimeError(f"staged build output contains symlink: {{relative}}")
         if child.is_dir():
             stage_dirs.add(relative)
         else:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2571,9 +2571,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         }}
 
         server {{
-            listen 443 ssl;
-            listen [::]:443 ssl;
-            http2 on;
+            listen 443 ssl http2;
+            listen [::]:443 ssl http2;
             server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
@@ -2758,6 +2757,10 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 try_files $uri =404;
             }}
 
+            location ^~ /assets/. {{
+                deny all;
+            }}
+
             location ^~ /assets/ {{
                 try_files $uri =404;
                 expires 1y;
@@ -2773,6 +2776,13 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
+                if ($uri ~ \\.php$) {{
+                    return 404;
+                }}
+            }}
+
+            location ^~ /_astro/. {{
+                deny all;
             }}
 
             location ^~ /_astro/ {{
@@ -2790,6 +2800,13 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
+                if ($uri ~ \\.php$) {{
+                    return 404;
+                }}
+            }}
+
+            location ^~ /_next/static/. {{
+                deny all;
             }}
 
             location ^~ /_next/static/ {{
@@ -2807,6 +2824,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
+                if ($uri ~ \\.php$) {{
+                    return 404;
+                }}
             }}
 
             location ~* \\.(?:svg|ico|png|jpg|jpeg|webp|avif|woff|woff2|ttf|otf|xml|txt)$ {{

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -560,16 +560,118 @@ def build_frontend_preview_build_command() -> str:
     script = textwrap.dedent(
         f"""\
 import os
+import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 {build_linked_workspace_resolver_source()}
+
+def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    dest_file.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
+    os.close(fd)
+    shutil.copy2(src_file, tmp_path)
+    if dest_file.is_dir() and not dest_file.is_symlink():
+        shutil.rmtree(dest_file)
+    os.replace(tmp_path, dest_file)
+
+def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
+    if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
+        dest_dir.unlink()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for child in sorted(src_dir.iterdir()):
+        dest_child = dest_dir / child.name
+        if child.is_dir():
+            merge_tree(child, dest_child, tmp_dir)
+        else:
+            replace_file(child, dest_child, tmp_dir)
+
+def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[Path]]:
+    stage_dirs = {{Path(".")}}
+    stage_files = set()
+    for child in stage_dir.rglob("*"):
+        if child == tmp_dir or tmp_dir in child.parents:
+            continue
+
+        relative = child.relative_to(stage_dir)
+        if child.is_dir():
+            stage_dirs.add(relative)
+        else:
+            stage_files.add(relative)
+    return stage_dirs, stage_files
+
+def prune_live_tree(live_root: Path, stage_dirs: set[Path], stage_files: set[Path]) -> None:
+    for child in sorted(live_root.rglob("*"), key=lambda path: len(path.relative_to(live_root).parts), reverse=True):
+        relative = child.relative_to(live_root)
+        if child.is_dir() and not child.is_symlink():
+            if relative not in stage_dirs:
+                shutil.rmtree(child)
+        elif relative not in stage_files:
+            child.unlink(missing_ok=True)
+
+def publish_preview_build(stage_dir: Path) -> None:
+    live_root = Path("dist")
+    live_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
+        tmp_dir = Path(_tmp)
+        stage_dirs, stage_files = collect_stage_paths(stage_dir, tmp_dir)
+
+        stage_assets = stage_dir / "assets"
+        if stage_assets.is_dir():
+            merge_tree(stage_assets, live_root / "assets", tmp_dir)
+
+        deferred_index: Path | None = None
+        for child in sorted(stage_dir.iterdir()):
+            if child.name == "assets":
+                continue
+            if child.name == tmp_dir.name:
+                continue
+            if child.name == "index.html":
+                deferred_index = child
+                continue
+            destination = live_root / child.name
+            if child.is_dir():
+                merge_tree(child, destination, tmp_dir)
+            else:
+                replace_file(child, destination, tmp_dir)
+
+        prune_live_tree(live_root, stage_dirs, stage_files)
+
+        if deferred_index is not None:
+            replace_file(deferred_index, live_root / "index.html", tmp_dir)
 
 workspace = Path.cwd().name
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
 env = os.environ.copy()
 env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
-raise SystemExit(subprocess.run(["npm", "run", "build", "--", "--mode", "preview"], env=env).returncode)
+stage_root = Path(".polyscope-preview-stage")
+stage_root.mkdir(exist_ok=True)
+stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
+try:
+    result = subprocess.run(
+        [
+            "npm",
+            "run",
+            "build",
+            "--",
+            "--mode",
+            "preview",
+            "--outDir",
+            stage_dir.as_posix(),
+        ],
+        env=env,
+    )
+    if result.returncode == 0:
+        try:
+            publish_preview_build(stage_dir)
+        except Exception as exc:
+            print(f"publish failed: {{exc}}", file=__import__("sys").stderr)
+            raise SystemExit(1) from exc
+    raise SystemExit(result.returncode)
+finally:
+    shutil.rmtree(stage_dir, ignore_errors=True)
         """
     ).strip()
 
@@ -581,8 +683,10 @@ def build_frontend_preview_build_watch_command() -> str:
         f"""\
 import hashlib
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -666,16 +770,113 @@ def snapshot() -> str:
 
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
+def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    dest_file.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
+    os.close(fd)
+    shutil.copy2(src_file, tmp_path)
+    if dest_file.is_dir() and not dest_file.is_symlink():
+        shutil.rmtree(dest_file)
+    os.replace(tmp_path, dest_file)
+
+def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
+    if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
+        dest_dir.unlink()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for child in sorted(src_dir.iterdir()):
+        dest_child = dest_dir / child.name
+        if child.is_dir():
+            merge_tree(child, dest_child, tmp_dir)
+        else:
+            replace_file(child, dest_child, tmp_dir)
+
+def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[Path]]:
+    stage_dirs = {{Path(".")}}
+    stage_files = set()
+    for child in stage_dir.rglob("*"):
+        if child == tmp_dir or tmp_dir in child.parents:
+            continue
+
+        relative = child.relative_to(stage_dir)
+        if child.is_dir():
+            stage_dirs.add(relative)
+        else:
+            stage_files.add(relative)
+    return stage_dirs, stage_files
+
+def prune_live_tree(live_root: Path, stage_dirs: set[Path], stage_files: set[Path]) -> None:
+    for child in sorted(live_root.rglob("*"), key=lambda path: len(path.relative_to(live_root).parts), reverse=True):
+        relative = child.relative_to(live_root)
+        if child.is_dir() and not child.is_symlink():
+            if relative not in stage_dirs:
+                shutil.rmtree(child)
+        elif relative not in stage_files:
+            child.unlink(missing_ok=True)
+
+def publish_preview_build(stage_dir: Path) -> None:
+    live_root = Path("dist")
+    live_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
+        tmp_dir = Path(_tmp)
+        stage_dirs, stage_files = collect_stage_paths(stage_dir, tmp_dir)
+
+        stage_assets = stage_dir / "assets"
+        if stage_assets.is_dir():
+            merge_tree(stage_assets, live_root / "assets", tmp_dir)
+
+        deferred_index = None
+        for child in sorted(stage_dir.iterdir()):
+            if child.name == "assets":
+                continue
+            if child.name == tmp_dir.name:
+                continue
+            if child.name == "index.html":
+                deferred_index = child
+                continue
+            destination = live_root / child.name
+            if child.is_dir():
+                merge_tree(child, destination, tmp_dir)
+            else:
+                replace_file(child, destination, tmp_dir)
+
+        prune_live_tree(live_root, stage_dirs, stage_files)
+
+        if deferred_index is not None:
+            replace_file(deferred_index, live_root / "index.html", tmp_dir)
+
 def run_build() -> int:
     api_workspace = resolve_linked_workspace("SecPal/api", Path.cwd().name)
     env = os.environ.copy()
     env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
+    stage_root = Path(".polyscope-preview-stage")
+    stage_root.mkdir(exist_ok=True)
+    stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
 
-    return subprocess.run(
-        ["npm", "run", "build", "--", "--mode", "preview"],
-        check=False,
-        env=env,
-    ).returncode
+    try:
+        result = subprocess.run(
+            [
+                "npm",
+                "run",
+                "build",
+                "--",
+                "--mode",
+                "preview",
+                "--outDir",
+                stage_dir.as_posix(),
+            ],
+            check=False,
+            env=env,
+        )
+        if result.returncode == 0:
+            try:
+                publish_preview_build(stage_dir)
+            except Exception as exc:
+                print(f"publish failed: {{exc}}", file=sys.stderr)
+                return 1
+        return result.returncode
+    finally:
+        shutil.rmtree(stage_dir, ignore_errors=True)
 
 print("Watching frontend preview sources for changes...", flush=True)
 previous_snapshot = None
@@ -2360,6 +2561,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         server {{
             listen 443 ssl;
             listen [::]:443 ssl;
+            http2 on;
             server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
@@ -2388,6 +2590,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
+            set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
             if (-f $api_public/index.php) {{
                 set $preview_docroot $api_public;
@@ -2448,6 +2652,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
 
             root $preview_docroot;
 
+            add_header Content-Security-Policy $secpal_csp always;
+            add_header Permissions-Policy $secpal_permissions_policy always;
             add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "0" always;
@@ -2468,6 +2674,132 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
 
             location / {{
                 try_files $uri @preview_router;
+            }}
+
+            location = / {{
+                if ($route_mode = api) {{
+                    rewrite ^ /index.php last;
+                }}
+
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+                add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+                try_files /index.html =404;
+            }}
+
+            location = /index.html {{
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+                add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+                try_files $uri =404;
+            }}
+
+            location = /sw.js {{
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+                add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+                add_header Service-Worker-Allowed "/" always;
+                try_files $uri =404;
+            }}
+
+            location = /manifest.webmanifest {{
+                default_type application/manifest+json;
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+                add_header Cache-Control "no-cache, must-revalidate" always;
+                try_files $uri =404;
+            }}
+
+            location ^~ /assets/ {{
+                try_files $uri =404;
+                expires 1y;
+                add_header Cache-Control "public, immutable" always;
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+            }}
+
+            location ^~ /_astro/ {{
+                try_files $uri =404;
+                expires 1y;
+                add_header Cache-Control "public, immutable" always;
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+            }}
+
+            location ^~ /_next/static/ {{
+                try_files $uri =404;
+                expires 1y;
+                add_header Cache-Control "public, immutable" always;
+                add_header Content-Security-Policy $secpal_csp always;
+                add_header Permissions-Policy $secpal_permissions_policy always;
+                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "0" always;
+                add_header X-Frame-Options "DENY" always;
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+                add_header Cross-Origin-Opener-Policy "same-origin" always;
+                add_header Cross-Origin-Resource-Policy "same-origin" always;
+                add_header Origin-Agent-Cluster "?1" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+            }}
+
+            location ~* \\.(?:svg|ico|png|jpg|jpeg|webp|avif|woff|woff2|ttf|otf|xml|txt)$ {{
+                try_files $uri =404;
+                expires 1d;
             }}
 
             location @preview_router {{

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -568,8 +568,6 @@ from pathlib import Path
 {build_linked_workspace_resolver_source()}
 
 def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
-    if src_file.is_symlink():
-        raise RuntimeError(f"staged build output contains symlink: {{src_file}}")
     dest_file.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
@@ -579,8 +577,6 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     os.replace(tmp_path, dest_file)
 
 def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
-    if src_dir.is_symlink():
-        raise RuntimeError(f"staged build output contains symlink: {{src_dir}}")
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -618,6 +614,8 @@ def prune_live_tree(live_root: Path, stage_dirs: set[Path], stage_files: set[Pat
 
 def publish_preview_build(stage_dir: Path) -> None:
     live_root = Path("dist")
+    if live_root.is_symlink():
+        raise RuntimeError("live preview dist is a symlink")
     live_root.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
@@ -777,8 +775,6 @@ def snapshot() -> str:
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
 def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
-    if src_file.is_symlink():
-        raise RuntimeError(f"staged build output contains symlink: {{src_file}}")
     dest_file.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
@@ -788,8 +784,6 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     os.replace(tmp_path, dest_file)
 
 def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
-    if src_dir.is_symlink():
-        raise RuntimeError(f"staged build output contains symlink: {{src_dir}}")
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -827,6 +821,8 @@ def prune_live_tree(live_root: Path, stage_dirs: set[Path], stage_files: set[Pat
 
 def publish_preview_build(stage_dir: Path) -> None:
     live_root = Path("dist")
+    if live_root.is_symlink():
+        raise RuntimeError("live preview dist is a symlink")
     live_root.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
@@ -2601,7 +2597,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
             if (-f $api_public/index.php) {{
@@ -2757,14 +2753,10 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 try_files $uri =404;
             }}
 
-            location ^~ /assets/. {{
-                deny all;
-            }}
-
             location ^~ /assets/ {{
                 try_files $uri =404;
-                expires 1y;
-                add_header Cache-Control "public, immutable" always;
+                expires off;
+                add_header Cache-Control "no-cache, must-revalidate" always;
                 add_header Content-Security-Policy $secpal_csp always;
                 add_header Permissions-Policy $secpal_permissions_policy always;
                 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
@@ -2776,13 +2768,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
-                if ($uri ~ \\.php$) {{
+                if ($uri ~ (?:/\\.|\\.php$)) {{
                     return 404;
                 }}
-            }}
-
-            location ^~ /_astro/. {{
-                deny all;
             }}
 
             location ^~ /_astro/ {{
@@ -2800,13 +2788,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
-                if ($uri ~ \\.php$) {{
+                if ($uri ~ (?:/\\.|\\.php$)) {{
                     return 404;
                 }}
-            }}
-
-            location ^~ /_next/static/. {{
-                deny all;
             }}
 
             location ^~ /_next/static/ {{
@@ -2824,7 +2808,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
                 add_header Cross-Origin-Resource-Policy "same-origin" always;
                 add_header Origin-Agent-Cluster "?1" always;
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
-                if ($uri ~ \\.php$) {{
+                if ($uri ~ (?:/\\.|\\.php$)) {{
                     return 404;
                 }}
             }}

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -637,10 +637,10 @@ def publish_preview_build(stage_dir: Path) -> None:
             else:
                 replace_file(child, destination, tmp_dir)
 
-        prune_live_tree(live_root, stage_dirs, stage_files)
-
         if deferred_index is not None:
             replace_file(deferred_index, live_root / "index.html", tmp_dir)
+
+        prune_live_tree(live_root, stage_dirs, stage_files)
 
 workspace = Path.cwd().name
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
@@ -840,10 +840,10 @@ def publish_preview_build(stage_dir: Path) -> None:
             else:
                 replace_file(child, destination, tmp_dir)
 
-        prune_live_tree(live_root, stage_dirs, stage_files)
-
         if deferred_index is not None:
             replace_file(deferred_index, live_root / "index.html", tmp_dir)
+
+        prune_live_tree(live_root, stage_dirs, stage_files)
 
 def run_build() -> int:
     api_workspace = resolve_linked_workspace("SecPal/api", Path.cwd().name)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -858,6 +858,10 @@ if "run" in args and "build" in args:
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "assets").mkdir(parents=True, exist_ok=True)
     (out_dir / "index.html").write_text(f"<!doctype html>build {counter}\\n")
+    if os.environ.get("FAKE_NPM_SYMLINK") == "1":
+        Path("outside-preview-stage.txt").write_text("must not publish\\n")
+        (out_dir / "assets" / "linked-secret.txt").symlink_to(Path.cwd() / "outside-preview-stage.txt")
+        sys.exit(0)
 
     if counter == 0:
         (out_dir / "sw.js").write_text("self.skipWaiting();\\n")
@@ -874,7 +878,8 @@ sys.exit(0)
 """
 )
 fake_npm.chmod(0o755)
-build_env = {**env, "PATH": str(fake_bin) + os.pathsep + "/usr/bin:/bin"}
+existing_path = env.get("PATH", "")
+build_env = {**env, "PATH": str(fake_bin) if not existing_path else str(fake_bin) + os.pathsep + existing_path}
 build_command = module.build_frontend_preview_build_command()
 build_script = shlex.split(build_command)[2]
 build_publish_source = build_script[
@@ -883,6 +888,7 @@ build_publish_source = build_script[
 assert build_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < build_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), build_publish_source
+assert "child.is_symlink()" in build_script, build_script
 build_result = subprocess.run(
     ["bash", "-c", "set -euo pipefail; " + build_command],
     cwd=frontend_worktree,
@@ -935,6 +941,17 @@ assert frontend_worktree.joinpath("dist", "assets", "shape").is_file()
 assert frontend_worktree.joinpath("dist", "assets", "current.js").is_file()
 assert frontend_worktree.joinpath("npm-vite-api-url.log").read_text() == "https://api-azure-cheetah-165552b7.preview.secpal.dev\n"
 
+symlink_build_result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + build_command],
+    cwd=frontend_worktree,
+    env={**build_env, "FAKE_NPM_SYMLINK": "1"},
+    capture_output=True,
+    text=True,
+)
+assert symlink_build_result.returncode == 1, symlink_build_result.stderr
+assert "staged build output contains symlink: assets/linked-secret.txt" in symlink_build_result.stderr, symlink_build_result.stderr
+assert not frontend_worktree.joinpath("dist", "assets", "linked-secret.txt").exists()
+
 # Run the resolver portion only (up to subprocess.run) by patching subprocess.run to capture env.
 import textwrap as _textwrap
 resolver_probe = _textwrap.dedent(f"""
@@ -972,6 +989,7 @@ assert 'Path("dist")' in watch_script, watch_script
 assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
+assert "child.is_symlink()" in watch_script, watch_script
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -952,6 +952,13 @@ assert symlink_build_result.returncode == 1, symlink_build_result.stderr
 assert "staged build output contains symlink: assets/linked-secret.txt" in symlink_build_result.stderr, symlink_build_result.stderr
 assert not frontend_worktree.joinpath("dist", "assets", "linked-secret.txt").exists()
 
+frontend_worktree.joinpath("dist").rename(frontend_worktree / "old-dist")
+frontend_worktree.joinpath("live-dist-target").mkdir()
+frontend_worktree.joinpath("dist").symlink_to(frontend_worktree / "live-dist-target", target_is_directory=True)
+live_symlink_result = subprocess.run(["bash", "-c", "set -euo pipefail; " + build_command], cwd=frontend_worktree, env=build_env, capture_output=True, text=True)
+assert live_symlink_result.returncode == 1, live_symlink_result.stderr
+assert "publish failed: live preview dist is a symlink" in live_symlink_result.stderr, live_symlink_result.stderr
+
 # Run the resolver portion only (up to subprocess.run) by patching subprocess.run to capture env.
 import textwrap as _textwrap
 resolver_probe = _textwrap.dedent(f"""
@@ -1338,6 +1345,7 @@ grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
 grep -qF "set \$secpal_csp " "$nginx_output"
+grep -qF "script-src 'self' 'unsafe-inline'" "$nginx_output"
 grep -qF "set \$secpal_permissions_policy " "$nginx_output"
 grep -qF "if (!-f \$php_root/index.php) {" "$nginx_output"
 grep -qF "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-preview.sock;" "$nginx_output"
@@ -1354,14 +1362,6 @@ grep -qF "default_type application/manifest+json;" "$nginx_output"
 grep -qF "location ^~ /assets/ {" "$nginx_output"
 grep -qF "location ^~ /_astro/ {" "$nginx_output"
 grep -qF "location ^~ /_next/static/ {" "$nginx_output"
-for _hidden_asset_loc in "/assets/." "/_astro/." "/_next/static/."; do
-    _hidden_asset_block=$(awk "/location \^\~ ${_hidden_asset_loc//\//\\/} \{/,/^[[:space:]]*\}/" "$nginx_output")
-    if ! printf '%s\n' "$_hidden_asset_block" | grep -qF "deny all;"; then
-        echo "nginx location ^~ ${_hidden_asset_loc} must deny hidden files below immutable asset prefixes" >&2
-        exit 1
-    fi
-done
-unset _hidden_asset_loc _hidden_asset_block
 # Immutable-asset location blocks must carry the full security header set; nginx add_header
 # inheritance is blocked whenever a location defines its own add_header directives, so each
 # block must repeat every header explicitly rather than relying on the parent server block.
@@ -1377,15 +1377,20 @@ for _immutable_loc in "/assets/" "/_astro/" "/_next/static/"; do
         'add_header Strict-Transport-Security' \
         'add_header X-Content-Type-Options' \
         'add_header X-Frame-Options' \
-        'add_header X-Permitted-Cross-Domain-Policies' \
-        'add_header Cache-Control "public, immutable"'; do
+        'add_header X-Permitted-Cross-Domain-Policies'; do
         if ! printf '%s\n' "$_immutable_block" | grep -qF "$_immutable_header"; then
             echo "nginx location ^~ ${_immutable_loc} is missing: ${_immutable_header}" >&2
             exit 1
         fi
     done
-    if ! printf '%s\n' "$_immutable_block" | grep -qF 'if ($uri ~ \.php$) {'; then
-        echo "nginx location ^~ ${_immutable_loc} must deny PHP files below immutable asset prefixes" >&2
+    _cache_header='add_header Cache-Control "public, immutable"'
+    [ "$_immutable_loc" = "/assets/" ] && _cache_header='add_header Cache-Control "no-cache, must-revalidate"'
+    if ! printf '%s\n' "$_immutable_block" | grep -qF "$_cache_header"; then
+        echo "nginx location ^~ ${_immutable_loc} is missing: ${_cache_header}" >&2
+        exit 1
+    fi
+    if ! printf '%s\n' "$_immutable_block" | grep -qF 'if ($uri ~ (?:/\.|\.php$)) {'; then
+        echo "nginx location ^~ ${_immutable_loc} must deny nested hidden files and PHP files" >&2
         exit 1
     fi
 done

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -736,6 +736,8 @@ frontend_worktree.mkdir(parents=True)
 api_worktree.mkdir(parents=True)
 relinked_api_worktree.mkdir(parents=True)
 source_api.mkdir(parents=True)
+fake_bin = fixture / "fake-bin"
+fake_bin.mkdir()
 
 source_api.joinpath(".env").write_text(
     "\n".join(
@@ -832,14 +834,76 @@ with sqlite3.connect(db_path) as connection:
     )
 
 # build_frontend_preview_build_command: assert linked API workspace is used in VITE_API_URL
+fake_npm = fake_bin / "npm"
+fake_npm.write_text(
+    """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+out_dir = Path("dist")
+for index, arg in enumerate(args[:-1]):
+    if arg == "--outDir":
+        out_dir = Path(args[index + 1])
+        break
+
+Path("npm-vite-api-url.log").write_text(os.environ.get("VITE_API_URL", "") + "\\n")
+
+if "run" in args and "build" in args:
+    counter_path = Path(".fake-npm-build-count")
+    counter = int(counter_path.read_text()) if counter_path.exists() else 0
+    counter_path.write_text(str(counter + 1))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "assets").mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.html").write_text(f"<!doctype html>build {counter}\\n")
+
+    if counter == 0:
+        (out_dir / "sw.js").write_text("self.skipWaiting();\\n")
+        (out_dir / ".well-known").mkdir(parents=True, exist_ok=True)
+        (out_dir / ".well-known" / "assetlinks.json").write_text("{}\\n")
+        (out_dir / "assets" / "removed.js").write_text("console.log('removed');\\n")
+        (out_dir / "assets" / "shape").mkdir(parents=True, exist_ok=True)
+        (out_dir / "assets" / "shape" / "chunk.js").write_text("console.log('old shape');\\n")
+    else:
+        (out_dir / "assets" / "shape").write_text("console.log('new shape');\\n")
+        (out_dir / "assets" / "current.js").write_text("console.log('current');\\n")
+
+sys.exit(0)
+"""
+)
+fake_npm.chmod(0o755)
+build_env = {**env, "PATH": str(fake_bin) + os.pathsep + "/usr/bin:/bin"}
 build_result = subprocess.run(
     ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_build_command()],
     cwd=frontend_worktree,
-    env={**env, "PATH": "/usr/bin:/bin", "VITE_BUILD_CAPTURE": "1"},
+    env=build_env,
     capture_output=True,
+    text=True,
 )
-# The command calls npm run build which won't exist in the fixture; what we test is that
-# the generated script resolves the correct api_workspace before invoking npm.
+assert build_result.returncode == 0, build_result.stderr
+assert frontend_worktree.joinpath("dist", "index.html").is_file()
+assert frontend_worktree.joinpath("dist", "sw.js").is_file()
+assert frontend_worktree.joinpath("dist", "assets", "removed.js").is_file()
+assert frontend_worktree.joinpath("dist", "assets", "shape").is_dir()
+
+second_build_result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_build_command()],
+    cwd=frontend_worktree,
+    env=build_env,
+    capture_output=True,
+    text=True,
+)
+assert second_build_result.returncode == 0, second_build_result.stderr
+assert "build 1" in frontend_worktree.joinpath("dist", "index.html").read_text()
+assert not frontend_worktree.joinpath("dist", "sw.js").exists()
+assert not frontend_worktree.joinpath("dist", ".well-known", "assetlinks.json").exists()
+assert not frontend_worktree.joinpath("dist", "assets", "removed.js").exists()
+assert frontend_worktree.joinpath("dist", "assets", "shape").is_file()
+assert frontend_worktree.joinpath("dist", "assets", "current.js").is_file()
+assert frontend_worktree.joinpath("npm-vite-api-url.log").read_text() == "https://api-azure-cheetah-165552b7.preview.secpal.dev\n"
+
 # Run the resolver portion only (up to subprocess.run) by patching subprocess.run to capture env.
 import textwrap as _textwrap
 resolver_probe = _textwrap.dedent(f"""
@@ -868,6 +932,9 @@ watch_script = shlex.split(watch_command)[2]
 run_build_source = watch_script[watch_script.index("def run_build()") :]
 assert 'api_url = f"https://api-' not in watch_script, watch_script
 assert 'resolve_linked_workspace("SecPal/api", Path.cwd().name)' in run_build_source, run_build_source
+assert '--outDir' in run_build_source, run_build_source
+assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
+assert 'Path("dist")' in watch_script, watch_script
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""
@@ -1209,12 +1276,47 @@ grep -qF "set \$php_root \$guardguide_public;" "$nginx_output"
 grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
+grep -qF "set \$secpal_csp " "$nginx_output"
+grep -qF "set \$secpal_permissions_policy " "$nginx_output"
 grep -qF "if (!-f \$php_root/index.php) {" "$nginx_output"
 grep -qF "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-preview.sock;" "$nginx_output"
 grep -qF "fastcgi_buffer_size 32k;" "$nginx_output"
 grep -qF "fastcgi_buffers 16 16k;" "$nginx_output"
 grep -qF "fastcgi_param SCRIPT_FILENAME \$php_root/index.php;" "$nginx_output"
 grep -qF "fastcgi_param DOCUMENT_ROOT \$php_root;" "$nginx_output"
+grep -qF "location = / {" "$nginx_output"
+grep -qF 'add_header Cache-Control "no-cache, no-store, must-revalidate" always;' "$nginx_output"
+grep -qF "location = /sw.js {" "$nginx_output"
+grep -qF 'add_header Service-Worker-Allowed "/" always;' "$nginx_output"
+grep -qF "location = /manifest.webmanifest {" "$nginx_output"
+grep -qF "default_type application/manifest+json;" "$nginx_output"
+grep -qF "location ^~ /assets/ {" "$nginx_output"
+grep -qF "location ^~ /_astro/ {" "$nginx_output"
+grep -qF "location ^~ /_next/static/ {" "$nginx_output"
+# Immutable-asset location blocks must carry the full security header set; nginx add_header
+# inheritance is blocked whenever a location defines its own add_header directives, so each
+# block must repeat every header explicitly rather than relying on the parent server block.
+for _immutable_loc in "/assets/" "/_astro/" "/_next/static/"; do
+    _immutable_block=$(awk "/location \^\~ ${_immutable_loc//\//\\/} \{/,/^[[:space:]]*\}/" "$nginx_output")
+    if printf '%s\n' "$_immutable_block" | tail -n +2 | grep -qE '^[[:space:]]*location '; then
+        echo "nginx location ^~ ${_immutable_loc} block parser captured a following location" >&2
+        exit 1
+    fi
+    for _immutable_header in \
+        'add_header Content-Security-Policy' \
+        'add_header Permissions-Policy' \
+        'add_header Strict-Transport-Security' \
+        'add_header X-Content-Type-Options' \
+        'add_header X-Frame-Options' \
+        'add_header X-Permitted-Cross-Domain-Policies' \
+        'add_header Cache-Control "public, immutable"'; do
+        if ! printf '%s\n' "$_immutable_block" | grep -qF "$_immutable_header"; then
+            echo "nginx location ^~ ${_immutable_loc} is missing: ${_immutable_header}" >&2
+            exit 1
+        fi
+    done
+done
+unset _immutable_loc _immutable_block _immutable_header
 
 if grep -qF "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-api.sock;" "$nginx_output"; then
     echo "preview nginx config must not route shared preview PHP traffic through the API-specific FPM pool" >&2
@@ -1411,8 +1513,21 @@ if [[ "$*" == *" ci"* || "$1" == "ci" ]]; then
     mkdir -p node_modules
 fi
 if [[ "$*" == *"run build"* ]]; then
-    mkdir -p dist
-    printf '<!doctype html>\n' > dist/index.html
+    out_dir="dist"
+    prev=""
+    for arg in "$@"; do
+        if [[ "$prev" == "--outDir" ]]; then
+            out_dir="$arg"
+            break
+        fi
+        prev="$arg"
+    done
+    mkdir -p "$out_dir/assets" "$out_dir/.well-known"
+    printf '<!doctype html>\n' > "$out_dir/index.html"
+    printf 'self.skipWaiting();\n' > "$out_dir/sw.js"
+    printf '{}\n' > "$out_dir/manifest.webmanifest"
+    printf 'console.log("chunk");\n' > "$out_dir/assets/index-abc123.js"
+    printf '{}\n' > "$out_dir/.well-known/assetlinks.json"
 fi
 exit 0
 STUB

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -875,8 +875,16 @@ sys.exit(0)
 )
 fake_npm.chmod(0o755)
 build_env = {**env, "PATH": str(fake_bin) + os.pathsep + "/usr/bin:/bin"}
+build_command = module.build_frontend_preview_build_command()
+build_script = shlex.split(build_command)[2]
+build_publish_source = build_script[
+    build_script.index("def publish_preview_build(stage_dir: Path) -> None:") : build_script.index("workspace = Path.cwd().name")
+]
+assert build_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < build_publish_source.index(
+    "prune_live_tree(live_root, stage_dirs, stage_files)"
+), build_publish_source
 build_result = subprocess.run(
-    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_build_command()],
+    ["bash", "-c", "set -euo pipefail; " + build_command],
     cwd=frontend_worktree,
     env=build_env,
     capture_output=True,
@@ -888,15 +896,38 @@ assert frontend_worktree.joinpath("dist", "sw.js").is_file()
 assert frontend_worktree.joinpath("dist", "assets", "removed.js").is_file()
 assert frontend_worktree.joinpath("dist", "assets", "shape").is_dir()
 
-second_build_result = subprocess.run(
-    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_build_command()],
+failing_build_script = build_script.replace(
+    "def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:\n",
+    """def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    if src_file.name == "index.html" and dest_file.name == "index.html" and os.environ.get("FAIL_INDEX_SWAP") == "1":
+        raise RuntimeError("simulated index replace failure")
+""",
+    1,
+)
+failed_build_result = subprocess.run(
+    ["python3", "-c", failing_build_script],
+    cwd=frontend_worktree,
+    env={**build_env, "FAIL_INDEX_SWAP": "1"},
+    capture_output=True,
+    text=True,
+)
+assert failed_build_result.returncode == 1, failed_build_result.stderr
+assert "publish failed: simulated index replace failure" in failed_build_result.stderr, failed_build_result.stderr
+assert "build 0" in frontend_worktree.joinpath("dist", "index.html").read_text()
+assert frontend_worktree.joinpath("dist", "sw.js").is_file()
+assert frontend_worktree.joinpath("dist", ".well-known", "assetlinks.json").is_file()
+assert frontend_worktree.joinpath("dist", "assets", "removed.js").is_file()
+assert frontend_worktree.joinpath("dist", "assets", "current.js").is_file()
+
+recovery_build_result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + build_command],
     cwd=frontend_worktree,
     env=build_env,
     capture_output=True,
     text=True,
 )
-assert second_build_result.returncode == 0, second_build_result.stderr
-assert "build 1" in frontend_worktree.joinpath("dist", "index.html").read_text()
+assert recovery_build_result.returncode == 0, recovery_build_result.stderr
+assert "build 2" in frontend_worktree.joinpath("dist", "index.html").read_text()
 assert not frontend_worktree.joinpath("dist", "sw.js").exists()
 assert not frontend_worktree.joinpath("dist", ".well-known", "assetlinks.json").exists()
 assert not frontend_worktree.joinpath("dist", "assets", "removed.js").exists()
@@ -929,12 +960,18 @@ assert "VITE_API_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in p
 
 watch_command = module.build_frontend_preview_build_watch_command()
 watch_script = shlex.split(watch_command)[2]
+watch_publish_source = watch_script[
+    watch_script.index("def publish_preview_build(stage_dir: Path) -> None:") : watch_script.index("def run_build()")
+]
 run_build_source = watch_script[watch_script.index("def run_build()") :]
 assert 'api_url = f"https://api-' not in watch_script, watch_script
 assert 'resolve_linked_workspace("SecPal/api", Path.cwd().name)' in run_build_source, run_build_source
 assert '--outDir' in run_build_source, run_build_source
 assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
 assert 'Path("dist")' in watch_script, watch_script
+assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
+    "prune_live_tree(live_root, stage_dirs, stage_files)"
+), watch_publish_source
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1323,6 +1323,12 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
 fi
 
 grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
+grep -qF "listen 443 ssl http2;" "$nginx_output"
+grep -qF "listen [::]:443 ssl http2;" "$nginx_output"
+if grep -qF "http2 on;" "$nginx_output"; then
+    echo "preview nginx config must use listen-level http2 syntax for nginx 1.24 compatibility" >&2
+    exit 1
+fi
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
 grep -qF "if (\$repo = guardguide) {" "$nginx_output"
@@ -1348,6 +1354,14 @@ grep -qF "default_type application/manifest+json;" "$nginx_output"
 grep -qF "location ^~ /assets/ {" "$nginx_output"
 grep -qF "location ^~ /_astro/ {" "$nginx_output"
 grep -qF "location ^~ /_next/static/ {" "$nginx_output"
+for _hidden_asset_loc in "/assets/." "/_astro/." "/_next/static/."; do
+    _hidden_asset_block=$(awk "/location \^\~ ${_hidden_asset_loc//\//\\/} \{/,/^[[:space:]]*\}/" "$nginx_output")
+    if ! printf '%s\n' "$_hidden_asset_block" | grep -qF "deny all;"; then
+        echo "nginx location ^~ ${_hidden_asset_loc} must deny hidden files below immutable asset prefixes" >&2
+        exit 1
+    fi
+done
+unset _hidden_asset_loc _hidden_asset_block
 # Immutable-asset location blocks must carry the full security header set; nginx add_header
 # inheritance is blocked whenever a location defines its own add_header directives, so each
 # block must repeat every header explicitly rather than relying on the parent server block.
@@ -1370,6 +1384,10 @@ for _immutable_loc in "/assets/" "/_astro/" "/_next/static/"; do
             exit 1
         fi
     done
+    if ! printf '%s\n' "$_immutable_block" | grep -qF 'if ($uri ~ \.php$) {'; then
+        echo "nginx location ^~ ${_immutable_loc} must deny PHP files below immutable asset prefixes" >&2
+        exit 1
+    fi
 done
 unset _immutable_loc _immutable_block _immutable_header
 


### PR DESCRIPTION
Validation first: `tests/polyscope-rollout.sh` now exercises the frontend preview publish path through a fake `npm` build, proving that linked API workspace env propagation still works while stale live `dist/` files are removed and asset path type changes are reconciled before `index.html` is published last.

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/polyscope-rollout.sh` now reproduces the stale frontend preview publish defect by running two fake preview builds and asserting that removed files, removed `.well-known` output, and an `assets/shape` directory-to-file change are reconciled in live `dist/`.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary

- Publish frontend preview builds through a temporary stage directory, merge assets into the live `dist/` tree, prune removed files, and defer `index.html` replacement until the rest of the staged output is reconciled.
- Add explicit preview nginx security, service-worker, manifest, and immutable asset cache/header handling so location-level `add_header` directives do not drop the inherited security header set.
- Tighten rollout regression coverage for staged preview publishing and immutable asset header assertions.
- Ignore generated Python bytecode artifacts and record the rollout hardening in `CHANGELOG.md`.

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- `git diff --check`
- Local four-pass review completed with no out-of-scope findings requiring a new issue.

## Linked Workspaces And Draft Status

- Linked workspace behavior covered: the rollout fixture validates the SecPal/api link selected for frontend preview `VITE_API_URL` propagation.
- No files were changed outside `SecPal/.github`.
- Keep this PR as draft until GitHub checks complete and the final self-review in the PR view finds zero issues.
