### PR TITLE
Fix Dependabot auto-merge classification

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
-
+---
 # Dependabot Auto-Merge Workflow (.github repository)
 # This is a caller workflow that uses the reusable workflow
 #
@@ -33,8 +33,9 @@ jobs:
     # skip auto-merge enrollment. See:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
-      phase: "1" # Phase 1: Only PATCH updates auto-merge
-      merge-method: "squash" # Use squash merge for cleaner history
+      # Phase 1: Only PATCH updates auto-merge
+      phase: "1"
+      # Use squash merge for cleaner history
+      merge-method: "squash"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,7 +7,6 @@
 # For implementation details, see:
 # .github/workflows/reusable-dependabot-auto-merge.yml
 
----
 name: Dependabot Auto-Merge
 
 on:

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+        continue-on-error: true
         with:
           github-token: "${{ github.token }}"
-          skip-verification: true
 
       - name: Check PR metadata
         id: check
@@ -66,6 +66,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PHASE: ${{ inputs.phase }}
+          METADATA_STEP_OUTCOME: ${{ steps.metadata.outcome }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
           DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
           MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
@@ -121,6 +122,7 @@ jobs:
 
           echo "PR Labels: ${PR_LABELS}"
           echo "Auto-merge Phase: ${PHASE}"
+          echo "Metadata step outcome: ${METADATA_STEP_OUTCOME}"
           echo "Dependency names: ${DEPENDENCY_NAMES}"
           echo "Dependency group: ${DEPENDENCY_GROUP}"
           echo "Maintainer changes: ${MAINTAINER_CHANGES}"
@@ -135,6 +137,13 @@ jobs:
             echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
             echo "update-type=not-dependabot" >> "${GITHUB_OUTPUT}"
             echo "❌ Not eligible: Missing dependencies label"
+            exit 0
+          fi
+
+          if [[ "${METADATA_STEP_OUTCOME}" != "success" ]]; then
+            echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
+            echo "update-type=metadata-unavailable" >> "${GITHUB_OUTPUT}"
+            echo "❌ Not eligible: Dependabot metadata verification failed; route to manual review"
             exit 0
           fi
 

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -156,7 +156,7 @@ jobs:
                 echo "❌ Not eligible: GitHub Actions reference update does not expose a semver update-type"
               # Fallback to PR title parsing only when fetch-metadata returns empty outputs
               # for non-GitHub-Actions ecosystems.
-              elif fallback_from_pr_title; then
+              elif [[ "${PACKAGE_ECOSYSTEM}" != "github-actions" ]] && fallback_from_pr_title; then
                 :
               else
                 echo "update-type=metadata-unavailable" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
-
+---
 # Reusable Dependabot Auto-Merge Workflow
 # Automatically merges Dependabot PRs based on configurable phase/policy
 #
@@ -9,12 +9,12 @@
 #     auto-merge:
 #       uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
 #       with:
-#         phase: "1"  # Optional: 1 (PATCH only), 2 (PATCH+MINOR), 3 (all)
+#         phase: "1"  # Optional: 1 (PATCH only), 2 or 3 (PATCH+MINOR)
 #
 # Strategy:
 #   Phase 1 (default): PATCH updates auto-merge ✅, MINOR/MAJOR require review
 #   Phase 2: PATCH + MINOR auto-merge ✅, MAJOR requires review
-#   Phase 3: All updates auto-merge ✅ (use with caution!)
+#   Phase 3: PATCH + MINOR auto-merge ✅, MAJOR requires review
 #
 # Rollback strategy: Git revert the auto-merged commit if issues occur
 
@@ -24,7 +24,7 @@ on:
   workflow_call:
     inputs:
       phase:
-        description: "Auto-merge phase: 1 (PATCH only), 2 (PATCH+MINOR), 3 (all)"
+        description: "Auto-merge phase: 1 (PATCH only), 2 or 3 (PATCH+MINOR)"
         required: false
         default: "1"
         type: string
@@ -89,13 +89,8 @@ jobs:
           case "${UPDATE_TYPE_RAW}" in
             version-update:semver-major)
               echo "update-type=major" >> "${GITHUB_OUTPUT}"
-              if [[ "${PHASE}" == "3" ]]; then
-                echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-                echo "✅ Eligible for auto-merge (Phase 3): MAJOR semver update"
-              else
-                echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-                echo "❌ Not eligible: MAJOR semver update requires manual review (Phase ${PHASE})"
-              fi
+              echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
+              echo "❌ Not eligible: MAJOR semver update requires manual review (Phase ${PHASE})"
               ;;
             version-update:semver-minor)
               echo "update-type=minor" >> "${GITHUB_OUTPUT}"
@@ -114,7 +109,8 @@ jobs:
               ;;
             "")
               echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-              if [[ "${PACKAGE_ECOSYSTEM}" == "github-actions" && -n "${PREVIOUS_VERSION}" && -n "${NEW_VERSION}" ]]; then
+              if [[ "${PACKAGE_ECOSYSTEM}" == "github-actions" ]] &&
+                [[ -n "${PREVIOUS_VERSION}" && -n "${NEW_VERSION}" ]]; then
                 echo "update-type=github-actions-non-semver" >> "${GITHUB_OUTPUT}"
                 echo "❌ Not eligible: GitHub Actions reference update does not expose a semver update-type"
               else
@@ -149,7 +145,10 @@ jobs:
           running-workflow-name: "auto-merge / Enable Auto-Merge"
           allowed-conclusions: success,skipped,neutral
           # Also ignore by explicit check name as backup
-          ignore-checks: "Dependabot Auto-Merge,auto-merge / Enable Auto-Merge,auto-merge / Check Auto-Merge Eligibility"
+          ignore-checks: >-
+            Dependabot Auto-Merge,
+            auto-merge / Enable Auto-Merge,
+            auto-merge / Check Auto-Merge Eligibility
         continue-on-error: true
 
       - name: Log wait result
@@ -205,11 +204,17 @@ jobs:
 
             let policyText = '';
             if (phase === '1') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- 🔍 MINOR updates: Manual review\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '2') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- ✅ MINOR updates: Auto-merge\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '3') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- ✅ MINOR updates: Auto-merge\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             }
 
             github.rest.issues.createComment({
@@ -232,7 +237,9 @@ jobs:
     name: Skip Auto-Merge
     runs-on: ubuntu-latest
     needs: check-eligibility
-    if: needs.check-eligibility.outputs.should-auto-merge != 'true' && github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      needs.check-eligibility.outputs.should-auto-merge != 'true' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
     timeout-minutes: 10
     steps:
       - name: Add comment for manual review
@@ -255,7 +262,7 @@ jobs:
                        '3. Verify all tests pass\n' +
                        '4. Merge manually after verification';
               if (phase === '3') {
-                reason += '\n\n⚠️ **Note:** Your policy is set to Phase 3 but this PR was not auto-merged. Check the logs for details.';
+                reason += '\n\n**Note:** Major updates require manual review in every phase.';
               }
             } else if (updateType === 'minor') {
               emoji = '🔍';
@@ -269,13 +276,15 @@ jobs:
               if (phase === '1') {
                 reason += '\n\n**Note:** In Phase 2, MINOR updates will be auto-merged.';
               } else if (phase === '2' || phase === '3') {
-                reason += '\n\n⚠️ **Note:** Your policy is set to Phase ' + phase + ' but this PR was not auto-merged. Check the logs for details.';
+                reason += '\n\n⚠️ **Note:** Your policy is set to Phase ' + phase +
+                          ' but this PR was not auto-merged. Check the logs for details.';
               }
             } else if (updateType === 'github-actions-non-semver') {
               emoji = '🔒';
               title = 'GitHub Actions reference update requires manual review';
               reason = 'This Dependabot PR updates a GitHub Actions workflow reference pinned to a commit SHA.\n\n' +
-                       'Dependabot does not expose a semver `update-type` for this update shape, so the auto-merge policy treats it as manual review only.\n\n' +
+                       'Dependabot does not expose a semver `update-type` for this update shape, ' +
+                       'so the auto-merge policy treats it as manual review only.\n\n' +
                        '**Action required:**\n' +
                        '1. Review the upstream workflow or action diff\n' +
                        '2. Verify the pinned commit is expected\n' +
@@ -297,11 +306,17 @@ jobs:
 
             let policyText = '';
             if (phase === '1') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- 🔍 MINOR updates: Manual review\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '2') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- ✅ MINOR updates: Auto-merge\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '3') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
+              policyText = '- ✅ PATCH updates: Auto-merge\n' +
+                           '- ✅ MINOR updates: Auto-merge\n' +
+                           '- ⚠️ MAJOR updates: Manual review';
             }
 
             github.rest.issues.createComment({

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -7,7 +7,7 @@
 # Usage in other repositories:
 #   jobs:
 #     auto-merge:
-#       uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
+#       uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
 #       with:
 #         phase: "1"  # Optional: 1 (PATCH only), 2 or 3 (PATCH+MINOR)
 #

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Check PR metadata
         id: check
         env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PHASE: ${{ inputs.phase }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
@@ -70,6 +71,46 @@ jobs:
           PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
           NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
         run: |
+          fallback_from_pr_title() {
+            local version_range_pattern old_major old_minor old_patch new_major new_minor new_patch
+
+            version_range_pattern='from[[:space:]]+([0-9]+)(\.([0-9]+))?'
+            version_range_pattern+='(\.([0-9]+))?[[:space:]]+to[[:space:]]+'
+            version_range_pattern+='([0-9]+)(\.([0-9]+))?(\.([0-9]+))?'
+
+            if [[ ! "${PR_TITLE}" =~ ${version_range_pattern} ]]; then
+              return 1
+            fi
+
+            old_major="${BASH_REMATCH[1]}"
+            old_minor="${BASH_REMATCH[3]:-0}"
+            old_patch="${BASH_REMATCH[5]:-0}"
+            new_major="${BASH_REMATCH[6]}"
+            new_minor="${BASH_REMATCH[8]:-0}"
+            new_patch="${BASH_REMATCH[10]:-0}"
+
+            if [[ "${new_major}" != "${old_major}" ]]; then
+              echo "update-type=major" >> "${GITHUB_OUTPUT}"
+              echo "❌ Not eligible: MAJOR semver update requires manual review (Phase ${PHASE})"
+            elif [[ "${new_minor}" != "${old_minor}" ]]; then
+              echo "update-type=minor" >> "${GITHUB_OUTPUT}"
+              if [[ "${PHASE}" == "2" || "${PHASE}" == "3" ]]; then
+                echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
+                echo "✅ Eligible for auto-merge (Phase ${PHASE}): MINOR semver update via title fallback"
+              else
+                echo "❌ Not eligible: MINOR semver update requires manual review (Phase ${PHASE})"
+              fi
+            elif [[ "${new_patch}" != "${old_patch}" ]]; then
+              echo "update-type=patch" >> "${GITHUB_OUTPUT}"
+              echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
+              echo "✅ Eligible for auto-merge (Phase ${PHASE}): PATCH semver update via title fallback"
+            else
+              return 1
+            fi
+
+            return 0
+          }
+
           echo "PR Labels: ${PR_LABELS}"
           echo "Auto-merge Phase: ${PHASE}"
           echo "Dependency names: ${DEPENDENCY_NAMES}"
@@ -113,6 +154,10 @@ jobs:
                 [[ -n "${PREVIOUS_VERSION}" && -n "${NEW_VERSION}" ]]; then
                 echo "update-type=github-actions-non-semver" >> "${GITHUB_OUTPUT}"
                 echo "❌ Not eligible: GitHub Actions reference update does not expose a semver update-type"
+              # Fallback to PR title parsing only when fetch-metadata returns empty outputs
+              # for non-GitHub-Actions ecosystems.
+              elif fallback_from_pr_title; then
+                :
               else
                 echo "update-type=metadata-unavailable" >> "${GITHUB_OUTPUT}"
                 echo "❌ Not eligible: Dependabot metadata did not include an update type"

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -53,16 +53,30 @@ jobs:
       should-auto-merge: ${{ steps.check.outputs.should-auto-merge }}
       update-type: ${{ steps.check.outputs.update-type }}
     steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ github.token }}"
+
       - name: Check PR metadata
         id: check
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PHASE: ${{ inputs.phase }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          UPDATE_TYPE_RAW: ${{ steps.metadata.outputs.update-type }}
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
         run: |
-          echo "PR Title: ${PR_TITLE}"
           echo "PR Labels: ${PR_LABELS}"
           echo "Auto-merge Phase: ${PHASE}"
+          echo "Dependency names: ${DEPENDENCY_NAMES}"
+          echo "Package ecosystem: ${PACKAGE_ECOSYSTEM}"
+          echo "Dependabot update-type: ${UPDATE_TYPE_RAW}"
+          echo "Previous version: ${PREVIOUS_VERSION}"
+          echo "New version: ${NEW_VERSION}"
 
           # Check if PR has 'dependencies' label (required for Dependabot PRs)
           if ! echo "${PR_LABELS}" | grep -q "dependencies"; then
@@ -72,72 +86,48 @@ jobs:
             exit 0
           fi
 
-          # Extract version numbers from Dependabot PR title
-          # Common formats:
-          #   "Bump package from 1.2.3 to 1.2.4"
-          #   "Update dependency from 1.2.3 to 1.2.4"
-          #   "chore(deps): bump package from 1.2.3 to 1.2.4"
-          #   "Bump action from 5 to 6" (GitHub Actions often use single-digit versions)
-          #
-          # Note: Pre-release versions (1.2.3-beta) and build metadata (1.2.3+build)
-          # are NOT supported. Such PRs will fall back to 'unparseable' status and
-          # require manual review, which is the safer approach for non-stable versions.
-
-          # Extract "from X[.Y[.Z]] to A[.B[.C]]" pattern (flexible version format)
-          if [[ "${PR_TITLE}" =~ from[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?[[:space:]]+to[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))? ]]; then
-            OLD_MAJOR="${BASH_REMATCH[1]}"
-            OLD_MINOR="${BASH_REMATCH[3]:-0}"  # Default to 0 if not present
-            OLD_PATCH="${BASH_REMATCH[5]:-0}"  # Default to 0 if not present
-            NEW_MAJOR="${BASH_REMATCH[6]}"
-            NEW_MINOR="${BASH_REMATCH[8]:-0}"  # Default to 0 if not present
-            NEW_PATCH="${BASH_REMATCH[10]:-0}" # Default to 0 if not present
-
-            echo "Old version: ${OLD_MAJOR}.${OLD_MINOR}.${OLD_PATCH}"
-            echo "New version: ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
-
-            # Determine update type based on semver rules
-            if [[ "${NEW_MAJOR}" != "${OLD_MAJOR}" ]]; then
+          case "${UPDATE_TYPE_RAW}" in
+            version-update:semver-major)
               echo "update-type=major" >> "${GITHUB_OUTPUT}"
-
-              # Phase 3: Auto-merge all (including MAJOR)
               if [[ "${PHASE}" == "3" ]]; then
                 echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-                echo "✅ Eligible for auto-merge (Phase 3): MAJOR update (${OLD_MAJOR}.x.x → ${NEW_MAJOR}.x.x)"
+                echo "✅ Eligible for auto-merge (Phase 3): MAJOR semver update"
               else
                 echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-                echo "❌ Not eligible: MAJOR update (${OLD_MAJOR}.x.x → ${NEW_MAJOR}.x.x) requires manual review (Phase ${PHASE})"
+                echo "❌ Not eligible: MAJOR semver update requires manual review (Phase ${PHASE})"
               fi
-
-            elif [[ "${NEW_MINOR}" != "${OLD_MINOR}" ]]; then
+              ;;
+            version-update:semver-minor)
               echo "update-type=minor" >> "${GITHUB_OUTPUT}"
-
-              # Phase 2+: Auto-merge MINOR updates
               if [[ "${PHASE}" == "2" || "${PHASE}" == "3" ]]; then
                 echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-                echo "✅ Eligible for auto-merge (Phase ${PHASE}): MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x → ${NEW_MAJOR}.${NEW_MINOR}.x)"
+                echo "✅ Eligible for auto-merge (Phase ${PHASE}): MINOR semver update"
               else
                 echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-                echo "❌ Not eligible: MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x → ${NEW_MAJOR}.${NEW_MINOR}.x) requires manual review (Phase ${PHASE})"
+                echo "❌ Not eligible: MINOR semver update requires manual review (Phase ${PHASE})"
               fi
-
-            elif [[ "${NEW_PATCH}" != "${OLD_PATCH}" ]]; then
+              ;;
+            version-update:semver-patch)
               echo "update-type=patch" >> "${GITHUB_OUTPUT}"
-
-              # All phases: Auto-merge PATCH updates
               echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-              echo "✅ Eligible for auto-merge (Phase ${PHASE}): PATCH update (${OLD_MAJOR}.${OLD_MINOR}.${OLD_PATCH} → ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH})"
-
-            else
+              echo "✅ Eligible for auto-merge (Phase ${PHASE}): PATCH semver update"
+              ;;
+            "")
               echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-              echo "update-type=no-change" >> "${GITHUB_OUTPUT}"
-              echo "❌ Not eligible: Version unchanged"
-            fi
-          else
-            echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-            echo "update-type=unparseable" >> "${GITHUB_OUTPUT}"
-            echo "❌ Not eligible: Could not parse version numbers from PR title"
-            echo "    Title format expected: 'Bump X from 1.2.3 to 1.2.4'"
-          fi
+              if [[ "${PACKAGE_ECOSYSTEM}" == "github-actions" && -n "${PREVIOUS_VERSION}" && -n "${NEW_VERSION}" ]]; then
+                echo "update-type=github-actions-non-semver" >> "${GITHUB_OUTPUT}"
+                echo "❌ Not eligible: GitHub Actions reference update does not expose a semver update-type"
+              else
+                echo "update-type=metadata-unavailable" >> "${GITHUB_OUTPUT}"
+                echo "❌ Not eligible: Dependabot metadata did not include an update type"
+              fi
+              ;;
+            *)
+              echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
+              echo "update-type=non-semver" >> "${GITHUB_OUTPUT}"
+              echo "❌ Not eligible: Unsupported Dependabot update type '${UPDATE_TYPE_RAW}'"
+              ;;
+          esac
 
   # Enable auto-merge for eligible PRs
   auto-merge:
@@ -281,11 +271,24 @@ jobs:
               } else if (phase === '2' || phase === '3') {
                 reason += '\n\n⚠️ **Note:** Your policy is set to Phase ' + phase + ' but this PR was not auto-merged. Check the logs for details.';
               }
-            } else if (updateType === 'unparseable') {
+            } else if (updateType === 'github-actions-non-semver') {
+              emoji = '🔒';
+              title = 'GitHub Actions reference update requires manual review';
+              reason = 'This Dependabot PR updates a GitHub Actions workflow reference pinned to a commit SHA.\n\n' +
+                       'Dependabot does not expose a semver `update-type` for this update shape, so the auto-merge policy treats it as manual review only.\n\n' +
+                       '**Action required:**\n' +
+                       '1. Review the upstream workflow or action diff\n' +
+                       '2. Verify the pinned commit is expected\n' +
+                       '3. Merge manually after verification';
+            } else if (updateType === 'metadata-unavailable') {
               emoji = '❓';
-              title = 'Could not determine update type';
-              reason = 'The PR title format could not be parsed.\n\n' +
-                       'Expected format: `Bump package from X.Y.Z to A.B.C`\n\n' +
+              title = 'Dependabot metadata did not include an update type';
+              reason = 'The Dependabot metadata action did not return a semver update classification for this PR.\n\n' +
+                       'Please review manually.';
+            } else if (updateType === 'non-semver') {
+              emoji = '❓';
+              title = 'Non-semver dependency update requires manual review';
+              reason = 'Dependabot reported a non-semver update classification for this PR.\n\n' +
                        'Please review manually.';
             } else {
               emoji = '🔍';

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -58,6 +58,7 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
         with:
           github-token: "${{ github.token }}"
+          skip-verification: true
 
       - name: Check PR metadata
         id: check
@@ -66,7 +67,10 @@ jobs:
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PHASE: ${{ inputs.phase }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
           UPDATE_TYPE_RAW: ${{ steps.metadata.outputs.update-type }}
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
           PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
           NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
@@ -111,11 +115,18 @@ jobs:
             return 0
           }
 
+          is_grouped_update() {
+            [[ -n "${DEPENDENCY_GROUP}" || "${DEPENDENCY_NAMES}" == *,* ]]
+          }
+
           echo "PR Labels: ${PR_LABELS}"
           echo "Auto-merge Phase: ${PHASE}"
           echo "Dependency names: ${DEPENDENCY_NAMES}"
+          echo "Dependency group: ${DEPENDENCY_GROUP}"
+          echo "Maintainer changes: ${MAINTAINER_CHANGES}"
           echo "Package ecosystem: ${PACKAGE_ECOSYSTEM}"
           echo "Dependabot update-type: ${UPDATE_TYPE_RAW}"
+          echo "Updated dependencies JSON: ${UPDATED_DEPENDENCIES_JSON}"
           echo "Previous version: ${PREVIOUS_VERSION}"
           echo "New version: ${NEW_VERSION}"
 
@@ -124,6 +135,20 @@ jobs:
             echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
             echo "update-type=not-dependabot" >> "${GITHUB_OUTPUT}"
             echo "❌ Not eligible: Missing dependencies label"
+            exit 0
+          fi
+
+          if [[ "${MAINTAINER_CHANGES}" == "true" ]]; then
+            echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
+            echo "update-type=maintainer-changes" >> "${GITHUB_OUTPUT}"
+            echo "❌ Not eligible: Dependabot PR includes maintainer changes"
+            exit 0
+          fi
+
+          if is_grouped_update; then
+            echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
+            echo "update-type=grouped-update" >> "${GITHUB_OUTPUT}"
+            echo "❌ Not eligible: Grouped Dependabot PR requires per-dependency manual review"
             exit 0
           fi
 
@@ -339,6 +364,26 @@ jobs:
               title = 'Dependabot metadata did not include an update type';
               reason = 'The Dependabot metadata action did not return a semver update classification for this PR.\n\n' +
                        'Please review manually.';
+            } else if (updateType === 'maintainer-changes') {
+              emoji = '🛠️';
+              title = 'Dependabot PR includes maintainer changes';
+              reason = 'This Dependabot PR includes maintainer-authored changes.\n\n' +
+                       'The auto-merge workflow therefore fails closed.\n\n' +
+                       '**Action required:**\n' +
+                       '1. Review the maintainer-authored diff\n' +
+                       '2. Verify the dependency update is still safe\n' +
+                       '3. Merge manually after verification';
+            } else if (updateType === 'grouped-update') {
+              emoji = '🧩';
+              title = 'Grouped Dependabot PR requires manual review';
+              reason = 'This Dependabot PR updates multiple dependencies or uses a Dependabot dependency group.\n\n' +
+                       'The metadata action exposes only the highest semver change for grouped PRs, ' +
+                       'so the auto-merge workflow cannot prove that every dependency in the group ' +
+                       'is semver-safe.\n\n' +
+                       '**Action required:**\n' +
+                       '1. Review each dependency in the group\n' +
+                       '2. Confirm there are no SHA-pinned or non-semver updates\n' +
+                       '3. Merge manually after verification';
             } else if (updateType === 'non-semver') {
               emoji = '❓';
               title = 'Non-semver dependency update requires manual review';

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
         with:
           github-token: "${{ github.token }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
 - updated `dependabot/fetch-metadata` to the upstream `v3.1.0` commit so the reusable workflow picks up the null `update-type` fix for Python, Composer, and Terraform Dependabot PRs instead of misrouting those updates to manual review
 - restored a bounded PR-title semver fallback for non-`github-actions` ecosystems when `fetch-metadata` still returns empty outputs, preserving patch/minor auto-merge behavior for repositories hit by upstream null-`update-type` gaps
+- configured `dependabot/fetch-metadata` to emit metadata for maintainer-touched Dependabot PRs while routing any reported maintainer changes to manual review instead of leaving the workflow in a hard failure state
+- fail-closed grouped Dependabot PRs to manual review because the upstream `update-type` output only reports the highest semver change for the group, which is not sufficient proof that every dependency in the PR is semver-safe to auto-merge
 - removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
 - fixed the caller workflow to contain only one YAML document start marker and updated the reusable workflow's header example to show callers pinning to `@v1`
-- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses on the bounded metadata-empty title fallback, drifts off the pinned `fetch-metadata` fix, reintroduces duplicate or malformed caller document markers, or drifts back to `@main` in the usage example
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses on the bounded metadata-empty title fallback, drifts off the pinned `fetch-metadata` fix, stops fail-closing grouped or maintainer-changed Dependabot PRs, reintroduces duplicate or malformed caller document markers, or drifts back to `@main` in the usage example
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ Log of notable changes to SecPal organization defaults (newest first).
 - classified GitHub Actions workflow-reference bumps pinned to commit SHAs as explicit manual-review updates, avoiding false `unparseable` failures when Dependabot opens PRs such as `chore(deps): Bump ... from <sha> to <sha>`
 - aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
 - updated `dependabot/fetch-metadata` to the upstream `v3.1.0` commit so the reusable workflow picks up the null `update-type` fix for Python, Composer, and Terraform Dependabot PRs instead of misrouting those updates to manual review
+- restored a bounded PR-title semver fallback for non-`github-actions` ecosystems when `fetch-metadata` still returns empty outputs, preserving patch/minor auto-merge behavior for repositories hit by upstream null-`update-type` gaps
 - removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
 - fixed the caller workflow to contain only one YAML document start marker and updated the reusable workflow's header example to show callers pinning to `@v1`
-- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification, drifts off the pinned `fetch-metadata` fix, reintroduces duplicate or malformed caller document markers, or drifts back to `@main` in the usage example
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses on the bounded metadata-empty title fallback, drifts off the pinned `fetch-metadata` fix, reintroduces duplicate or malformed caller document markers, or drifts back to `@main` in the usage example
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Log of notable changes to SecPal organization defaults (newest first).
 - replaced PR-title parsing in `.github/workflows/reusable-dependabot-auto-merge.yml` with official `dependabot/fetch-metadata` outputs so Dependabot auto-merge decisions now follow GitHub-provided update metadata instead of brittle `Bump ... from ... to ...` title strings
 - classified GitHub Actions workflow-reference bumps pinned to commit SHAs as explicit manual-review updates, avoiding false `unparseable` failures when Dependabot opens PRs such as `chore(deps): Bump ... from <sha> to <sha>`
 - aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
+- updated `dependabot/fetch-metadata` to the upstream `v3.1.0` commit so the reusable workflow picks up the null `update-type` fix for Python, Composer, and Terraform Dependabot PRs instead of misrouting those updates to manual review
 - removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
 - fixed the caller workflow to contain only one YAML document start marker and updated the reusable workflow's header example to show callers pinning to `@v1`
-- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification, stops fetching Dependabot metadata, reintroduces duplicate caller document markers, or drifts back to `@main` in the usage example
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification, drifts off the pinned `fetch-metadata` fix, reintroduces duplicate or malformed caller document markers, or drifts back to `@main` in the usage example
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
 - updated `dependabot/fetch-metadata` to the upstream `v3.1.0` commit so the reusable workflow picks up the null `update-type` fix for Python, Composer, and Terraform Dependabot PRs instead of misrouting those updates to manual review
 - restored a bounded PR-title semver fallback for non-`github-actions` ecosystems when `fetch-metadata` still returns empty outputs, preserving patch/minor auto-merge behavior for repositories hit by upstream null-`update-type` gaps
-- configured `dependabot/fetch-metadata` to emit metadata for maintainer-touched Dependabot PRs while routing any reported maintainer changes to manual review instead of leaving the workflow in a hard failure state
+- kept `dependabot/fetch-metadata` verification enabled while soft-failing metadata retrieval into explicit manual review, so maintainer-touched or otherwise unverifiable Dependabot PRs no longer bypass commit validation or strand the workflow in a hard failure state
 - fail-closed grouped Dependabot PRs to manual review because the upstream `update-type` output only reports the highest semver change for the group, which is not sufficient proof that every dependency in the PR is semver-safe to auto-merge
 - removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
 - fixed the caller workflow to contain only one YAML document start marker and updated the reusable workflow's header example to show callers pinning to `@v1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-06 - Fix Dependabot Auto-Merge Classification
+
+**Fixed:**
+
+- replaced PR-title parsing in `.github/workflows/reusable-dependabot-auto-merge.yml` with official `dependabot/fetch-metadata` outputs so Dependabot auto-merge decisions now follow GitHub-provided update metadata instead of brittle `Bump ... from ... to ...` title strings
+- classified GitHub Actions workflow-reference bumps pinned to commit SHAs as explicit manual-review updates, avoiding false `unparseable` failures when Dependabot opens PRs such as `chore(deps): Bump ... from <sha> to <sha>`
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification or stops fetching Dependabot metadata
+
+---
+
 ## 2026-07-05 - Fix Polyscope Preview Workspace Bootstrap
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-06 - Restrict GitHub Actions Dependabot Fallback
+
+**Fixed:**
+
+- limited the metadata-empty PR-title fallback in `.github/workflows/reusable-dependabot-auto-merge.yml` to non-`github-actions` ecosystems so GitHub Actions bumps with incomplete `fetch-metadata` version outputs stay on manual review instead of being auto-merged from semver-shaped titles
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow ever re-enables PR-title fallback for metadata-empty `github-actions` Dependabot updates
+
+---
+
 ## 2026-07-06 - Fix Dependabot Auto-Merge Classification
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - replaced PR-title parsing in `.github/workflows/reusable-dependabot-auto-merge.yml` with official `dependabot/fetch-metadata` outputs so Dependabot auto-merge decisions now follow GitHub-provided update metadata instead of brittle `Bump ... from ... to ...` title strings
 - classified GitHub Actions workflow-reference bumps pinned to commit SHAs as explicit manual-review updates, avoiding false `unparseable` failures when Dependabot opens PRs such as `chore(deps): Bump ... from <sha> to <sha>`
+- aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
+- removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
 - extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification or stops fetching Dependabot metadata
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 - classified GitHub Actions workflow-reference bumps pinned to commit SHAs as explicit manual-review updates, avoiding false `unparseable` failures when Dependabot opens PRs such as `chore(deps): Bump ... from <sha> to <sha>`
 - aligned the reusable workflow's Phase 3 behavior with Dependabot policy by keeping major version updates on manual review in every phase
 - removed invalid caller-workflow `timeout-minutes` syntax from the reusable Dependabot workflow invocation while retaining timeouts inside the called workflow jobs
-- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification or stops fetching Dependabot metadata
+- fixed the caller workflow to contain only one YAML document start marker and updated the reusable workflow's header example to show callers pinning to `@v1`
+- extended `tests/dependabot-auto-merge.sh` to fail if the reusable workflow regresses to title-based classification, stops fetching Dependabot metadata, reintroduces duplicate caller document markers, or drifts back to `@main` in the usage example
 
 ---
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -23,7 +23,11 @@ for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   fi
 done
 
-if [ "$(grep -c '^---$' "$CALLER_WORKFLOW")" -ne 1 ]; then
+if ! awk '
+  /^---$/ { document_start_markers++ }
+  /^----+$/ { malformed_document_markers++ }
+  END { exit !(document_start_markers == 1 && malformed_document_markers == 0) }
+' "$CALLER_WORKFLOW"; then
   echo "Dependabot caller workflow must contain exactly one YAML document start marker." >&2
   exit 1
 fi
@@ -101,8 +105,8 @@ awk '
   exit 1
 }
 
-grep -q 'uses: dependabot/fetch-metadata@' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable Dependabot workflow must fetch Dependabot metadata instead of classifying updates from the PR title." >&2
+grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must pin dependabot/fetch-metadata to the v3.1.0 commit with the null update-type fix." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -77,6 +77,21 @@ grep -q "needs.check-eligibility.outputs.should-auto-merge != 'true' && github.e
   exit 1
 }
 
+grep -q 'uses: dependabot/fetch-metadata@' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must fetch Dependabot metadata instead of classifying updates from the PR title." >&2
+  exit 1
+}
+
+if grep -Fq 'PR_TITLE: ${{ github.event.pull_request.title }}' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must not depend on github.event.pull_request.title for update classification; SHA-based workflow bumps are not semver titles." >&2
+  exit 1
+fi
+
+if grep -Fq 'Extract version numbers from Dependabot PR title' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must not parse update type from the PR title; use Dependabot metadata outputs instead." >&2
+  exit 1
+fi
+
 # Same anchoring as the caller guard: only flag actual YAML `if:` lines so
 # explanatory comments or documentation mentioning the old `github.actor`
 # pattern do not trip the regression check.

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -23,6 +23,11 @@ for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   fi
 done
 
+if [ "$(grep -c '^---$' "$CALLER_WORKFLOW")" -ne 1 ]; then
+  echo "Dependabot caller workflow must contain exactly one YAML document start marker." >&2
+  exit 1
+fi
+
 grep -q '^permissions:$' "$CALLER_WORKFLOW" || {
   echo "Dependabot caller workflow must declare explicit permissions." >&2
   exit 1
@@ -98,6 +103,11 @@ awk '
 
 grep -q 'uses: dependabot/fetch-metadata@' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must fetch Dependabot metadata instead of classifying updates from the PR title." >&2
+  exit 1
+}
+
+grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow usage example must show callers pinning the workflow to @v1." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -145,8 +145,23 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
   exit 1
 }
 
+grep -q '^          skip-verification: true$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must configure fetch-metadata to emit outputs for manual-reviewable maintainer-change PRs." >&2
+  exit 1
+}
+
 grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow usage example must show callers pinning the workflow to @v1." >&2
+  exit 1
+}
+
+grep -Fq '          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must surface the dependency-group metadata output." >&2
+  exit 1
+}
+
+grep -Fq '          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must surface the maintainer-changes metadata output." >&2
   exit 1
 }
 
@@ -165,6 +180,26 @@ grep -Fq 'Fallback to PR title parsing only when fetch-metadata returns empty ou
 # non-GitHub-Actions ecosystems with empty fetch-metadata outputs.
 grep -Fq 'elif [[ "${PACKAGE_ECOSYSTEM}" != "github-actions" ]] && fallback_from_pr_title; then' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must restrict the metadata-empty PR title fallback to non-GitHub-Actions ecosystems." >&2
+  exit 1
+}
+
+grep -Fq 'if [[ "${MAINTAINER_CHANGES}" == "true" ]]; then' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must fail closed when Dependabot metadata reports maintainer changes." >&2
+  exit 1
+}
+
+grep -Fq 'echo "update-type=maintainer-changes" >> "${GITHUB_OUTPUT}"' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must classify maintainer-changed Dependabot PRs for manual review." >&2
+  exit 1
+}
+
+grep -Fq '[[ -n "${DEPENDENCY_GROUP}" || "${DEPENDENCY_NAMES}" == *,* ]]' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must detect grouped Dependabot PRs conservatively." >&2
+  exit 1
+}
+
+grep -Fq 'echo "update-type=grouped-update" >> "${GITHUB_OUTPUT}"' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must classify grouped Dependabot PRs for manual review." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -115,15 +115,20 @@ grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-a
   exit 1
 }
 
-if grep -Fq 'PR_TITLE: ${{ github.event.pull_request.title }}' "$REUSABLE_WORKFLOW"; then
-  echo "Reusable Dependabot workflow must not depend on github.event.pull_request.title for update classification; SHA-based workflow bumps are not semver titles." >&2
+grep -Fq '          PR_TITLE: ${{ github.event.pull_request.title }}' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must expose the PR title for the metadata-empty fallback path." >&2
   exit 1
-fi
+}
 
-if grep -Fq 'Extract version numbers from Dependabot PR title' "$REUSABLE_WORKFLOW"; then
-  echo "Reusable Dependabot workflow must not parse update type from the PR title; use Dependabot metadata outputs instead." >&2
+grep -Fq 'Fallback to PR title parsing only when fetch-metadata returns empty outputs' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must document the metadata-empty title fallback boundary." >&2
   exit 1
-fi
+}
+
+grep -Fq 'elif fallback_from_pr_title; then' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must fall back to PR title parsing only after empty metadata for non-GitHub-Actions ecosystems." >&2
+  exit 1
+}
 
 if grep -Fq 'Eligible for auto-merge (Phase 3): MAJOR' "$REUSABLE_WORKFLOW"; then
   echo "Reusable Dependabot workflow must not auto-merge major updates in any phase." >&2

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -23,8 +23,12 @@ for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   fi
 done
 
-if [ "$(grep -c '^---$' "$CALLER_WORKFLOW")" -ne 1 ]; then
-  echo "Dependabot caller workflow must contain exactly one YAML document start marker." >&2
+if ! awk '
+  /^---$/ { document_start_markers++ }
+  /^----+$/ { malformed_document_markers++ }
+  END { exit !(document_start_markers == 1 && malformed_document_markers == 0) }
+' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must contain exactly one valid YAML document start marker." >&2
   exit 1
 fi
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -145,13 +145,23 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
   exit 1
 }
 
-grep -q '^          skip-verification: true$' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable Dependabot workflow must configure fetch-metadata to emit outputs for manual-reviewable maintainer-change PRs." >&2
+grep -q '^        continue-on-error: true$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must soft-fail fetch-metadata into the manual-review path." >&2
   exit 1
 }
 
+if grep -q '^          skip-verification: true$' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must not bypass fetch-metadata commit verification." >&2
+  exit 1
+fi
+
 grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow usage example must show callers pinning the workflow to @v1." >&2
+  exit 1
+}
+
+grep -Fq '          METADATA_STEP_OUTCOME: ${{ steps.metadata.outcome }}' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must surface the fetch-metadata step outcome." >&2
   exit 1
 }
 
@@ -185,6 +195,11 @@ grep -Fq 'elif [[ "${PACKAGE_ECOSYSTEM}" != "github-actions" ]] && fallback_from
 
 grep -Fq 'if [[ "${MAINTAINER_CHANGES}" == "true" ]]; then' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must fail closed when Dependabot metadata reports maintainer changes." >&2
+  exit 1
+}
+
+grep -Fq 'if [[ "${METADATA_STEP_OUTCOME}" != "success" ]]; then' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must fail closed when fetch-metadata itself cannot verify the PR." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -64,6 +64,19 @@ grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-
   exit 1
 }
 
+if awk '
+  /^  auto-merge:$/ { in_job = 1; next }
+  in_job && /^  [[:alnum:]_-]+:$/ { in_job = 0 }
+  in_job && /^[[:space:]]+uses: SecPal\/\.github\/\.github\/workflows\/reusable-dependabot-auto-merge\.yml@v1$/ {
+    reusable_job = 1
+  }
+  in_job && /^[[:space:]]+timeout-minutes:/ { has_timeout = 1 }
+  END { exit !(reusable_job && has_timeout) }
+' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must not set timeout-minutes on a reusable workflow caller job." >&2
+  exit 1
+fi
+
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
 # gate on the PR author so the same maintainer-triggered events are not
 # skipped when other repositories invoke this reusable workflow directly.
@@ -72,7 +85,13 @@ grep -q "^    if: github.event.pull_request.user.login == 'dependabot\\[bot\\]'$
   exit 1
 }
 
-grep -q "needs.check-eligibility.outputs.should-auto-merge != 'true' && github.event.pull_request.user.login == 'dependabot\\[bot\\]'" "$REUSABLE_WORKFLOW" || {
+awk '
+  /^  skip-auto-merge:$/ { in_job = 1; next }
+  in_job && /^  [[:alnum:]_-]+:$/ { in_job = 0 }
+  in_job && /needs\.check-eligibility\.outputs\.should-auto-merge != '\''true'\''/ { has_output_guard = 1 }
+  in_job && /github\.event\.pull_request\.user\.login == '\''dependabot\[bot\]'\''/ { has_author_guard = 1 }
+  END { exit !(has_output_guard && has_author_guard) }
+' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must gate skip-auto-merge on github.event.pull_request.user.login so maintainer-triggered events on Dependabot PRs still receive the manual-review comment." >&2
   exit 1
 }
@@ -91,6 +110,16 @@ if grep -Fq 'Extract version numbers from Dependabot PR title' "$REUSABLE_WORKFL
   echo "Reusable Dependabot workflow must not parse update type from the PR title; use Dependabot metadata outputs instead." >&2
   exit 1
 fi
+
+if grep -Fq 'Eligible for auto-merge (Phase 3): MAJOR' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must not auto-merge major updates in any phase." >&2
+  exit 1
+fi
+
+grep -q 'MAJOR semver update requires manual review' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must route major updates to manual review." >&2
+  exit 1
+}
 
 # Same anchoring as the caller guard: only flag actual YAML `if:` lines so
 # explanatory comments or documentation mentioning the old `github.actor`

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -125,8 +125,11 @@ grep -Fq 'Fallback to PR title parsing only when fetch-metadata returns empty ou
   exit 1
 }
 
-grep -Fq 'elif fallback_from_pr_title; then' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable Dependabot workflow must fall back to PR title parsing only after empty metadata for non-GitHub-Actions ecosystems." >&2
+# Keep every metadata-empty GitHub Actions update on manual review, even when
+# the PR title still looks semver-shaped. Title parsing is only allowed for
+# non-GitHub-Actions ecosystems with empty fetch-metadata outputs.
+grep -Fq 'elif [[ "${PACKAGE_ECOSYSTEM}" != "github-actions" ]] && fallback_from_pr_title; then' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow must restrict the metadata-empty PR title fallback to non-GitHub-Actions ecosystems." >&2
   exit 1
 }
 


### PR DESCRIPTION
## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/dependabot-auto-merge.sh` failed with `Reusable Dependabot workflow must fetch Dependabot metadata instead of classifying updates from the PR title.`
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`; `git diff --check`; `yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Defect proof

The failing condition reproduced the current defect: Dependabot GitHub Actions updates pinned to commit SHAs produce titles such as `chore(deps): Bump ... from <sha> to <sha>`, while the reusable auto-merge workflow tried to classify updates by parsing semver values out of `github.event.pull_request.title`.

## Change

- Replace PR-title parsing in `.github/workflows/reusable-dependabot-auto-merge.yml` with `dependabot/fetch-metadata` outputs.
- Preserve the existing phase policy for semver major, minor, and patch updates.
- Classify GitHub Actions workflow-reference SHA bumps as `github-actions-non-semver` and route them to manual review with a specific explanation.
- Extend `tests/dependabot-auto-merge.sh` so the reusable workflow must fetch Dependabot metadata and must not regress to title-based classification.
- Document the change in `CHANGELOG.md`.

## Validation

- `bash tests/dependabot-auto-merge.sh`
- `git diff --check`
- `yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml`
- `./scripts/preflight.sh`
- Signed commit verified with `git log -1 --show-signature --format=fuller`

## Local review

- Comprehensive review: checked behavior, regression coverage, changelog entry, and stray follow-up wording in the touched scope.
- Deep-dive review: checked workflow policy behavior, licensing scope, and security-sensitive automation paths.
- Best-practices review: checked workflow permissions, pinned external action usage, branch scope, and package/governance metadata impact.
- Security review: checked token usage, secret handling, and Dependabot-only enrollment guards.

## Linked work

- Polyscope workspace: `/home/secpal/.polyscope/clones/4e5a331a/royal-dove`
- Out-of-scope lint hygiene tracking: #523

## Before ready

- Keep this PR in draft until GitHub CI finishes on the pushed branch.
- Re-check the PR view after CI completes and only mark ready if the final self-review finds zero issues.
