### PR TITLE
fix: pin Copilot Review Memory workflow checkout to trusted base SHA

### DIFF
--- a/.github/workflows/copilot-review-memory.yml
+++ b/.github/workflows/copilot-review-memory.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Export unresolved Copilot findings
         id: scan

--- a/.github/workflows/copilot-review-memory.yml
+++ b/.github/workflows/copilot-review-memory.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.base.ref || github.sha }}
 
       - name: Export unresolved Copilot findings
         id: scan
@@ -77,11 +77,13 @@ jobs:
 
       - name: Publish workflow summary
         run: |
-          cat artifacts/copilot-review-memory/summary.md >> "$GITHUB_STEP_SUMMARY"
-          echo >> "$GITHUB_STEP_SUMMARY"
-          cat artifacts/copilot-review-memory/tracking.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            cat artifacts/copilot-review-memory/summary.md
+            echo
+            cat artifacts/copilot-review-memory/tracking.md
 
-          if [ "${{ steps.scan.outputs.match_count }}" = "0" ]; then
-            echo >> "$GITHUB_STEP_SUMMARY"
-            echo "No unresolved Copilot review findings matched this run." >> "$GITHUB_STEP_SUMMARY"
-          fi
+            if [ "${{ steps.scan.outputs.match_count }}" = "0" ]; then
+              echo
+              echo "No unresolved Copilot review findings matched this run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- pinned the Copilot Review Memory workflow checkout to the trusted pull request base SHA for `pull_request_review` events before running local scripts with the GitHub App token
+- pinned the Copilot Review Memory workflow checkout to the current trusted pull request base ref for `pull_request_review` events before running local scripts with the GitHub App token
 - added regression coverage so the workflow cannot silently return to the default review-event checkout when executing repository scripts with privileged credentials
 - tightened the Copilot review memory regression so it now anchors the trusted review-event checkout `ref` to the active `actions/checkout` step instead of accepting commented or unsafe `ref` lines
 - hardened the Copilot review memory regression diagnostics so missing checkout or script lines now fail with the dedicated privilege-boundary message instead of exiting early under `set -euo pipefail`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - pinned the Copilot Review Memory workflow checkout to the trusted pull request base SHA for `pull_request_review` events before running local scripts with the GitHub App token
 - added regression coverage so the workflow cannot silently return to the default review-event checkout when executing repository scripts with privileged credentials
 - tightened the Copilot review memory regression so it now anchors the trusted review-event checkout `ref` to the active `actions/checkout` step instead of accepting commented or unsafe `ref` lines
+- hardened the Copilot review memory regression diagnostics so missing checkout or script lines now fail with the dedicated privilege-boundary message instead of exiting early under `set -euo pipefail`
 - kept local preflight usable in checkouts without `origin/HEAD` so the required workflow validation can fall back to `main` instead of exiting early
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-04 - Pin Copilot Review Memory Checkout
+
+**Fixed:**
+
+- pinned the Copilot Review Memory workflow checkout to the trusted pull request base SHA for `pull_request_review` events before running local scripts with the GitHub App token
+- added regression coverage so the workflow cannot silently return to the default review-event checkout when executing repository scripts with privileged credentials
+- tightened the Copilot review memory regression so it now anchors the trusted review-event checkout `ref` to the active `actions/checkout` step instead of accepting commented or unsafe `ref` lines
+- kept local preflight usable in checkouts without `origin/HEAD` so the required workflow validation can fall back to `main` instead of exiting early
+
+---
+
 ## 2026-07-03 - Provision Android SDK Metadata For Polyscope Workspaces
 
 **Fixed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -131,6 +131,15 @@ if [ -f tests/copilot-review-memory.sh ]; then
   }
 fi
 
+if [ -f tests/copilot-review-memory-errors.sh ]; then
+  bash tests/copilot-review-memory-errors.sh || {
+    echo "" >&2
+    echo "❌ Copilot review memory workflow diagnostics regression test failed!" >&2
+    echo "Keep missing-line failures in the privileged review-event regression explicit before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/codeql-applicability.sh ]; then
   bash tests/codeql-applicability.sh || {
     echo "" >&2

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -36,7 +36,8 @@ done
 
 # Auto-detect default branch (fallback to main)
 # Use symbolic-ref instead of remote show to avoid network hang
-BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)"
+BASE="${BASE#refs/remotes/origin/}"
 [ -z "${BASE:-}" ] && BASE="main"
 
 echo "Using base branch: $BASE"
@@ -117,6 +118,15 @@ if [ -f tests/reusable-workflow-timeouts.sh ]; then
     echo "" >&2
     echo "❌ Reusable workflow timeout validation failed!" >&2
     echo "Add timeout-minutes to every reusable workflow job before continuing." >&2
+    exit 1
+  }
+fi
+
+if [ -f tests/copilot-review-memory.sh ]; then
+  bash tests/copilot-review-memory.sh || {
+    echo "" >&2
+    echo "❌ Copilot review memory workflow regression test failed!" >&2
+    echo "Keep privileged review-event local script execution pinned to trusted base code before continuing." >&2
     exit 1
   }
 fi

--- a/tests/copilot-review-memory-errors.sh
+++ b/tests/copilot-review-memory-errors.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/copilot-review-memory.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/copilot-review-memory.yml"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/copilot-review-memory-errors.XXXXXX")"
+WORKFLOW_BACKUP="$TMP_DIR/copilot-review-memory.yml.original"
+LOG_FILE="$TMP_DIR/test.log"
+
+cleanup() {
+  if [ -f "$WORKFLOW_BACKUP" ]; then
+    cp "$WORKFLOW_BACKUP" "$WORKFLOW"
+  fi
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+cp "$WORKFLOW" "$WORKFLOW_BACKUP"
+
+assert_dedicated_failure() {
+  local scenario="$1"
+  local expected_message="$2"
+
+  if bash "$TEST_SCRIPT" >"$LOG_FILE" 2>&1; then
+    cat "$LOG_FILE" >&2
+    echo "Regression test unexpectedly passed for scenario: $scenario" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "$expected_message" "$LOG_FILE"; then
+    cat "$LOG_FILE" >&2
+    echo "Regression test did not emit the dedicated error for scenario: $scenario" >&2
+    exit 1
+  fi
+}
+
+awk '
+  /^          \.\/scripts\/copilot-review-tool\.sh scan \\$/ { next }
+  { print }
+' "$WORKFLOW_BACKUP" >"$WORKFLOW"
+assert_dedicated_failure \
+  "missing privileged script line" \
+  "Copilot review memory workflow must checkout trusted code before running copilot-review-tool.sh."
+
+cp "$WORKFLOW_BACKUP" "$WORKFLOW"
+
+awk '
+  /^      - name: Checkout repository$/ { next }
+  { print }
+' "$WORKFLOW_BACKUP" >"$WORKFLOW"
+assert_dedicated_failure \
+  "missing checkout line" \
+  "Copilot review memory workflow must checkout trusted code before running copilot-review-tool.sh."
+
+echo "✓ copilot review memory workflow failure diagnostics are stable"

--- a/tests/copilot-review-memory.sh
+++ b/tests/copilot-review-memory.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+#
+# Regression checks for the Copilot review memory workflow privilege boundary.
+# pull_request_review events can be triggered by pull requests whose head tree
+# is attacker-controlled, so any local code run after minting the GitHub App
+# token must come from the trusted base commit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/copilot-review-memory.yml"
+TRUSTED_REVIEW_REF='          ref: ${{ github.event_name == '\''pull_request_review'\'' && github.event.pull_request.base.sha || github.sha }}'
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+grep -q '^  pull_request_review:$' "$WORKFLOW" || {
+  echo "Copilot review memory workflow must keep the pull_request_review trigger under regression coverage." >&2
+  exit 1
+}
+
+grep -q '^        uses: actions/create-github-app-token@v3$' "$WORKFLOW" || {
+  echo "Copilot review memory workflow must keep the GitHub App token step under regression coverage." >&2
+  exit 1
+}
+
+# The privileged job runs local repository scripts with GH_TOKEN set to the App
+# token. Guard against regressing to the default checkout for review events,
+# where the script path can be supplied by the pull request head tree.
+checkout_line=$(grep -n '^      - name: Checkout repository$' "$WORKFLOW" | cut -d: -f1 | head -n1)
+first_script_line=$(grep -n '^          ./scripts/copilot-review-tool\.sh scan \\$' "$WORKFLOW" | cut -d: -f1 | head -n1)
+if [ -z "$checkout_line" ] || [ -z "$first_script_line" ] || [ "$checkout_line" -ge "$first_script_line" ]; then
+  echo "Copilot review memory workflow must checkout trusted code before running copilot-review-tool.sh." >&2
+  exit 1
+fi
+
+if awk -v start="$checkout_line" -v trusted_ref="$TRUSTED_REVIEW_REF" '
+  NR == start { in_checkout = 1; next }
+  in_checkout && /^      - name:/ { in_checkout = 0 }
+  in_checkout && /^        with:/ { has_with = 1 }
+  in_checkout && $0 == trusted_ref { has_trusted_ref = 1 }
+  END { exit !(has_with && has_trusted_ref) }
+' "$WORKFLOW"; then
+  :
+else
+  echo "Checkout before privileged local script execution must include the trusted pull_request_review base SHA ref." >&2
+  exit 1
+fi
+
+echo "✓ copilot review memory workflow privilege-boundary checks passed"

--- a/tests/copilot-review-memory.sh
+++ b/tests/copilot-review-memory.sh
@@ -5,7 +5,7 @@
 # Regression checks for the Copilot review memory workflow privilege boundary.
 # pull_request_review events can be triggered by pull requests whose head tree
 # is attacker-controlled, so any local code run after minting the GitHub App
-# token must come from the trusted base commit.
+# token must come from the current trusted base ref.
 
 set -euo pipefail
 
@@ -14,7 +14,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/copilot-review-memory.yml"
 # shellcheck disable=SC2016
 # Literal GitHub expression expected in workflow YAML.
-TRUSTED_REVIEW_REF='          ref: ${{ github.event_name == '\''pull_request_review'\'' && github.event.pull_request.base.sha || github.sha }}'
+TRUSTED_REVIEW_REF='          ref: ${{ github.event_name == '\''pull_request_review'\'' && github.event.pull_request.base.ref || github.sha }}'
 
 first_line_number() {
   local pattern="$1"
@@ -62,7 +62,7 @@ if awk -v start="$checkout_line" -v trusted_ref="$TRUSTED_REVIEW_REF" '
 ' "$WORKFLOW"; then
   :
 else
-  echo "Checkout before privileged local script execution must include the trusted pull_request_review base SHA ref." >&2
+  echo "Checkout before privileged local script execution must include the current trusted pull_request_review base ref." >&2
   exit 1
 fi
 

--- a/tests/copilot-review-memory.sh
+++ b/tests/copilot-review-memory.sh
@@ -12,7 +12,21 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/copilot-review-memory.yml"
+# shellcheck disable=SC2016
+# Literal GitHub expression expected in workflow YAML.
 TRUSTED_REVIEW_REF='          ref: ${{ github.event_name == '\''pull_request_review'\'' && github.event.pull_request.base.sha || github.sha }}'
+
+first_line_number() {
+  local pattern="$1"
+  local match
+
+  match="$(grep -n -m1 "$pattern" "$WORKFLOW" || true)"
+  if [ -z "$match" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "${match%%:*}"
+}
 
 if [ ! -f "$WORKFLOW" ]; then
   echo "Expected workflow was not found: $WORKFLOW" >&2
@@ -32,8 +46,8 @@ grep -q '^        uses: actions/create-github-app-token@v3$' "$WORKFLOW" || {
 # The privileged job runs local repository scripts with GH_TOKEN set to the App
 # token. Guard against regressing to the default checkout for review events,
 # where the script path can be supplied by the pull request head tree.
-checkout_line=$(grep -n '^      - name: Checkout repository$' "$WORKFLOW" | cut -d: -f1 | head -n1)
-first_script_line=$(grep -n '^          ./scripts/copilot-review-tool\.sh scan \\$' "$WORKFLOW" | cut -d: -f1 | head -n1)
+checkout_line="$(first_line_number '^      - name: Checkout repository$' || true)"
+first_script_line="$(first_line_number '^          ./scripts/copilot-review-tool\.sh scan \\$' || true)"
 if [ -z "$checkout_line" ] || [ -z "$first_script_line" ] || [ "$checkout_line" -ge "$first_script_line" ]; then
   echo "Copilot review memory workflow must checkout trusted code before running copilot-review-tool.sh." >&2
   exit 1


### PR DESCRIPTION
### Motivation
- Prevent execution of PR-controlled code with an organization GitHub App token by ensuring the workflow checks out the trusted base commit for `pull_request_review` events.
- Add automated regression coverage so the privileged workflow cannot silently regress back to the default review-event checkout behavior.

### Description
- Update `.github/workflows/copilot-review-memory.yml` to pin the `actions/checkout` step with `ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.base.sha || github.sha }}` so review events use the trusted base SHA.
- Add `tests/copilot-review-memory.sh`, a focused regression test that asserts the workflow keeps the `pull_request_review` trigger, creates the App token step, pins the checkout ref, and checks out before running local scripts.
- Wire the new regression into `scripts/preflight.sh` so local preflight runs the test and fails when the privilege boundary is broken, and make preflight tolerate checkouts missing `origin/HEAD` by adding a safe fallback for base detection.
- Update `CHANGELOG.md` with a brief note describing the security fix and the added validation coverage.

### Testing
- Ran the new regression: `bash tests/copilot-review-memory.sh`, which passed and confirmed the trusted ref and checkout-before-script ordering. (passed)
- Ran repository unit/validation checks: `npm test` (openapi presence checks) completed successfully. (passed)
- Verified formatting and style with Prettier: `npx prettier@3.5.3 --check CHANGELOG.md .github/workflows/copilot-review-memory.yml` completed successfully. (passed)
- Verified workflow YAML parsing via Node/`js-yaml`: parsed the updated workflow file successfully. (passed)
- Executed `bash -n scripts/preflight.sh` and exercised the new Copilot regression within preflight; preflight reached and passed the new regression but later failed in an unrelated, environment-specific commit-signature regression under this container because `/usr/bin/env bash` is unavailable here (environment warning).
- Note: `yamllint` and `reuse lint` were not available in this execution environment so those checks could not be run here (tools missing warnings).

## TDD / Validate-First Evidence
- Failing proof before implementation: The security invariant was violated because `.github/workflows/copilot-review-memory.yml` used the default `actions/checkout` ref during `pull_request_review`, allowing PR-controlled code to run in a privileged review workflow.
- Passing proof after implementation: `bash tests/copilot-review-memory.sh` now passes and asserts the workflow keeps the `pull_request_review` trigger, pins checkout to `github.event.pull_request.base.sha` for review events, and checks out before running local scripts.
- Validate-first exception reference: N/A
- No executable change reason: N/A

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48863601b88332b810ba31259a1d81)
