### PR TITLE
Fix post-merge AI instruction follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - introduced `scripts/validate-ai-instructions.sh` as the canonical validator, kept `scripts/validate-copilot-instructions.sh` as a compatibility wrapper, and extended regression coverage so repositories now fail governance validation when `AGENTS.md` is missing or weak, or when `.github/copilot-instructions.md` stops clearly mirroring the authoritative `AGENTS.md`
 - added provider-neutral `Review guidelines` and no-attribution/no-self-promotion rules to each managed `AGENTS.md`, so AI review output focuses on evidence, impact, and fix paths instead of tool identity
 - extended `scripts/validate-ai-instructions.sh` and regression coverage to enforce provider-neutral review guidance and keep `AGENTS.md` below the default runtime discovery size limit
+- narrowed GuardGuide package-name detection in `scripts/validate-ai-instructions.sh` to exact `guardguide` manifests, so Astro sites such as `guardguide.de` keep the `website` validator path instead of being misclassified as the GuardGuide app
 - aligned the AGENTS rollout with the merged `markdownlint-cli@0.49.0` toolchain from PR 506 instead of reintroducing `markdownlint-cli2`
 - documented the new split between authoritative `AGENTS.md`, Copilot compatibility mirrors, and focused `.github/instructions/*.instructions.md` overlays in `docs/development-principles.md` and `docs/VALIDATION_SYSTEM.md`
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1846,14 +1846,21 @@ def load_runtime_instructions_text(spec: dict[str, Any]) -> str:
     return spec["copilot_instructions"].read_text()
 
 
+def extract_agents_runtime_body(text: str) -> str:
+    body = strip_html_comment_header(text)
+    core_index = body.find("## Core Runtime Baseline")
+    if core_index != -1:
+        return body[core_index:].strip()
+    heading = re.search(r"^##\s+", body, re.MULTILINE)
+    if heading is None:
+        raise SystemExit("AGENTS.md is missing a section heading after the repository preamble")
+    return body[heading.start() :].strip()
+
+
 def render_copilot_compat_instructions(spec: dict[str, Any]) -> str:
     if not spec["agent_instructions"].exists():
         raise FileNotFoundError(spec["agent_instructions"])
-    agents_text = strip_html_comment_header(spec["agent_instructions"].read_text())
-    core_index = agents_text.find("## Core Runtime Baseline")
-    if core_index == -1:
-        raise SystemExit(f"AGENTS.md is missing '## Core Runtime Baseline' in {spec['path']}")
-    body = agents_text[core_index:].strip()
+    body = extract_agents_runtime_body(spec["agent_instructions"].read_text())
     focus_lines = "\n".join(
         f"- `{path.relative_to(spec['path']).as_posix()}`" for path in spec["focus_instruction_paths"]
     )

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -229,6 +229,15 @@ if [ -f tests/validate-ai-instructions.sh ]; then
   }
 fi
 
+if [ -f tests/validate-copilot-instructions.sh ]; then
+  bash tests/validate-copilot-instructions.sh || {
+    echo "" >&2
+    echo "❌ Copilot-instructions compatibility regression test failed!" >&2
+    echo "Fix scripts/validate-copilot-instructions.sh and the legacy reusable workflow compatibility path before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/sync-required-checks.sh ]; then
   bash tests/sync-required-checks.sh || {
     echo "" >&2

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -23,7 +23,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "check-conflicts / Detect Git Conflict Markers",
     "Check PR Size / Check PR Size",
     "Detect repository manifests",
-    "Copilot Instructions / Validate Copilot Instructions",
+    "AI Instructions / Validate AI Instructions",
     "Check REUSE Compliance / Check REUSE Compliance",
     "Detect JavaScript manifest",
     "Detect PHP manifest",
@@ -49,7 +49,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Vitest Tests",
     "Analyze with CodeQL (javascript-typescript)",
     "Check PR Size / Check PR Size",
-    "Copilot Instructions / Validate Copilot Instructions",
+    "AI Instructions / Validate AI Instructions",
     "Markdown Lint / Lint Markdown Files"
   ],
   "api": [
@@ -62,7 +62,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Check PR Size / Check PR Size",
     "PEST Tests",
     "check-conflicts / Detect Git Conflict Markers",
-    "Copilot Instructions / Validate Copilot Instructions"
+    "AI Instructions / Validate AI Instructions"
   ],
   "changelog": [
     "Check REUSE Compliance / Check REUSE Compliance",
@@ -75,7 +75,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "check-conflicts / Detect Git Conflict Markers",
     "TypeScript Check / Build Project",
     "Analyze Code (javascript-typescript)",
-    "Copilot Instructions / Validate Copilot Instructions"
+    "AI Instructions / Validate AI Instructions"
   ],
   "guardguide.de": [
     "Check REUSE Compliance / Check REUSE Compliance",
@@ -88,7 +88,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Check PR Size / Check PR Size",
     "check-conflicts / Detect Git Conflict Markers",
     "Analyze Code (javascript-typescript)",
-    "Copilot Instructions / Validate Copilot Instructions",
+    "AI Instructions / Validate AI Instructions",
     "Node Tests / Run Tests"
   ],
   "contracts": [
@@ -100,7 +100,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "License Compatibility / Check License Compatibility",
     "Markdown Lint / Lint Markdown Files",
     "check-conflicts / Detect Git Conflict Markers",
-    "Copilot Instructions / Validate Copilot Instructions"
+    "AI Instructions / Validate AI Instructions"
   ],
   "frontend": [
     "Check REUSE Compliance / Check REUSE Compliance",
@@ -113,7 +113,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Check PR Size / Check PR Size",
     "Vitest Tests",
     "check-conflicts / Detect Git Conflict Markers",
-    "Copilot Instructions / Validate Copilot Instructions"
+    "AI Instructions / Validate AI Instructions"
   ],
   "secpal.app": [
     "Check REUSE Compliance / Check REUSE Compliance",
@@ -126,7 +126,7 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Check PR Size / Check PR Size",
     "check-conflicts / Detect Git Conflict Markers",
     "Analyze Code (javascript-typescript)",
-    "Copilot Instructions / Validate Copilot Instructions",
+    "AI Instructions / Validate AI Instructions",
     "Node Tests / Run Tests"
   ]
 }

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -44,7 +44,7 @@ detect_repo_type() {
     fi
 
     if [ "$(basename "$PWD")" = "GuardGuide" ] \
-        || grep -qiE '"name"[[:space:]]*:[[:space:]]*"[^"]*guardguide' composer.json package.json 2>/dev/null; then
+        || grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"]*/)?guardguide"' composer.json package.json 2>/dev/null; then
         echo "guardguide"
         return
     fi

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -43,6 +43,12 @@ detect_repo_type() {
         return
     fi
 
+    if [ "$(basename "$PWD")" = "GuardGuide" ] \
+        || grep -qiE '"name"[[:space:]]*:[[:space:]]*"[^"]*guardguide' composer.json package.json 2>/dev/null; then
+        echo "guardguide"
+        return
+    fi
+
     if [ -f "artisan" ] || [ -f "composer.json" ]; then
         echo "api"
         return
@@ -479,6 +485,11 @@ test_repo_specific_ai_risk_guidance() {
             first_pattern='listener-handle|listener handle|teardown|bridge'
             second_pattern='WebView history|back behavior|back-navigation|managed-mode|owner-state'
             message='Missing android AI guardrails for bridge teardown or managed/back-navigation behavior'
+            ;;
+        guardguide)
+            first_pattern='shadcn/ui|Lingui|localization|application-layer encryption|QR|magic-link|supervised fallback'
+            second_pattern='MariaDB|PostgreSQL|tenant-scoped|mutable display name|IP addresses|user-agent strings'
+            message='Missing GuardGuide AI guardrails for localization, sensitive-data handling, or dual-database acknowledgement flows'
             ;;
         website)
             first_pattern='static|client-only|route|build'

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -43,8 +43,13 @@ detect_repo_type() {
         return
     fi
 
-    if [ "$(basename "$PWD")" = "GuardGuide" ] \
-        || grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"]*/)?guardguide"' composer.json package.json 2>/dev/null; then
+    if [ "$(basename "$PWD")" = "GuardGuide" ]; then
+        echo "guardguide"
+        return
+    fi
+
+    if { [ -f "composer.json" ] && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"]*/)?guardguide"' composer.json; } \
+        || { [ -f "package.json" ] && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"]*/)?guardguide"' package.json; }; then
         echo "guardguide"
         return
     fi

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -637,6 +637,14 @@ applyTo: '.github/workflows/**/*.yml'
 
 write_repo_runtime_files
 
+python3 - <<'PY' "$workspace_root/frontend/AGENTS.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace("## Core Runtime Baseline\n\n", "", 1))
+PY
+
 db_path="$workspace/polyscope.db"
 repos_json="$workspace/repos.json"
 nginx_output="$workspace/preview.secpal.dev.conf"
@@ -719,6 +727,7 @@ if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api
 fi
 grep -q 'frontend/AGENTS.md before taking action' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://frontend-{{folder}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
+grep -q '## Always-On Rules' "$workspace_root/frontend/.github/copilot-instructions.md"
 grep -q 'https://guardguide-{{folder}}.preview.secpal.dev' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -q 'https://secpal-app-{{folder}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
 grep -q 'https://guardguide-de-{{folder}}.preview.secpal.dev' "$workspace_root/guardguide.de/polyscope.local.json"

--- a/tests/preflight-markdownlint-scope.sh
+++ b/tests/preflight-markdownlint-scope.sh
@@ -12,8 +12,10 @@ trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/scripts" "$workspace/bin"
 cp "$REPO_ROOT/scripts/preflight.sh" "$workspace/scripts/preflight.sh"
+mkdir -p "$workspace/tests"
 
 log_file="$workspace/npx.log"
+test_log="$workspace/test.log"
 
 cat >"$workspace/bin/npx" <<'EOF'
 #!/usr/bin/env bash
@@ -27,6 +29,18 @@ cat >"$workspace/bin/reuse" <<'EOF'
 exit 0
 EOF
 chmod +x "$workspace/bin/reuse"
+
+cat >"$workspace/tests/validate-ai-instructions.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "validate-ai-instructions" >> "$TEST_LOG"
+EOF
+chmod +x "$workspace/tests/validate-ai-instructions.sh"
+
+cat >"$workspace/tests/validate-copilot-instructions.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "validate-copilot-instructions" >> "$TEST_LOG"
+EOF
+chmod +x "$workspace/tests/validate-copilot-instructions.sh"
 
 cat >"$workspace/README.md" <<'EOF'
 # Test Workspace
@@ -42,7 +56,7 @@ EOF
   git checkout --quiet -b test-branch
   git update-ref refs/remotes/origin/main HEAD
   git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
-  LOG_FILE="$log_file" PATH="$workspace/bin:$PATH" bash scripts/preflight.sh >/dev/null
+  LOG_FILE="$log_file" TEST_LOG="$test_log" PATH="$workspace/bin:$PATH" bash scripts/preflight.sh >/dev/null
 )
 
 if ! grep -Eq '(^|[[:space:]])markdownlint-cli($|[[:space:]])|(^|[[:space:]])markdownlint($|[[:space:]])' "$log_file"; then
@@ -54,5 +68,11 @@ fi
 if ! grep -Eq '(^|[[:space:]])--ignore($|[[:space:]])' "$log_file" || ! grep -Eq '(^|[[:space:]])\.git($|[[:space:]])' "$log_file"; then
   echo "Expected preflight markdownlint invocation to exclude .git paths" >&2
   cat "$log_file" >&2
+  exit 1
+fi
+
+if ! grep -Fxq 'validate-ai-instructions' "$test_log" || ! grep -Fxq 'validate-copilot-instructions' "$test_log"; then
+  echo "Expected preflight to execute both AI-instructions and legacy Copilot compatibility regression tests" >&2
+  cat "$test_log" >&2
   exit 1
 fi

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -51,13 +51,13 @@ if ! grep -Fq 'sync-required-checks.${repo//[^A-Za-z0-9]/_}.json.XXXXXX' "$SYNC_
 fi
 
 api_payload="$(bash "$SYNC_SCRIPT" --repo api --print-payload)"
-assert_payload_has_context "$api_payload" "Copilot Instructions / Validate Copilot Instructions"
+assert_payload_has_context "$api_payload" "AI Instructions / Validate AI Instructions"
 assert_payload_has_context "$api_payload" "PEST Tests"
 
 android_payload="$(bash "$SYNC_SCRIPT" --repo android --print-payload)"
 assert_payload_has_context "$android_payload" "Check PR Size / Check PR Size"
 assert_payload_has_context "$android_payload" "Markdown Lint / Lint Markdown Files"
-assert_payload_has_context "$android_payload" "Copilot Instructions / Validate Copilot Instructions"
+assert_payload_has_context "$android_payload" "AI Instructions / Validate AI Instructions"
 
 guardguide_payload="$(bash "$SYNC_SCRIPT" --repo GuardGuide --print-payload)"
 assert_payload_has_context "$guardguide_payload" "Pest Tests (PostgreSQL)"
@@ -82,7 +82,7 @@ assert_payload_has_context "$frontend_payload" "Vitest Tests"
 
 contracts_payload="$(bash "$SYNC_SCRIPT" --repo contracts --print-payload)"
 assert_payload_has_context "$contracts_payload" "OpenAPI Lint / Validate OpenAPI Specification"
-assert_payload_has_context "$contracts_payload" "Copilot Instructions / Validate Copilot Instructions"
+assert_payload_has_context "$contracts_payload" "AI Instructions / Validate AI Instructions"
 
 # The bare 'CodeQL' context is only emitted by .github (its CodeQL Applicability
 # Guardrail workflow names its job exactly 'CodeQL'). For every other repo the

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -170,6 +170,12 @@ normalized_mirror_repo="$workspace/normalized-mirror"
 mkdir -p "$normalized_mirror_repo"
 touch "$normalized_mirror_repo/composer.json"
 write_common_instruction_file "$normalized_mirror_repo" "$valid_api_extra_ai_lines"
+cat >"$normalized_mirror_repo/.markdownlint.json" <<'EOF'
+{
+  "MD012": false,
+  "MD013": false
+}
+EOF
 python3 - <<'PY' "$normalized_mirror_repo/AGENTS.md"
 from pathlib import Path
 import sys
@@ -420,3 +426,31 @@ if [ "$android_exit" -ne 0 ]; then
     exit 1
 fi
 grep -q 'Repository Type: android' "$android_output"
+
+guardguide_repo="$workspace/GuardGuide"
+mkdir -p "$guardguide_repo"
+touch "$guardguide_repo/composer.json"
+cat >"$guardguide_repo/package.json" <<'EOF'
+{
+  "name": "secpal/guardguide"
+}
+EOF
+write_common_instruction_file "$guardguide_repo" '- Reject AI-generated UI refactors that drift away from shadcn/ui, weaken Lingui localization coverage, or reduce accessibility semantics.
+- Reject AI-generated persistence or auth changes that bypass application-layer encryption, store unhashed acknowledgement tokens, persist IP addresses or user-agent strings, or couple standard paths to only one database engine.
+- Reject AI-generated identifier or tenancy changes that derive stable keys from mutable display names or ignore tenant-scoped uniqueness constraints.
+- Reject AI-generated acknowledgement flow changes that weaken QR, magic-link, or supervised fallback auditability across MariaDB and PostgreSQL.'
+
+guardguide_output="$workspace/guardguide-output.txt"
+set +e
+(
+    cd "$guardguide_repo"
+    PATH="$workspace/bin:$PATH" bash "$REPO_ROOT/scripts/validate-ai-instructions.sh" >"$guardguide_output" 2>&1
+)
+guardguide_exit=$?
+set -e
+if [ "$guardguide_exit" -ne 0 ]; then
+    cat "$guardguide_output"
+    echo "validator failed for valid GuardGuide fixture" >&2
+    exit 1
+fi
+grep -q 'Repository Type: guardguide' "$guardguide_output"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -454,3 +454,29 @@ if [ "$guardguide_exit" -ne 0 ]; then
     exit 1
 fi
 grep -q 'Repository Type: guardguide' "$guardguide_output"
+
+guardguide_de_repo="$workspace/guardguide.de"
+mkdir -p "$guardguide_de_repo"
+touch "$guardguide_de_repo/astro.config.mjs"
+cat >"$guardguide_de_repo/package.json" <<'EOF'
+{
+  "name": "guardguide-de"
+}
+EOF
+write_common_instruction_file "$guardguide_de_repo" '- Reject AI-generated static rendering or accessibility changes that weaken metadata, structured data, keyboard navigation, or semantic landmark coverage.
+- Reject AI-generated page, asset, or build-pipeline changes that break deterministic static output, localized content parity, or deploy-time verification.'
+
+guardguide_de_output="$workspace/guardguide-de-output.txt"
+set +e
+(
+    cd "$guardguide_de_repo"
+    PATH="$workspace/bin:$PATH" bash "$REPO_ROOT/scripts/validate-ai-instructions.sh" >"$guardguide_de_output" 2>&1
+)
+guardguide_de_exit=$?
+set -e
+if [ "$guardguide_de_exit" -ne 0 ]; then
+    cat "$guardguide_de_output"
+    echo "validator failed for valid guardguide.de website fixture" >&2
+    exit 1
+fi
+grep -q 'Repository Type: website' "$guardguide_de_output"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -427,10 +427,9 @@ if [ "$android_exit" -ne 0 ]; then
 fi
 grep -q 'Repository Type: android' "$android_output"
 
-guardguide_repo="$workspace/GuardGuide"
+guardguide_repo="$workspace/monolith-fixture"
 mkdir -p "$guardguide_repo"
-touch "$guardguide_repo/composer.json"
-cat >"$guardguide_repo/package.json" <<'EOF'
+cat >"$guardguide_repo/composer.json" <<'EOF'
 {
   "name": "secpal/guardguide"
 }


### PR DESCRIPTION
## Summary
- make Polyscope mirror valid repo-local AGENTS bodies even without the org-specific Core Runtime Baseline heading
- detect GuardGuide before the generic Laravel/api path and keep `guardguide.de` on the `website` validator path
- keep the legacy Copilot wrapper regression covered from preflight while preserving the existing AI-instructions checks

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash tests/validate-ai-instructions.sh` failed once `guardguide.de` was auto-detected as `guardguide`, and PR review reported the same misclassification risk for `scripts/validate-ai-instructions.sh`.
- Passing proof after implementation: `bash tests/validate-ai-instructions.sh`, `bash tests/validate-copilot-instructions.sh`, `bash tests/preflight-markdownlint-scope.sh`, and `bash tests/polyscope-rollout.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Testing
- bash tests/validate-ai-instructions.sh
- bash tests/validate-copilot-instructions.sh
- bash tests/preflight-markdownlint-scope.sh
- bash tests/polyscope-rollout.sh
