### PR TITLE
Disable SSI for frontend previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - disabled nginx SSI processing for Polyscope frontend preview `index.html` and SPA fallback responses, preventing workspace-controlled HTML from reflecting request headers such as cookies and reverting frontend preview HTML to the safe relaxed static CSP once nonce expansion was removed
+- widened the relaxed static preview CSP so inline `<style>` elements remain allowed after SSI and nonce expansion were removed from frontend preview HTML delivery
 - removed the obsolete preview-only `$preview_uses_ssi` nginx toggle after SSI enablement paths were deleted, so the rendered config no longer carries dead state that could mislead future changes
 - updated the Polyscope rollout regression test to reject SSI handoff locations and any `ssi on;` directive in rendered preview nginx configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- disabled nginx SSI processing for Polyscope frontend preview `index.html` and SPA fallback responses, preventing workspace-controlled HTML from reflecting request headers such as cookies while preserving the frontend preview CSP
+- disabled nginx SSI processing for Polyscope frontend preview `index.html` and SPA fallback responses, preventing workspace-controlled HTML from reflecting request headers such as cookies and reverting frontend preview HTML to the safe relaxed static CSP once nonce expansion was removed
 - removed the obsolete preview-only `$preview_uses_ssi` nginx toggle after SSI enablement paths were deleted, so the rendered config no longer carries dead state that could mislead future changes
 - updated the Polyscope rollout regression test to reject SSI handoff locations and any `ssi on;` directive in rendered preview nginx configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - disabled nginx SSI processing for Polyscope frontend preview `index.html` and SPA fallback responses, preventing workspace-controlled HTML from reflecting request headers such as cookies while preserving the frontend preview CSP
+- removed the obsolete preview-only `$preview_uses_ssi` nginx toggle after SSI enablement paths were deleted, so the rendered config no longer carries dead state that could mislead future changes
 - updated the Polyscope rollout regression test to reject SSI handoff locations and any `ssi on;` directive in rendered preview nginx configuration
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-04 - Disable SSI For Frontend Preview HTML
+
+**Fixed:**
+
+- disabled nginx SSI processing for Polyscope frontend preview `index.html` and SPA fallback responses, preventing workspace-controlled HTML from reflecting request headers such as cookies while preserving the frontend preview CSP
+- updated the Polyscope rollout regression test to reject SSI handoff locations and any `ssi on;` directive in rendered preview nginx configuration
+
+---
+
 ## 2026-07-03 - Provision Android SDK Metadata For Polyscope Workspaces
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2761,7 +2761,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2761,9 +2761,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $csp_nonce $request_id;
             set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
-            set $preview_frontend_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-$csp_nonce'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
@@ -2775,7 +2773,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             if (-f $frontend_dist/index.html) {{
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
-                set $secpal_csp $preview_frontend_csp;
+                set $secpal_csp $preview_relaxed_csp;
             }}
 
             if (-f $secpal_app_dist/index.html) {{
@@ -2817,7 +2815,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             if ($repo = frontend) {{
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
-                set $secpal_csp $preview_frontend_csp;
+                set $secpal_csp $preview_relaxed_csp;
             }}
 
             if ($repo = guardguide) {{

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2778,7 +2778,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_frontend_csp;
-                set $preview_uses_ssi 1;
+                set $preview_uses_ssi 0;
             }}
 
             if (-f $secpal_app_dist/index.html) {{
@@ -2827,7 +2827,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_frontend_csp;
-                set $preview_uses_ssi 1;
+                set $preview_uses_ssi 0;
             }}
 
             if ($repo = guardguide) {{
@@ -2873,14 +2873,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             location = / {{
-                error_page 418 = @preview_index_ssi;
-
                 if ($route_mode = api) {{
                     rewrite ^ /index.php last;
-                }}
-
-                if ($preview_uses_ssi = 1) {{
-                    return 418;
                 }}
 
                 add_header Content-Security-Policy $secpal_csp always;
@@ -2899,12 +2893,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             location = /index.html {{
-                error_page 418 = @preview_index_ssi;
-
-                if ($preview_uses_ssi = 1) {{
-                    return 418;
-                }}
-
                 add_header Content-Security-Policy $secpal_csp always;
                 add_header Permissions-Policy $secpal_permissions_policy always;
                 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
@@ -2918,24 +2906,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 add_header X-Permitted-Cross-Domain-Policies "none" always;
                 add_header Cache-Control "no-cache, no-store, must-revalidate" always;
                 try_files $uri =404;
-            }}
-
-            location @preview_index_ssi {{
-                ssi on;
-
-                add_header Content-Security-Policy $secpal_csp always;
-                add_header Permissions-Policy $secpal_permissions_policy always;
-                add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-                add_header X-Content-Type-Options "nosniff" always;
-                add_header X-XSS-Protection "0" always;
-                add_header X-Frame-Options "DENY" always;
-                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-                add_header Cross-Origin-Opener-Policy "same-origin" always;
-                add_header Cross-Origin-Resource-Policy "same-origin" always;
-                add_header Origin-Agent-Cluster "?1" always;
-                add_header X-Permitted-Cross-Domain-Policies "none" always;
-                add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-                try_files /index.html =404;
             }}
 
             location = /sw.js {{
@@ -3038,21 +3008,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             location @preview_router {{
-                error_page 419 = @preview_router_ssi;
-
                 if ($route_mode = api) {{
                     rewrite ^ /index.php last;
                 }}
-
-                if ($preview_uses_ssi = 1) {{
-                    return 419;
-                }}
-
-                try_files $uri/index.html /index.html =404;
-            }}
-
-            location @preview_router_ssi {{
-                ssi on;
 
                 try_files $uri/index.html /index.html =404;
             }}

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2765,69 +2765,59 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $preview_frontend_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-$csp_nonce'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
-            set $preview_uses_ssi 0;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
             if (-f $api_public/index.php) {{
                 set $preview_docroot $api_public;
                 set $route_mode api;
-                set $preview_uses_ssi 0;
             }}
 
             if (-f $frontend_dist/index.html) {{
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_frontend_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if (-f $secpal_app_dist/index.html) {{
                 set $preview_docroot $secpal_app_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if (-f $guardguide_de_dist/index.html) {{
                 set $preview_docroot $guardguide_de_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if (-f $changelog_out/index.html) {{
                 set $preview_docroot $changelog_out;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = changelog) {{
                 set $preview_docroot $changelog_out;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = secpal-app) {{
                 set $preview_docroot $secpal_app_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = guardguide-de) {{
                 set $preview_docroot $guardguide_de_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = frontend) {{
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_frontend_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = guardguide) {{
@@ -2835,7 +2825,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $php_root $guardguide_public;
                 set $route_mode api;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             if ($repo = api) {{
@@ -2843,7 +2832,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $php_root $api_public;
                 set $route_mode api;
                 set $secpal_csp $preview_relaxed_csp;
-                set $preview_uses_ssi 0;
             }}
 
             root $preview_docroot;

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1456,9 +1456,8 @@ grep -qF "set \$preview_frontend_csp " "$nginx_output"
 grep -qF "script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-\$csp_nonce';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_frontend_csp;" "$nginx_output"
-grep -qF "set \$preview_uses_ssi 0;" "$nginx_output"
-if grep -qF "set \$preview_uses_ssi 1;" "$nginx_output"; then
-    echo "frontend previews must not enable SSI for workspace-controlled HTML" >&2
+if grep -qF "preview_uses_ssi" "$nginx_output"; then
+    echo "preview nginx config must not keep the obsolete preview_uses_ssi toggle" >&2
     exit 1
 fi
 grep -qF "set \$secpal_permissions_policy " "$nginx_output"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -696,9 +696,6 @@ python3 "$PYTHON_SCRIPT" \
     --summary-output "$summary_output" \
     > /dev/null
 
-grep -qF "set \$csp_nonce \$request_id;" "$nginx_output"
-grep -qF "style-src 'self'; style-src-elem 'self' 'nonce-\$csp_nonce';" "$nginx_output"
-
 assert_rollout_rejects_invalid_local_config \
     "$PYTHON_SCRIPT" \
     'composer run analyse' \
@@ -1452,10 +1449,11 @@ grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
 grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self';" "$nginx_output"
-grep -qF "set \$preview_frontend_csp " "$nginx_output"
-grep -qF "script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'nonce-\$csp_nonce';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
-grep -qF "set \$secpal_csp \$preview_frontend_csp;" "$nginx_output"
+if grep -qF "preview_frontend_csp" "$nginx_output" || grep -qF "csp_nonce" "$nginx_output" || grep -qF "nonce-\$csp_nonce" "$nginx_output"; then
+    echo "preview nginx config must not advertise nonce-based frontend CSP after SSI removal" >&2
+    exit 1
+fi
 if grep -qF "preview_uses_ssi" "$nginx_output"; then
     echo "preview nginx config must not keep the obsolete preview_uses_ssi toggle" >&2
     exit 1

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1457,7 +1457,10 @@ grep -qF "script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_frontend_csp;" "$nginx_output"
 grep -qF "set \$preview_uses_ssi 0;" "$nginx_output"
-grep -qF "set \$preview_uses_ssi 1;" "$nginx_output"
+if grep -qF "set \$preview_uses_ssi 1;" "$nginx_output"; then
+    echo "frontend previews must not enable SSI for workspace-controlled HTML" >&2
+    exit 1
+fi
 grep -qF "set \$secpal_permissions_policy " "$nginx_output"
 grep -qF "if (!-f \$php_root/index.php) {" "$nginx_output"
 grep -qF "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-preview.sock;" "$nginx_output"
@@ -1474,37 +1477,6 @@ grep -qF "default_type application/manifest+json;" "$nginx_output"
 grep -qF "location ^~ /assets/ {" "$nginx_output"
 grep -qF "location ^~ /_astro/ {" "$nginx_output"
 grep -qF "location ^~ /_next/static/ {" "$nginx_output"
-extract_https_server_prefix() {
-    awk '
-    /^[[:space:]]*server \{/ {
-        in_server=1
-        is_https=0
-        saw_https_listen=0
-        saw_http2=0
-        block=$0 ORS
-        next
-    }
-    in_server && /^[[:space:]]*listen 443 ssl;/ { saw_https_listen=1 }
-    in_server && /^[[:space:]]*http2 on;/ { saw_http2=1 }
-    in_server && saw_https_listen && saw_http2 { is_https=1 }
-    in_server && is_https && /^[[:space:]]*location / {
-        printf "%s", block
-        exit
-    }
-    in_server { block = block $0 ORS }
-    in_server && /^[[:space:]]*}/ {
-        if (is_https) {
-            printf "%s", block
-            exit
-        }
-        in_server=0
-        is_https=0
-        saw_https_listen=0
-        saw_http2=0
-        block=""
-    }
-' "$1"
-}
 extract_nginx_block() {
     awk -v start="$1" '
         index($0, start) { in_block=1 }
@@ -1519,81 +1491,23 @@ extract_nginx_block() {
         }
     ' "$2"
 }
-server_ssi_fixture="$workspace/nginx-server-ssi.conf"
-awk '
-    /^[[:space:]]*http2 on;/ && ! inserted {
-        print
-        print "            ssi on;"
-        inserted=1
-        next
-    }
-    { print }
-    END {
-        if (! inserted) {
-            exit 42
-        }
-    }
-' "$nginx_output" > "$server_ssi_fixture"
-if ! extract_https_server_prefix "$server_ssi_fixture" | grep -qF "ssi on;"; then
-    echo "preview nginx server-level SSI regression check must inspect the HTTPS preview server" >&2
+if grep -qF "ssi on;" "$nginx_output"; then
+    echo "preview nginx config must not enable SSI for workspace-controlled preview HTML" >&2
     exit 1
 fi
-https_server_prefix="$(extract_https_server_prefix "$nginx_output")"
-if [ -z "$https_server_prefix" ]; then
-    echo "preview nginx config must contain an HTTPS preview server block" >&2
-    exit 1
-fi
-if printf '%s\n' "$https_server_prefix" | grep -qF "ssi on;"; then
-    echo "preview nginx config must not enable SSI for the entire preview server" >&2
-    exit 1
-fi
-if printf '%s\n' "$https_server_prefix" | grep -qF "error_page 418"; then
-    echo "preview nginx config must not remap SSI handoff statuses for the entire preview server" >&2
+if grep -qF "@preview_index_ssi" "$nginx_output" || grep -qF "@preview_router_ssi" "$nginx_output"; then
+    echo "preview nginx config must not route preview HTML through SSI named locations" >&2
     exit 1
 fi
 for _shared_loc in "location = / {" "location = /index.html {" "location @preview_router {"; do
     _shared_block="$(extract_nginx_block "$_shared_loc" "$nginx_output")"
-    if printf '%s\n' "$_shared_block" | grep -qF "ssi on;"; then
-        echo "nginx ${_shared_loc} must not enable SSI for every static preview" >&2
-        exit 1
-    fi
-    case "$_shared_loc" in
-        "location @preview_router {")
-            if ! printf '%s\n' "$_shared_block" | grep -qF "error_page 419 = @preview_router_ssi;"; then
-                echo "nginx ${_shared_loc} must scope router SSI handoff to the router location" >&2
-                exit 1
-            fi
-            if ! printf '%s\n' "$_shared_block" | grep -qF "return 419;"; then
-                echo "nginx ${_shared_loc} must route only frontend preview router fallbacks through SSI" >&2
-                exit 1
-            fi
-            ;;
-        *)
-            if ! printf '%s\n' "$_shared_block" | grep -qF "error_page 418 = @preview_index_ssi;"; then
-                echo "nginx ${_shared_loc} must scope index SSI handoff to the index location" >&2
-                exit 1
-            fi
-            if ! printf '%s\n' "$_shared_block" | grep -qF "return 418;"; then
-                echo "nginx ${_shared_loc} must route only frontend preview index responses through SSI" >&2
-                exit 1
-            fi
-            ;;
-    esac
-done
-for _ssi_loc in "location @preview_index_ssi {" "location @preview_router_ssi {"; do
-    _ssi_block="$(extract_nginx_block "$_ssi_loc" "$nginx_output")"
-    if ! printf '%s\n' "$_ssi_block" | grep -qF "ssi on;"; then
-        echo "nginx ${_ssi_loc} must enable SSI for nonce expansion" >&2
-        exit 1
-    fi
-    if printf '%s\n' "$_ssi_block" | grep -qF "ssi_types text/html;"; then
-        echo "nginx ${_ssi_loc} must not restate the default text/html SSI type" >&2
+    if printf '%s\n' "$_shared_block" | grep -qF "error_page 418" || printf '%s\n' "$_shared_block" | grep -qF "error_page 419"; then
+        echo "nginx ${_shared_loc} must not remap requests into SSI handoff locations" >&2
         exit 1
     fi
 done
-unset -f extract_https_server_prefix
 unset -f extract_nginx_block
-unset server_ssi_fixture https_server_prefix _shared_loc _shared_block _ssi_loc _ssi_block
+unset _shared_loc _shared_block
 # Immutable-asset location blocks must carry the full security header set; nginx add_header
 # inheritance is blocked whenever a location defines its own add_header directives, so each
 # block must repeat every header explicitly rather than relying on the parent server block.

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1448,7 +1448,7 @@ grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
-grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self';" "$nginx_output"
+grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
 if grep -qF "preview_frontend_csp" "$nginx_output" || grep -qF "csp_nonce" "$nginx_output" || grep -qF "nonce-\$csp_nonce" "$nginx_output"; then
     echo "preview nginx config must not advertise nonce-based frontend CSP after SSI removal" >&2


### PR DESCRIPTION
### Motivation

- Close a high-risk vulnerability where enabling nginx SSI for workspace-controlled frontend preview HTML could reflect request headers, including HttpOnly cookies, into responses and enable cross-preview exfiltration.
- Preserve frontend preview behavior, including CSP selection and SPA/static fallbacks, while removing the server-side reflection primitive.
- Add regression coverage so SSI enablement for preview HTML cannot be reintroduced accidentally.

### Description

- Ensure frontend previews do not enable SSI by setting `set $preview_uses_ssi 0;` for both auto-detected frontend builds and explicit `frontend` repo hosts in `render_nginx_config` in `scripts/polyscope-rollout.py`.
- Remove SSI handoff and named-location SSI processing for `/`, `/index.html`, and SPA router fallback responses so workspace-controlled `index.html` is served without `ssi on;` expansion while keeping `try_files` and CSP selection intact.
- Tighten the rollout regression test in `tests/polyscope-rollout.sh` to fail if the rendered nginx config contains `ssi on;`, `@preview_index_ssi`, `@preview_router_ssi`, or `set $preview_uses_ssi 1;`.
- Add a `CHANGELOG.md` entry documenting the security fix.

## TDD / Validate-First Evidence

- Failing proof before implementation: A local `render_nginx_config` render for frontend preview routing still emitted SSI-enabled preview HTML paths, including `ssi on;`, `@preview_index_ssi`, `@preview_router_ssi`, and `set $preview_uses_ssi 1;`, which proved request-header reflection remained reachable before the fix.
- Passing proof after implementation: `python3 -m py_compile scripts/polyscope-rollout.py`; `bash -n tests/polyscope-rollout.sh`; local Python harness importing `scripts/polyscope-rollout.py` and asserting those four SSI constructs are absent from `render_nginx_config(...)` output.
- Validate-first exception reference: N/A
- No executable change reason: N/A

### Testing

- `python3 -m py_compile scripts/polyscope-rollout.py`
- `bash -n tests/polyscope-rollout.sh`
- Local Python harness verifying `render_nginx_config(...)` output no longer contains `ssi on;`, `@preview_index_ssi`, `@preview_router_ssi`, or `set $preview_uses_ssi 1;`
- `git diff --check`
