### PR TITLE
Drop preview nginx deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- updated `scripts/polyscope-rollout.py` so generated preview nginx config now uses `http2 on;` with plain `listen ... ssl;` directives instead of the deprecated `listen ... http2` syntax
+- updated `scripts/polyscope-rollout.py` so generated preview nginx config now uses `http2 on;` with plain `listen ... ssl;` directives by default instead of the deprecated `listen ... http2` syntax, while `--install-nginx` auto-detects the local nginx version and keeps the legacy listen-level fallback for nginx older than 1.25.1
 - removed redundant `ssi_types text/html;` from the generated SSI-only preview locations because `text/html` is already enabled by default, eliminating the duplicate MIME-type warning during `nginx -t`
-- extended `tests/polyscope-rollout.sh` so preview rollout regressions now fail if deprecated `http2` listen syntax or the redundant SSI MIME override reappear
+- extended `tests/polyscope-rollout.sh` so preview rollout regressions now fail if the modern render path reintroduces deprecated `http2` listen syntax, the nginx 1.24 fallback drops listen-level HTTP/2, or the redundant SSI MIME override reappears
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-25 - Drop Preview Nginx Deprecation Warnings
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so generated preview nginx config now uses `http2 on;` with plain `listen ... ssl;` directives instead of the deprecated `listen ... http2` syntax
+- removed redundant `ssi_types text/html;` from the generated SSI-only preview locations because `text/html` is already enabled by default, eliminating the duplicate MIME-type warning during `nginx -t`
+- extended `tests/polyscope-rollout.sh` so preview rollout regressions now fail if deprecated `http2` listen syntax or the redundant SSI MIME override reappear
+
+---
+
 ## 2026-06-25 - Harden Polyscope Preview CSP Rollout
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2572,8 +2572,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         }}
 
         server {{
-            listen 443 ssl http2;
-            listen [::]:443 ssl http2;
+            listen 443 ssl;
+            listen [::]:443 ssl;
+            http2 on;
             server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
@@ -2763,7 +2764,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
 
             location @preview_index_ssi {{
                 ssi on;
-                ssi_types text/html;
 
                 add_header Content-Security-Policy $secpal_csp always;
                 add_header Permissions-Policy $secpal_permissions_policy always;
@@ -2895,7 +2895,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
 
             location @preview_router_ssi {{
                 ssi on;
-                ssi_types text/html;
 
                 try_files $uri/index.html /index.html =404;
             }}

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -37,6 +37,8 @@ NO_AI_ATTRIBUTION_RULE = (
     "`[codex]` prefixes, or AI `Co-authored-by` trailers to commits, branches, pull request "
     "titles or bodies, issues, comments, or any other GitHub-facing content."
 )
+MODERN_NGINX_HTTP2_VERSION = (1, 25, 1)
+NGINX_HTTP2_SYNTAX_CHOICES = ("modern", "legacy", "auto")
 
 
 def default_polyscope_db_path() -> pathlib.Path:
@@ -2546,17 +2548,44 @@ def sync_repository_metadata(
     return backup_path
 
 
-def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
+def parse_nginx_version(version_output: str) -> tuple[int, int, int] | None:
+    match = re.search(r"nginx/(\d+)\.(\d+)\.(\d+)", version_output)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def select_nginx_http2_syntax(nginx_version: tuple[int, int, int]) -> str:
+    if nginx_version >= MODERN_NGINX_HTTP2_VERSION:
+        return "modern"
+    return "legacy"
+
+
+def detect_nginx_http2_syntax() -> str:
+    nginx_bin = shutil.which("nginx") or "/usr/sbin/nginx"
+    result = subprocess.run([nginx_bin, "-v"], check=True, capture_output=True, text=True)
+    nginx_version = parse_nginx_version(result.stdout + result.stderr)
+    if nginx_version is None:
+        raise RuntimeError("could not parse nginx version from `nginx -v` output")
+    return select_nginx_http2_syntax(nginx_version)
+
+
+def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_syntax: str = "modern") -> str:
+    if nginx_http2_syntax not in {"modern", "legacy"}:
+        raise ValueError(f"unsupported nginx HTTP/2 syntax: {nginx_http2_syntax}")
     api_id = repo_state["api"]["id"]
     frontend_id = repo_state["frontend"]["id"]
     guardguide_id = repo_state["GuardGuide"]["id"]
     secpal_app_id = repo_state["secpal.app"]["id"]
     guardguide_de_id = repo_state["guardguide.de"]["id"]
     changelog_id = repo_state["changelog"]["id"]
+    http2_listen_suffix = "" if nginx_http2_syntax == "modern" else " http2"
+    http2_directive = "\n            http2 on;" if nginx_http2_syntax == "modern" else ""
     # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-, secpal-app-, or changelog- are
     # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
     # Generic workspaces must not use those prefixes; the regex will treat them as legacy
     # hosts and route them to the wrong backend.
+    # `http2 on;` requires nginx >= 1.25.1, so install mode version-gates this render option.
     return textwrap.dedent(
         f"""
         server {{
@@ -2572,9 +2601,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]]) -> str:
         }}
 
         server {{
-            listen 443 ssl;
-            listen [::]:443 ssl;
-            http2 on;
+            listen 443 ssl{http2_listen_suffix};
+            listen [::]:443 ssl{http2_listen_suffix};{http2_directive}
             server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
@@ -2971,6 +2999,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--polyscope-api-base", default="http://127.0.0.1:4321/api")
     parser.add_argument("--repo-state-file", type=pathlib.Path)
     parser.add_argument("--nginx-output", type=pathlib.Path, default=pathlib.Path.home() / "copilot-preview-secpal-dev.nginx.conf")
+    parser.add_argument(
+        "--nginx-http2-syntax",
+        choices=NGINX_HTTP2_SYNTAX_CHOICES,
+        default="modern",
+        help="HTTP/2 syntax for rendered nginx config; install mode always auto-detects the host-safe syntax.",
+    )
     parser.add_argument("--summary-output", type=pathlib.Path)
     parser.add_argument("--skip-local-configs", action="store_true")
     parser.add_argument("--skip-db-sync", action="store_true")
@@ -3008,7 +3042,11 @@ def main() -> int:
     if not args.skip_db_sync:
         db_backup = sync_repository_metadata(args.db_path, repo_state, repo_specs)
 
-    args.nginx_output.write_text(render_nginx_config(repo_state))
+    nginx_http2_syntax = args.nginx_http2_syntax
+    if args.install_nginx or nginx_http2_syntax == "auto":
+        nginx_http2_syntax = detect_nginx_http2_syntax()
+
+    args.nginx_output.write_text(render_nginx_config(repo_state, nginx_http2_syntax=nginx_http2_syntax))
 
     if args.install_nginx:
         install_nginx_config(args.nginx_output)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1347,6 +1347,48 @@ if grep -qF "ssi_types text/html;" "$nginx_output"; then
     echo "preview nginx config must not redundantly restate the default text/html SSI type" >&2
     exit 1
 fi
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$repos_json" "$workspace/preview-legacy-nginx.conf"
+import importlib.util
+import json
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+repos_json = pathlib.Path(sys.argv[2])
+legacy_output = pathlib.Path(sys.argv[3])
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+assert module.parse_nginx_version("nginx version: nginx/1.24.0") == (1, 24, 0)
+assert module.parse_nginx_version("nginx version: nginx/1.25.1") == (1, 25, 1)
+assert module.parse_nginx_version("nginx version: nginx/1.27.4 (Ubuntu)") == (1, 27, 4)
+assert module.select_nginx_http2_syntax((1, 24, 0)) == "legacy"
+assert module.select_nginx_http2_syntax((1, 25, 0)) == "legacy"
+assert module.select_nginx_http2_syntax((1, 25, 1)) == "modern"
+
+repo_state = json.loads(repos_json.read_text())
+legacy_config = module.render_nginx_config(repo_state, nginx_http2_syntax="legacy")
+legacy_output.write_text(legacy_config)
+
+if "listen 443 ssl http2;" not in legacy_config:
+    raise SystemExit("legacy nginx render must preserve listen-level http2 for nginx 1.24")
+if "listen [::]:443 ssl http2;" not in legacy_config:
+    raise SystemExit("legacy nginx render must preserve IPv6 listen-level http2 for nginx 1.24")
+if "http2 on;" in legacy_config:
+    raise SystemExit("legacy nginx render must not emit the nginx >= 1.25.1 http2 directive")
+if "ssi_types text/html;" in legacy_config:
+    raise SystemExit("legacy nginx render must not restate the default text/html SSI type")
+
+try:
+    module.render_nginx_config(repo_state, nginx_http2_syntax="invalid")
+except ValueError:
+    pass
+else:
+    raise SystemExit("unsupported nginx HTTP/2 syntax must fail before rendering")
+PY
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
 grep -qF "if (\$repo = guardguide) {" "$nginx_output"
@@ -1385,11 +1427,13 @@ extract_https_server_prefix() {
         in_server=1
         is_https=0
         saw_https_listen=0
+        saw_http2=0
         block=$0 ORS
         next
     }
     in_server && /^[[:space:]]*listen 443 ssl;/ { saw_https_listen=1 }
-    in_server && saw_https_listen && /^[[:space:]]*http2 on;/ { is_https=1 }
+    in_server && /^[[:space:]]*http2 on;/ { saw_http2=1 }
+    in_server && saw_https_listen && saw_http2 { is_https=1 }
     in_server && is_https && /^[[:space:]]*location / {
         printf "%s", block
         exit
@@ -1403,6 +1447,7 @@ extract_https_server_prefix() {
         in_server=0
         is_https=0
         saw_https_listen=0
+        saw_http2=0
         block=""
     }
 ' "$1"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1336,10 +1336,15 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
 fi
 
 grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
-grep -qF "listen 443 ssl http2;" "$nginx_output"
-grep -qF "listen [::]:443 ssl http2;" "$nginx_output"
-if grep -qF "http2 on;" "$nginx_output"; then
-    echo "preview nginx config must use listen-level http2 syntax for nginx 1.24 compatibility" >&2
+grep -qF "listen 443 ssl;" "$nginx_output"
+grep -qF "listen [::]:443 ssl;" "$nginx_output"
+grep -qF "http2 on;" "$nginx_output"
+if grep -qF "listen 443 ssl http2;" "$nginx_output" || grep -qF "listen [::]:443 ssl http2;" "$nginx_output"; then
+    echo "preview nginx config must not use deprecated listen-level http2 syntax" >&2
+    exit 1
+fi
+if grep -qF "ssi_types text/html;" "$nginx_output"; then
+    echo "preview nginx config must not redundantly restate the default text/html SSI type" >&2
     exit 1
 fi
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
@@ -1379,10 +1384,12 @@ extract_https_server_prefix() {
     /^[[:space:]]*server \{/ {
         in_server=1
         is_https=0
+        saw_https_listen=0
         block=$0 ORS
         next
     }
-    in_server && /^[[:space:]]*listen 443 ssl http2;/ { is_https=1 }
+    in_server && /^[[:space:]]*listen 443 ssl;/ { saw_https_listen=1 }
+    in_server && saw_https_listen && /^[[:space:]]*http2 on;/ { is_https=1 }
     in_server && is_https && /^[[:space:]]*location / {
         printf "%s", block
         exit
@@ -1395,6 +1402,7 @@ extract_https_server_prefix() {
         }
         in_server=0
         is_https=0
+        saw_https_listen=0
         block=""
     }
 ' "$1"
@@ -1415,7 +1423,7 @@ extract_nginx_block() {
 }
 server_ssi_fixture="$workspace/nginx-server-ssi.conf"
 awk '
-    /^[[:space:]]*listen 443 ssl http2;/ && ! inserted {
+    /^[[:space:]]*http2 on;/ && ! inserted {
         print
         print "            ssi on;"
         inserted=1
@@ -1480,8 +1488,8 @@ for _ssi_loc in "location @preview_index_ssi {" "location @preview_router_ssi {"
         echo "nginx ${_ssi_loc} must enable SSI for nonce expansion" >&2
         exit 1
     fi
-    if ! printf '%s\n' "$_ssi_block" | grep -qF "ssi_types text/html;"; then
-        echo "nginx ${_ssi_loc} must scope SSI to text/html responses" >&2
+    if printf '%s\n' "$_ssi_block" | grep -qF "ssi_types text/html;"; then
+        echo "nginx ${_ssi_loc} must not restate the default text/html SSI type" >&2
         exit 1
     fi
 done


### PR DESCRIPTION
## What changed

- updated the generated preview nginx config to use `http2 on;` with plain `listen ... ssl;` directives instead of deprecated `listen ... http2` syntax
- removed redundant `ssi_types text/html;` lines from the preview SSI-only locations because `text/html` is already enabled by default
- tightened the rollout regression test so it now fails if deprecated preview `http2` syntax or the redundant SSI MIME override reappear
- documented the warning cleanup in `CHANGELOG.md`

## Root cause

The CSP rollout in `#503` fixed preview nonce delivery, but the generated preview nginx config still carried two legacy patterns that now produce avoidable `nginx -t` warnings on the host:

- deprecated `listen ... http2` syntax
- redundant `ssi_types text/html;` declarations

## Impact

- future preview nginx rollouts stay warning-free for these two cases
- preview infrastructure keeps the nonce-based CSP behavior from `#503` without the noisy validation drift
- the regression test now locks in the updated nginx contract

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` passed while the generated preview nginx config still contained deprecated `listen 443 ssl http2;` directives and redundant `ssi_types text/html;` lines that trigger avoidable `nginx -t` warnings on the host.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A