### PR TITLE
Replace markdownlint-cli2 with markdownlint-cli

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -58,4 +58,4 @@ jobs:
         run: npm ci
 
       - name: Run markdownlint
-        run: npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git"
+        run: npx markdownlint --config .markdownlint.json --dot "**/*.md" --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,8 +49,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          globs: "**/*.md"
-          config: ".markdownlint.json"
+          node-version: "22.x"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run markdownlint
+        run: npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git"

--- a/.github/workflows/reusable-copilot-instructions.yml
+++ b/.github/workflows/reusable-copilot-instructions.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: "main"
       node-version:
-        description: "Node.js version used for markdownlint-cli2"
+        description: "Node.js version used for markdownlint-cli"
         required: false
         type: string
         default: "22"

--- a/.github/workflows/reusable-copilot-instructions.yml
+++ b/.github/workflows/reusable-copilot-instructions.yml
@@ -7,7 +7,11 @@ on:
   workflow_call:
     inputs:
       governance-ref:
-        description: "Ref of SecPal/.github to use when validating sibling repositories"
+        description: >
+          Ref of SecPal/.github to use when validating sibling repositories.
+          Defaults to 'main' (always tracks the latest governance HEAD). Pin to a
+          specific commit SHA for reproducible, supply-chain-safe runs, because this
+          ref controls the validator script and lint binary — not just configuration.
         required: false
         type: string
         default: "main"
@@ -42,8 +46,16 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+      - name: Install governance Node dependencies
+        run: |
+          if [ "${{ github.repository }}" = "SecPal/.github" ]; then
+            npm ci
+            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          else
+            cd .secpal-governance
+            npm ci
+            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Select validator path
         id: validator

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -13,7 +13,7 @@ on:
         default: ".markdownlint.json"
       governance-ref:
         description: >
-          Ref of SecPal/.github to use for the pinned markdownlint-cli2 dependency.
+          Ref of SecPal/.github to use for the pinned markdownlint-cli dependency.
           Defaults to 'main' (always tracks the latest governance HEAD). Pin to a
           specific commit SHA for reproducible, supply-chain-safe runs, because this
           ref controls the actual lint binary — not just configuration.
@@ -21,7 +21,7 @@ on:
         type: string
         default: "main"
       node-version:
-        description: "Node.js version used for markdownlint-cli2"
+        description: "Node.js version used for markdownlint-cli"
         required: false
         type: string
         default: "22"
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Install pinned markdownlint-cli2
+      - name: Install pinned markdownlint-cli
         run: |
           if [ "${{ github.repository }}" = "SecPal/.github" ]; then
             npm ci
@@ -63,4 +63,4 @@ jobs:
           fi
 
       - name: Run markdownlint
-        run: markdownlint-cli2 --config "${{ inputs.config-file }}" "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git" "#.secpal-governance"
+        run: markdownlint --config "${{ inputs.config-file }}" --dot "**/*.md" --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git --ignore .secpal-governance

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ".markdownlint.json"
+      governance-ref:
+        description: >
+          Ref of SecPal/.github to use for the pinned markdownlint-cli2 dependency.
+          Defaults to 'main' (always tracks the latest governance HEAD). Pin to a
+          specific commit SHA for reproducible, supply-chain-safe runs, because this
+          ref controls the actual lint binary — not just configuration.
+        required: false
+        type: string
+        default: "main"
+      node-version:
+        description: "Node.js version used for markdownlint-cli2"
+        required: false
+        type: string
+        default: "22"
+
+permissions:
+  contents: read
 
 jobs:
   markdown-lint:
@@ -21,8 +38,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+      - name: Checkout governance repository
+        if: ${{ github.repository != 'SecPal/.github' }}
+        uses: actions/checkout@v7
         with:
-          globs: "**/*.md"
-          config: ${{ inputs.config-file }}
+          repository: SecPal/.github
+          ref: ${{ inputs.governance-ref }}
+          path: .secpal-governance
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install pinned markdownlint-cli2
+        run: |
+          if [ "${{ github.repository }}" = "SecPal/.github" ]; then
+            npm ci
+            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          else
+            cd .secpal-governance
+            npm ci
+            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Run markdownlint
+        run: markdownlint-cli2 --config "${{ inputs.config-file }}" "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git"

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -63,4 +63,4 @@ jobs:
           fi
 
       - name: Run markdownlint
-        run: markdownlint-cli2 --config "${{ inputs.config-file }}" "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git"
+        run: markdownlint-cli2 --config "${{ inputs.config-file }}" "**/*.md" "#node_modules" "#vendor" "#storage" "#build" "#.git" "#.secpal-governance"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,13 @@ repos:
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
   # Markdown linting
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
+  - repo: local
     hooks:
-      - id: markdownlint-cli2
-        args: ["--config", ".markdownlint.json"]
+      - id: markdownlint
+        name: markdownlint
+        entry: bash -c 'npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json "$@"' --
+        language: system
+        types: [markdown]
 
   # YAML linting
   - repo: https://github.com/adrienverge/yamllint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-27 - Replace markdownlint-cli2 With markdownlint-cli
+
+**Changed:**
+
+- replaced `markdownlint-cli2` with `markdownlint-cli@0.49.0` in the local
+  Node toolchain so the repository keeps the same markdownlint rule set while
+  dropping the dependency path that triggered the remaining moderate
+  `npm audit` findings
+- updated `scripts/preflight.sh`, `scripts/validate-copilot-instructions.sh`,
+  `.github/workflows/quality.yml`, and `reusable-markdown-lint.yml` to invoke
+  `markdownlint-cli` with explicit `--ignore` exclusions and `.markdownlint`
+  config handling
+- updated markdown lint documentation, system requirements guidance, and the
+  focused preflight regression test to match the new CLI path
+
+**Fixed:**
+
+- `npm audit` now returns zero vulnerabilities for the local `.github`
+  markdown lint toolchain after removing `markdownlint-cli2`
+
+---
+
 ## 2026-06-27 - Fix Review Findings from markdownlint-cli2 Audit Migration
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-06-27 - Fix Review Findings from markdownlint-cli2 Audit Migration
+
+**Fixed:**
+
+- added missing `permissions: contents: read` to `reusable-markdown-lint.yml`
+  so the reusable job no longer inherits elevated permissions from calling
+  workflows (least-privilege compliance)
+- restored `--yes` fallback in `scripts/preflight.sh`: the script now prefers
+  the local `node_modules/.bin/markdownlint-cli2` when available, and falls
+  back to `npx --yes` with an explanatory message when `npm ci` has not been
+  run, preventing a hang or silent failure in pre-push hooks
+- documented the `governance-ref` supply-chain risk in both
+  `reusable-markdown-lint.yml` and `reusable-copilot-instructions.yml` input
+  descriptions: callers can pin to a commit SHA to prevent the `main`-tracking
+  default from pulling an updated binary unexpectedly
+
+---
+
+## 2026-06-27 - Track Remaining markdownlint-cli2 Audit Findings
+
+**Added:**
+
+- pinned `markdownlint-cli2@0.22.1` in `package.json` and `package-lock.json`
+  so local markdown linting now runs from repo-owned dependencies after
+  `npm ci`
+
+**Changed:**
+
+- updated `scripts/preflight.sh`, `scripts/validate-copilot-instructions.sh`,
+  `.github/workflows/quality.yml`, and the reusable markdown/Copilot workflows
+  to use the pinned local `markdownlint-cli2` instead of global installs or
+  interactive `npx --yes` downloads
+- documented the remaining `npm audit` state in `docs/VALIDATION_SYSTEM.md` and
+  `scripts/README.md`: 3 moderate findings still flow through
+  `markdownlint-cli2` (`js-yaml@4.1.1` and `markdown-it@14.1.1`) and must be
+  revisited when upstream updates its dependency graph
+
+---
+
 ## 2026-06-25 - Drop Preview Nginx Deprecation Warnings
 
 **Fixed:**

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -120,7 +120,7 @@ This test always skips.
 
 **Purpose:** Ensure markdown quality standards
 
-**Tool:** markdownlint-cli2
+**Tool:** markdownlint-cli
 
 **Config:** `.markdownlint.json` (repo-specific)
 
@@ -133,24 +133,14 @@ This test always skips.
 
 **Failure Impact:** MEDIUM - Quality standards
 
-**Auto-fix:** `npx markdownlint-cli2 .github/copilot-instructions.md --fix`
+**Auto-fix:** `npx markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix`
 
-### Known Advisory State
+### Audit Status
 
-`SecPal/.github` now pins `markdownlint-cli2@0.22.1` locally so markdown
-linting runs reproducibly after `npm ci` instead of depending on global
-installs or interactive `npx` downloads.
-
-`npm audit` still reports 3 moderate vulnerabilities through the current
-`markdownlint-cli2` dependency graph:
-
-- `js-yaml@4.1.1` via `markdownlint-cli2` (`GHSA-h67p-54hq-rp68`)
-- `markdown-it@14.1.1` via `markdownlint-cli2` (`GHSA-6v5v-wf23-fmfq`)
-- direct audit attribution to `markdownlint-cli2@0.22.1`
-
-There is no in-repo mitigation short of replacing the lint tool or carrying a
-downstream override. Re-evaluate when `markdownlint-cli2` releases a dependency
-update that clears these advisories.
+`SecPal/.github` now pins `markdownlint-cli@0.49.0` locally so markdown
+linting stays reproducible after `npm ci` without depending on the
+`markdownlint-cli2` package graph that kept the remaining `npm audit` findings
+open.
 
 ### 6. YAML Syntax Validation
 
@@ -271,10 +261,10 @@ EOF
 
 ```bash
 # Auto-fix markdown issues
-npx markdownlint-cli2 .github/copilot-instructions.md --fix
+npx markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix
 
 # Manual review
-npx markdownlint-cli2 .github/copilot-instructions.md
+npx markdownlint --config .markdownlint.json .github/copilot-instructions.md
 ```
 
 ### Test 6 Failed: YAML Syntax
@@ -349,7 +339,7 @@ EOF
 chmod +x scripts/validate-copilot-instructions.sh
 ```
 
-### markdownlint-cli2 Not Found
+### markdownlint-cli Not Found
 
 ```bash
 npm ci

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -133,7 +133,7 @@ This test always skips.
 
 **Failure Impact:** MEDIUM - Quality standards
 
-**Auto-fix:** `npx markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix`
+**Auto-fix:** `./node_modules/.bin/markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix`
 
 ### Audit Status
 
@@ -261,10 +261,10 @@ EOF
 
 ```bash
 # Auto-fix markdown issues
-npx markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix
+./node_modules/.bin/markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix
 
 # Manual review
-npx markdownlint --config .markdownlint.json .github/copilot-instructions.md
+./node_modules/.bin/markdownlint --config .markdownlint.json .github/copilot-instructions.md
 ```
 
 ### Test 6 Failed: YAML Syntax

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -65,7 +65,7 @@ repositories: `.github`, `api`, `frontend`, `contracts`, `android`,
 
 1. Checkout the caller repository
 2. Checkout `SecPal/.github` when the caller is a sibling repository
-3. Setup Node.js 22 and install `markdownlint-cli2`
+3. Setup Node.js 22 and run `npm ci` in `SecPal/.github`
 4. Run `scripts/validate-copilot-instructions.sh`
 5. Fail the caller workflow when required guidance is missing
 
@@ -134,6 +134,23 @@ This test always skips.
 **Failure Impact:** MEDIUM - Quality standards
 
 **Auto-fix:** `npx markdownlint-cli2 .github/copilot-instructions.md --fix`
+
+### Known Advisory State
+
+`SecPal/.github` now pins `markdownlint-cli2@0.22.1` locally so markdown
+linting runs reproducibly after `npm ci` instead of depending on global
+installs or interactive `npx` downloads.
+
+`npm audit` still reports 3 moderate vulnerabilities through the current
+`markdownlint-cli2` dependency graph:
+
+- `js-yaml@4.1.1` via `markdownlint-cli2` (`GHSA-h67p-54hq-rp68`)
+- `markdown-it@14.1.1` via `markdownlint-cli2` (`GHSA-6v5v-wf23-fmfq`)
+- direct audit attribution to `markdownlint-cli2@0.22.1`
+
+There is no in-repo mitigation short of replacing the lint tool or carrying a
+downstream override. Re-evaluate when `markdownlint-cli2` releases a dependency
+update that clears these advisories.
 
 ### 6. YAML Syntax Validation
 
@@ -335,7 +352,7 @@ chmod +x scripts/validate-copilot-instructions.sh
 ### markdownlint-cli2 Not Found
 
 ```bash
-npm install -g markdownlint-cli2
+npm ci
 ```
 
 ### Ruby Not Found

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,103 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "js-yaml": "^4.2.0",
+        "markdownlint-cli2": "0.22.1",
         "prettier": "3.5.3"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -19,6 +115,322 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
@@ -43,6 +455,762 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "16.2.0",
+        "js-yaml": "4.1.1",
+        "jsonc-parser": "3.3.1",
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.1.1",
+        "markdownlint": "0.40.0",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.6.1"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
@@ -57,6 +1225,164 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,59 +10,8 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "js-yaml": "^4.2.0",
-        "markdownlint-cli2": "0.22.1",
+        "markdownlint-cli": "0.49.0",
         "prettier": "3.5.3"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@types/debug": {
@@ -116,17 +65,27 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/character-entities": {
@@ -163,13 +122,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/debug": {
@@ -202,6 +161,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/dequal": {
@@ -241,44 +210,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
       "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
+        "node": ">=12.0.0"
       },
-      "engines": {
-        "node": ">=8"
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/get-east-asian-width": {
@@ -294,40 +241,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.5",
-        "is-path-inside": "^4.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -336,6 +249,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -375,29 +298,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -407,29 +307,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-yaml": {
@@ -489,6 +366,16 @@
         "katex": "cli.js"
       }
     },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
@@ -510,15 +397,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -528,9 +425,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
+      "integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -542,66 +439,40 @@
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
         "micromark-util-types": "2.0.2",
-        "string-width": "8.1.0"
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
-    "node_modules/markdownlint-cli2": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
-      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
+    "node_modules/markdownlint-cli": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.0.tgz",
+      "integrity": "sha512-vS5tWq5W91Gg33LD4pyAaXPclnz/sRvo6/RGOyDQjQ3eds2DkK6H4szUuE0M9TiRB/u/VBx1gtd9Ktrtx5WlSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.2.0",
-        "js-yaml": "4.1.1",
-        "jsonc-parser": "3.3.1",
-        "jsonpointer": "5.0.1",
-        "markdown-it": "14.1.1",
-        "markdownlint": "0.40.0",
-        "markdownlint-cli2-formatter-default": "0.0.6",
-        "micromatch": "4.0.8",
-        "smol-toml": "1.6.1"
+        "commander": "~15.0.0",
+        "deep-extend": "~0.6.0",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.2.0",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.2.0",
+        "markdownlint": "~0.41.0",
+        "minimatch": "~10.2.5",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.1",
+        "tinyglobby": "~0.2.17"
       },
       "bin": {
-        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+        "markdownlint": "markdownlint.js"
       },
       "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/DavidAnson"
-      }
-    },
-    "node_modules/markdownlint-cli2-formatter-default": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
-      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/DavidAnson"
-      },
-      "peerDependencies": {
-        "markdownlint-cli2": ">=0.0.4"
-      }
-    },
-    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "node": ">=22"
       }
     },
     "node_modules/mdurl": {
@@ -610,16 +481,6 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -1157,18 +1018,30 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -1199,13 +1072,13 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1237,73 +1110,20 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+    "node_modules/run-con": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
+        "deep-extend": "^0.6.0",
+        "ini": "~4.1.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "bin": {
+        "run-con": "cli.js"
       }
     },
     "node_modules/smol-toml": {
@@ -1320,14 +1140,14 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -1352,17 +1172,34 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-number": "^7.0.0"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/uc.micro": {
@@ -1371,19 +1208,6 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "SecPal organization-wide documentation and settings",
   "private": true,
   "scripts": {
+    "lint:markdown": "markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git'",
+    "lint:markdown:fix": "markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' --fix",
+    "lint:markdown:copilot": "markdownlint-cli2 .github/copilot-instructions.md",
     "test": "npm run test:openapi-verified-presence",
     "test:openapi-verified-presence": "bash tests/check-openapi-verified-endpoints.sh",
     "copilot:review:threads": "./scripts/copilot-review-tool.sh threads",
@@ -25,6 +28,7 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "js-yaml": "^4.2.0",
+    "markdownlint-cli2": "0.22.1",
     "prettier": "3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "SecPal organization-wide documentation and settings",
   "private": true,
   "scripts": {
-    "lint:markdown": "markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git'",
-    "lint:markdown:fix": "markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' --fix",
-    "lint:markdown:copilot": "markdownlint-cli2 .github/copilot-instructions.md",
+    "lint:markdown": "markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git",
+    "lint:markdown:fix": "markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git --fix",
+    "lint:markdown:copilot": "markdownlint --config .markdownlint.json .github/copilot-instructions.md",
     "test": "npm run test:openapi-verified-presence",
     "test:openapi-verified-presence": "bash tests/check-openapi-verified-endpoints.sh",
     "copilot:review:threads": "./scripts/copilot-review-tool.sh threads",
@@ -28,7 +28,7 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "js-yaml": "^4.2.0",
-    "markdownlint-cli2": "0.22.1",
+    "markdownlint-cli": "0.49.0",
     "prettier": "3.5.3"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -136,8 +136,8 @@ Validates Copilot instructions and configuration files across all repositories.
 
 3. **Markdown Linting**
 
-   - Runs markdownlint-cli2 on instructions
-   - Uses the repo-pinned `markdownlint-cli2` installed by `npm ci`
+   - Runs markdownlint-cli on instructions
+   - Uses the repo-pinned `markdownlint-cli` installed by `npm ci`
    - Suggests auto-fix command on failure
 
 4. **YAML Syntax**
@@ -202,13 +202,8 @@ See `.github/workflows/validate-copilot-instructions.yml`
 
 - `bash` (required)
 - `grep` (required)
-- `npm ci` in `SecPal/.github` (installs the pinned `markdownlint-cli2` and `prettier` CLIs)
+- `npm ci` in `SecPal/.github` (installs the pinned `markdownlint-cli` and `prettier` CLIs)
 - `yq` (optional, for YAML validation)
-
-**Known audit note:** `npm audit` still reports 3 moderate vulnerabilities
-through `markdownlint-cli2@0.22.1` (`GHSA-h67p-54hq-rp68` in `js-yaml@4.1.1`
-and `GHSA-6v5v-wf23-fmfq` in `markdown-it@14.1.1`). Re-evaluate when upstream
-ships updated dependencies.
 
 **Repository Detection:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,6 +137,7 @@ Validates Copilot instructions and configuration files across all repositories.
 3. **Markdown Linting**
 
    - Runs markdownlint-cli2 on instructions
+   - Uses the repo-pinned `markdownlint-cli2` installed by `npm ci`
    - Suggests auto-fix command on failure
 
 4. **YAML Syntax**
@@ -201,8 +202,13 @@ See `.github/workflows/validate-copilot-instructions.yml`
 
 - `bash` (required)
 - `grep` (required)
-- `npx markdownlint-cli2` (optional, for markdown linting)
+- `npm ci` in `SecPal/.github` (installs the pinned `markdownlint-cli2` and `prettier` CLIs)
 - `yq` (optional, for YAML validation)
+
+**Known audit note:** `npm audit` still reports 3 moderate vulnerabilities
+through `markdownlint-cli2@0.22.1` (`GHSA-h67p-54hq-rp68` in `js-yaml@4.1.1`
+and `GHSA-6v5v-wf23-fmfq` in `markdown-it@14.1.1`). Re-evaluate when upstream
+ships updated dependencies.
 
 **Repository Detection:**
 

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -132,7 +132,7 @@ check_npx_tool() {
   fi
 }
 
-check_npx_tool "markdownlint-cli2"
+check_npx_tool "markdownlint-cli"
 check_npx_tool "prettier"
 
 check_command "shellcheck" "ShellCheck" "critical" "Install: sudo apt install shellcheck / brew install shellcheck"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -117,8 +117,10 @@ check_command "npx" "npx (Node Package Runner)" "critical" "Comes with npm (inst
 # Helper function to check npx-based tools (DRY principle)
 check_npx_tool() {
   local tool_name="$1"
+  local package_name="${2:-$tool_name}"
+  local executable_name="${3:-$tool_name}"
   if command -v npx >/dev/null 2>&1; then
-    if npx --yes "$tool_name" --version >/dev/null 2>&1; then
+    if npx --yes --package "$package_name" "$executable_name" --version >/dev/null 2>&1; then
       echo -e "${GREEN}✓${NC} $tool_name (via npx)"
       OK_COUNT=$((OK_COUNT + 1))
     else
@@ -132,7 +134,7 @@ check_npx_tool() {
   fi
 }
 
-check_npx_tool "markdownlint-cli"
+check_npx_tool "markdownlint-cli" "markdownlint-cli" "markdownlint"
 check_npx_tool "prettier"
 
 check_command "shellcheck" "ShellCheck" "critical" "Install: sudo apt install shellcheck / brew install shellcheck"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -48,7 +48,12 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier@3.5.3 --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  npx markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
+  if [ -x ./node_modules/.bin/markdownlint ]; then
+    ./node_modules/.bin/markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
+  else
+    echo "ℹ️  markdownlint not found in node_modules — run 'npm ci' first for reproducible linting." >&2
+    npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
+  fi
 fi
 # Workflow linting is enforced by pre-commit hooks and CI.
 # Local preflight keeps this as guidance only because direct actionlint runs

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -48,7 +48,12 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier@3.5.3 --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
+  if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+    node_modules/.bin/markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
+  else
+    echo "ℹ️  markdownlint-cli2 not found in node_modules — run 'npm ci' first for reproducible linting." >&2
+    npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
+  fi
 fi
 # Workflow linting is enforced by pre-commit hooks and CI.
 # Local preflight keeps this as guidance only because direct actionlint runs

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -48,12 +48,7 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier@3.5.3 --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  if [ -x node_modules/.bin/markdownlint-cli2 ]; then
-    node_modules/.bin/markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
-  else
-    echo "ℹ️  markdownlint-cli2 not found in node_modules — run 'npm ci' first for reproducible linting." >&2
-    npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' '#.git' || FORMAT_EXIT=1
-  fi
+  npx markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
 fi
 # Workflow linting is enforced by pre-commit hooks and CI.
 # Local preflight keeps this as guidance only because direct actionlint runs

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -184,6 +184,15 @@ if [ -f tests/preflight-markdownlint-scope.sh ]; then
   }
 fi
 
+if [ -f tests/markdownlint-precommit-config.sh ]; then
+  bash tests/markdownlint-precommit-config.sh || {
+    echo "" >&2
+    echo "❌ Markdownlint pre-commit config regression test failed!" >&2
+    echo "Keep .pre-commit-config.yaml aligned with the pinned markdownlint-cli path before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/mktemp-portability.sh ]; then
   bash tests/mktemp-portability.sh || {
     echo "" >&2

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -135,9 +135,15 @@ test_yaml_config_reuse() {
 }
 
 test_markdown_lint() {
-    local markdownlint_cli="./node_modules/.bin/markdownlint"
+    local markdownlint_cli=""
 
-    if [ ! -x "$markdownlint_cli" ]; then
+    if [ -x "./node_modules/.bin/markdownlint" ]; then
+        markdownlint_cli="./node_modules/.bin/markdownlint"
+    elif command -v markdownlint >/dev/null 2>&1; then
+        markdownlint_cli="markdownlint"
+    fi
+
+    if [ -z "$markdownlint_cli" ]; then
         print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli)"
         return
     fi

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -135,12 +135,12 @@ test_yaml_config_reuse() {
 }
 
 test_markdown_lint() {
-    if command -v npx >/dev/null 2>&1 && npx markdownlint-cli2 .github/copilot-instructions.md >/dev/null 2>&1; then
+    if command -v markdownlint-cli2 >/dev/null 2>&1 && markdownlint-cli2 .github/copilot-instructions.md >/dev/null 2>&1; then
         print_result "copilot-instructions.md passes markdown lint" "PASS"
-    elif command -v npx >/dev/null 2>&1; then
-        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: npx markdownlint-cli2 .github/copilot-instructions.md --fix"
+    elif command -v markdownlint-cli2 >/dev/null 2>&1; then
+        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: markdownlint-cli2 .github/copilot-instructions.md --fix"
     else
-        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (markdownlint-cli2 not available)"
+        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in SecPal/.github to install markdownlint-cli2)"
     fi
 }
 

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -137,18 +137,18 @@ test_yaml_config_reuse() {
 test_markdown_lint() {
     local markdownlint_cli=""
 
-    if [ -x "./node_modules/.bin/markdownlint-cli2" ]; then
-        markdownlint_cli="./node_modules/.bin/markdownlint-cli2"
-    elif command -v markdownlint-cli2 >/dev/null 2>&1; then
-        markdownlint_cli="markdownlint-cli2"
+    if [ -x "./node_modules/.bin/markdownlint" ]; then
+        markdownlint_cli="./node_modules/.bin/markdownlint"
+    elif command -v markdownlint >/dev/null 2>&1; then
+        markdownlint_cli="markdownlint"
     fi
 
-    if [ -n "$markdownlint_cli" ] && "$markdownlint_cli" .github/copilot-instructions.md >/dev/null 2>&1; then
+    if [ -n "$markdownlint_cli" ] && "$markdownlint_cli" --config .markdownlint.json .github/copilot-instructions.md >/dev/null 2>&1; then
         print_result "copilot-instructions.md passes markdown lint" "PASS"
     elif [ -n "$markdownlint_cli" ]; then
-        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: $markdownlint_cli .github/copilot-instructions.md --fix"
+        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: $markdownlint_cli --config .markdownlint.json .github/copilot-instructions.md --fix"
     else
-        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli2)"
+        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli)"
     fi
 }
 

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -135,20 +135,17 @@ test_yaml_config_reuse() {
 }
 
 test_markdown_lint() {
-    local markdownlint_cli=""
+    local markdownlint_cli="./node_modules/.bin/markdownlint"
 
-    if [ -x "./node_modules/.bin/markdownlint" ]; then
-        markdownlint_cli="./node_modules/.bin/markdownlint"
-    elif command -v markdownlint >/dev/null 2>&1; then
-        markdownlint_cli="markdownlint"
+    if [ ! -x "$markdownlint_cli" ]; then
+        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli)"
+        return
     fi
 
-    if [ -n "$markdownlint_cli" ] && "$markdownlint_cli" --config .markdownlint.json .github/copilot-instructions.md >/dev/null 2>&1; then
+    if "$markdownlint_cli" --config .markdownlint.json .github/copilot-instructions.md >/dev/null 2>&1; then
         print_result "copilot-instructions.md passes markdown lint" "PASS"
-    elif [ -n "$markdownlint_cli" ]; then
-        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: $markdownlint_cli --config .markdownlint.json .github/copilot-instructions.md --fix"
     else
-        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli)"
+        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: $markdownlint_cli --config .markdownlint.json .github/copilot-instructions.md --fix"
     fi
 }
 

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -139,7 +139,7 @@ test_markdown_lint() {
 
     if [ -x "./node_modules/.bin/markdownlint" ]; then
         markdownlint_cli="./node_modules/.bin/markdownlint"
-    elif command -v markdownlint >/dev/null 2>&1; then
+    elif [ -f ".markdownlint.json" ] && command -v markdownlint >/dev/null 2>&1; then
         markdownlint_cli="markdownlint"
     fi
 

--- a/scripts/validate-copilot-instructions.sh
+++ b/scripts/validate-copilot-instructions.sh
@@ -135,12 +135,20 @@ test_yaml_config_reuse() {
 }
 
 test_markdown_lint() {
-    if command -v markdownlint-cli2 >/dev/null 2>&1 && markdownlint-cli2 .github/copilot-instructions.md >/dev/null 2>&1; then
-        print_result "copilot-instructions.md passes markdown lint" "PASS"
+    local markdownlint_cli=""
+
+    if [ -x "./node_modules/.bin/markdownlint-cli2" ]; then
+        markdownlint_cli="./node_modules/.bin/markdownlint-cli2"
     elif command -v markdownlint-cli2 >/dev/null 2>&1; then
-        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: markdownlint-cli2 .github/copilot-instructions.md --fix"
+        markdownlint_cli="markdownlint-cli2"
+    fi
+
+    if [ -n "$markdownlint_cli" ] && "$markdownlint_cli" .github/copilot-instructions.md >/dev/null 2>&1; then
+        print_result "copilot-instructions.md passes markdown lint" "PASS"
+    elif [ -n "$markdownlint_cli" ]; then
+        print_result "copilot-instructions.md passes markdown lint" "FAIL" "Run: $markdownlint_cli .github/copilot-instructions.md --fix"
     else
-        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in SecPal/.github to install markdownlint-cli2)"
+        print_result "copilot-instructions.md passes markdown lint" "PASS" "Skipped (run npm ci in the repo root to install markdownlint-cli2)"
     fi
 }
 

--- a/tests/markdownlint-precommit-config.sh
+++ b/tests/markdownlint-precommit-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRE_COMMIT_CONFIG="$REPO_ROOT/.pre-commit-config.yaml"
+
+if grep -Fq 'https://github.com/DavidAnson/markdownlint-cli2' "$PRE_COMMIT_CONFIG"; then
+  echo "Expected .pre-commit-config.yaml to stop using the markdownlint-cli2 hook repo" >&2
+  exit 1
+fi
+
+if grep -Fq 'id: markdownlint-cli2' "$PRE_COMMIT_CONFIG"; then
+  echo "Expected .pre-commit-config.yaml to stop using the markdownlint-cli2 hook id" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'id: markdownlint' "$PRE_COMMIT_CONFIG"; then
+  echo "Expected .pre-commit-config.yaml to define a markdownlint hook" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json' "$PRE_COMMIT_CONFIG"; then
+  echo "Expected .pre-commit-config.yaml to pin markdownlint-cli@0.49.0 via npx" >&2
+  exit 1
+fi
+
+echo "tests/markdownlint-precommit-config.sh: markdownlint pre-commit hook verified."

--- a/tests/preflight-markdownlint-scope.sh
+++ b/tests/preflight-markdownlint-scope.sh
@@ -45,7 +45,13 @@ EOF
   LOG_FILE="$log_file" PATH="$workspace/bin:$PATH" bash scripts/preflight.sh >/dev/null
 )
 
-if ! grep -F 'markdownlint-cli2' "$log_file" | grep -Eq '(^|[[:space:]])#\.git($|[[:space:]])'; then
+if ! grep -Eq '(^|[[:space:]])markdownlint-cli($|[[:space:]])|(^|[[:space:]])markdownlint($|[[:space:]])' "$log_file"; then
+  echo "Expected preflight to invoke markdownlint" >&2
+  cat "$log_file" >&2
+  exit 1
+fi
+
+if ! grep -Eq '(^|[[:space:]])--ignore($|[[:space:]])' "$log_file" || ! grep -Eq '(^|[[:space:]])\.git($|[[:space:]])' "$log_file"; then
   echo "Expected preflight markdownlint invocation to exclude .git paths" >&2
   cat "$log_file" >&2
   exit 1

--- a/tests/reusable-markdown-lint-scope.sh
+++ b/tests/reusable-markdown-lint-scope.sh
@@ -8,9 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 workflow_file="$REPO_ROOT/.github/workflows/reusable-markdown-lint.yml"
 
-lint_step="$(grep -F 'run: markdownlint-cli2 --config "${{ inputs.config-file }}"' "$workflow_file")"
+lint_step="$(grep -F 'run: markdownlint --config "${{ inputs.config-file }}"' "$workflow_file")"
 
-if ! printf '%s\n' "$lint_step" | grep -Eq '(^|[[:space:]])"#\.secpal-governance"($|[[:space:]])'; then
+if ! printf '%s\n' "$lint_step" | grep -Eq '(^|[[:space:]])--ignore[[:space:]]+\.secpal-governance($|[[:space:]])'; then
     echo "Expected reusable markdown lint workflow to exclude .secpal-governance" >&2
     printf '%s\n' "$lint_step" >&2
     exit 1

--- a/tests/reusable-markdown-lint-scope.sh
+++ b/tests/reusable-markdown-lint-scope.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+workflow_file="$REPO_ROOT/.github/workflows/reusable-markdown-lint.yml"
+
+lint_step="$(grep -F 'run: markdownlint-cli2 --config "${{ inputs.config-file }}"' "$workflow_file")"
+
+if ! printf '%s\n' "$lint_step" | grep -Eq '(^|[[:space:]])"#\.secpal-governance"($|[[:space:]])'; then
+    echo "Expected reusable markdown lint workflow to exclude .secpal-governance" >&2
+    printf '%s\n' "$lint_step" >&2
+    exit 1
+fi

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -94,6 +94,11 @@ valid_api_extra_ai_lines="$(cat <<'EOF'
 EOF
 )"
 write_common_instruction_file "$valid_api_repo" "$valid_api_extra_ai_lines"
+cat >"$workspace/bin/markdownlint" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$workspace/bin/markdownlint"
 
 valid_output="$workspace/valid-output.txt"
 (
@@ -101,6 +106,7 @@ valid_output="$workspace/valid-output.txt"
     run_validator api "$valid_output"
 )
 grep -q 'copilot-instructions.md has REUSE license' "$valid_output"
+rm -f "$workspace/bin/markdownlint"
 
 local_markdownlint_repo="$workspace/local-markdownlint"
 mkdir -p "$local_markdownlint_repo/node_modules/.bin"
@@ -131,6 +137,7 @@ path_markdownlint_repo="$workspace/path-markdownlint"
 mkdir -p "$path_markdownlint_repo"
 touch "$path_markdownlint_repo/composer.json"
 write_common_instruction_file "$path_markdownlint_repo" "$valid_api_extra_ai_lines"
+cp "$REPO_ROOT/.markdownlint.json" "$path_markdownlint_repo/.markdownlint.json"
 cat >"$workspace/bin/markdownlint" <<'EOF'
 #!/usr/bin/env bash
 exit 1

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -102,6 +102,31 @@ valid_output="$workspace/valid-output.txt"
 )
 grep -q 'copilot-instructions.md has REUSE license' "$valid_output"
 
+local_markdownlint_repo="$workspace/local-markdownlint"
+mkdir -p "$local_markdownlint_repo/node_modules/.bin"
+touch "$local_markdownlint_repo/composer.json"
+write_common_instruction_file "$local_markdownlint_repo" "$valid_api_extra_ai_lines"
+cat >"$local_markdownlint_repo/node_modules/.bin/markdownlint-cli2" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$local_markdownlint_repo/node_modules/.bin/markdownlint-cli2"
+
+local_markdownlint_output="$workspace/local-markdownlint-output.txt"
+set +e
+(
+    cd "$local_markdownlint_repo"
+    run_validator api "$local_markdownlint_output"
+)
+local_markdownlint_exit=$?
+set -e
+if [ "$local_markdownlint_exit" -eq 0 ]; then
+    cat "$local_markdownlint_output"
+    echo "validator unexpectedly skipped repo-local markdownlint-cli2" >&2
+    exit 1
+fi
+grep -q 'Run: ./node_modules/.bin/markdownlint-cli2 .github/copilot-instructions.md --fix' "$local_markdownlint_output"
+
 missing_generic_repo="$workspace/missing-generic"
 mkdir -p "$missing_generic_repo/.github"
 touch "$missing_generic_repo/composer.json"

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -106,11 +106,11 @@ local_markdownlint_repo="$workspace/local-markdownlint"
 mkdir -p "$local_markdownlint_repo/node_modules/.bin"
 touch "$local_markdownlint_repo/composer.json"
 write_common_instruction_file "$local_markdownlint_repo" "$valid_api_extra_ai_lines"
-cat >"$local_markdownlint_repo/node_modules/.bin/markdownlint-cli2" <<'EOF'
+cat >"$local_markdownlint_repo/node_modules/.bin/markdownlint" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$local_markdownlint_repo/node_modules/.bin/markdownlint-cli2"
+chmod +x "$local_markdownlint_repo/node_modules/.bin/markdownlint"
 
 local_markdownlint_output="$workspace/local-markdownlint-output.txt"
 set +e
@@ -122,10 +122,10 @@ local_markdownlint_exit=$?
 set -e
 if [ "$local_markdownlint_exit" -eq 0 ]; then
     cat "$local_markdownlint_output"
-    echo "validator unexpectedly skipped repo-local markdownlint-cli2" >&2
+    echo "validator unexpectedly skipped repo-local markdownlint" >&2
     exit 1
 fi
-grep -q 'Run: ./node_modules/.bin/markdownlint-cli2 .github/copilot-instructions.md --fix' "$local_markdownlint_output"
+grep -q 'Run: ./node_modules/.bin/markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix' "$local_markdownlint_output"
 
 missing_generic_repo="$workspace/missing-generic"
 mkdir -p "$missing_generic_repo/.github"

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -127,6 +127,32 @@ if [ "$local_markdownlint_exit" -eq 0 ]; then
 fi
 grep -q 'Run: ./node_modules/.bin/markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix' "$local_markdownlint_output"
 
+path_markdownlint_repo="$workspace/path-markdownlint"
+mkdir -p "$path_markdownlint_repo"
+touch "$path_markdownlint_repo/composer.json"
+write_common_instruction_file "$path_markdownlint_repo" "$valid_api_extra_ai_lines"
+cat >"$workspace/bin/markdownlint" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$workspace/bin/markdownlint"
+
+path_markdownlint_output="$workspace/path-markdownlint-output.txt"
+set +e
+(
+    cd "$path_markdownlint_repo"
+    run_validator api "$path_markdownlint_output"
+)
+path_markdownlint_exit=$?
+set -e
+if [ "$path_markdownlint_exit" -eq 0 ]; then
+    cat "$path_markdownlint_output"
+    echo "validator unexpectedly skipped PATH markdownlint" >&2
+    exit 1
+fi
+grep -q 'Run: markdownlint --config .markdownlint.json .github/copilot-instructions.md --fix' "$path_markdownlint_output"
+rm -f "$workspace/bin/markdownlint"
+
 missing_generic_repo="$workspace/missing-generic"
 mkdir -p "$missing_generic_repo/.github"
 touch "$missing_generic_repo/composer.json"


### PR DESCRIPTION
`bash tests/preflight-markdownlint-scope.sh` failed because the local preflight path still invoked `markdownlint-cli2`, and `npm audit --json` still reported 3 moderate findings through the `markdownlint-cli2@0.22.1` dependency graph.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/preflight-markdownlint-scope.sh` failed because preflight still invoked `markdownlint-cli2`, and `npm audit --json` reported 3 moderate findings through `markdownlint-cli2@0.22.1`
- Passing proof after implementation: `bash tests/preflight-markdownlint-scope.sh`, `bash tests/validate-copilot-instructions.sh`, `bash tests/prettier-version-alignment.sh`, `npm run lint:markdown:copilot`, `npx markdownlint --config .markdownlint.json CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md .github/copilot-instructions.md`, `./scripts/preflight.sh`, and `npm audit --json` all passed after replacing `markdownlint-cli2` with `markdownlint-cli@0.49.0`
- Validate-first exception reference: n/a
- No executable change reason: n/a

## Current change

- replace `markdownlint-cli2` with `markdownlint-cli@0.49.0` in `package.json` and `package-lock.json`
- switch local and reusable `.github` markdown lint paths to the new CLI with explicit `--ignore` exclusions and `.markdownlint.json` handling
- update Copilot-instructions validation, system requirements guidance, and markdown lint documentation to match the new command path
- remove the remaining local `.github` markdown lint audit findings by dropping the `markdownlint-cli2` dependency graph

## Validations already run

- `bash tests/preflight-markdownlint-scope.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/prettier-version-alignment.sh`
- `npm run lint:markdown:copilot`
- `npx markdownlint --config .markdownlint.json CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md .github/copilot-instructions.md`
- `npx prettier --check package.json package-lock.json CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md .github/workflows/quality.yml .github/workflows/reusable-copilot-instructions.yml .github/workflows/reusable-markdown-lint.yml`
- `bash -n scripts/preflight.sh scripts/validate-copilot-instructions.sh scripts/check-system-requirements.sh`
- `./scripts/preflight.sh`
- `npm audit --json`

## Before marking ready

- draft PR CI checks still need to rerun against the updated commit set
- linked workspaces: none

Closes #505
