### PR TITLE
fix: stop copying source env into Polyscope API worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 - hardened the Copilot review memory regression diagnostics so missing checkout or script lines now fail with the dedicated privilege-boundary message instead of exiting early under `set -euo pipefail`
 - kept local preflight usable in checkouts without `origin/HEAD` so the required workflow validation can fall back to `main` instead of exiting early
 
+## 2026-07-04 - Harden Polyscope API Preview Env Handling
+
+**Fixed:**
+
+- stopped Polyscope API worktree preparation from copying the source API `.env` into worktrees that do not already have their own preview `.env`, keeping source secrets and database credentials out of untrusted or external-branch preview setup commands
+- disabled gitignored-file copying in generated API `polyscope.local.json` configs so Polyscope no longer pre-populates new API worktrees with the source checkout `.env` before the fail-closed preview setup guard runs
+- added regression coverage to ensure missing API worktree `.env` files fail closed without inheriting source checkout secrets
+
 ---
 
 ## 2026-07-03 - Provision Android SDK Metadata For Polyscope Workspaces

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -429,13 +429,16 @@ def ensure_api_worktree_ready(
     env_path = worktree_path / ".env"
     if not env_path.exists():
         source_env_path = source_repo_path / ".env"
-        if not source_env_path.exists():
-            print(
-                f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
-                f".env missing and source preview env not found at {source_env_path}"
-            )
-            return False, None
-        shutil.copy2(source_env_path, env_path)
+        source_hint = (
+            f"; source .env exists at {source_env_path} but is not copied into worktrees"
+            if source_env_path.exists()
+            else f"; source preview env not found at {source_env_path}"
+        )
+        print(
+            f"Skipping api worktree {worktree_path.name} at {worktree_path}: "
+            f".env missing{source_hint}"
+        )
+        return False, None
 
     env_text = env_path.read_text()
     env_values = load_env_assignments(env_path)
@@ -1318,7 +1321,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         "review_focus": "Laravel 13, Pest 4, Request -> Controller -> Service -> Repository -> Model, Sanctum session versus bearer-token flows, and encrypted data handling via *_plain/*_idx without direct *_enc reads.",
         "link_names": ["frontend", "contracts", "android"],
         "local_config": {
-            "copyGitignored": True,
+            "copyGitignored": False,
             "runMode": "replace",
             "preview": {"url": build_preview_url_template("api")},
             "scripts": {

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -720,6 +720,7 @@ grep -qF '"command": "php artisan test && vendor/bin/pint --dirty && vendor/bin/
 grep -qF '"label": "Preflight"' "$workspace_root/api/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/api/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"copyGitignored": false' "$workspace_root/api/polyscope.local.json"
 if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api/polyscope.local.json"; then
     echo "preview API refresh command must use the hardened reseed flow and not raw migrate:fresh --seed" >&2
     exit 1
@@ -1076,6 +1077,38 @@ playwright_probe_result = subprocess.run(
 )
 assert "PLAYWRIGHT_BASE_URL=https://frontend-azure-cheetah.preview.secpal.dev" in playwright_probe_result.stdout, playwright_probe_result.stdout
 assert "PLAYWRIGHT_API_BASE_URL=https://api-azure-cheetah-165552b7.preview.secpal.dev" in playwright_probe_result.stdout, playwright_probe_result.stdout
+PY
+
+# ensure_api_worktree_ready must not copy source .env secrets into missing API worktree envs.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "source-env-secret-fixture" / "source-api"
+api_worktree = workspace / "source-env-secret-fixture" / "clones" / "api12345" / "attacker-pr"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_api.joinpath(".env").write_text(
+    "APP_URL=https://api.secpal.dev\n"
+    "DB_CONNECTION=pgsql\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal\n"
+    "DB_PASSWORD=prod-secret-password\n"
+    "APP_KEY=base64:SOURCE_APP_KEY_SHOULD_NOT_LEAVE_SOURCE\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+ready, preview_storage_target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is False
+assert preview_storage_target is None
+assert not api_worktree.joinpath(".env").exists(), "missing worktree .env must fail closed without copying source secrets"
 PY
 
 # --prepare-api-worktree CLI path: assert --db-path is threaded into ensure_api_worktree_ready
@@ -2062,6 +2095,7 @@ grep -qF 'DROP DATABASE IF EXISTS "secpal__preview__fix" WITH (FORCE)' "$fake_ps
 stale_api_clone="$home_dir/.polyscope/clones/api12345/stale-otter"
 mkdir -p "$stale_api_clone/.git/info" "$stale_api_clone/.git/hooks" "$stale_api_clone/scripts"
 seed_api_worktree_files "$stale_api_clone"
+cp "$workspace_root/api/.env" "$stale_api_clone/.env"
 
 cat >"$stale_api_clone/.pre-commit-config.yaml" <<'EOF'
 repos: []
@@ -2206,6 +2240,7 @@ seed_node_worktree_files "$failing_frontend_manifest_clone" "frontend-broken-ibi
 seed_node_worktree_files "$failing_frontend_io_clone" "frontend-locked-oryx"
 seed_api_worktree_files "$guardguide_clone"
 seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+cp "$workspace_root/api/.env" "$failing_api_clone/.env"
 printf '{\n  "packages": []\n}\n' > "$guardguide_clone/composer.lock"
 printf '{"scripts": ' > "$failing_api_cleanup_clone/composer.json"
 printf '{"scripts": ' > "$failing_frontend_manifest_clone/package.json"


### PR DESCRIPTION
### Motivation
- Prevent source checkout secrets from being copied into untrusted or external-branch API worktrees during Polyscope provisioning to avoid secret exfiltration and accidental DB mutations.

### Description
- Change `ensure_api_worktree_ready()` so a missing worktree `.env` now fails closed and does **not** copy the source repo `.env` into the worktree, and print a clear skip message instead.
- Add a regression test to `tests/polyscope-rollout.sh` that exercises the fail-closed behavior for API worktrees missing `.env` and asserts no source `.env` is copied into the worktree.
- Update the stale-worktree test fixture to explicitly place a preview `.env` into the `stale_api_clone` so existing provisioning coverage remains deterministic.
- Update `CHANGELOG.md` with an entry describing the Polyscope API preview env hardening.

### Testing
- Ran `python3 -m py_compile scripts/polyscope-rollout.py`, which succeeded.
- Ran `git diff --check`, which succeeded.
- Ran `bash tests/polyscope-rollout.sh`; the new missing-`.env` regression passed, and the suite later hit pre-existing invalid-worktree assertion failures tracked separately in issue `#515`.

## TDD / Validate-First Evidence

- Failing proof before implementation: Pre-change, `ensure_api_worktree_ready()` called `shutil.copy2(source_env_path, env_path)` whenever the worktree `.env` was missing, so the new regression assertion `assert not api_worktree.joinpath(".env").exists()` would fail by creating a copied secrets file in the preview worktree.
- Passing proof after implementation: `python3 -m py_compile scripts/polyscope-rollout.py` passed, and the new regression in `bash tests/polyscope-rollout.sh` now prints the fail-closed skip message for the missing worktree `.env` path without creating `api_worktree/.env`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48613fb6208332b8f12faa9e887898)
