### PR TITLE
Fix yamllint warnings in Dependabot workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,7 @@
 # For implementation details, see:
 # .github/workflows/reusable-dependabot-auto-merge.yml
 
+---
 name: Dependabot Auto-Merge
 
 on:
@@ -36,5 +37,7 @@ jobs:
     timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
-      phase: "1" # Phase 1: Only PATCH updates auto-merge
-      merge-method: "squash" # Use squash merge for cleaner history
+      # Phase 1: Only PATCH updates auto-merge
+      phase: "1"
+      # Use squash merge for cleaner history
+      merge-method: "squash"

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -85,7 +85,9 @@ jobs:
           # require manual review, which is the safer approach for non-stable versions.
 
           # Extract "from X[.Y[.Z]] to A[.B[.C]]" pattern (flexible version format)
-          VERSION_RANGE_PATTERN='from[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?[[:space:]]+to[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?'
+          VERSION_RANGE_PATTERN='from[[:space:]]+([0-9]+)(\.([0-9]+))?'
+          VERSION_RANGE_PATTERN+='(\.([0-9]+))?[[:space:]]+to[[:space:]]+'
+          VERSION_RANGE_PATTERN+='([0-9]+)(\.([0-9]+))?(\.([0-9]+))?'
           if [[ "${PR_TITLE}" =~ ${VERSION_RANGE_PATTERN} ]]; then
             OLD_MAJOR="${BASH_REMATCH[1]}"
             OLD_MINOR="${BASH_REMATCH[3]:-0}"  # Default to 0 if not present

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -18,6 +18,7 @@
 #
 # Rollback strategy: Git revert the auto-merged commit if issues occur
 
+---
 name: Reusable Dependabot Auto-Merge
 
 on:
@@ -84,7 +85,8 @@ jobs:
           # require manual review, which is the safer approach for non-stable versions.
 
           # Extract "from X[.Y[.Z]] to A[.B[.C]]" pattern (flexible version format)
-          if [[ "${PR_TITLE}" =~ from[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?[[:space:]]+to[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))? ]]; then
+          VERSION_RANGE_PATTERN='from[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?[[:space:]]+to[[:space:]]+([0-9]+)(\.([0-9]+))?(\.([0-9]+))?'
+          if [[ "${PR_TITLE}" =~ ${VERSION_RANGE_PATTERN} ]]; then
             OLD_MAJOR="${BASH_REMATCH[1]}"
             OLD_MINOR="${BASH_REMATCH[3]:-0}"  # Default to 0 if not present
             OLD_PATCH="${BASH_REMATCH[5]:-0}"  # Default to 0 if not present
@@ -105,7 +107,8 @@ jobs:
                 echo "✅ Eligible for auto-merge (Phase 3): MAJOR update (${OLD_MAJOR}.x.x → ${NEW_MAJOR}.x.x)"
               else
                 echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-                echo "❌ Not eligible: MAJOR update (${OLD_MAJOR}.x.x → ${NEW_MAJOR}.x.x) requires manual review (Phase ${PHASE})"
+                echo "❌ Not eligible: MAJOR update (${OLD_MAJOR}.x.x →"
+                echo "${NEW_MAJOR}.x.x) requires manual review (Phase ${PHASE})"
               fi
 
             elif [[ "${NEW_MINOR}" != "${OLD_MINOR}" ]]; then
@@ -114,10 +117,14 @@ jobs:
               # Phase 2+: Auto-merge MINOR updates
               if [[ "${PHASE}" == "2" || "${PHASE}" == "3" ]]; then
                 echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-                echo "✅ Eligible for auto-merge (Phase ${PHASE}): MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x → ${NEW_MAJOR}.${NEW_MINOR}.x)"
+                echo "✅ Eligible for auto-merge (Phase ${PHASE}):"
+                echo "MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x →"
+                echo "${NEW_MAJOR}.${NEW_MINOR}.x)"
               else
                 echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
-                echo "❌ Not eligible: MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x → ${NEW_MAJOR}.${NEW_MINOR}.x) requires manual review (Phase ${PHASE})"
+                echo "❌ Not eligible: MINOR update (${OLD_MAJOR}.${OLD_MINOR}.x"
+                echo "→ ${NEW_MAJOR}.${NEW_MINOR}.x) requires manual review"
+                echo "(Phase ${PHASE})"
               fi
 
             elif [[ "${NEW_PATCH}" != "${OLD_PATCH}" ]]; then
@@ -125,7 +132,9 @@ jobs:
 
               # All phases: Auto-merge PATCH updates
               echo "should-auto-merge=true" >> "${GITHUB_OUTPUT}"
-              echo "✅ Eligible for auto-merge (Phase ${PHASE}): PATCH update (${OLD_MAJOR}.${OLD_MINOR}.${OLD_PATCH} → ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH})"
+              echo "✅ Eligible for auto-merge (Phase ${PHASE}): PATCH update"
+              echo "(${OLD_MAJOR}.${OLD_MINOR}.${OLD_PATCH} →"
+              echo "${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH})"
 
             else
               echo "should-auto-merge=false" >> "${GITHUB_OUTPUT}"
@@ -159,7 +168,9 @@ jobs:
           running-workflow-name: "auto-merge / Enable Auto-Merge"
           allowed-conclusions: success,skipped,neutral
           # Also ignore by explicit check name as backup
-          ignore-checks: "Dependabot Auto-Merge,auto-merge / Enable Auto-Merge,auto-merge / Check Auto-Merge Eligibility"
+          ignore-checks: >-
+            Dependabot Auto-Merge,auto-merge / Enable Auto-Merge,auto-merge /
+            Check Auto-Merge Eligibility
         continue-on-error: true
 
       - name: Log wait result
@@ -215,11 +226,14 @@ jobs:
 
             let policyText = '';
             if (phase === '1') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '2') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '3') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
             }
 
             github.rest.issues.createComment({
@@ -242,7 +256,9 @@ jobs:
     name: Skip Auto-Merge
     runs-on: ubuntu-latest
     needs: check-eligibility
+    # yamllint disable rule:line-length
     if: needs.check-eligibility.outputs.should-auto-merge != 'true' && github.event.pull_request.user.login == 'dependabot[bot]'
+    # yamllint enable rule:line-length
     timeout-minutes: 10
     steps:
       - name: Add comment for manual review
@@ -265,7 +281,9 @@ jobs:
                        '3. Verify all tests pass\n' +
                        '4. Merge manually after verification';
               if (phase === '3') {
-                reason += '\n\n⚠️ **Note:** Your policy is set to Phase 3 but this PR was not auto-merged. Check the logs for details.';
+                reason +=
+                  '\n\n⚠️ **Note:** Your policy is set to Phase 3 but this PR was not auto-merged.' +
+                  ' Check the logs for details.';
               }
             } else if (updateType === 'minor') {
               emoji = '🔍';
@@ -279,7 +297,9 @@ jobs:
               if (phase === '1') {
                 reason += '\n\n**Note:** In Phase 2, MINOR updates will be auto-merged.';
               } else if (phase === '2' || phase === '3') {
-                reason += '\n\n⚠️ **Note:** Your policy is set to Phase ' + phase + ' but this PR was not auto-merged. Check the logs for details.';
+                reason +=
+                  '\n\n⚠️ **Note:** Your policy is set to Phase ' + phase +
+                  ' but this PR was not auto-merged. Check the logs for details.';
               }
             } else if (updateType === 'unparseable') {
               emoji = '❓';
@@ -294,11 +314,14 @@ jobs:
 
             let policyText = '';
             if (phase === '1') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- 🔍 MINOR updates: Manual review\n- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '2') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ⚠️ MAJOR updates: Manual review';
             } else if (phase === '3') {
-              policyText = '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
+              policyText =
+                '- ✅ PATCH updates: Auto-merge\n- ✅ MINOR updates: Auto-merge\n- ✅ MAJOR updates: Auto-merge';
             }
 
             github.rest.issues.createComment({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-06 - Clean Up Dependabot Workflow yamllint Warnings
+
+**Fixed:**
+
+- added YAML document start markers and wrapped overlong strings in the reusable and caller Dependabot auto-merge workflows so `yamllint` no longer reports style-noise warnings for those files
+
+---
+
 ## 2026-07-05 - Fix Polyscope Preview Workspace Bootstrap
 
 **Fixed:**


### PR DESCRIPTION
## Summary

`yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml` reproduced the issue from #523 with existing warnings for missing document start markers, long lines in the reusable workflow, and inline comment spacing in the caller workflow.

This change cleans up those workflow-style warnings without changing Dependabot auto-merge behavior:

- adds YAML document start markers to both workflows
- reformats long shell and JavaScript strings in the reusable workflow to satisfy `yamllint`
- moves the caller workflow's inline `with:` comments to standalone comments to avoid the `Prettier` versus `yamllint` spacing conflict
- preserves the existing Dependabot-only guard expected by the repository regression test while scoping the necessary `yamllint` suppression to that single line
- records the workflow-hygiene fix in `CHANGELOG.md`

## Validation

- `yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml`
- `./scripts/preflight.sh`

## TDD / Validate-First Evidence

- Failing proof before implementation: `yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml` reported existing warnings for missing YAML document start markers, long lines in the reusable workflow, and comment spacing in the caller workflow.
- Passing proof after implementation: `yamllint .github/workflows/reusable-dependabot-auto-merge.yml .github/workflows/dependabot-auto-merge.yml` and `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Ready Review

- No linked workspaces.
- No unresolved local validation failures remain.
- Keep this PR in draft until the final self-review in the PR view still finds zero issues.

Closes #523
