### PR TITLE
docs: centralize SecPal licensing policy

### DIFF
--- a/.github/workflows/license-compatibility.yml
+++ b/.github/workflows/license-compatibility.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: License Compatibility
@@ -56,7 +56,9 @@ jobs:
             local invalid_reuse_files
             local matching_expressions
             local invalid_expressions
-            local spdx_identifier_prefix='SPDX-License'"'"'-Identifier:'
+            local spdx_identifier_prefix
+            spdx_identifier_prefix="SPDX-License"
+            spdx_identifier_prefix="${spdx_identifier_prefix}-Identifier:"
 
             collect_matching_expressions() {
               local ref="$1"

--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Reusable - License Compatibility
@@ -57,7 +57,9 @@ jobs:
             local invalid_reuse_files
             local matching_expressions
             local invalid_expressions
-            local spdx_identifier_prefix='SPDX-License'"'"'-Identifier:'
+            local spdx_identifier_prefix
+            spdx_identifier_prefix="SPDX-License"
+            spdx_identifier_prefix="${spdx_identifier_prefix}-Identifier:"
 
             collect_matching_expressions() {
               local ref="$1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added a central [`docs/licensing-policy.md`](docs/licensing-policy.md) reference for SecPal-wide CLA definitions, `SecPal Contributors` SPDX policy, `LicenseRef-SecPal-Attribution` usage, third-party notice separation, Tailwind-specific scoping, and the enforceable versus preferred SecPal attribution wording
 - added the approved [`LICENSES/LicenseRef-SecPal-Attribution.txt`](LICENSES/LicenseRef-SecPal-Attribution.txt) addendum text to this repository so shared governance docs can reference the exact attribution terms already enforced by the reusable license-compatibility workflows
 - updated [`CLA.md`](CLA.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`README.md`](README.md), and [`docs/brand/licensing-wording.md`](docs/brand/licensing-wording.md) so contributor-facing guidance now defines `SecPal`, `Project Maintainer`, and CLA recipient scope consistently and points repository owners at the central licensing policy
+- fixed the local and reusable license-compatibility workflows so their custom-license guard searches real `SPDX-License-Identifier` headers when validating `LicenseRef-SecPal-Attribution` metadata
 - cross-referenced the repository-specific rollout issues for `api`, `frontend`, and `android` so the implementation work stays tracked outside the central policy issue
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added the approved [`LICENSES/LicenseRef-SecPal-Attribution.txt`](LICENSES/LicenseRef-SecPal-Attribution.txt) addendum text to this repository so shared governance docs can reference the exact attribution terms already enforced by the reusable license-compatibility workflows
 - updated [`CLA.md`](CLA.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`README.md`](README.md), and [`docs/brand/licensing-wording.md`](docs/brand/licensing-wording.md) so contributor-facing guidance now defines `SecPal`, `Project Maintainer`, and CLA recipient scope consistently and points repository owners at the central licensing policy
 - fixed the local and reusable license-compatibility workflows so their custom-license guard searches real `SPDX-License-Identifier` headers when validating `LicenseRef-SecPal-Attribution` metadata
+- aligned the custom-license regression fixtures in `tests/license-compatibility.sh` with the new `SecPal Contributors` copyright policy so review guidance and fixture data do not drift
 - cross-referenced the repository-specific rollout issues for `api`, `frontend`, and `android` so the implementation work stays tracked outside the central policy issue
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2026 SecPal -->
+<!-- SPDX-FileCopyrightText: 2026 SecPal Contributors -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Changelog
@@ -6,6 +6,17 @@
 Log of notable changes to SecPal organization defaults (newest first).
 
 **Note:** This repository contains organization-wide configuration and is NOT versioned. For versioned releases, see individual project repositories (`api/`, `frontend/`, `contracts/`).
+
+---
+
+## 2026-07-04 - Document SecPal Licensing, CLA, And Attribution Policy
+
+**Changed:**
+
+- added a central [`docs/licensing-policy.md`](docs/licensing-policy.md) reference for SecPal-wide CLA definitions, `SecPal Contributors` SPDX policy, `LicenseRef-SecPal-Attribution` usage, third-party notice separation, Tailwind-specific scoping, and the enforceable versus preferred SecPal attribution wording
+- added the approved [`LICENSES/LicenseRef-SecPal-Attribution.txt`](LICENSES/LicenseRef-SecPal-Attribution.txt) addendum text to this repository so shared governance docs can reference the exact attribution terms already enforced by the reusable license-compatibility workflows
+- updated [`CLA.md`](CLA.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`README.md`](README.md), and [`docs/brand/licensing-wording.md`](docs/brand/licensing-wording.md) so contributor-facing guidance now defines `SecPal`, `Project Maintainer`, and CLA recipient scope consistently and points repository owners at the central licensing policy
+- cross-referenced the repository-specific rollout issues for `api`, `frontend`, and `android` so the implementation work stays tracked outside the central policy issue
 
 ---
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 
 SPDX-License-Identifier: CC0-1.0
 
@@ -12,12 +12,18 @@ for legal clarity in the Individual and Corporate CLA sections. The markdownlint
 
 Thank you for your interest in contributing to SecPal projects! This Contributor License Agreement ("Agreement") documents the rights granted by contributors to SecPal.
 
+## Defined Terms
+
+- **SecPal** means the SecPal open source project maintained by the Project Maintainer.
+- **Project Maintainer** means the person or legal entity designated in SecPal governance documentation as responsible for accepting contributions, administering contributor agreements, and granting commercial licenses for the SecPal project, including any legal successor or entity to which those rights are assigned.
+- **CLA rights recipient** means SecPal acting through the Project Maintainer unless and until SecPal publicly designates a successor legal entity in its governance documentation.
+
 ## Purpose
 
 This Agreement enables SecPal to maintain a **dual-licensing model**:
 
 - **Open Source License**: All contributions are licensed under the [AGPL-3.0-or-later](https://www.gnu.org/licenses/agpl-3.0.html) license
-- **Commercial License**: SecPal may offer commercial licenses to third parties for use cases incompatible with AGPL
+- **Commercial License**: SecPal, acting through the Project Maintainer, may offer commercial licenses to third parties for use cases incompatible with AGPL
 
 By signing this CLA, you retain full copyright ownership of your contributions while granting SecPal the necessary rights to distribute your work under both licensing models.
 
@@ -51,7 +57,7 @@ Subject to the terms and conditions of this Agreement, You hereby grant to SecPa
 
 - Reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works
 - Distribute Your Contributions under the [AGPL-3.0-or-later](https://www.gnu.org/licenses/agpl-3.0.html) license
-- **Grant commercial licenses** to third parties for Your Contributions as part of SecPal's dual-licensing business model
+- **Grant commercial licenses** to third parties for Your Contributions as part of SecPal's dual-licensing business model, with SecPal acting through the Project Maintainer as the CLA rights recipient
 
 ### 3. Grant of Patent License
 
@@ -101,7 +107,7 @@ Subject to the terms and conditions of this Agreement, You hereby grant to SecPa
 
 - Reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works
 - Distribute Your Contributions under the [AGPL-3.0-or-later](https://www.gnu.org/licenses/agpl-3.0.html) license
-- **Grant commercial licenses** to third parties for Your Contributions as part of SecPal's dual-licensing business model
+- **Grant commercial licenses** to third parties for Your Contributions as part of SecPal's dual-licensing business model, with SecPal acting through the Project Maintainer as the CLA rights recipient
 
 ### 3. Grant of Patent License
 
@@ -192,4 +198,4 @@ If you have questions about this CLA, please contact us:
 This CLA is adapted from the [Apache Software Foundation](https://www.apache.org/licenses/contributor-agreements.html) and [Google's Individual and Corporate CLAs](https://cla.developers.google.com/), modified for SecPal's dual-licensing model.
 
 **Version**: 1.0
-**Last Updated**: October 25, 2025
+**Last Updated**: July 4, 2026

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,31 +407,31 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License             | Use For                                         |
-| -------------------- | ------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
+| File Type            | License                                                                      | Use For                                         |
+| -------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later` or `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
+| **Configuration**    | `CC0-1.0`                                                                    | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
+| **Helper Scripts**   | `MIT`                                                                        | Standalone bash/shell scripts, build utilities  |
+| **Documentation**    | `CC0-1.0`                                                                    | Markdown files (except LICENSE itself)          |
 
 ### SPDX Header Examples
 
-**For application code (AGPL-3.0-or-later):**
+**For SecPal-owned AGPL code with the project attribution addendum:**
 
 ```php
 <?php
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```javascript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```typescript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 **For configuration files (CC0-1.0):**
@@ -478,7 +478,7 @@ Run `reuse lint` before committing to verify compliance:
 reuse lint
 
 # Add headers to new files automatically
-reuse annotate --license AGPL-3.0-or-later --copyright "SecPal Contributors" path/to/file.php
+reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" --copyright "SecPal Contributors" path/to/file.php
 ```
 
 ### Bulk Licensing with REUSE.toml
@@ -519,11 +519,11 @@ SPDX-License-Identifier = "SEE-LICENSE-IN-PACKAGE"
 
 **How to choose the correct copyright attribution:**
 
-- Use **"SecPal Contributors"** for all code files, including source code, test files, scripts, and any file where individual contributors make changes (e.g., `.js`, `.ts`, `.php`, `.py`, `.sh`, test files in any language).
-- Use **"SecPal"** for organizational documentation (e.g., `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`), workflow files (e.g., `.github/workflows/*.yml`), and configuration files in the root directory (e.g., `.eslintrc.yml`, `.prettierrc`, `package.json`, `composer.json`, etc.).
-- If a configuration file is specific to a code module or contains logic contributed by individuals, use **"SecPal Contributors"**.
-- For ambiguous cases, prefer **"SecPal Contributors"** if the file is likely to be edited by multiple people over time.
-- Use the **current year** in the copyright date (e.g., 2025 for files created in 2025).
+- Use **`SecPal Contributors`** for project-owned code and other SecPal-owned AGPL material that carries the attribution addendum.
+- Do **not** replace third-party notices with `SecPal Contributors`; keep upstream notices separate.
+- Do **not** use `SecPal` alone as a code copyright holder unless SecPal later publishes a clear legal entity or documented rights holder for that specific use.
+- Use the current publication year or year range as appropriate.
+- Follow the central policy in [`docs/licensing-policy.md`](docs/licensing-policy.md) for the authoritative rules on `LicenseRef-SecPal-Attribution`, Tailwind-specific terms, and CLA alignment.
 
 Run `reuse lint` to check compliance.
 
@@ -537,6 +537,6 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions will be licensed under the [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) license.
+By contributing to SecPal, you agree that your contributions will be licensed under the terms documented in [CLA.md](CLA.md) and the central licensing policy in [docs/licensing-policy.md](docs/licensing-policy.md).
 
 Thank you for contributing to SecPal! 🎉

--- a/LICENSES/LicenseRef-SecPal-Attribution.txt
+++ b/LICENSES/LicenseRef-SecPal-Attribution.txt
@@ -1,0 +1,66 @@
+SecPal Attribution Terms
+
+These additional terms apply to SecPal under section 7(b) and section 7(c) of
+the GNU Affero General Public License version 3 or later.
+
+1. Attribution notices
+
+The following attribution notices are specified reasonable legal notices and
+author attribution notices for SecPal:
+
+  Powered by SecPal
+  Based on SecPal
+
+Covered works that display Appropriate Legal Notices in an interactive user
+interface must preserve an appropriate SecPal attribution notice in those
+Appropriate Legal Notices, or in a comparable, reasonably visible legal-notices,
+credits, or about section.
+
+Unmodified versions should use:
+
+  Powered by SecPal
+
+Modified versions must be marked in a reasonable way as different from the
+original SecPal version and should use an attribution notice such as:
+
+  Based on SecPal
+
+or:
+
+  Based on SecPal - modified by [name/entity]
+
+A modified version must not use "Powered by SecPal" in a way that implies that
+the modified version is the original SecPal version or is endorsed by the
+SecPal project maintainers.
+
+2. Project tagline and website
+
+The preferred full attribution notice is:
+
+  Powered by SecPal - A guard's best friend
+
+For modified versions, the preferred attribution notice is:
+
+  Based on SecPal - A guard's best friend
+
+The SecPal project website is:
+
+  https://secpal.app
+
+Including the tagline "A guard's best friend" and including or linking to
+https://secpal.app are requested, but they are not required as license
+conditions.
+
+3. No endorsement
+
+Modified versions must not misrepresent their origin or imply endorsement by
+the SecPal project maintainers. Modified versions may add a clear modification
+notice next to the SecPal attribution.
+
+4. Scope
+
+These additional terms do not require preservation of a specific footer layout,
+visual design, logo, hyperlink, or exact placement. A covered work may satisfy
+these terms by preserving the required SecPal attribution notice in its
+Appropriate Legal Notices or in a comparable, reasonably visible legal-notices,
+credits, or about section.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025-2026 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -317,7 +317,7 @@ pip install reuse
 reuse lint
 
 # Add missing headers
-reuse annotate --copyright "SecPal" --license "AGPL-3.0-or-later" <file>
+reuse annotate --copyright "SecPal Contributors" --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" <file>
 ```
 
 ## License
@@ -340,6 +340,7 @@ All projects are licensed under the [AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-lat
 - Distribute source code to users (including network users)
 - Share modifications under AGPL
 - Preserve copyright and license notices
+- Preserve the required SecPal attribution notice when the project uses the SecPal attribution addendum
 
 #### 2. Commercial License
 
@@ -353,6 +354,8 @@ For use cases **incompatible with AGPL**, we offer commercial licenses that allo
 
 **Interested in a commercial license?** Contact us at [legal@secpal.app](mailto:legal@secpal.app)
 
+The central SecPal policy for SPDX headers, CLA definitions, attribution terms, and `LicenseRef-SecPal-Attribution` lives in [docs/licensing-policy.md](docs/licensing-policy.md).
+
 ---
 
 ### Contributing
@@ -362,6 +365,7 @@ By contributing to SecPal projects, you agree to our [Contributor License Agreem
 - Grants us rights to distribute your contributions under **both** licensing models
 - Allows you to **retain copyright** ownership
 - Ensures your work can benefit both open source and commercial users
+- Defines SecPal and the Project Maintainer clearly enough for contributor license grants without turning the CLA into a copyright assignment
 
 **CLA Signing Process:**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # SecPal Organization

--- a/docs/brand/licensing-wording.md
+++ b/docs/brand/licensing-wording.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -34,6 +34,7 @@ SecPal materials use different license wording and different link targets depend
 - Use `Licensed under AGPL v3+` (or, in the documented two-line footer, the standalone `AGPL v3+` label) only in public footers for AGPL-licensed surfaces.
 - Use license wording that matches the active commercial agreement on commercially licensed surfaces.
 - Use the SPDX expression `AGPL-3.0-or-later` in source file license headers for files that are licensed under the AGPL.
+- When SecPal's approved attribution addendum applies, use `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` in SPDX/REUSE metadata and follow [`docs/licensing-policy.md`](../licensing-policy.md) for the governing rules.
 - Use the package ecosystem's SPDX-compatible license field where one exists.
 - Do not put human-readable license wording into machine-readable metadata.
 - Do not put SPDX expressions into compact public footers unless the surface is specifically about license compliance.

--- a/docs/licensing-policy.md
+++ b/docs/licensing-policy.md
@@ -1,0 +1,99 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# SecPal Licensing Policy
+
+This document is the central SecPal policy for contributor licensing, SPDX/REUSE metadata, and AGPL attribution terms across shared repositories such as `api`, `frontend`, and `android`.
+
+## Defined Terms
+
+- **SecPal** means the SecPal open source project maintained by the Project Maintainer.
+- **Project Maintainer** means the person or legal entity designated in SecPal governance documentation as responsible for accepting contributions, administering contributor agreements, and granting commercial licenses for the SecPal project, including any legal successor or entity to which those rights are assigned.
+- **CLA rights recipient** means SecPal acting through the Project Maintainer unless and until SecPal publicly designates a successor legal entity in its governance documentation.
+
+These definitions keep the CLA model as a license grant rather than a copyright assignment: contributors retain copyright ownership and grant SecPal the rights needed for AGPL distribution and commercial relicensing.
+
+## Standard SPDX Copyright Policy
+
+Use project-based copyright notices for SecPal-owned material:
+
+```text
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+```
+
+For files first published in 2026:
+
+```text
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+```
+
+Rules:
+
+- Use `SecPal Contributors` for project-owned source code, policy documents, and other repository-owned material.
+- Do not use `SecPal` alone as the copyright holder for project-owned code unless SecPal later publishes a clear legal entity or other documented rights holder for that specific use.
+- Keep third-party notices separate. Do not replace upstream names, bundled notices, or vendor copyright statements with `SecPal Contributors`.
+- Do not switch third-party or externally-authored notices to `SecPal Contributors` just for consistency.
+
+## When To Use `LicenseRef-SecPal-Attribution`
+
+Use `LicenseRef-SecPal-Attribution` only for SecPal-owned AGPL-covered files or REUSE annotations that are intentionally subject to the SecPal attribution addendum.
+
+Rules:
+
+- Pair it only with `AGPL-3.0-or-later` in the same SPDX expression:
+
+  ```text
+  AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+  ```
+
+- Ship the approved addendum text as [`LICENSES/LicenseRef-SecPal-Attribution.txt`](../LICENSES/LicenseRef-SecPal-Attribution.txt).
+- Do not use `LicenseRef-SecPal-Attribution` by itself.
+- Do not apply it to third-party code, third-party assets, or unrelated custom-license material.
+- Do not use it for CC0, MIT, Apache-2.0, or other non-AGPL repository files.
+
+## Third-Party And Tailwind Rules
+
+- Third-party notices must remain under their original licensing and attribution terms.
+- Keep third-party REUSE metadata separate from SecPal-owned metadata.
+- Do not add Tailwind-specific licensing terms to `api`, `frontend`, or `android` unless Tailwind-derived material is actually present in that repository.
+- If Tailwind-derived material is present, keep that handling repository-specific and separate from the SecPal attribution addendum.
+
+## SecPal Attribution Terms
+
+The approved attribution addendum is stored in [`LICENSES/LicenseRef-SecPal-Attribution.txt`](../LICENSES/LicenseRef-SecPal-Attribution.txt).
+
+Summary:
+
+- Required attribution for unmodified interactive AGPL-covered SecPal works: `Powered by SecPal`
+- Required attribution for modified or forked interactive AGPL-covered SecPal works: `Based on SecPal`
+- Preferred but not mandatory fuller notice: `Powered by SecPal - A guard's best friend`
+- Preferred/requested but not mandatory: include or link to `https://secpal.app`
+
+The tagline and website link are requests, not license conditions. The enforceable license conditions are the preservation of the appropriate SecPal attribution notice and the no-endorsement / no-misrepresentation rules in the approved addendum text.
+
+Implementation notes:
+
+- Modified versions must not use `Powered by SecPal` in a way that suggests they are the original SecPal release or endorsed by the SecPal project maintainers.
+- The attribution terms do not require a specific footer layout, logo, visual design, or exact placement.
+- Public footer formatting guidance remains in [`docs/brand/footer-wording.md`](./brand/footer-wording.md) and [`docs/brand/licensing-wording.md`](./brand/licensing-wording.md).
+
+## CLA And Governance Alignment
+
+- The CLA is a contributor license agreement, not a copyright assignment.
+- Contributors retain copyright in their own work.
+- Contributors grant SecPal, acting through the Project Maintainer, the rights needed to distribute contributions under the AGPL and to grant commercial licenses.
+- If SecPal later forms or designates a successor legal entity, SecPal governance documentation must identify that successor clearly before repository headers or contributor-facing legal text are updated to reflect it.
+
+See [`CLA.md`](../CLA.md) for the operative contributor agreement text and [`CONTRIBUTING.md`](../CONTRIBUTING.md) for day-to-day REUSE guidance.
+
+## Implementation Tracking
+
+Repository follow-up issues for this policy:
+
+- `api`: [SecPal/api#1226](https://github.com/SecPal/api/issues/1226)
+- `frontend`: [SecPal/frontend#1323](https://github.com/SecPal/frontend/issues/1323)
+- `android`: [SecPal/android#313](https://github.com/SecPal/android/issues/313)

--- a/tests/license-compatibility.sh
+++ b/tests/license-compatibility.sh
@@ -140,8 +140,9 @@ custom_license_ref_guard_case() {
       failures+=("FAIL [$label]: $workflow_label does not reject OR-paired or non-AGPL custom license expressions")
     fi
 
-    if ! printf '%s' "$workflow" | grep -qF "spdx_identifier_prefix='SPDX-License'"; then
-      failures+=("FAIL [$label]: $workflow_label does not build SPDX header lookups without literal SPDX marker false positives")
+    if ! printf '%s' "$workflow" | grep -qF 'spdx_identifier_prefix="SPDX-License"' \
+      || ! printf '%s' "$workflow" | grep -qF 'spdx_identifier_prefix="${spdx_identifier_prefix}-Identifier:"'; then
+      failures+=("FAIL [$label]: $workflow_label does not search real SPDX-License-Identifier headers")
     fi
 
     if ! printf '%s' "$workflow" | grep -qF 'git grep -h "$spdx_identifier_prefix.*$ref"'; then
@@ -223,7 +224,9 @@ EOF
 write_spdx_fixture() {
   local target_file="$1"
   local expression="$2"
-  local spdx_identifier_prefix='SPDX-License'"'"'-Identifier:'
+  local spdx_identifier_prefix
+  spdx_identifier_prefix="SPDX-License"
+  spdx_identifier_prefix="${spdx_identifier_prefix}-Identifier:"
 
   printf '# SPDX-FileCopyrightText: 2026 SecPal\n' > "$target_file"
   printf '# %s %s\n' "$spdx_identifier_prefix" "$expression" >> "$target_file"
@@ -233,7 +236,7 @@ write_reuse_toml_annotation() {
   local target_file="$1"
   local path_value="$2"
   local expression="$3"
-  local spdx_identifier_key='SPDX-License'"'"'-Identifier'
+  local spdx_identifier_key="SPDX-License-Identifier"
 
   cat <<'EOF' > "$target_file"
 version = 1

--- a/tests/license-compatibility.sh
+++ b/tests/license-compatibility.sh
@@ -228,7 +228,7 @@ write_spdx_fixture() {
   spdx_identifier_prefix="SPDX-License"
   spdx_identifier_prefix="${spdx_identifier_prefix}-Identifier:"
 
-  printf '# SPDX-FileCopyrightText: 2026 SecPal\n' > "$target_file"
+  printf '# SPDX-FileCopyrightText: 2026 SecPal Contributors\n' > "$target_file"
   printf '# %s %s\n' "$spdx_identifier_prefix" "$expression" >> "$target_file"
 }
 
@@ -244,7 +244,7 @@ version = 1
 [[annotations]]
 EOF
   printf 'path = "%s"\n' "$path_value" >> "$target_file"
-  printf 'SPDX-FileCopyrightText = "2026 SecPal"\n' >> "$target_file"
+  printf 'SPDX-FileCopyrightText = "2026 SecPal Contributors"\n' >> "$target_file"
   printf '%s = "%s"\n' "$spdx_identifier_key" "$expression" >> "$target_file"
 }
 
@@ -321,7 +321,7 @@ EOF
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: docs/dep5-only.md
-Copyright: 2026 SecPal
+Copyright: 2026 SecPal Contributors
 License: LicenseRef-SecPal-Attribution
 EOF
 


### PR DESCRIPTION
## Why

Reproduced defect: `SecPal/.github#510` identified that the shared `.github` repository was still missing a single central policy for SecPal licensing, CLA recipient definitions, SPDX/REUSE guidance, and AGPL attribution terms, even though the reusable license-compatibility workflows already enforced `LicenseRef-SecPal-Attribution` usage. Contributor-facing documents also diverged on whether project-owned material should use `SecPal` or `SecPal Contributors`, and the CLA did not define `SecPal` and the `Project Maintainer` clearly enough for contributor license grants and future successor assignment.

## TDD / Validate-First Evidence

- Failing proof before implementation: `SecPal/.github#510` documented the missing central licensing, CLA, SPDX, and attribution policy across `api`, `frontend`, and `android`.
- Passing proof after implementation: `./scripts/preflight.sh`
- Validate-first exception reference: not applicable
- No executable change reason: documentation and license-policy-only change; no executable behavior changed.

## What Changed

- added `docs/licensing-policy.md` as the central SecPal policy for CLA definitions, `SecPal Contributors` SPDX usage, `LicenseRef-SecPal-Attribution`, third-party notice separation, Tailwind-specific scoping, and attribution wording
- added `LICENSES/LicenseRef-SecPal-Attribution.txt` with the approved SecPal attribution addendum text already enforced by the shared compatibility workflows
- aligned `CLA.md`, `CONTRIBUTING.md`, `README.md`, `docs/brand/licensing-wording.md`, and `CHANGELOG.md` with the central policy
- fixed the local and reusable license-compatibility workflows so `LicenseRef-SecPal-Attribution` validation searches real `SPDX-License-Identifier` headers
- cross-referenced the repository-specific rollout issues: `SecPal/api#1226`, `SecPal/frontend#1323`, and `SecPal/android#313`

## Validation

- `./scripts/preflight.sh`
- `bash tests/license-compatibility.sh`
- `PR_BODY="$(cat .context/pr-519-body.md)" bash scripts/validate-pull-request-evidence.sh`

## Follow-Up Before Ready

- final self-review in the PR view still needs to confirm zero findings before marking this draft ready
- GitHub CI for this branch still needs to complete in the PR view
- linked workspaces: none
- cross-repository implementation remains tracked in `SecPal/api#1226`, `SecPal/frontend#1323`, and `SecPal/android#313`

Closes #510.
