### PR TITLE
[codex] Harden Polyscope preview CSP rollout

### DIFF
--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1380,6 +1380,11 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     {"label": "Typecheck", "command": "npm run typecheck", "runMode": "preserve"},
                     {"label": "Vitest", "command": "npm run test:watch", "runMode": "replace"},
                     {
+                        "label": "Workspace Preview CSP Smoke",
+                        "command": "npm run test:preview:pwa-headers",
+                        "runMode": "preserve",
+                    },
+                    {
                         "label": "Playwright Local Preview Smoke",
                         "command": "npm run test:e2e:ci",
                         "runMode": "preserve",
@@ -2597,7 +2602,10 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            ssi on;
+            ssi_types text/html;
+            set $csp_nonce $request_id;
+            set $secpal_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-$csp_nonce'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
             if (-f $api_public/index.php) {{

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -99,6 +99,7 @@ package_scripts = {
         "test:run:all": "vitest run --coverage",
         "test:watch": "vitest",
         "test:e2e:ci": "cross-env CI=true playwright test",
+        "test:preview:pwa-headers": "node ./scripts/check-workspace-preview-pwa-headers.mjs",
         "test:e2e:staging": "cross-env PLAYWRIGHT_BASE_URL=https://app.secpal.dev playwright test",
     },
     "contracts": {
@@ -644,6 +645,10 @@ python3 "$PYTHON_SCRIPT" \
     --summary-output "$summary_output" \
     > /dev/null
 
+grep -qF "ssi on;" "$nginx_output"
+grep -qF "set \$csp_nonce \$request_id;" "$nginx_output"
+grep -qF "style-src 'self'; style-src-elem 'self' 'nonce-\$csp_nonce';" "$nginx_output"
+
 assert_rollout_rejects_invalid_local_config \
     "$PYTHON_SCRIPT" \
     'composer run analyse' \
@@ -685,6 +690,8 @@ grep -qF 'Watching frontend preview sources for changes...' "$workspace_root/fro
 grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run:all && npm run build"' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '"label": "Workspace Preview CSP Smoke"' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '"command": "npm run test:preview:pwa-headers"' "$workspace_root/frontend/polyscope.local.json"
 if grep -qF "npx vite build --watch --mode preview" "$workspace_root/frontend/polyscope.local.json"; then
     echo "generated frontend Polyscope config must not rely on Vite watch mode for preview rebuilds" >&2
     exit 1
@@ -1345,7 +1352,7 @@ grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
 grep -qF "set \$secpal_csp " "$nginx_output"
-grep -qF "script-src 'self' 'unsafe-inline'" "$nginx_output"
+grep -qF "script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-\$csp_nonce';" "$nginx_output"
 grep -qF "set \$secpal_permissions_policy " "$nginx_output"
 grep -qF "if (!-f \$php_root/index.php) {" "$nginx_output"
 grep -qF "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-preview.sock;" "$nginx_output"
@@ -1389,7 +1396,7 @@ for _immutable_loc in "/assets/" "/_astro/" "/_next/static/"; do
         echo "nginx location ^~ ${_immutable_loc} is missing: ${_cache_header}" >&2
         exit 1
     fi
-    if ! printf '%s\n' "$_immutable_block" | grep -qF 'if ($uri ~ (?:/\.|\.php$)) {'; then
+    if ! printf '%s\n' "$_immutable_block" | grep -qF "if (\$uri ~ (?:/\\.|\\.php$)) {"; then
         echo "nginx location ^~ ${_immutable_loc} must deny nested hidden files and PHP files" >&2
         exit 1
     fi


### PR DESCRIPTION
## What changed
- added a generated frontend Polyscope command for a workspace-preview CSP smoke check: `npm run test:preview:pwa-headers`
- updated preview nginx generation to enable SSI nonce expansion and emit the nonce-aware CSP required by current frontend previews
- extended rollout regression coverage so generated nginx and generated frontend workspace config both fail if this preview CSP contract regresses
- updated the existing rollout assertion that still expected the old `script-src 'self' 'unsafe-inline'` preview CSP

## Root cause
The frontend runtime fix was not enough on its own because future Polyscope workspaces would still inherit the older preview CSP from `.github/scripts/polyscope-rollout.py`. That left preview infrastructure behind the hardened frontend expectation.

## Why this belongs in `.github`
This change affects Polyscope workspace provisioning and generated preview infrastructure, not frontend runtime code. The goal here is to make newly provisioned or regenerated workspaces inherit the correct preview defaults automatically.

## Impact
- new frontend workspaces get a dedicated preview CSP smoke command by default
- generated preview nginx config now supports nonce expansion and the stricter preview CSP needed by the frontend
- rollout regressions now cover both workspace command generation and nginx CSP generation

## Validation
- `bash tests/polyscope-rollout.sh`