### PR TITLE
Harden Polyscope preview rollout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,6 +175,8 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
       timeout-minutes: 15
   ```
 
+  Reusable-workflow caller jobs that use `jobs.<job_id>.uses` cannot set `timeout-minutes` on the caller job because GitHub rejects that key alongside `uses:`. Put timeout coverage on the called reusable workflow's jobs instead.
+
 - Set **explicit permissions** on every workflow (principle of least privilege). Start with the minimal baseline and add scopes only when a specific job requires them:
 
   ```yaml

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -20,6 +20,8 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
       timeout-minutes: 15
   ```
 
+  Reusable-workflow caller jobs that use `jobs.<job_id>.uses` cannot set `timeout-minutes` on the caller job because GitHub rejects that key alongside `uses:`. Put timeout coverage on the called reusable workflow's jobs instead.
+
 - Set **explicit permissions** on every workflow (principle of least privilege). Start with the minimal baseline and add scopes only when a specific job requires them:
 
   ```yaml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
     # skip auto-merge enrollment. See:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
-
+---
 # Dependabot Auto-Merge Workflow (.github repository)
 # This is a caller workflow that uses the reusable workflow
 #
@@ -35,5 +35,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
-      phase: "1" # Phase 1: Only PATCH updates auto-merge
-      merge-method: "squash" # Use squash merge for cleaner history
+      # Phase 1: Only PATCH updates auto-merge
+      phase: "1"
+      # Use squash merge for cleaner history
+      merge-method: "squash"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
----
 # Dependabot Auto-Merge Workflow (.github repository)
 # This is a caller workflow that uses the reusable workflow
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,8 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
       timeout-minutes: 15
   ```
 
+  Reusable-workflow caller jobs that use `jobs.<job_id>.uses` cannot set `timeout-minutes` on the caller job because GitHub rejects that key alongside `uses:`. Put timeout coverage on the called reusable workflow's jobs instead.
+
 - Set **explicit permissions** on every workflow (principle of least privilege). Start with the minimal baseline and add scopes only when a specific job requires them:
 
   ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,25 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-06 - Harden Polyscope Preview Rollout
+
+**Fixed:**
+
+- kept displayed preview URLs and linked-workspace preview hosts pinned to the original provisioned workspace slug after later workspace-path renames, while normalizing marker-derived workspace values before they are used in aliases or hostnames
+- kept source PostgreSQL passwords transient during preview database provisioning and bootstrap commands instead of persisting them into generated API worktree `.env` files
+- kept generated inline linked-workspace resolvers from creating empty SQLite files when the configured Polyscope database path is missing
+- passed PostgreSQL host, port, and username explicitly to `psql` during preview database management and covered the command shape in rollout regression tests
+- made generated API `polyscope.local.json` configs start a dedicated `php artisan schedule:work` background run action automatically, so preview API workspaces keep Laravel scheduler tasks running without manual startup
+
+---
+
 ## 2026-07-06 - Fix Dependabot Auto-Merge Caller Workflow Parsing
 
 **Fixed:**
 
 - removed the invalid `timeout-minutes` key from the `jobs.auto-merge` reusable-workflow caller in `.github/workflows/dependabot-auto-merge.yml`, so GitHub no longer rejects the workflow at parse time before any Dependabot auto-merge job can start
 - added a regression check in `tests/dependabot-auto-merge.sh` to keep reusable-workflow caller jobs from reintroducing job-level keys that GitHub disallows alongside `uses:`
+- documented the reusable-workflow caller timeout exception in both the root and focused workflow instructions while keeping timeout coverage required inside called reusable workflows
 
 ---
 
@@ -34,7 +47,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - kept the preview rewrite step on top of the generated template so each workspace now receives its own preview-facing `APP_URL`, linked `FRONTEND_URL`, and per-workspace PostgreSQL settings without manual correction after creation
 - routed generated API setup through the rollout bootstrap command so new preview worktrees can borrow source PostgreSQL credentials transiently for database provisioning, migrations, and seeding without persisting those credentials into the generated worktree
 - routed the destructive `Preview Only: Refresh DB + E2E User` Polyscope action through the same rollout bootstrap path so PostgreSQL-backed preview refreshes keep borrowing source-only DB credentials transiently instead of failing once the worktree `.env` leaves `DB_PASSWORD` blank
-- kept schema-mode preview `DB_URL` values free of embedded PostgreSQL passwords across repeated `--prepare-api-worktree` reruns while still persisting the separate `DB_PASSWORD` field for bootstrap commands that need it
+- kept schema-mode preview `DB_URL` values free of embedded PostgreSQL passwords across repeated `--prepare-api-worktree` reruns while continuing to borrow source PostgreSQL passwords only transiently for bootstrap commands that need them
 - aligned Polyscope rollout regression coverage and preview URL template assertions with the current `{{worktree}}` placeholder used for path-derived preview hostnames
 - removed an impossible rollout assertion for a nonexistent `--api-worktree-migration-command` flag so the API preview config regression test matches the generated refresh command it actually validates
 
@@ -1864,5 +1877,3 @@ This is the foundational release establishing:
 - [Issue #37](https://github.com/SecPal/.github/issues/37): Dependabot check frequency (daily vs weekly)
 - [Issue #38](https://github.com/SecPal/.github/issues/38): AGPL-3.0-or-later license strategy review
 - [Issue #39](https://github.com/SecPal/.github/issues/39): TDD mandatory policy vs exploration exceptions
-- made generated API `polyscope.local.json` configs start a dedicated `php artisan schedule:work` background run action automatically, so preview API workspaces keep Laravel scheduler tasks running without manual startup
-- fixed Polyscope preview workspace resolution so displayed preview URLs and callable linked-workspace preview hosts stay pinned to the original provisioned workspace slug even after later workspace-path renames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - kept the preview rewrite step on top of the generated template so each workspace now receives its own preview-facing `APP_URL`, linked `FRONTEND_URL`, and per-workspace PostgreSQL settings without manual correction after creation
 - routed generated API setup through the rollout bootstrap command so new preview worktrees can borrow source PostgreSQL credentials transiently for database provisioning, migrations, and seeding without persisting those credentials into the generated worktree
 - routed the destructive `Preview Only: Refresh DB + E2E User` Polyscope action through the same rollout bootstrap path so PostgreSQL-backed preview refreshes keep borrowing source-only DB credentials transiently instead of failing once the worktree `.env` leaves `DB_PASSWORD` blank
+- kept schema-mode preview `DB_URL` values free of embedded PostgreSQL passwords across repeated `--prepare-api-worktree` reruns while still persisting the separate `DB_PASSWORD` field for bootstrap commands that need it
 - aligned Polyscope rollout regression coverage and preview URL template assertions with the current `{{worktree}}` placeholder used for path-derived preview hostnames
 - removed an impossible rollout assertion for a nonexistent `--api-worktree-migration-command` flag so the API preview config regression test matches the generated refresh command it actually validates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-06 - Fix Dependabot Auto-Merge Caller Workflow Parsing
+
+**Fixed:**
+
+- removed the invalid `timeout-minutes` key from the `jobs.auto-merge` reusable-workflow caller in `.github/workflows/dependabot-auto-merge.yml`, so GitHub no longer rejects the workflow at parse time before any Dependabot auto-merge job can start
+- added a regression check in `tests/dependabot-auto-merge.sh` to keep reusable-workflow caller jobs from reintroducing job-level keys that GitHub disallows alongside `uses:`
+
+---
+
 ## 2026-07-05 - Fix Polyscope Preview Workspace Bootstrap
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1854,3 +1854,5 @@ This is the foundational release establishing:
 - [Issue #37](https://github.com/SecPal/.github/issues/37): Dependabot check frequency (daily vs weekly)
 - [Issue #38](https://github.com/SecPal/.github/issues/38): AGPL-3.0-or-later license strategy review
 - [Issue #39](https://github.com/SecPal/.github/issues/39): TDD mandatory policy vs exploration exceptions
+- made generated API `polyscope.local.json` configs start a dedicated `php artisan schedule:work` background run action automatically, so preview API workspaces keep Laravel scheduler tasks running without manual startup
+- fixed Polyscope preview workspace resolution so displayed preview URLs and callable linked-workspace preview hosts stay pinned to the original provisioned workspace slug even after later workspace-path renames

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -142,6 +142,30 @@ def resolve_workspace_name_fallback(worktree_path: pathlib.Path) -> str:
     return resolve_workspace_name_from_path(worktree_path)
 
 
+def resolve_workspace_name_from_marker(worktree_path: pathlib.Path) -> str | None:
+    marker = load_provision_marker(worktree_path / PROVISION_MARKER_FILENAME)
+    if marker is None:
+        return None
+
+    workspace = marker.get("workspace")
+    if not isinstance(workspace, str):
+        return None
+
+    workspace = workspace.strip()
+    if not workspace:
+        return None
+
+    return workspace
+
+
+def resolve_stable_workspace_name(worktree_path: pathlib.Path) -> str:
+    marker_workspace = resolve_workspace_name_from_marker(worktree_path)
+    if marker_workspace is not None:
+        return marker_workspace
+
+    return resolve_workspace_name_from_path(worktree_path)
+
+
 def find_current_worktree_record(
     connection: sqlite3.Connection,
     worktree_path: pathlib.Path,
@@ -171,6 +195,21 @@ def find_current_worktree_record(
 
 
 def resolve_current_workspace_name(worktree_path: pathlib.Path, *, db_path: pathlib.Path | None = None) -> str:
+    marker_workspace = resolve_workspace_name_from_marker(worktree_path)
+    if marker_workspace is not None:
+        return marker_workspace
+
+    resolved_db_path = db_path or default_polyscope_db_path()
+    if resolved_db_path.exists():
+        try:
+            with sqlite3.connect(resolved_db_path) as connection:
+                current_worktree = find_current_worktree_record(connection, worktree_path)
+        except sqlite3.Error:
+            current_worktree = None
+
+        if current_worktree is not None and isinstance(current_worktree[1], str) and current_worktree[1].strip():
+            return resolve_stable_workspace_name(pathlib.Path(current_worktree[1]))
+
     return resolve_workspace_name_fallback(worktree_path)
 
 
@@ -210,7 +249,7 @@ def resolve_linked_workspace_name(
     if row is None:
         return None
 
-    return resolve_workspace_name_from_path(pathlib.Path(row[0]))
+    return resolve_stable_workspace_name(pathlib.Path(row[0]))
 
 
 def collect_linked_setup_context(
@@ -246,7 +285,7 @@ def collect_linked_setup_context(
 
     context: dict[str, str] = {}
     for repo_name, linked_path in rows:
-        workspace_name = resolve_workspace_name_from_path(pathlib.Path(linked_path))
+        workspace_name = resolve_stable_workspace_name(pathlib.Path(linked_path))
         context.setdefault(repo_name, workspace_name)
 
     return context
@@ -257,6 +296,7 @@ def build_linked_workspace_resolver_source() -> str:
         """
         from pathlib import Path
         import hashlib
+        import json
         import os
         import re
         import sqlite3
@@ -354,7 +394,52 @@ def build_linked_workspace_resolver_source() -> str:
         def resolve_workspace_fallback(fallback):
             return resolve_workspace_name_from_path(Path(fallback))
 
+        def load_provision_marker(marker_path):
+            if not marker_path.exists():
+                return None
+            try:
+                marker = json.loads(marker_path.read_text())
+            except json.JSONDecodeError:
+                return None
+            if not isinstance(marker, dict):
+                return None
+            return marker
+
+        def resolve_workspace_name_from_marker(worktree_path):
+            marker = load_provision_marker(worktree_path / ".polyscope-secpal-provisioned.json")
+            if marker is None:
+                return None
+            workspace = marker.get("workspace")
+            if not isinstance(workspace, str):
+                return None
+            workspace = workspace.strip()
+            if not workspace:
+                return None
+            return workspace
+
+        def resolve_stable_workspace_name(worktree_path):
+            marker_workspace = resolve_workspace_name_from_marker(worktree_path)
+            if marker_workspace is not None:
+                return marker_workspace
+            return resolve_workspace_name_from_path(worktree_path)
+
         def resolve_current_workspace(fallback):
+            marker_workspace = resolve_workspace_name_from_marker(Path(fallback))
+            if marker_workspace is not None:
+                return marker_workspace
+            db_path = os.environ.get(
+                "POLYSCOPE_DB_PATH",
+                str(Path.home() / ".polyscope" / "polyscope.db"),
+            )
+            try:
+                with sqlite3.connect(db_path) as connection:
+                    current_worktree = find_current_worktree(connection)
+            except sqlite3.Error:
+                current_worktree = None
+
+            if current_worktree is not None and isinstance(current_worktree[1], str) and current_worktree[1].strip():
+                return resolve_stable_workspace_name(Path(current_worktree[1]))
+
             return resolve_workspace_fallback(fallback)
 
         def resolve_linked_workspace(linked_repo_name, fallback):
@@ -387,7 +472,7 @@ def build_linked_workspace_resolver_source() -> str:
             if row is None:
                 return fallback
 
-            return resolve_workspace_name_from_path(Path(row[0]))
+            return resolve_stable_workspace_name(Path(row[0]))
         """
     ).strip()
 
@@ -556,9 +641,21 @@ def build_postgres_command_env(env_values: dict[str, str]) -> dict[str, str]:
 
 
 def run_postgres_command(env_values: dict[str, str], database_name: str, sql: str) -> str:
+    command = ["psql", "-v", "ON_ERROR_STOP=1"]
+    host = env_values.get("DB_HOST", "").strip()
+    port = env_values.get("DB_PORT", "").strip()
+    username = env_values.get("DB_USERNAME", "").strip()
+    if host:
+        command.extend(["-h", host])
+    if port:
+        command.extend(["-p", port])
+    if username:
+        command.extend(["-U", username])
+    command.extend(["-d", database_name, "-Atqc", sql])
+
     try:
         result = subprocess.run(
-            ["psql", "-v", "ON_ERROR_STOP=1", "-d", database_name, "-Atqc", sql],
+            command,
             check=True,
             capture_output=True,
             text=True,
@@ -819,6 +916,12 @@ def ensure_api_worktree_ready(
         frontend_workspace,
         worktree_path=worktree_path,
     )
+    if (
+        env_values.get("DB_CONNECTION", "").strip().lower() == "pgsql"
+        and not env_values.get("DB_PASSWORD", "").strip()
+        and runtime_env_values.get("DB_PASSWORD", "").strip()
+    ):
+        updated_values["DB_PASSWORD"] = runtime_env_values["DB_PASSWORD"]
     if not env_values.get("APP_KEY", "").strip():
         updated_values["APP_KEY"] = generate_laravel_app_key()
 
@@ -1912,6 +2015,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 ],
                 "run": [
                     {"label": "Queue Worker", "command": "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600", "runMode": "replace"},
+                    {"label": "Scheduler", "command": "php artisan schedule:work", "autostart": True, "runMode": "replace"},
                     {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
                     # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.
                     # It intentionally reseeds the canonical E2E login `test@example.com` / `password` and must never target production.

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -155,7 +155,7 @@ def resolve_workspace_name_from_marker(worktree_path: pathlib.Path) -> str | Non
     if not workspace:
         return None
 
-    return workspace
+    return normalize_workspace_name(workspace)
 
 
 def resolve_stable_workspace_name(worktree_path: pathlib.Path) -> str:
@@ -399,7 +399,7 @@ def build_linked_workspace_resolver_source() -> str:
                 return None
             try:
                 marker = json.loads(marker_path.read_text())
-            except json.JSONDecodeError:
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
                 return None
             if not isinstance(marker, dict):
                 return None
@@ -415,7 +415,7 @@ def build_linked_workspace_resolver_source() -> str:
             workspace = workspace.strip()
             if not workspace:
                 return None
-            return workspace
+            return normalize_workspace_name(workspace)
 
         def resolve_stable_workspace_name(worktree_path):
             marker_workspace = resolve_workspace_name_from_marker(worktree_path)
@@ -431,6 +431,8 @@ def build_linked_workspace_resolver_source() -> str:
                 "POLYSCOPE_DB_PATH",
                 str(Path.home() / ".polyscope" / "polyscope.db"),
             )
+            if not Path(db_path).exists():
+                return resolve_workspace_fallback(fallback)
             try:
                 with sqlite3.connect(db_path) as connection:
                     current_worktree = find_current_worktree(connection)
@@ -916,12 +918,6 @@ def ensure_api_worktree_ready(
         frontend_workspace,
         worktree_path=worktree_path,
     )
-    if (
-        env_values.get("DB_CONNECTION", "").strip().lower() == "pgsql"
-        and not env_values.get("DB_PASSWORD", "").strip()
-        and runtime_env_values.get("DB_PASSWORD", "").strip()
-    ):
-        updated_values["DB_PASSWORD"] = runtime_env_values["DB_PASSWORD"]
     if not env_values.get("APP_KEY", "").strip():
         updated_values["APP_KEY"] = generate_laravel_app_key()
 
@@ -3048,7 +3044,7 @@ def load_provision_marker(marker_path: pathlib.Path) -> dict[str, Any] | None:
 
     try:
         marker = json.loads(marker_path.read_text())
-    except json.JSONDecodeError:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
     if not isinstance(marker, dict):

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -938,8 +938,14 @@ def ensure_api_worktree_ready(
             updated_values[PREVIEW_SCHEMA_ENV_KEY] = ""
         else:
             ensure_postgres_preview_schema(runtime_env_values, base_database, preview_target)
+            schema_url_env_values = runtime_env_values.copy()
+            schema_url_env_values["DB_PASSWORD"] = ""
             updated_values["DB_DATABASE"] = base_database
-            updated_values["DB_URL"] = build_postgres_url(env_values, base_database, preview_target)
+            updated_values["DB_URL"] = build_postgres_url(
+                schema_url_env_values,
+                base_database,
+                preview_target,
+            )
             updated_values[PREVIEW_STORAGE_MODE_ENV_KEY] = "schema"
             updated_values[PREVIEW_SCHEMA_ENV_KEY] = preview_target
         updated_values[PREVIEW_DATABASE_BASE_ENV_KEY] = base_database

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -24,6 +24,33 @@ for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   fi
 done
 
+for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
+  marker_count="$(grep -c '^---$' "$workflow")"
+  if [ "$marker_count" -ne 1 ]; then
+    echo "Dependabot workflows must contain exactly one YAML document marker: $workflow" >&2
+    exit 1
+  fi
+done
+
+grep -q '^---$' "$CALLER_WORKFLOW" || {
+  echo "Dependabot caller workflow must include a YAML document marker." >&2
+  exit 1
+}
+
+grep -q '^name: Dependabot Auto-Merge$' "$CALLER_WORKFLOW" || {
+  echo "Dependabot caller workflow must declare its workflow name." >&2
+  exit 1
+}
+
+if ! awk '
+  /^---$/ { marker = NR; next }
+  /^name: Dependabot Auto-Merge$/ { name = NR }
+  END { exit !(marker > 0 && name == marker + 1) }
+' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow YAML document marker must appear immediately before name:." >&2
+  exit 1
+fi
+
 if [ ! -f "$WORKFLOW_INSTRUCTIONS" ]; then
   echo "Expected workflow instructions were not found: $WORKFLOW_INSTRUCTIONS" >&2
   exit 1

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -64,6 +64,13 @@ grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-
   exit 1
 }
 
+# Reusable-workflow caller jobs cannot declare timeout-minutes alongside uses:.
+# GitHub rejects that combination at workflow-parse time before any job starts.
+if grep -q '^    timeout-minutes:' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must not set timeout-minutes on a reusable-workflow uses job." >&2
+  exit 1
+fi
+
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
 # gate on the PR author so the same maintainer-triggered events are not
 # skipped when other repositories invoke this reusable workflow directly.

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -15,6 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
+WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instructions.md"
 
 for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   if [ ! -f "$workflow" ]; then
@@ -22,6 +23,11 @@ for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
     exit 1
   fi
 done
+
+if [ ! -f "$WORKFLOW_INSTRUCTIONS" ]; then
+  echo "Expected workflow instructions were not found: $WORKFLOW_INSTRUCTIONS" >&2
+  exit 1
+fi
 
 grep -q '^permissions:$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must declare explicit permissions." >&2
@@ -70,6 +76,11 @@ if grep -q '^    timeout-minutes:' "$CALLER_WORKFLOW"; then
   echo "Dependabot caller workflow must not set timeout-minutes on a reusable-workflow uses job." >&2
   exit 1
 fi
+
+grep -q 'Reusable-workflow caller jobs that use `jobs\.<job_id>\.uses` cannot set `timeout-minutes` on the caller job' "$WORKFLOW_INSTRUCTIONS" || {
+  echo "Workflow instructions must document the reusable-workflow caller timeout-minutes exception." >&2
+  exit 1
+}
 
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
 # gate on the PR author so the same maintainer-triggered events are not

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1398,6 +1398,46 @@ current_workspace_result = subprocess.run(
 assert current_workspace_result.stdout.strip() == "azure-cheetah-11111111", current_workspace_result.stdout
 PY
 
+# Generated inline resolvers must not create a new SQLite file when the
+# Polyscope database path is missing.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "missing-polyscope-db-fixture"
+worktree = fixture / "clones" / "fe123456" / "steady-otter"
+missing_db = fixture / "missing.db"
+worktree.mkdir(parents=True, exist_ok=True)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+env = os.environ.copy()
+env["POLYSCOPE_DB_PATH"] = str(missing_db)
+probe = (
+    "from pathlib import Path\n\n"
+    f"{module.build_linked_workspace_resolver_source()}\n\n"
+    "print(resolve_current_workspace(Path.cwd()))\n"
+)
+result = subprocess.run(
+    ["python3", "-c", probe],
+    cwd=worktree,
+    env=env,
+    capture_output=True,
+    text=True,
+    check=True,
+)
+assert result.stdout.strip() == "steady-otter", result.stdout
+assert not missing_db.exists(), missing_db
+PY
+
 # Linked-workspace resolution must stay compatible with older Polyscope DBs
 # whose `worktrees` table lacks an unused `branch` column.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
@@ -1550,6 +1590,41 @@ assert preview_updates["APP_URL"] == "https://api-bubbly-salmon.preview.secpal.d
 module.ensure_workspace_alias(renamed_worktree, db_path=db_path)
 assert original_alias.is_symlink(), original_alias
 assert original_alias.resolve() == renamed_worktree.resolve(), original_alias.resolve()
+PY
+
+# Provision markers are worktree-local state and must not be able to inject
+# path components into aliases or preview hostnames.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import json
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "unsafe-provision-marker-fixture"
+worktree = fixture / "clones" / "api12345" / "feature-branch"
+outside_alias = fixture / "clones" / "outside-alias"
+safe_alias = worktree.parent / "outside-alias"
+worktree.mkdir(parents=True, exist_ok=True)
+worktree.joinpath(".polyscope-secpal-provisioned.json").write_text(
+    json.dumps({"workspace": "../outside-alias"})
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+workspace_name = module.resolve_current_workspace_name(worktree)
+assert workspace_name == "outside-alias", workspace_name
+preview_updates = module.build_api_preview_env_updates(workspace_name)
+assert preview_updates["APP_URL"] == "https://api-outside-alias.preview.secpal.dev", preview_updates
+
+module.ensure_workspace_alias(worktree)
+assert safe_alias.is_symlink(), safe_alias
+assert safe_alias.resolve() == worktree.resolve(), safe_alias.resolve()
+assert not outside_alias.exists(), outside_alias
 PY
 
 # Linked-workspace resolution and generated callable preview URLs must keep the
@@ -1861,9 +1936,9 @@ updated = module.upsert_env_assignments(
 assert r"DB_PASSWORD=secret\path\1" in updated, updated
 PY
 
-# ensure_api_worktree_ready must use a source-only PostgreSQL password for
-# preview database provisioning and persist it into the generated worktree .env
-# so follow-up artisan and psql calls stay self-contained.
+# ensure_api_worktree_ready must use a source-only PostgreSQL password
+# transiently for preview database provisioning without persisting it into the
+# generated worktree .env.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -1919,11 +1994,12 @@ assert calls == [
     ("create", "source-only-password", "secpal", "secpal__preview__quiet_bear"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
+assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
 PY
 
-# ensure_api_worktree_ready must persist a source-only PostgreSQL password for
-# schema-mode previews without leaking it into DB_URL values.
+# ensure_api_worktree_ready must not persist a source-only PostgreSQL password
+# into schema-mode preview .env values or DB_URL values.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -1979,7 +2055,8 @@ assert calls == [
     ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
+assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 
@@ -1992,7 +2069,8 @@ assert calls == [
     ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
+assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 PY
@@ -2915,6 +2993,7 @@ cat >"$fake_exec_dir/psql" <<'STUB'
 import json
 import os
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -2933,7 +3012,7 @@ elif "-c" in args:
     sql = args[args.index("-c") + 1]
 
 with log_path.open("a") as handle:
-    handle.write(f"psql:{os.getcwd()}:{sql}\n")
+    handle.write(f"psql:{os.getcwd()}:{shlex.join(args)}:{sql}\n")
 
 databases = state.get("databases", [])
 schemas = state.get("schemas", [])
@@ -3152,6 +3231,7 @@ grep -qF "pre-commit:$api_clone:install --install-hooks --hook-type pre-commit" 
 grep -qF "pre-commit:$frontend_clone:install --install-hooks --hook-type pre-commit" "$provision_log"
 grep -qF "SELECT 1 FROM pg_database WHERE datname = 'secpal__preview__auto_hawk'" "$fake_psql_log"
 grep -qF 'CREATE DATABASE "secpal__preview__auto_hawk"' "$fake_psql_log"
+grep -qF -- '-h 127.0.0.1 -p 5432 -U secpal -d secpal -Atqc' "$fake_psql_log"
 
 if grep -qF "$broken_api_clone" "$provision_log"; then
     echo "provisioning must skip invalid api stub directories" >&2

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -708,6 +708,9 @@ grep -q 'AGENTS.md' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --bootstrap-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600' "$workspace_root/api/polyscope.local.json"
+grep -qF '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json"
+grep -qF '"command": "php artisan schedule:work"' "$workspace_root/api/polyscope.local.json"
+grep -A3 '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json" | grep -qF '"autostart": true'
 if grep -qF 'php artisan queue:listen --tries=1' "$workspace_root/api/polyscope.local.json"; then
     echo "preview API queue worker must use combined queue:work and not queue:listen" >&2
     exit 1
@@ -1489,6 +1492,150 @@ probe_result = subprocess.run(
 assert "VITE_API_URL=https://api-azure-cheetah.preview.secpal.dev" in probe_result.stdout, probe_result.stdout
 PY
 
+# Provisioned worktrees must keep their original preview slug even when the
+# physical workspace directory is renamed later.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import json
+import pathlib
+import sqlite3
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "renamed-provisioned-workspace-fixture"
+db_path = fixture / "polyscope.db"
+original_alias = fixture / "clones" / "api12345" / "bubbly-salmon"
+renamed_worktree = fixture / "clones" / "api12345" / "fix-db-password-check"
+renamed_worktree.mkdir(parents=True, exist_ok=True)
+renamed_worktree.joinpath(".polyscope-secpal-provisioned.json").write_text(
+    json.dumps(
+        {
+            "repo": "api",
+            "workspace": "bubbly-salmon",
+            "physical_workspace": "bubbly-salmon",
+            "setup_hash": "fixture",
+            "provisioned_at": "2026-07-06T00:00:00+00:00",
+        }
+    )
+)
+
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        """
+        create table worktrees (
+            id text primary key,
+            repo_id text not null,
+            branch text not null,
+            path text not null,
+            created_at text default (datetime('now')) not null
+        )
+        """
+    )
+    connection.execute(
+        "insert into worktrees (id, repo_id, branch, path) values (?, ?, ?, ?)",
+        ("api-worktree", "api12345", "fix-db-password-check", str(renamed_worktree)),
+    )
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+workspace_name = module.resolve_current_workspace_name(renamed_worktree, db_path=db_path)
+assert workspace_name == "bubbly-salmon", workspace_name
+preview_updates = module.build_api_preview_env_updates(workspace_name)
+assert preview_updates["APP_URL"] == "https://api-bubbly-salmon.preview.secpal.dev", preview_updates
+
+module.ensure_workspace_alias(renamed_worktree, db_path=db_path)
+assert original_alias.is_symlink(), original_alias
+assert original_alias.resolve() == renamed_worktree.resolve(), original_alias.resolve()
+PY
+
+# Linked-workspace resolution and generated callable preview URLs must keep the
+# original provisioned slug after a linked worktree directory rename.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import json
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "renamed-linked-workspace-fixture"
+db_path = fixture / "polyscope.db"
+frontend_worktree = fixture / "clones" / "fe123456" / "inspect-session-check"
+renamed_api_worktree = fixture / "clones" / "api12345" / "fix-db-password-check"
+frontend_worktree.mkdir(parents=True, exist_ok=True)
+renamed_api_worktree.mkdir(parents=True, exist_ok=True)
+renamed_api_worktree.joinpath(".polyscope-secpal-provisioned.json").write_text(
+    json.dumps(
+        {
+            "repo": "api",
+            "workspace": "bubbly-salmon",
+            "physical_workspace": "bubbly-salmon",
+            "setup_hash": "fixture",
+            "provisioned_at": "2026-07-06T00:00:00+00:00",
+        }
+    )
+)
+frontend_worktree.joinpath(".env.local").write_text("VITE_API_URL=https://api.secpal.dev\n")
+
+with sqlite3.connect(db_path) as connection:
+    connection.executescript(
+        """
+        create table repositories (id text primary key, name text not null, path text not null);
+        create table worktrees (id text primary key, repo_id text not null, path text not null, created_at text default (datetime('now')) not null);
+        create table worktree_links (worktree_id text not null, linked_worktree_id text not null, created_at text default (datetime('now')) not null);
+        """
+    )
+    connection.executemany(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        [
+            ("api12345", "SecPal/api", str(fixture / "source-api")),
+            ("fe123456", "SecPal/frontend", str(fixture / "source-frontend")),
+        ],
+    )
+    connection.executemany(
+        "insert into worktrees (id, repo_id, path) values (?, ?, ?)",
+        [
+            ("frontend-worktree", "fe123456", str(frontend_worktree)),
+            ("api-worktree", "api12345", str(renamed_api_worktree)),
+        ],
+    )
+    connection.execute(
+        "insert into worktree_links (worktree_id, linked_worktree_id) values (?, ?)",
+        ("frontend-worktree", "api-worktree"),
+    )
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+linked_api_workspace = module.resolve_linked_workspace_name(
+    frontend_worktree,
+    "SecPal/api",
+    db_path=db_path,
+)
+assert linked_api_workspace == "bubbly-salmon", linked_api_workspace
+
+env = os.environ.copy()
+env["POLYSCOPE_DB_PATH"] = str(db_path)
+subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_frontend_preview_env_setup_command()],
+    cwd=frontend_worktree,
+    env=env,
+    check=True,
+)
+frontend_env = frontend_worktree.joinpath(".env.local").read_text()
+assert "VITE_API_URL=https://api-bubbly-salmon.preview.secpal.dev" in frontend_env, frontend_env
+assert "fix-db-password-check" not in frontend_env, frontend_env
+PY
+
 # Legacy hash-suffixed worktree directory names must not leak into preview hostnames
 # when the Polyscope DB and git branch are unavailable.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
@@ -1714,9 +1861,9 @@ updated = module.upsert_env_assignments(
 assert r"DB_PASSWORD=secret\path\1" in updated, updated
 PY
 
-# ensure_api_worktree_ready must use a source-only PostgreSQL password
-# transiently for preview database provisioning without persisting it into the
-# generated worktree .env.
+# ensure_api_worktree_ready must use a source-only PostgreSQL password for
+# preview database provisioning and persist it into the generated worktree .env
+# so follow-up artisan and psql calls stay self-contained.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -1772,12 +1919,11 @@ assert calls == [
     ("create", "source-only-password", "secpal", "secpal__preview__quiet_bear"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
-assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
 PY
 
-# ensure_api_worktree_ready must not persist a source-only PostgreSQL password
-# into schema-mode DB_URL values when the role cannot create databases.
+# ensure_api_worktree_ready must persist a source-only PostgreSQL password for
+# schema-mode previews without leaking it into DB_URL values.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -1833,7 +1979,7 @@ assert calls == [
     ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 PY

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1982,6 +1982,19 @@ worktree_env = api_worktree.joinpath(".env").read_text()
 assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
+
+calls.clear()
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "schema:secpal:secpal__preview__careful_otter", target
+assert calls == [
+    ("role", "source-only-password", "secpal"),
+    ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
+], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+assert "source-only-password@" not in worktree_env, worktree_env
+assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 PY
 
 # refresh_api_worktree must reuse the transient runtime DB password injection


### PR DESCRIPTION
## Summary
- keep preview and linked workspace URLs pinned to the original provisioned workspace slug even after later workspace renames
- keep the PostgreSQL password transient during generated API worktree bootstrap instead of persisting it into preview URLs or generated worktree `.env` files
- auto-start `php artisan schedule:work` for API previews via the generated Polyscope run configuration

## Root cause
Polyscope rollout state still derived callable and displayed preview hostnames from mutable workspace paths in some flows, especially when linked workspaces were resolved after a rename. Separately, API worktree bootstrap could leak or omit PostgreSQL credentials in the wrong places, and preview API configs did not start the Laravel scheduler worker automatically.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` failed before implementation for the Polyscope preview rollout regressions covered by this PR.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation
- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
