### PR TITLE
Fix Android workspace provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - updated `scripts/polyscope-rollout.py` so SecPal Android workspaces and provisioned Polyscope clones now receive `android/local.properties` automatically, using `POLYSCOPE_ANDROID_SDK_ROOT`, `ANDROID_SDK_ROOT`, `ANDROID_HOME`, or `$HOME/Android/Sdk` to keep direct `./gradlew` runs from failing when the shell did not preload Android environment variables
 - extended `scripts/check-system-requirements.sh` with an Android-specific repository mode that validates Node 22, Java 21, `javac`, `sdkmanager`, `adb`, the resolved SDK directory, Android local Node dependencies, and the committed native `android/` project layout
+- aligned the Android requirements check with the rollout SDK resolution order, made Node 22 failures block `--repo=android`, removed the stray local-dependencies heading when no sibling `android/` repo is present, and hardened the regression test to use a sandboxed SDK path instead of host state
 - documented the Android toolchain baseline and the new `--repo=android` verification path in `WORKSPACE_SETUP.md`, `docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md`, and `scripts/README.md`
 - added regression coverage for both the rollout-generated Android `local.properties` contract and the Android system-requirements checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - updated `scripts/polyscope-rollout.py` so SecPal Android workspaces and provisioned Polyscope clones now receive `android/local.properties` automatically, using `POLYSCOPE_ANDROID_SDK_ROOT`, `ANDROID_SDK_ROOT`, `ANDROID_HOME`, or `$HOME/Android/Sdk` to keep direct `./gradlew` runs from failing when the shell did not preload Android environment variables
 - extended `scripts/check-system-requirements.sh` with an Android-specific repository mode that validates Node 22, Java 21, `javac`, `sdkmanager`, `adb`, the resolved SDK directory, Android local Node dependencies, and the committed native `android/` project layout
 - aligned the Android requirements check with the rollout SDK resolution order, made Node 22 failures block `--repo=android`, removed the stray local-dependencies heading when no sibling `android/` repo is present, and hardened the regression test to use a sandboxed SDK path instead of host state
+- tightened the Android Java toolchain validation so a `JAVA_HOME` runtime without its matching Java 21 `javac` no longer passes by falling back to a different compiler found on `PATH`
 - documented the Android toolchain baseline and the new `--repo=android` verification path in `WORKSPACE_SETUP.md`, `docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md`, and `scripts/README.md`
 - added regression coverage for both the rollout-generated Android `local.properties` contract and the Android system-requirements checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-03 - Provision Android SDK Metadata For Polyscope Workspaces
+
+**Fixed:**
+
+- updated `scripts/polyscope-rollout.py` so SecPal Android workspaces and provisioned Polyscope clones now receive `android/local.properties` automatically, using `POLYSCOPE_ANDROID_SDK_ROOT`, `ANDROID_SDK_ROOT`, `ANDROID_HOME`, or `$HOME/Android/Sdk` to keep direct `./gradlew` runs from failing when the shell did not preload Android environment variables
+- extended `scripts/check-system-requirements.sh` with an Android-specific repository mode that validates Node 22, Java 21, `javac`, `sdkmanager`, `adb`, the resolved SDK directory, Android local Node dependencies, and the committed native `android/` project layout
+- documented the Android toolchain baseline and the new `--repo=android` verification path in `WORKSPACE_SETUP.md`, `docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md`, and `scripts/README.md`
+- added regression coverage for both the rollout-generated Android `local.properties` contract and the Android system-requirements checks
+
+---
+
 ## 2026-06-27 - Make AGENTS The Authoritative AI Runtime Baseline
 
 **Fixed:**

--- a/WORKSPACE_SETUP.md
+++ b/WORKSPACE_SETUP.md
@@ -53,6 +53,30 @@ pip install --user pre-commit
 ./scripts/setup-pre-push.sh
 ```
 
+## Android Toolchain
+
+For the `android/` repository, hooks alone are not enough. Local and
+Polyscope-driven Gradle runs also need a discoverable Android toolchain:
+
+- Java 21
+- `adb`
+- `sdkmanager`
+- an Android SDK under `$HOME/Android/Sdk`, or explicit `ANDROID_SDK_ROOT` /
+  `ANDROID_HOME`
+
+If you are provisioning or restoring a workspace machine, verify that baseline
+from `.github` with:
+
+```bash
+./scripts/check-system-requirements.sh --repo=android
+```
+
+Polyscope rollout now writes `android/local.properties` automatically for
+Android workspaces, using `POLYSCOPE_ANDROID_SDK_ROOT`, `ANDROID_SDK_ROOT`,
+`ANDROID_HOME`, or the default `$HOME/Android/Sdk` path in that order. That
+keeps direct `./gradlew ...` runs from failing when the shell environment was
+not preloaded explicitly.
+
 ## Hook Architecture
 
 SecPal uses two types of Git hooks:

--- a/docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md
+++ b/docs/scripts/CHECK_SYSTEM_REQUIREMENTS.md
@@ -21,6 +21,9 @@ The `check-system-requirements.sh` script validates that all required tools and 
 
 # Check only Contracts repository
 ./scripts/check-system-requirements.sh --repo=contracts
+
+# Check only Android repository
+./scripts/check-system-requirements.sh --repo=android
 ```
 
 ## Checked Components
@@ -100,7 +103,34 @@ If you want to run workflow linting locally outside pre-commit and CI, install `
 
 - @redocly/cli
 
-### 5. Optional but Recommended
+### 5. Android Repository (Capacitor + Native Android Toolchain)
+
+**Node.js & npm:**
+
+- Node.js 22.x+ - critical
+- npm - critical
+
+**Java & Android SDK:**
+
+- Java 21 runtime - critical
+- `javac` from the Java 21 development package - critical
+- Android SDK Command-Line Tools (`sdkmanager`) - critical
+- Android SDK Platform-Tools (`adb`) - critical
+- Android SDK directory under `$HOME/Android/Sdk`, or explicit
+  `ANDROID_SDK_ROOT` / `ANDROID_HOME` - critical
+
+**Local Dependencies (android/node_modules):**
+
+- TypeScript
+- Vite
+- Vitest
+- ESLint
+
+**Native Project Layout:**
+
+- committed `android/` native project directory present
+
+### 6. Optional but Recommended
 
 - GitHub CLI (`gh`)
 - pre-commit framework
@@ -169,6 +199,7 @@ SecPal is **not a monorepo**, but consists of multiple independent repositories:
 - `api/` - Laravel Backend
 - `frontend/` - React Frontend
 - `contracts/` - OpenAPI Specifications
+- `android/` - Capacitor Android app plus native Gradle project
 - `.github/` - Organization-wide Configuration
 
 Each repository has its own dependencies and quality gates.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,6 +92,34 @@ bash scripts/audit-closed-epics.sh --org SecPal --repo .github --repo api
 - `1`: One or more checklist issues found
 - `2`: Usage or dependency error
 
+### `check-system-requirements.sh`
+
+Validates the local toolchain baseline for the managed SecPal repositories,
+including the Android-specific Java/SDK requirements that direct Gradle and
+Polyscope-provisioned workspaces need.
+
+**Usage:**
+
+```bash
+bash scripts/check-system-requirements.sh
+bash scripts/check-system-requirements.sh --repo=android
+```
+
+**What It Checks For Android:**
+
+1. Node.js 22 and `npm`
+2. Java 21 plus `javac`
+3. Android command-line tools via `sdkmanager`
+4. Android platform-tools via `adb`
+5. An SDK path under `$HOME/Android/Sdk` or via `ANDROID_SDK_ROOT` / `ANDROID_HOME`
+6. Android local dependencies such as TypeScript, Vite, Vitest, and ESLint
+7. Presence of the committed native `android/` project directory
+
+**Exit Codes:**
+
+- `0`: All critical requirements met
+- `1`: One or more critical requirements missing
+
 ### `check-openapi-verified-endpoints.mjs`
 
 Regression guard that fails if `docs/openapi.yaml` in any SecPal repo omits an

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -450,9 +450,9 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
         echo -e "${GREEN}✓${NC} Node.js v$node_version (>= 22.x required)"
         OK_COUNT=$((OK_COUNT + 1))
       else
-        echo -e "${YELLOW}⚠${NC} Node.js v$node_version ${YELLOW}(>= 22.x recommended)${NC}"
+        echo -e "${RED}✗${NC} Node.js v$node_version ${RED}(>= 22.x required)${NC}"
         echo -e "  ${YELLOW}→${NC} Update Node.js to 22.x LTS"
-        WARNING_COUNT=$((WARNING_COUNT + 1))
+        CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
       fi
     else
       echo -e "${RED}✗${NC} Node.js ${RED}(not found)${NC}"
@@ -485,19 +485,19 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   check_command "sdkmanager" "Android SDK Command-Line Tools (sdkmanager)" "critical" "Install the Android command-line tools and place them under \$HOME/Android/Sdk/cmdline-tools/latest"
   check_command "adb" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
 
-  android_sdk_dir="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}"
+  android_sdk_dir="${POLYSCOPE_ANDROID_SDK_ROOT:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}}"
   if [ -d "$android_sdk_dir" ]; then
     echo -e "${GREEN}✓${NC} Android SDK directory exists ($android_sdk_dir)"
     OK_COUNT=$((OK_COUNT + 1))
   else
     echo -e "${RED}✗${NC} Android SDK directory ${RED}(not found)${NC}"
-    echo -e "  ${YELLOW}→${NC} Install the Android SDK under $android_sdk_dir or export ANDROID_SDK_ROOT/ANDROID_HOME"
+    echo -e "  ${YELLOW}→${NC} Install the Android SDK under $android_sdk_dir or export POLYSCOPE_ANDROID_SDK_ROOT/ANDROID_SDK_ROOT/ANDROID_HOME"
     CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
   fi
 
-  print_section "Android Repository - Local Dependencies"
-
   if [ -d "../android" ]; then
+    print_section "Android Repository - Local Dependencies"
+
     if pushd "../android" >/dev/null 2>&1; then
       if [ -d "node_modules" ]; then
         echo -e "${GREEN}✓${NC} node_modules/ directory exists"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -73,9 +73,13 @@ increment_critical_missing() {
 resolve_java_tool() {
   local tool_name="$1"
 
-  if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME%/}/bin/$tool_name" ]; then
-    printf '%s\n' "${JAVA_HOME%/}/bin/$tool_name"
-    return 0
+  if [ -n "${JAVA_HOME:-}" ]; then
+    if [ -x "${JAVA_HOME%/}/bin/$tool_name" ]; then
+      printf '%s\n' "${JAVA_HOME%/}/bin/$tool_name"
+      return 0
+    fi
+
+    return 1
   fi
 
   if command -v "$tool_name" >/dev/null 2>&1; then
@@ -104,7 +108,62 @@ resolve_javac_for_java() {
 is_java_21_version() {
   local version_output="$1"
 
-  printf '%s' "$version_output" | grep -Eq '(^|[[:space:]\"])21(\.|"|[[:space:]]|$)'
+  printf '%s\n' "$version_output" | grep -Eq '(^|[[:space:]])(openjdk|java)[[:space:]]+version[[:space:]]+"21(\.|"|$)'
+}
+
+check_resolved_command() {
+  local cmd_path="$1"
+  local name="$2"
+  local severity="${3:-critical}"
+  local install_hint="${4:-}"
+
+  if [ -n "$cmd_path" ] && [ -x "$cmd_path" ]; then
+    echo -e "${GREEN}✓${NC} $name"
+    OK_COUNT=$((OK_COUNT + 1))
+    return 0
+  fi
+
+  if [ "$severity" = "critical" ]; then
+    echo -e "${RED}✗${NC} $name ${RED}(REQUIRED)${NC}"
+    [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
+    increment_critical_missing
+    return 0
+  fi
+
+  echo -e "${YELLOW}⚠${NC} $name ${YELLOW}(optional but recommended)${NC}"
+  [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
+  increment_warning
+  return 0
+}
+
+resolve_android_sdk_tool() {
+  local tool_name="$1"
+  local android_sdk_dir="$2"
+  local sdk_tool_path=""
+
+  case "$tool_name" in
+    sdkmanager)
+      sdk_tool_path="$android_sdk_dir/cmdline-tools/latest/bin/sdkmanager"
+      ;;
+    adb)
+      sdk_tool_path="$android_sdk_dir/platform-tools/adb"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if [ -x "$sdk_tool_path" ]; then
+    printf '%s\n' "$sdk_tool_path"
+    return 0
+  fi
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return 0
+  fi
+
+  return 1
 }
 
 check_command() {
@@ -511,11 +570,14 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
 
   print_section "Java & Android SDK"
 
+  android_sdk_dir="${POLYSCOPE_ANDROID_SDK_ROOT:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}}"
   java_bin="$(resolve_java_tool java || true)"
   javac_bin="$(resolve_javac_for_java "$java_bin" || true)"
+  sdkmanager_bin="$(resolve_android_sdk_tool sdkmanager "$android_sdk_dir" || true)"
+  adb_bin="$(resolve_android_sdk_tool adb "$android_sdk_dir" || true)"
 
   if [ -n "$java_bin" ]; then
-    java_version_output="$("$java_bin" -version 2>&1 | head -n 1)"
+    java_version_output="$("$java_bin" -version 2>&1)"
     if is_java_21_version "$java_version_output"; then
       echo -e "${GREEN}✓${NC} Java 21"
       OK_COUNT=$((OK_COUNT + 1))
@@ -531,8 +593,8 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   fi
 
   if [ -n "$javac_bin" ]; then
-    javac_version_output="$("$javac_bin" -version 2>&1 | head -n 1)"
-    if printf '%s' "$javac_version_output" | grep -Eq 'javac 21(\.|$)'; then
+    javac_version_output="$("$javac_bin" -version 2>&1)"
+    if printf '%s\n' "$javac_version_output" | grep -Eq '(^|[[:space:]])javac[[:space:]]+21(\.|$)'; then
       echo -e "${GREEN}✓${NC} Java compiler (javac)"
       OK_COUNT=$((OK_COUNT + 1))
     else
@@ -545,10 +607,9 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
     echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
     increment_critical_missing
   fi
-  check_command "sdkmanager" "Android SDK Command-Line Tools (sdkmanager)" "critical" "Install the Android command-line tools and place them under \$HOME/Android/Sdk/cmdline-tools/latest"
-  check_command "adb" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
+  check_resolved_command "$sdkmanager_bin" "Android SDK Command-Line Tools (sdkmanager)" "critical" "Install the Android command-line tools and place them under \$HOME/Android/Sdk/cmdline-tools/latest"
+  check_resolved_command "$adb_bin" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
 
-  android_sdk_dir="${POLYSCOPE_ANDROID_SDK_ROOT:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}}"
   if [ -d "$android_sdk_dir" ] \
     && [ -d "$android_sdk_dir/platform-tools" ] \
     && [ -d "$android_sdk_dir/cmdline-tools/latest" ]; then
@@ -577,12 +638,12 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
         WARNING_COUNT=$((WARNING_COUNT + 1))
       fi
 
-      if [ -d "android" ]; then
-        echo -e "${GREEN}✓${NC} Native Android project directory exists"
+      if [ -f "android/settings.gradle" ]; then
+        echo -e "${GREEN}✓${NC} Native Android Gradle project exists"
         OK_COUNT=$((OK_COUNT + 1))
       else
-        echo -e "${RED}✗${NC} Native Android project directory missing"
-        echo -e "  ${YELLOW}→${NC} Run: npm run cap:add:android"
+        echo -e "${RED}✗${NC} Native Android Gradle project missing"
+        echo -e "  ${YELLOW}→${NC} Ensure the committed android/settings.gradle sentinel exists before provisioning"
         CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
       fi
 

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -101,6 +101,12 @@ resolve_javac_for_java() {
   resolve_java_tool javac
 }
 
+is_java_21_version() {
+  local version_output="$1"
+
+  printf '%s' "$version_output" | grep -Eq '(^|[[:space:]\"])21(\.|"|[[:space:]]|$)'
+}
+
 check_command() {
   local cmd=$1
   local name=$2
@@ -510,7 +516,7 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
 
   if [ -n "$java_bin" ]; then
     java_version_output="$("$java_bin" -version 2>&1 | head -n 1)"
-    if printf '%s' "$java_version_output" | grep -Eq '"21(\.|")'; then
+    if is_java_21_version "$java_version_output"; then
       echo -e "${GREEN}✓${NC} Java 21"
       OK_COUNT=$((OK_COUNT + 1))
     else

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -6,7 +6,7 @@
 # SecPal System Requirements Check
 # ============================================================================
 # Validates that all required tools and dependencies are installed for
-# development across all SecPal repositories (api, frontend, contracts).
+# development across all SecPal repositories (api, frontend, contracts, android).
 #
 # Usage:
 #   ./scripts/check-system-requirements.sh [--repo=<name>]
@@ -15,6 +15,7 @@
 #   --repo=api        Check only API repository requirements
 #   --repo=frontend   Check only Frontend repository requirements
 #   --repo=contracts  Check only Contracts repository requirements
+#   --repo=android    Check only Android repository requirements
 #   (no option)       Check all repositories
 #
 # Exit codes:
@@ -61,6 +62,14 @@ print_section() {
   echo -e "${BLUE}─── $1 ───${NC}"
 }
 
+increment_warning() {
+  WARNING_COUNT=$((WARNING_COUNT + 1))
+}
+
+increment_critical_missing() {
+  CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+}
+
 check_command() {
   local cmd=$1
   local name=$2
@@ -75,14 +84,27 @@ check_command() {
     if [ "$severity" = "critical" ]; then
       echo -e "${RED}✗${NC} $name ${RED}(REQUIRED)${NC}"
       [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
-      CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+      increment_critical_missing
       return 1
     else
       echo -e "${YELLOW}⚠${NC} $name ${YELLOW}(optional but recommended)${NC}"
       [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
-      WARNING_COUNT=$((WARNING_COUNT + 1))
+      increment_warning
       return 0  # Don't stop script for optional tools
     fi
+  fi
+}
+
+check_android_dependency() {
+  local package_name="$1"
+  local display_name="$2"
+
+  if npm list "$package_name" --silent >/dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} $display_name installed"
+    OK_COUNT=$((OK_COUNT + 1))
+  else
+    echo -e "${RED}✗${NC} $display_name not installed"
+    increment_critical_missing
   fi
 }
 
@@ -411,10 +433,107 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "contracts" ]; then
 fi
 
 # ============================================================================
-# 5. Optional but Recommended Tools
+# 5. Android Repository Requirements (Capacitor + Native Android Toolchain)
 # ============================================================================
 
-print_header "5. Optional but Recommended Tools"
+if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
+  print_header "5. Android Repository (Capacitor + Native Android Toolchain)"
+
+  print_section "Node.js & npm"
+
+  if [ "$NODE_CHECKED" = false ]; then
+    if command -v node >/dev/null 2>&1; then
+      node_version=$(node --version | sed 's/v//')
+      major_version=$(echo "$node_version" | cut -d. -f1)
+
+      if [ "$major_version" -ge 22 ]; then
+        echo -e "${GREEN}✓${NC} Node.js v$node_version (>= 22.x required)"
+        OK_COUNT=$((OK_COUNT + 1))
+      else
+        echo -e "${YELLOW}⚠${NC} Node.js v$node_version ${YELLOW}(>= 22.x recommended)${NC}"
+        echo -e "  ${YELLOW}→${NC} Update Node.js to 22.x LTS"
+        WARNING_COUNT=$((WARNING_COUNT + 1))
+      fi
+    else
+      echo -e "${RED}✗${NC} Node.js ${RED}(not found)${NC}"
+      CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+    fi
+
+    check_command "npm" "npm" "critical" "Comes with Node.js"
+    NODE_CHECKED=true
+  fi
+
+  print_section "Java & Android SDK"
+
+  if command -v java >/dev/null 2>&1; then
+    java_version_output="$(java -version 2>&1 | head -n 1)"
+    if printf '%s' "$java_version_output" | grep -Eq '"21(\.|")'; then
+      echo -e "${GREEN}✓${NC} Java 21"
+      OK_COUNT=$((OK_COUNT + 1))
+    else
+      echo -e "${RED}✗${NC} Java 21 ${RED}(required)${NC}"
+      echo -e "  ${YELLOW}→${NC} Install Java 21 and export JAVA_HOME if needed"
+      CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+    fi
+  else
+    echo -e "${RED}✗${NC} Java runtime ${RED}(required)${NC}"
+    echo -e "  ${YELLOW}→${NC} Install Java 21 and export JAVA_HOME if needed"
+    CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+  fi
+
+  check_command "javac" "Java compiler (javac)" "critical" "Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+  check_command "sdkmanager" "Android SDK Command-Line Tools (sdkmanager)" "critical" "Install the Android command-line tools and place them under \$HOME/Android/Sdk/cmdline-tools/latest"
+  check_command "adb" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
+
+  android_sdk_dir="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}"
+  if [ -d "$android_sdk_dir" ]; then
+    echo -e "${GREEN}✓${NC} Android SDK directory exists ($android_sdk_dir)"
+    OK_COUNT=$((OK_COUNT + 1))
+  else
+    echo -e "${RED}✗${NC} Android SDK directory ${RED}(not found)${NC}"
+    echo -e "  ${YELLOW}→${NC} Install the Android SDK under $android_sdk_dir or export ANDROID_SDK_ROOT/ANDROID_HOME"
+    CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+  fi
+
+  print_section "Android Repository - Local Dependencies"
+
+  if [ -d "../android" ]; then
+    if pushd "../android" >/dev/null 2>&1; then
+      if [ -d "node_modules" ]; then
+        echo -e "${GREEN}✓${NC} node_modules/ directory exists"
+        OK_COUNT=$((OK_COUNT + 1))
+        check_android_dependency "typescript" "TypeScript"
+        check_android_dependency "vite" "Vite"
+        check_android_dependency "vitest" "Vitest"
+        check_android_dependency "eslint" "ESLint"
+      else
+        echo -e "${YELLOW}⚠${NC} node_modules/ directory not found"
+        echo -e "  ${YELLOW}→${NC} Run: npm install"
+        WARNING_COUNT=$((WARNING_COUNT + 1))
+      fi
+
+      if [ -d "android" ]; then
+        echo -e "${GREEN}✓${NC} Native Android project directory exists"
+        OK_COUNT=$((OK_COUNT + 1))
+      else
+        echo -e "${RED}✗${NC} Native Android project directory missing"
+        echo -e "  ${YELLOW}→${NC} Run: npm run cap:add:android"
+        CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+      fi
+
+      popd >/dev/null 2>&1
+    else
+      echo -e "${YELLOW}⚠${NC} Cannot access ../android directory"
+      WARNING_COUNT=$((WARNING_COUNT + 1))
+    fi
+  fi
+fi
+
+# ============================================================================
+# 6. Optional but Recommended Tools
+# ============================================================================
+
+print_header "6. Optional but Recommended Tools"
 
 check_command "gh" "GitHub CLI" "optional" "Install: https://cli.github.com/"
 check_command "pre-commit" "pre-commit framework" "optional" "Install: pip3 install pre-commit"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -70,6 +70,22 @@ increment_critical_missing() {
   CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
 }
 
+resolve_java_tool() {
+  local tool_name="$1"
+
+  if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME%/}/bin/$tool_name" ]; then
+    printf '%s\n' "${JAVA_HOME%/}/bin/$tool_name"
+    return 0
+  fi
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return 0
+  fi
+
+  return 1
+}
+
 check_command() {
   local cmd=$1
   local name=$2
@@ -474,8 +490,11 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
 
   print_section "Java & Android SDK"
 
-  if command -v java >/dev/null 2>&1; then
-    java_version_output="$(java -version 2>&1 | head -n 1)"
+  java_bin="$(resolve_java_tool java || true)"
+  javac_bin="$(resolve_java_tool javac || true)"
+
+  if [ -n "$java_bin" ]; then
+    java_version_output="$("$java_bin" -version 2>&1 | head -n 1)"
     if printf '%s' "$java_version_output" | grep -Eq '"21(\.|")'; then
       echo -e "${GREEN}✓${NC} Java 21"
       OK_COUNT=$((OK_COUNT + 1))
@@ -490,7 +509,14 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
     CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
   fi
 
-  check_command "javac" "Java compiler (javac)" "critical" "Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+  if [ -n "$javac_bin" ]; then
+    echo -e "${GREEN}✓${NC} Java compiler (javac)"
+    OK_COUNT=$((OK_COUNT + 1))
+  else
+    echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(REQUIRED)${NC}"
+    echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+    increment_critical_missing
+  fi
   check_command "sdkmanager" "Android SDK Command-Line Tools (sdkmanager)" "critical" "Install the Android command-line tools and place them under \$HOME/Android/Sdk/cmdline-tools/latest"
   check_command "adb" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
 

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -461,6 +461,15 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
 
     check_command "npm" "npm" "critical" "Comes with Node.js"
     NODE_CHECKED=true
+  elif command -v node >/dev/null 2>&1; then
+    node_version=$(node --version | sed 's/v//')
+    major_version=$(echo "$node_version" | cut -d. -f1)
+
+    if [ "$major_version" -lt 22 ]; then
+      echo -e "${RED}✗${NC} Node.js v$node_version ${RED}(>= 22.x required)${NC}"
+      echo -e "  ${YELLOW}→${NC} Update Node.js to 22.x LTS"
+      increment_critical_missing
+    fi
   fi
 
   print_section "Java & Android SDK"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -86,6 +86,21 @@ resolve_java_tool() {
   return 1
 }
 
+resolve_javac_for_java() {
+  local java_bin="$1"
+
+  if [ -n "${JAVA_HOME:-}" ] && [ "$java_bin" = "${JAVA_HOME%/}/bin/java" ]; then
+    if [ -x "${JAVA_HOME%/}/bin/javac" ]; then
+      printf '%s\n' "${JAVA_HOME%/}/bin/javac"
+      return 0
+    fi
+
+    return 1
+  fi
+
+  resolve_java_tool javac
+}
+
 check_command() {
   local cmd=$1
   local name=$2
@@ -491,7 +506,7 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   print_section "Java & Android SDK"
 
   java_bin="$(resolve_java_tool java || true)"
-  javac_bin="$(resolve_java_tool javac || true)"
+  javac_bin="$(resolve_javac_for_java "$java_bin" || true)"
 
   if [ -n "$java_bin" ]; then
     java_version_output="$("$java_bin" -version 2>&1 | head -n 1)"
@@ -510,8 +525,15 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   fi
 
   if [ -n "$javac_bin" ]; then
-    echo -e "${GREEN}✓${NC} Java compiler (javac)"
-    OK_COUNT=$((OK_COUNT + 1))
+    javac_version_output="$("$javac_bin" -version 2>&1 | head -n 1)"
+    if printf '%s' "$javac_version_output" | grep -Eq 'javac 21(\.|$)'; then
+      echo -e "${GREEN}✓${NC} Java compiler (javac)"
+      OK_COUNT=$((OK_COUNT + 1))
+    else
+      echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(Java 21 required)${NC}"
+      echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+      increment_critical_missing
+    fi
   else
     echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(REQUIRED)${NC}"
     echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -166,6 +166,19 @@ resolve_android_sdk_tool() {
   return 1
 }
 
+probe_version_output() {
+  local binary_path="$1"
+  shift
+  local probe_output=""
+
+  if probe_output="$("$binary_path" "$@" 2>&1)"; then
+    printf '%s' "$probe_output"
+    return 0
+  fi
+
+  return 1
+}
+
 check_command() {
   local cmd=$1
   local name=$2
@@ -577,13 +590,18 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   adb_bin="$(resolve_android_sdk_tool adb "$android_sdk_dir" || true)"
 
   if [ -n "$java_bin" ]; then
-    java_version_output="$("$java_bin" -version 2>&1)"
-    if is_java_21_version "$java_version_output"; then
-      echo -e "${GREEN}✓${NC} Java 21"
-      OK_COUNT=$((OK_COUNT + 1))
+    if java_version_output="$(probe_version_output "$java_bin" -version)"; then
+      if is_java_21_version "$java_version_output"; then
+        echo -e "${GREEN}✓${NC} Java 21"
+        OK_COUNT=$((OK_COUNT + 1))
+      else
+        echo -e "${RED}✗${NC} Java 21 ${RED}(required)${NC}"
+        echo -e "  ${YELLOW}→${NC} Install Java 21 and export JAVA_HOME if needed"
+        CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
+      fi
     else
       echo -e "${RED}✗${NC} Java 21 ${RED}(required)${NC}"
-      echo -e "  ${YELLOW}→${NC} Install Java 21 and export JAVA_HOME if needed"
+      echo -e "  ${YELLOW}→${NC} Ensure $java_bin can execute 'java -version' successfully"
       CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
     fi
   else
@@ -593,13 +611,18 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   fi
 
   if [ -n "$javac_bin" ]; then
-    javac_version_output="$("$javac_bin" -version 2>&1)"
-    if printf '%s\n' "$javac_version_output" | grep -Eq '(^|[[:space:]])javac[[:space:]]+21(\.|$)'; then
-      echo -e "${GREEN}✓${NC} Java compiler (javac)"
-      OK_COUNT=$((OK_COUNT + 1))
+    if javac_version_output="$(probe_version_output "$javac_bin" -version)"; then
+      if printf '%s\n' "$javac_version_output" | grep -Eq '(^|[[:space:]])javac[[:space:]]+21(\.|$)'; then
+        echo -e "${GREEN}✓${NC} Java compiler (javac)"
+        OK_COUNT=$((OK_COUNT + 1))
+      else
+        echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(Java 21 required)${NC}"
+        echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+        increment_critical_missing
+      fi
     else
-      echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(Java 21 required)${NC}"
-      echo -e "  ${YELLOW}→${NC} Install the Java 21 development package (for example openjdk-21-jdk or java-21-openjdk-devel)"
+      echo -e "${RED}✗${NC} Java compiler (javac) ${RED}(REQUIRED)${NC}"
+      echo -e "  ${YELLOW}→${NC} Ensure $javac_bin can execute 'javac -version' successfully"
       increment_critical_missing
     fi
   else

--- a/scripts/check-system-requirements.sh
+++ b/scripts/check-system-requirements.sh
@@ -85,7 +85,7 @@ check_command() {
       echo -e "${RED}✗${NC} $name ${RED}(REQUIRED)${NC}"
       [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
       increment_critical_missing
-      return 1
+      return 0
     else
       echo -e "${YELLOW}⚠${NC} $name ${YELLOW}(optional but recommended)${NC}"
       [ -n "$install_hint" ] && echo -e "  ${YELLOW}→${NC} $install_hint"
@@ -495,12 +495,14 @@ if [ -z "$REPO_FILTER" ] || [ "$REPO_FILTER" = "android" ]; then
   check_command "adb" "Android SDK Platform-Tools (adb)" "critical" "Install Android platform-tools so debug builds and device validation can use adb"
 
   android_sdk_dir="${POLYSCOPE_ANDROID_SDK_ROOT:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}}"
-  if [ -d "$android_sdk_dir" ]; then
+  if [ -d "$android_sdk_dir" ] \
+    && [ -d "$android_sdk_dir/platform-tools" ] \
+    && [ -d "$android_sdk_dir/cmdline-tools/latest" ]; then
     echo -e "${GREEN}✓${NC} Android SDK directory exists ($android_sdk_dir)"
     OK_COUNT=$((OK_COUNT + 1))
   else
-    echo -e "${RED}✗${NC} Android SDK directory ${RED}(not found)${NC}"
-    echo -e "  ${YELLOW}→${NC} Install the Android SDK under $android_sdk_dir or export POLYSCOPE_ANDROID_SDK_ROOT/ANDROID_SDK_ROOT/ANDROID_HOME"
+    echo -e "${RED}✗${NC} Android SDK directory ${RED}(incomplete or not found)${NC}"
+    echo -e "  ${YELLOW}→${NC} Install the Android SDK under $android_sdk_dir with platform-tools and cmdline-tools/latest, or export POLYSCOPE_ANDROID_SDK_ROOT/ANDROID_SDK_ROOT/ANDROID_HOME"
     CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
   fi
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1765,6 +1765,7 @@ def sync_repo_auxiliary_files(repo_name: str, repo_path: pathlib.Path) -> None:
         raise SystemExit(f"android worktree at {repo_path} is missing committed android/ project directory")
 
     write_text_if_changed(android_project_dir / "local.properties", render_android_local_properties())
+    ensure_exclude(repo_path, {"android/local.properties"})
 
 
 def extract_bullets_from_lines(lines: list[str]) -> list[str]:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1752,8 +1752,23 @@ def resolve_android_sdk_root() -> pathlib.Path:
     return DEFAULT_ANDROID_SDK_ROOT
 
 
-def render_android_local_properties() -> str:
-    return f"sdk.dir={resolve_android_sdk_root().as_posix()}\n"
+def render_android_local_properties(existing_text: str = "") -> str:
+    sdk_dir_line = f"sdk.dir={resolve_android_sdk_root().as_posix()}"
+    preserved_lines: list[str] = []
+    sdk_dir_written = False
+
+    for raw_line in existing_text.splitlines():
+        if raw_line.startswith("sdk.dir="):
+            if not sdk_dir_written:
+                preserved_lines.append(sdk_dir_line)
+                sdk_dir_written = True
+            continue
+        preserved_lines.append(raw_line)
+
+    if not sdk_dir_written:
+        preserved_lines.append(sdk_dir_line)
+
+    return "\n".join(preserved_lines) + "\n"
 
 
 def sync_repo_auxiliary_files(repo_name: str, repo_path: pathlib.Path) -> None:
@@ -1764,7 +1779,9 @@ def sync_repo_auxiliary_files(repo_name: str, repo_path: pathlib.Path) -> None:
     if not android_project_dir.is_dir():
         raise SystemExit(f"android worktree at {repo_path} is missing committed android/ project directory")
 
-    write_text_if_changed(android_project_dir / "local.properties", render_android_local_properties())
+    local_properties_path = android_project_dir / "local.properties"
+    existing_local_properties = local_properties_path.read_text() if local_properties_path.exists() else ""
+    write_text_if_changed(local_properties_path, render_android_local_properties(existing_local_properties))
     ensure_exclude(repo_path, {"android/local.properties"})
 
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -26,6 +26,7 @@ from typing import Any
 POLYSCOPE_LOCAL_CONFIG_NAME = "polyscope.local.json"
 PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
 ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
+DEFAULT_ANDROID_SDK_ROOT = pathlib.Path.home() / "Android" / "Sdk"
 PREVIEW_DATABASE_BASE_ENV_KEY = "POLYSCOPE_BASE_DB_DATABASE"
 PREVIEW_SCHEMA_ENV_KEY = "POLYSCOPE_PREVIEW_SCHEMA"
 PREVIEW_STORAGE_MODE_ENV_KEY = "POLYSCOPE_PREVIEW_STORAGE_MODE"
@@ -1738,8 +1739,28 @@ def strip_html_comment_header(text: str) -> str:
 def write_text_if_changed(path: pathlib.Path, content: str) -> bool:
     if path.exists() and path.read_text() == content:
         return False
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return True
+
+
+def resolve_android_sdk_root() -> pathlib.Path:
+    for variable_name in ("POLYSCOPE_ANDROID_SDK_ROOT", "ANDROID_SDK_ROOT", "ANDROID_HOME"):
+        value = os.environ.get(variable_name, "").strip()
+        if value:
+            return pathlib.Path(value).expanduser()
+    return DEFAULT_ANDROID_SDK_ROOT
+
+
+def render_android_local_properties() -> str:
+    return f"sdk.dir={resolve_android_sdk_root().as_posix()}\n"
+
+
+def sync_repo_auxiliary_files(repo_name: str, repo_path: pathlib.Path) -> None:
+    if repo_name != "android":
+        return
+
+    write_text_if_changed(repo_path / "android" / "local.properties", render_android_local_properties())
 
 
 def extract_bullets_from_lines(lines: list[str]) -> list[str]:
@@ -2217,10 +2238,11 @@ def ensure_exclude(repo_path: pathlib.Path, entries: set[str] | None = None) -> 
 
 
 def write_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
-    for spec in repo_specs.values():
+    for repo_name, spec in repo_specs.items():
         repo_path = pathlib.Path(spec["path"])
         config_path = repo_path / POLYSCOPE_LOCAL_CONFIG_NAME
         config_path.write_text(render_pretty_json(render_local_config(spec)) + "\n")
+        sync_repo_auxiliary_files(repo_name, repo_path)
         ensure_exclude(repo_path)
 
 
@@ -2300,6 +2322,10 @@ def run_setup_commands(worktree_path: pathlib.Path, commands: list[str], *, db_p
 def sync_worktree_local_config(worktree_path: pathlib.Path, config_text: str) -> None:
     (worktree_path / POLYSCOPE_LOCAL_CONFIG_NAME).write_text(config_text)
     ensure_exclude(worktree_path, {POLYSCOPE_LOCAL_CONFIG_NAME, PROVISION_MARKER_FILENAME})
+
+
+def sync_worktree_auxiliary_files(repo_name: str, worktree_path: pathlib.Path) -> None:
+    sync_repo_auxiliary_files(repo_name, worktree_path)
 
 
 def resolve_executable(command: str) -> str | None:
@@ -2411,6 +2437,7 @@ def provision_worktrees(
                     continue
 
                 sync_worktree_local_config(worktree_path, config_text)
+                sync_worktree_auxiliary_files(repo_name, worktree_path)
                 ensure_worktree_hooks(worktree_path)
                 linked_setup_context = collect_linked_setup_context(worktree_path, db_path=db_path)
                 setup_hash = build_setup_hash(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1760,7 +1760,11 @@ def sync_repo_auxiliary_files(repo_name: str, repo_path: pathlib.Path) -> None:
     if repo_name != "android":
         return
 
-    write_text_if_changed(repo_path / "android" / "local.properties", render_android_local_properties())
+    android_project_dir = repo_path / "android"
+    if not android_project_dir.is_dir():
+        raise SystemExit(f"android worktree at {repo_path} is missing committed android/ project directory")
+
+    write_text_if_changed(android_project_dir / "local.properties", render_android_local_properties())
 
 
 def extract_bullets_from_lines(lines: list[str]) -> list[str]:
@@ -2189,6 +2193,9 @@ def is_provisionable_worktree(
             return skip("missing .git")
     except SystemExit:
         return skip("invalid .git pointer")
+
+    if repo_name == "android" and not (worktree_path / "android").is_dir():
+        return skip("missing committed android/ project directory")
 
     copilot_instructions_rel = REPO_SETTINGS[repo_name]["copilot_instructions"]
     copilot_instructions_path = worktree_path / copilot_instructions_rel

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2195,8 +2195,12 @@ def is_provisionable_worktree(
     except SystemExit:
         return skip("invalid .git pointer")
 
-    if repo_name == "android" and not (worktree_path / "android").is_dir():
-        return skip("missing committed android/ project directory")
+    if repo_name == "android":
+        android_project_dir = worktree_path / "android"
+        if not android_project_dir.is_dir():
+            return skip("missing committed android/ project directory")
+        if not (android_project_dir / "settings.gradle").is_file():
+            return skip("missing committed native Android Gradle project")
 
     copilot_instructions_rel = REPO_SETTINGS[repo_name]["copilot_instructions"]
     copilot_instructions_path = worktree_path / copilot_instructions_rel

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -93,6 +93,15 @@ if [ -f tests/check-domains.sh ]; then
   }
 fi
 
+if [ -f tests/check-system-requirements.sh ]; then
+  bash tests/check-system-requirements.sh || {
+    echo "" >&2
+    echo "❌ System requirements regression test failed!" >&2
+    echo "Keep scripts/check-system-requirements.sh aligned with tests/check-system-requirements.sh before continuing." >&2
+    exit 1
+  }
+fi
+
 # Conflict Marker Check (prevents accidental commits of broken code)
 if [ -f scripts/check-conflict-markers.sh ]; then
   bash scripts/check-conflict-markers.sh || {
@@ -180,6 +189,15 @@ if [ -f tests/preflight-markdownlint-scope.sh ]; then
     echo "" >&2
     echo "❌ Preflight markdownlint scope regression test failed!" >&2
     echo "Exclude Git metadata from the local markdownlint scan before continuing." >&2
+    exit 1
+  }
+fi
+
+if [ -f tests/preflight-check-system-requirements.sh ]; then
+  bash tests/preflight-check-system-requirements.sh || {
+    echo "" >&2
+    echo "❌ Preflight check-system-requirements wiring regression test failed!" >&2
+    echo "Restore tests/check-system-requirements.sh in scripts/preflight.sh before continuing." >&2
     exit 1
   }
 fi

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -15,8 +15,11 @@ sdk_root="$workspace/polyscope-android-sdk"
 test_home="$workspace/home"
 mkdir -p \
   "$workspace/.github/scripts" \
+  "$workspace/api/vendor/bin" \
   "$workspace/android/android" \
   "$workspace/android/node_modules/.bin" \
+  "$workspace/contracts/node_modules/.bin" \
+  "$workspace/frontend/node_modules/.bin" \
   "$workspace/bin" \
   "$sdk_root" \
   "$test_home"
@@ -37,6 +40,34 @@ cat >"$workspace/android/package.json" <<'JSON'
   }
 }
 JSON
+
+cat >"$workspace/frontend/package.json" <<'JSON'
+{
+  "name": "@secpal/frontend-test",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "1.0.0",
+    "vite": "1.0.0",
+    "vitest": "1.0.0",
+    "eslint": "1.0.0"
+  }
+}
+JSON
+
+cat >"$workspace/contracts/package.json" <<'JSON'
+{
+  "name": "@secpal/contracts-test",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "@redocly/cli": "1.0.0"
+  }
+}
+JSON
+
+touch "$workspace/api/vendor/bin/pest" "$workspace/api/vendor/bin/pint" "$workspace/api/vendor/bin/phpstan"
+chmod +x "$workspace/api/vendor/bin/pest" "$workspace/api/vendor/bin/pint" "$workspace/api/vendor/bin/phpstan"
 
 stub_command() {
   local name="$1"
@@ -81,6 +112,8 @@ fi
 exit 0
 '
 stub_command "shellcheck" 'exit 0'
+stub_command "php" 'echo "8.4.0"'
+stub_command "composer" 'exit 0'
 # shellcheck disable=SC2016
 stub_command "node" 'echo "${TEST_NODE_VERSION:-v22.1.0}"'
 # shellcheck disable=SC2016
@@ -90,6 +123,8 @@ if [ "${1:-}" = "list" ]; then
 fi
 echo "10.0.0"
 '
+stub_command "yarn" 'exit 0'
+stub_command "pnpm" 'exit 0'
 # shellcheck disable=SC2016
 stub_command "java" '
 if [ "${1:-}" = "-version" ]; then
@@ -101,6 +136,9 @@ exit 0
 stub_command "javac" 'echo "javac 21.0.11"'
 stub_command "adb" 'echo "Android Debug Bridge version 1.0.41"'
 stub_command "sdkmanager" 'echo "25.2.0"'
+stub_command "gh" 'exit 0'
+stub_command "pre-commit" 'exit 0'
+stub_command "ssh" 'exit 0'
 link_system_command "grep"
 link_system_command "sed"
 link_system_command "cut"
@@ -151,6 +189,18 @@ fi
 
 grep -Fq 'Node.js v20.15.0' "$old_node_output"
 grep -Fq '>= 22.x required' "$old_node_output"
+
+all_repos_old_node_output="$sandbox/all-repos-node-too-old.txt"
+if TEST_NODE_VERSION="v20.15.0" run_check "$all_repos_old_node_output"; then
+  cat "$all_repos_old_node_output"
+  echo "all-repositories requirements check unexpectedly succeeded with Node.js 20 and sibling android repo" >&2
+  exit 1
+fi
+
+grep -Fq '3. Frontend Repository (React + TypeScript + Node)' "$all_repos_old_node_output"
+grep -Fq '5. Android Repository (Capacitor + Native Android Toolchain)' "$all_repos_old_node_output"
+grep -Fq 'Node.js v20.15.0' "$all_repos_old_node_output"
+grep -Fq '>= 22.x required' "$all_repos_old_node_output"
 
 mv "$workspace/android" "$workspace/android-hidden"
 

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+sandbox="$(mktemp -d "${TMPDIR:-/tmp}/check-system-requirements.XXXXXX")"
+trap 'rm -rf "$sandbox"' EXIT
+
+workspace="$sandbox/workspace"
+mkdir -p "$workspace/.github/scripts" "$workspace/android/android" "$workspace/android/node_modules/.bin" "$workspace/bin"
+
+cp "$REPO_ROOT/scripts/check-system-requirements.sh" "$workspace/.github/scripts/check-system-requirements.sh"
+chmod +x "$workspace/.github/scripts/check-system-requirements.sh"
+
+cat >"$workspace/android/package.json" <<'JSON'
+{
+  "name": "@secpal/android-test",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "1.0.0",
+    "vite": "1.0.0",
+    "vitest": "1.0.0",
+    "eslint": "1.0.0"
+  }
+}
+JSON
+
+stub_command() {
+  local name="$1"
+  local body="$2"
+  cat >"$workspace/bin/$name" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$body
+EOF
+  chmod +x "$workspace/bin/$name"
+}
+
+link_system_command() {
+  local name="$1"
+  ln -sf "$(command -v "$name")" "$workspace/bin/$name"
+}
+
+# shellcheck disable=SC2016
+stub_command "git" '
+if [ "${1:-}" = "config" ] && [ "${2:-}" = "--get" ] && [ "${3:-}" = "user.name" ]; then
+  echo "SecPal Tester"
+  exit 0
+fi
+if [ "${1:-}" = "config" ] && [ "${2:-}" = "--get" ] && [ "${3:-}" = "user.email" ]; then
+  echo "tester@secpal.app"
+  exit 0
+fi
+if [ "${1:-}" = "config" ] && [ "${2:-}" = "--get" ] && [ "${3:-}" = "commit.gpgsign" ]; then
+  echo "true"
+  exit 0
+fi
+exit 0
+'
+stub_command "curl" 'exit 0'
+stub_command "jq" 'exit 0'
+stub_command "reuse" 'exit 0'
+# shellcheck disable=SC2016
+stub_command "npx" '
+if [ "${*: -1}" = "--version" ]; then
+  echo "1.0.0"
+fi
+exit 0
+'
+stub_command "shellcheck" 'exit 0'
+stub_command "node" 'echo "v22.1.0"'
+# shellcheck disable=SC2016
+stub_command "npm" '
+if [ "${1:-}" = "list" ]; then
+  exit 0
+fi
+echo "10.0.0"
+'
+# shellcheck disable=SC2016
+stub_command "java" '
+if [ "${1:-}" = "-version" ]; then
+  echo "openjdk version \"21.0.11\""
+  exit 0
+fi
+exit 0
+'
+stub_command "javac" 'echo "javac 21.0.11"'
+stub_command "adb" 'echo "Android Debug Bridge version 1.0.41"'
+stub_command "sdkmanager" 'echo "25.2.0"'
+link_system_command "grep"
+link_system_command "sed"
+link_system_command "cut"
+link_system_command "head"
+link_system_command "awk"
+link_system_command "bash"
+link_system_command "cat"
+link_system_command "dirname"
+link_system_command "pwd"
+
+run_check() {
+  local output_file="$1"
+  shift
+  (
+    cd "$workspace/.github"
+    PATH="$workspace/bin" /bin/bash ./scripts/check-system-requirements.sh "$@"
+  ) >"$output_file" 2>&1
+}
+
+success_output="$sandbox/success.txt"
+if ! run_check "$success_output" --repo=android; then
+  cat "$success_output"
+  echo "android requirements check unexpectedly failed on happy path" >&2
+  exit 1
+fi
+
+grep -Fq '5. Android Repository (Capacitor + Native Android Toolchain)' "$success_output"
+grep -Fq 'Java 21' "$success_output"
+grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$success_output"
+grep -Fq 'Android SDK Platform-Tools (adb)' "$success_output"
+grep -Fq 'TypeScript installed' "$success_output"
+grep -Fq 'Vitest installed' "$success_output"
+grep -Fq 'All critical requirements met!' "$success_output"
+
+rm -f "$workspace/bin/sdkmanager"
+
+failure_output="$sandbox/failure.txt"
+if run_check "$failure_output" --repo=android; then
+  cat "$failure_output"
+  echo "android requirements check unexpectedly succeeded without sdkmanager" >&2
+  exit 1
+fi
+
+grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$failure_output"
+
+echo "tests/check-system-requirements.sh: android happy and missing-sdkmanager paths verified."

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -21,6 +21,8 @@ mkdir -p \
   "$workspace/contracts/node_modules/.bin" \
   "$workspace/frontend/node_modules/.bin" \
   "$workspace/bin" \
+  "$sdk_root/platform-tools" \
+  "$sdk_root/cmdline-tools/latest" \
   "$sdk_root" \
   "$test_home"
 
@@ -229,5 +231,9 @@ if run_check "$failure_output" --repo=android; then
 fi
 
 grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$failure_output"
+grep -Fq 'Android SDK Platform-Tools (adb)' "$failure_output"
+grep -Fq "Android SDK directory exists ($sdk_root)" "$failure_output"
+grep -Fq 'Native Android project directory exists' "$failure_output"
+grep -Fq 'TypeScript installed' "$failure_output"
 
 echo "tests/check-system-requirements.sh: android happy and missing-sdkmanager paths verified."

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -222,6 +222,41 @@ grep -Fq 'Java 21' "$java_home_output"
 grep -Fq 'Java compiler (javac)' "$java_home_output"
 grep -Fq 'All critical requirements met!' "$java_home_output"
 
+java_runtime_only_dir="$workspace/jre-21"
+mkdir -p "$java_runtime_only_dir/bin"
+cat >"$java_runtime_only_dir/bin/java" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-version" ]; then
+  echo 'openjdk version "21.0.11"'
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$java_runtime_only_dir/bin/java"
+
+java_runtime_only_output="$sandbox/java-home-runtime-only.txt"
+if (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="$java_runtime_only_dir" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVA_VERSION="17.0.12" \
+    TEST_JAVAC_VERSION="17.0.12" \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$java_runtime_only_output" 2>&1; then
+  cat "$java_runtime_only_output"
+  echo "android requirements check unexpectedly succeeded with JAVA_HOME runtime but PATH javac only" >&2
+  exit 1
+fi
+
+grep -Fq 'Java 21' "$java_runtime_only_output"
+grep -Fq 'Java compiler (javac)' "$java_runtime_only_output"
+grep -Fq 'critical requirement(s) missing' "$java_runtime_only_output"
+
 old_node_output="$sandbox/node-too-old.txt"
 if TEST_NODE_VERSION="v20.15.0" run_check "$old_node_output" --repo=android; then
   cat "$old_node_output"

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -158,6 +158,7 @@ run_check() {
     cd "$workspace/.github"
     PATH="$workspace/bin" \
       HOME="$test_home" \
+      JAVA_HOME="" \
       POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
       ANDROID_SDK_ROOT="" \
       ANDROID_HOME="" \
@@ -240,6 +241,7 @@ if (
   cd "$workspace/.github"
   PATH="$workspace/bin" \
     HOME="$test_home" \
+    JAVA_HOME="$java_runtime_only_dir" \
     JAVA_HOME="$java_runtime_only_dir" \
     POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
     ANDROID_SDK_ROOT="" \

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -11,7 +11,15 @@ sandbox="$(mktemp -d "${TMPDIR:-/tmp}/check-system-requirements.XXXXXX")"
 trap 'rm -rf "$sandbox"' EXIT
 
 workspace="$sandbox/workspace"
-mkdir -p "$workspace/.github/scripts" "$workspace/android/android" "$workspace/android/node_modules/.bin" "$workspace/bin"
+sdk_root="$workspace/polyscope-android-sdk"
+test_home="$workspace/home"
+mkdir -p \
+  "$workspace/.github/scripts" \
+  "$workspace/android/android" \
+  "$workspace/android/node_modules/.bin" \
+  "$workspace/bin" \
+  "$sdk_root" \
+  "$test_home"
 
 cp "$REPO_ROOT/scripts/check-system-requirements.sh" "$workspace/.github/scripts/check-system-requirements.sh"
 chmod +x "$workspace/.github/scripts/check-system-requirements.sh"
@@ -73,7 +81,8 @@ fi
 exit 0
 '
 stub_command "shellcheck" 'exit 0'
-stub_command "node" 'echo "v22.1.0"'
+# shellcheck disable=SC2016
+stub_command "node" 'echo "${TEST_NODE_VERSION:-v22.1.0}"'
 # shellcheck disable=SC2016
 stub_command "npm" '
 if [ "${1:-}" = "list" ]; then
@@ -107,7 +116,13 @@ run_check() {
   shift
   (
     cd "$workspace/.github"
-    PATH="$workspace/bin" /bin/bash ./scripts/check-system-requirements.sh "$@"
+    PATH="$workspace/bin" \
+      HOME="$test_home" \
+      POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+      ANDROID_SDK_ROOT="" \
+      ANDROID_HOME="" \
+      TEST_NODE_VERSION="${TEST_NODE_VERSION:-v22.1.0}" \
+      /bin/bash ./scripts/check-system-requirements.sh "$@"
   ) >"$output_file" 2>&1
 }
 
@@ -122,9 +137,37 @@ grep -Fq '5. Android Repository (Capacitor + Native Android Toolchain)' "$succes
 grep -Fq 'Java 21' "$success_output"
 grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$success_output"
 grep -Fq 'Android SDK Platform-Tools (adb)' "$success_output"
+grep -Fq "Android SDK directory exists ($sdk_root)" "$success_output"
 grep -Fq 'TypeScript installed' "$success_output"
 grep -Fq 'Vitest installed' "$success_output"
 grep -Fq 'All critical requirements met!' "$success_output"
+
+old_node_output="$sandbox/node-too-old.txt"
+if TEST_NODE_VERSION="v20.15.0" run_check "$old_node_output" --repo=android; then
+  cat "$old_node_output"
+  echo "android requirements check unexpectedly succeeded with Node.js 20" >&2
+  exit 1
+fi
+
+grep -Fq 'Node.js v20.15.0' "$old_node_output"
+grep -Fq '>= 22.x required' "$old_node_output"
+
+mv "$workspace/android" "$workspace/android-hidden"
+
+missing_repo_output="$sandbox/missing-repo.txt"
+if ! run_check "$missing_repo_output" --repo=android; then
+  cat "$missing_repo_output"
+  echo "android requirements check unexpectedly failed without sibling android repo" >&2
+  exit 1
+fi
+
+if grep -Fq 'Android Repository - Local Dependencies' "$missing_repo_output"; then
+  cat "$missing_repo_output"
+  echo "android requirements check unexpectedly printed local dependencies header without sibling repo" >&2
+  exit 1
+fi
+
+mv "$workspace/android-hidden" "$workspace/android"
 
 rm -f "$workspace/bin/sdkmanager"
 

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -130,12 +130,12 @@ stub_command "pnpm" 'exit 0'
 # shellcheck disable=SC2016
 stub_command "java" '
 if [ "${1:-}" = "-version" ]; then
-  echo "openjdk version \"21.0.11\""
+  echo "openjdk version \"${TEST_JAVA_VERSION:-21.0.11}\""
   exit 0
 fi
 exit 0
 '
-stub_command "javac" 'echo "javac 21.0.11"'
+stub_command "javac" 'echo "javac ${TEST_JAVAC_VERSION:-21.0.11}"'
 stub_command "adb" 'echo "Android Debug Bridge version 1.0.41"'
 stub_command "sdkmanager" 'echo "25.2.0"'
 stub_command "gh" 'exit 0'
@@ -181,6 +181,46 @@ grep -Fq "Android SDK directory exists ($sdk_root)" "$success_output"
 grep -Fq 'TypeScript installed' "$success_output"
 grep -Fq 'Vitest installed' "$success_output"
 grep -Fq 'All critical requirements met!' "$success_output"
+
+java_home_dir="$workspace/jdk-21"
+mkdir -p "$java_home_dir/bin"
+cat >"$java_home_dir/bin/java" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-version" ]; then
+  echo 'openjdk version "21.0.11"'
+  exit 0
+fi
+exit 0
+EOF
+cat >"$java_home_dir/bin/javac" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo 'javac 21.0.11'
+EOF
+chmod +x "$java_home_dir/bin/java" "$java_home_dir/bin/javac"
+
+java_home_output="$sandbox/java-home-success.txt"
+if ! (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="$java_home_dir" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVA_VERSION="17.0.12" \
+    TEST_JAVAC_VERSION="17.0.12" \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$java_home_output" 2>&1; then
+  cat "$java_home_output"
+  echo "android requirements check unexpectedly ignored JAVA_HOME when PATH java was too old" >&2
+  exit 1
+fi
+
+grep -Fq 'Java 21' "$java_home_output"
+grep -Fq 'Java compiler (javac)' "$java_home_output"
+grep -Fq 'All critical requirements met!' "$java_home_output"
 
 old_node_output="$sandbox/node-too-old.txt"
 if TEST_NODE_VERSION="v20.15.0" run_check "$old_node_output" --repo=android; then

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -25,6 +25,7 @@ mkdir -p \
   "$sdk_root/cmdline-tools/latest" \
   "$sdk_root" \
   "$test_home"
+touch "$workspace/android/android/settings.gradle"
 
 cp "$REPO_ROOT/scripts/check-system-requirements.sh" "$workspace/.github/scripts/check-system-requirements.sh"
 chmod +x "$workspace/.github/scripts/check-system-requirements.sh"
@@ -130,6 +131,10 @@ stub_command "pnpm" 'exit 0'
 # shellcheck disable=SC2016
 stub_command "java" '
 if [ "${1:-}" = "-version" ]; then
+  if [ -n "${TEST_JAVA_VERSION_OUTPUT:-}" ]; then
+    printf "%s\n" "$TEST_JAVA_VERSION_OUTPUT"
+    exit 0
+  fi
   echo "openjdk version \"${TEST_JAVA_VERSION:-21.0.11}\""
   exit 0
 fi
@@ -242,7 +247,6 @@ if (
   PATH="$workspace/bin" \
     HOME="$test_home" \
     JAVA_HOME="$java_runtime_only_dir" \
-    JAVA_HOME="$java_runtime_only_dir" \
     POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
     ANDROID_SDK_ROOT="" \
     ANDROID_HOME="" \
@@ -258,6 +262,52 @@ fi
 grep -Fq 'Java 21' "$java_runtime_only_output"
 grep -Fq 'Java compiler (javac)' "$java_runtime_only_output"
 grep -Fq 'critical requirement(s) missing' "$java_runtime_only_output"
+
+java_home_stale_dir="$workspace/jdk-missing-java"
+mkdir -p "$java_home_stale_dir/bin"
+
+stale_java_home_output="$sandbox/java-home-stale.txt"
+if (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="$java_home_stale_dir" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVA_VERSION="21.0.11" \
+    TEST_JAVAC_VERSION="21.0.11" \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$stale_java_home_output" 2>&1; then
+  cat "$stale_java_home_output"
+  echo "android requirements check unexpectedly fell back to PATH when JAVA_HOME was stale" >&2
+  exit 1
+fi
+
+grep -Fq 'Java runtime' "$stale_java_home_output"
+grep -Fq 'Java compiler (javac)' "$stale_java_home_output"
+grep -Fq 'critical requirement(s) missing' "$stale_java_home_output"
+
+java_banner_output="$sandbox/java-banner.txt"
+if ! (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVA_VERSION_OUTPUT=$'picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8\nopenjdk version "21.0.11"' \
+    TEST_JAVAC_VERSION="21.0.11" \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$java_banner_output" 2>&1; then
+  cat "$java_banner_output"
+  echo "android requirements check unexpectedly failed when java -version printed a banner before the version line" >&2
+  exit 1
+fi
+
+grep -Fq 'Java 21' "$java_banner_output"
+grep -Fq 'All critical requirements met!' "$java_banner_output"
 
 old_node_output="$sandbox/node-too-old.txt"
 if TEST_NODE_VERSION="v20.15.0" run_check "$old_node_output" --repo=android; then
@@ -299,18 +349,44 @@ fi
 mv "$workspace/android-hidden" "$workspace/android"
 
 rm -f "$workspace/bin/sdkmanager"
+rm -f "$workspace/bin/adb"
+mkdir -p "$sdk_root/cmdline-tools/latest/bin"
+cat >"$sdk_root/cmdline-tools/latest/bin/sdkmanager" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo '25.2.0'
+EOF
+cat >"$sdk_root/platform-tools/adb" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo 'Android Debug Bridge version 1.0.41'
+EOF
+chmod +x "$sdk_root/cmdline-tools/latest/bin/sdkmanager" "$sdk_root/platform-tools/adb"
+
+sdk_root_tools_output="$sandbox/sdk-root-tools.txt"
+if ! run_check "$sdk_root_tools_output" --repo=android; then
+  cat "$sdk_root_tools_output"
+  echo "android requirements check unexpectedly failed when sdkmanager and adb were only available under the SDK root" >&2
+  exit 1
+fi
+
+grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$sdk_root_tools_output"
+grep -Fq 'Android SDK Platform-Tools (adb)' "$sdk_root_tools_output"
+grep -Fq 'All critical requirements met!' "$sdk_root_tools_output"
+
+rm -f "$workspace/android/android/settings.gradle"
 
 failure_output="$sandbox/failure.txt"
 if run_check "$failure_output" --repo=android; then
   cat "$failure_output"
-  echo "android requirements check unexpectedly succeeded without sdkmanager" >&2
+  echo "android requirements check unexpectedly succeeded without native Android Gradle sentinel" >&2
   exit 1
 fi
 
 grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$failure_output"
 grep -Fq 'Android SDK Platform-Tools (adb)' "$failure_output"
 grep -Fq "Android SDK directory exists ($sdk_root)" "$failure_output"
-grep -Fq 'Native Android project directory exists' "$failure_output"
+grep -Fq 'Native Android Gradle project missing' "$failure_output"
 grep -Fq 'TypeScript installed' "$failure_output"
 
-echo "tests/check-system-requirements.sh: android happy and missing-sdkmanager paths verified."
+echo "tests/check-system-requirements.sh: android validator paths verified."

--- a/tests/check-system-requirements.sh
+++ b/tests/check-system-requirements.sh
@@ -131,6 +131,10 @@ stub_command "pnpm" 'exit 0'
 # shellcheck disable=SC2016
 stub_command "java" '
 if [ "${1:-}" = "-version" ]; then
+  if [ -n "${TEST_JAVA_VERSION_EXIT_CODE:-}" ]; then
+    printf "%s\n" "${TEST_JAVA_VERSION_STDERR:-broken java runtime}" >&2
+    exit "$TEST_JAVA_VERSION_EXIT_CODE"
+  fi
   if [ -n "${TEST_JAVA_VERSION_OUTPUT:-}" ]; then
     printf "%s\n" "$TEST_JAVA_VERSION_OUTPUT"
     exit 0
@@ -140,7 +144,13 @@ if [ "${1:-}" = "-version" ]; then
 fi
 exit 0
 '
-stub_command "javac" 'echo "javac ${TEST_JAVAC_VERSION:-21.0.11}"'
+stub_command "javac" '
+if [ -n "${TEST_JAVAC_VERSION_EXIT_CODE:-}" ]; then
+  printf "%s\n" "${TEST_JAVAC_VERSION_STDERR:-broken javac runtime}" >&2
+  exit "$TEST_JAVAC_VERSION_EXIT_CODE"
+fi
+echo "javac ${TEST_JAVAC_VERSION:-21.0.11}"
+'
 stub_command "adb" 'echo "Android Debug Bridge version 1.0.41"'
 stub_command "sdkmanager" 'echo "25.2.0"'
 stub_command "gh" 'exit 0'
@@ -308,6 +318,50 @@ fi
 
 grep -Fq 'Java 21' "$java_banner_output"
 grep -Fq 'All critical requirements met!' "$java_banner_output"
+
+broken_java_probe_output="$sandbox/java-probe-broken.txt"
+if (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVA_VERSION_EXIT_CODE=127 \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$broken_java_probe_output" 2>&1; then
+  cat "$broken_java_probe_output"
+  echo "android requirements check unexpectedly succeeded when java -version failed" >&2
+  exit 1
+fi
+
+grep -Fq 'Java 21' "$broken_java_probe_output"
+grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$broken_java_probe_output"
+grep -Fq 'Android SDK Platform-Tools (adb)' "$broken_java_probe_output"
+grep -Fq 'critical requirement(s) missing' "$broken_java_probe_output"
+
+broken_javac_probe_output="$sandbox/javac-probe-broken.txt"
+if (
+  cd "$workspace/.github"
+  PATH="$workspace/bin" \
+    HOME="$test_home" \
+    JAVA_HOME="" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$sdk_root" \
+    ANDROID_SDK_ROOT="" \
+    ANDROID_HOME="" \
+    TEST_JAVAC_VERSION_EXIT_CODE=127 \
+    /bin/bash ./scripts/check-system-requirements.sh --repo=android
+) >"$broken_javac_probe_output" 2>&1; then
+  cat "$broken_javac_probe_output"
+  echo "android requirements check unexpectedly succeeded when javac -version failed" >&2
+  exit 1
+fi
+
+grep -Fq 'Java compiler (javac)' "$broken_javac_probe_output"
+grep -Fq 'Android SDK Command-Line Tools (sdkmanager)' "$broken_javac_probe_output"
+grep -Fq 'Android SDK Platform-Tools (adb)' "$broken_javac_probe_output"
+grep -Fq 'critical requirement(s) missing' "$broken_javac_probe_output"
 
 old_node_output="$sandbox/node-too-old.txt"
 if TEST_NODE_VERSION="v20.15.0" run_check "$old_node_output" --repo=android; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1124,6 +1124,7 @@ grep -qF '"label": "Fix current findings"' "$workspace_root/contracts/polyscope.
 grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify"' "$workspace_root/android/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/android/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/android/polyscope.local.json"
+grep -q '^sdk.dir=' "$workspace_root/android/android/local.properties"
 grep -qF '"command": "npm run check && npm run lint && npm run test && npm run build"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope.local.json"
@@ -1793,7 +1794,8 @@ broken_api_clone="$home_dir/.polyscope/clones/api12345/fix"
 garbled_git_api_clone="$home_dir/.polyscope/clones/api12345/chore"
 frontend_clone="$home_dir/.polyscope/clones/fe123456/auto-hawk"
 broken_frontend_clone="$home_dir/.polyscope/clones/fe123456/feat"
-mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$garbled_git_api_clone" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone"
+android_clone="$home_dir/.polyscope/clones/an123456/auto-hawk"
+mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$garbled_git_api_clone" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone" "$android_clone/.git/info" "$android_clone/.git/hooks"
 printf 'not-a-git-pointer\n' > "$garbled_git_api_clone/.git"
 mkdir -p "$home_dir/.local/bin"
 
@@ -1951,6 +1953,8 @@ EOF
 
 seed_api_worktree_files "$api_clone"
 seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
+seed_node_worktree_files "$android_clone" "android-auto-hawk"
+mkdir -p "$android_clone/android"
 
 cp "$workspace_root/api/.env" "$api_clone/.env"
 : > "$broken_api_clone/.env"
@@ -2010,6 +2014,7 @@ provisioned = summary.get('provisioned_worktrees', [])
 cleaned = summary.get('cleaned_preview_storage_targets', [])
 assert 'api:auto-hawk' in provisioned, f"expected api:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'frontend:auto-hawk' in provisioned, f"expected frontend:auto-hawk in provisioned_worktrees, got {provisioned}"
+assert 'android:auto-hawk' in provisioned, f"expected android:auto-hawk in provisioned_worktrees, got {provisioned}"
 assert 'api:fix' not in provisioned, f"did not expect api:fix in provisioned_worktrees, got {provisioned}"
 assert 'api:chore' not in provisioned, f"did not expect api:chore in provisioned_worktrees, got {provisioned}"
 assert 'frontend:feat' not in provisioned, f"did not expect frontend:feat in provisioned_worktrees, got {provisioned}"
@@ -2028,6 +2033,7 @@ grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clon
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.production.local"
 cmp -s "$workspace_root/api/polyscope.local.json" "$api_clone/polyscope.local.json"
 cmp -s "$workspace_root/frontend/polyscope.local.json" "$frontend_clone/polyscope.local.json"
+cmp -s "$workspace_root/android/android/local.properties" "$android_clone/android/local.properties"
 grep -q '^polyscope.local.json$' "$api_clone/.git/info/exclude"
 grep -qF '.polyscope-secpal-provisioned.json' "$api_clone/.git/info/exclude"
 test -x "$api_clone/.git/hooks/pre-commit"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1996,8 +1996,11 @@ EOF
 chmod +x "$frontend_clone/scripts/preflight.sh"
 
 provision_summary_json="$workspace/provision-summary.json"
+shared_android_sdk_root="$workspace/shared-android-sdk"
+mkdir -p "$shared_android_sdk_root/platform-tools" "$shared_android_sdk_root/cmdline-tools/latest"
 env HOME="$home_dir" \
     PATH="$service_path" \
+    POLYSCOPE_ANDROID_SDK_ROOT="$shared_android_sdk_root" \
     PROVISION_LOG="$provision_log" \
     FAKE_PSQL_LOG="$fake_psql_log" \
     FAKE_PSQL_STATE="$fake_pg_state" \
@@ -2038,7 +2041,7 @@ grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clon
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.production.local"
 cmp -s "$workspace_root/api/polyscope.local.json" "$api_clone/polyscope.local.json"
 cmp -s "$workspace_root/frontend/polyscope.local.json" "$frontend_clone/polyscope.local.json"
-cmp -s "$workspace_root/android/android/local.properties" "$android_clone/android/local.properties"
+grep -q '^sdk\.dir='"$shared_android_sdk_root"'$' "$android_clone/android/local.properties"
 grep -q '^polyscope.local.json$' "$api_clone/.git/info/exclude"
 grep -qF '.polyscope-secpal-provisioned.json' "$api_clone/.git/info/exclude"
 test -x "$api_clone/.git/hooks/pre-commit"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1960,6 +1960,11 @@ seed_node_worktree_files "$broken_android_clone" "android-feat"
 seed_node_worktree_files "$android_clone" "android-auto-hawk"
 mkdir -p "$android_clone/android"
 touch "$android_clone/android/settings.gradle"
+cat >"$android_clone/android/local.properties" <<'EOF'
+ndk.dir=/opt/android-ndk
+sdk.dir=/tmp/obsolete-sdk
+cmake.dir=/opt/android-cmake
+EOF
 
 cp "$workspace_root/api/.env" "$api_clone/.env"
 : > "$broken_api_clone/.env"
@@ -2043,6 +2048,8 @@ grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clon
 cmp -s "$workspace_root/api/polyscope.local.json" "$api_clone/polyscope.local.json"
 cmp -s "$workspace_root/frontend/polyscope.local.json" "$frontend_clone/polyscope.local.json"
 grep -q '^sdk\.dir='"$shared_android_sdk_root"'$' "$android_clone/android/local.properties"
+grep -q '^ndk\.dir=/opt/android-ndk$' "$android_clone/android/local.properties"
+grep -q '^cmake\.dir=/opt/android-cmake$' "$android_clone/android/local.properties"
 grep -q '^polyscope.local.json$' "$api_clone/.git/info/exclude"
 grep -qF '.polyscope-secpal-provisioned.json' "$api_clone/.git/info/exclude"
 grep -q '^android/local\.properties$' "$android_clone/.git/info/exclude"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -205,6 +205,8 @@ for repo_name, scripts in package_scripts.items():
     }
     (repo_dir / "package.json").write_text(json.dumps(package_json, indent=2) + "\n")
     (repo_dir / "package-lock.json").write_text(json.dumps(package_lock, indent=2) + "\n")
+
+(workspace_root / "android" / "android").mkdir(parents=True, exist_ok=True)
 PY
 }
 
@@ -1794,8 +1796,9 @@ broken_api_clone="$home_dir/.polyscope/clones/api12345/fix"
 garbled_git_api_clone="$home_dir/.polyscope/clones/api12345/chore"
 frontend_clone="$home_dir/.polyscope/clones/fe123456/auto-hawk"
 broken_frontend_clone="$home_dir/.polyscope/clones/fe123456/feat"
+broken_android_clone="$home_dir/.polyscope/clones/an123456/feat"
 android_clone="$home_dir/.polyscope/clones/an123456/auto-hawk"
-mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$garbled_git_api_clone" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone" "$android_clone/.git/info" "$android_clone/.git/hooks"
+mkdir -p "$fake_exec_dir" "$api_clone/.git/info" "$api_clone/.git/hooks" "$api_clone/scripts" "$broken_api_clone/.git" "$garbled_git_api_clone" "$frontend_clone/.git/info" "$frontend_clone/.git/hooks" "$frontend_clone/scripts" "$broken_frontend_clone" "$broken_android_clone/.git/info" "$broken_android_clone/.git/hooks" "$android_clone/.git/info" "$android_clone/.git/hooks"
 printf 'not-a-git-pointer\n' > "$garbled_git_api_clone/.git"
 mkdir -p "$home_dir/.local/bin"
 
@@ -1953,6 +1956,7 @@ EOF
 
 seed_api_worktree_files "$api_clone"
 seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
+seed_node_worktree_files "$broken_android_clone" "android-feat"
 seed_node_worktree_files "$android_clone" "android-auto-hawk"
 mkdir -p "$android_clone/android"
 
@@ -2018,6 +2022,7 @@ assert 'android:auto-hawk' in provisioned, f"expected android:auto-hawk in provi
 assert 'api:fix' not in provisioned, f"did not expect api:fix in provisioned_worktrees, got {provisioned}"
 assert 'api:chore' not in provisioned, f"did not expect api:chore in provisioned_worktrees, got {provisioned}"
 assert 'frontend:feat' not in provisioned, f"did not expect frontend:feat in provisioned_worktrees, got {provisioned}"
+assert 'android:feat' not in provisioned, f"did not expect android:feat in provisioned_worktrees, got {provisioned}"
 assert cleaned == [], f"expected no cleaned preview databases on first provisioning run, got {cleaned}"
 PY
 
@@ -2054,6 +2059,8 @@ test ! -f "$garbled_git_api_clone/polyscope.local.json"
 test ! -f "$garbled_git_api_clone/.polyscope-secpal-provisioned.json"
 test ! -f "$broken_frontend_clone/polyscope.local.json"
 test ! -f "$broken_frontend_clone/.polyscope-secpal-provisioned.json"
+test ! -f "$broken_android_clone/android/local.properties"
+test ! -f "$broken_android_clone/.polyscope-secpal-provisioned.json"
 grep -qF "composer:$api_clone:install" "$provision_log"
 grep -qF "php:$api_clone:artisan config:clear" "$provision_log"
 grep -qF "php:$api_clone:artisan migrate --force" "$provision_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1126,7 +1126,7 @@ grep -qF '"label": "Fix current findings"' "$workspace_root/contracts/polyscope.
 grep -qF '"command": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify"' "$workspace_root/android/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/android/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/android/polyscope.local.json"
-grep -q '^sdk.dir=' "$workspace_root/android/android/local.properties"
+grep -q '^sdk\.dir=' "$workspace_root/android/android/local.properties"
 grep -qF '"command": "npm run check && npm run lint && npm run test && npm run build"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/secpal.app/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/secpal.app/polyscope.local.json"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1959,6 +1959,7 @@ seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
 seed_node_worktree_files "$broken_android_clone" "android-feat"
 seed_node_worktree_files "$android_clone" "android-auto-hawk"
 mkdir -p "$android_clone/android"
+touch "$android_clone/android/settings.gradle"
 
 cp "$workspace_root/api/.env" "$api_clone/.env"
 : > "$broken_api_clone/.env"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2044,6 +2044,7 @@ cmp -s "$workspace_root/frontend/polyscope.local.json" "$frontend_clone/polyscop
 grep -q '^sdk\.dir='"$shared_android_sdk_root"'$' "$android_clone/android/local.properties"
 grep -q '^polyscope.local.json$' "$api_clone/.git/info/exclude"
 grep -qF '.polyscope-secpal-provisioned.json' "$api_clone/.git/info/exclude"
+grep -q '^android/local\.properties$' "$android_clone/.git/info/exclude"
 test -x "$api_clone/.git/hooks/pre-commit"
 test -L "$api_clone/.git/hooks/pre-push"
 test "$(readlink "$api_clone/.git/hooks/pre-push")" = '../../scripts/preflight.sh'

--- a/tests/preflight-check-system-requirements.sh
+++ b/tests/preflight-check-system-requirements.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT_SCRIPT="$REPO_ROOT/scripts/preflight.sh"
+
+if [ ! -f "$PREFLIGHT_SCRIPT" ]; then
+  echo "Missing preflight script: $PREFLIGHT_SCRIPT" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'tests/check-system-requirements.sh' "$PREFLIGHT_SCRIPT"; then
+  echo "scripts/preflight.sh must invoke tests/check-system-requirements.sh so Android requirements regressions run in enforced validation." >&2
+  exit 1
+fi
+
+echo "tests/preflight-check-system-requirements.sh: preflight wiring verified."


### PR DESCRIPTION
## Summary

- provision Android workspaces and Polyscope clones with android/local.properties based on the local SDK path
- add Android-specific system requirement checks for Java 21, sdkmanager, adb, the SDK directory, and native Android workspace layout
- document the Android toolchain expectations and add rollout plus requirements regression coverage

## Root Cause

Android test and Gradle failures on provisioned workspaces were not caused by missing repository code. The recurring breakage came from Android SDK discovery: Gradle was often invoked without shell-level ANDROID_HOME or ANDROID_SDK_ROOT, and the rollout automation did not generate android/local.properties for Android workspaces.

## Impact

- direct ./gradlew invocations work in newly provisioned Android workspaces even when the shell environment was not preloaded explicitly
- workspace setup and restore checks now surface missing Android toolchain pieces before PR work reaches residual-risk notes

## Validation

- bash tests/check-system-requirements.sh
- bash tests/polyscope-rollout.sh
- ./scripts/preflight.sh

## TDD / Validate-First Evidence

- Failing proof before implementation: Reproduced the defect in provisioned Android workspaces where `android/local.properties` was missing and direct `./gradlew` invocations still depended on manually preloaded `ANDROID_HOME` or `ANDROID_SDK_ROOT`.
- Passing proof after implementation: `bash tests/check-system-requirements.sh`, `bash tests/polyscope-rollout.sh`, and `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A
