### PR TITLE
Stabilize Polyscope API runtime credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-07 - Stabilize Polyscope API Runtime Credentials
+
+**Fixed:**
+
+- routed generated API preview run actions for `queue:work`, `schedule:work`, and `pail` through `scripts/polyscope-rollout.py`, so long-running preview processes now inherit the same transient PostgreSQL password injection already used during bootstrap and refresh
+- made the API runtime wrapper hand off to the long-running artisan process with `exec`, avoiding stale child processes when Polyscope replaces or stops preview run actions
+- extended `tests/polyscope-rollout.sh` to fail if API runtime commands ever regress to direct artisan invocations without the rollout wrapper, depend on display labels for wrapping, keep a parent wrapper process alive, or stop propagating transient `DB_PASSWORD` and `PGPASSWORD` values into those long-running preview processes
+
+---
+
 ## 2026-07-06 - Restrict GitHub Actions Dependabot Fallback
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -58,6 +58,19 @@ MODERN_NGINX_HTTP2_VERSION = (1, 25, 1)
 NGINX_HTTP2_SYNTAX_CHOICES = ("modern", "legacy", "auto")
 API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_BOOTSTRAP_SETUP__"
 API_REFRESH_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_REFRESH__"
+API_QUEUE_WORKER_COMMAND = (
+    "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default "
+    "--sleep=3 --tries=3 --max-time=3600"
+)
+API_SCHEDULER_COMMAND = "php artisan schedule:work"
+API_PAIL_COMMAND = "php artisan pail --timeout=0"
+API_RUNTIME_PREVIEW_COMMANDS = frozenset(
+    {
+        API_QUEUE_WORKER_COMMAND,
+        API_SCHEDULER_COMMAND,
+        API_PAIL_COMMAND,
+    }
+)
 
 
 def default_polyscope_db_path() -> pathlib.Path:
@@ -495,6 +508,16 @@ def build_api_preview_env_setup_command(source_repo_path: pathlib.Path) -> str:
     return (
         f"python3 {rollout_script} --prepare-api-worktree \"$PWD\" "
         f"--source-repo-path {source_repo}"
+    )
+
+
+def build_api_preview_runtime_shell_command(command: str, source_repo_path: pathlib.Path) -> str:
+    rollout_script = shlex.quote(str(ROLLOUT_SCRIPT_PATH))
+    source_repo = shlex.quote(str(source_repo_path))
+    shell_command = shlex.quote(command)
+    return (
+        f"python3 {rollout_script} --run-api-worktree \"$PWD\" "
+        f"--source-repo-path {source_repo} --shell-command {shell_command}"
     )
 
 
@@ -1044,6 +1067,27 @@ def refresh_api_worktree(
         migration_command=["php", "artisan", "migrate:fresh", "--force"],
         migration_label="refreshing database",
     )
+
+
+def run_api_worktree_shell_command(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    shell_command: str,
+    *,
+    db_path: pathlib.Path | None = None,
+) -> None:
+    env_path = worktree_path / ".env"
+    if not env_path.exists():
+        raise SystemExit(f"api worktree {worktree_path} is missing .env")
+
+    env_values = load_env_assignments(env_path)
+    source_env_values = load_optional_env_assignments(source_repo_path / ".env")
+    command_env = build_api_worktree_command_env(env_values, source_env_values)
+    if db_path is not None:
+        command_env["POLYSCOPE_DB_PATH"] = str(db_path)
+
+    os.chdir(worktree_path)
+    os.execvpe("bash", ["bash", "-lc", f"set -euo pipefail; exec {shell_command}"], command_env)
 
 
 def cleanup_removed_api_preview_databases(
@@ -2016,9 +2060,9 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,
                 ],
                 "run": [
-                    {"label": "Queue Worker", "command": "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600", "runMode": "replace"},
-                    {"label": "Scheduler", "command": "php artisan schedule:work", "autostart": True, "runMode": "replace"},
-                    {"label": "Pail", "command": "php artisan pail --timeout=0", "runMode": "replace"},
+                    {"label": "Queue Worker", "command": API_QUEUE_WORKER_COMMAND, "runMode": "replace"},
+                    {"label": "Scheduler", "command": API_SCHEDULER_COMMAND, "autostart": True, "runMode": "replace"},
+                    {"label": "Pail", "command": API_PAIL_COMMAND, "runMode": "replace"},
                     # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.
                     # It intentionally reseeds the canonical E2E login `test@example.com` / `password` and must never target production.
                     {
@@ -2572,6 +2616,9 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
             for run_action in spec["local_config"]["scripts"]["run"]:
                 if run_action.get("command") == API_REFRESH_COMMAND_PLACEHOLDER:
                     run_action["command"] = build_api_preview_refresh_command(repo_path)
+                    continue
+                if run_action.get("command") in API_RUNTIME_PREVIEW_COMMANDS:
+                    run_action["command"] = build_api_preview_runtime_shell_command(run_action["command"], repo_path)
         repo_specs[repo_name] = spec
     return repo_specs
 
@@ -3868,7 +3915,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prepare-api-worktree", type=pathlib.Path)
     parser.add_argument("--bootstrap-api-worktree", type=pathlib.Path)
     parser.add_argument("--refresh-api-worktree", type=pathlib.Path)
+    parser.add_argument("--run-api-worktree", type=pathlib.Path)
     parser.add_argument("--source-repo-path", type=pathlib.Path)
+    parser.add_argument("--shell-command")
     parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
     parser.add_argument("--db-path", type=pathlib.Path, default=default_polyscope_db_path())
     parser.add_argument("--clone-root", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "clones")
@@ -3925,6 +3974,19 @@ def main() -> int:
             db_path=args.db_path,
         )
         return 0 if ready else 1
+
+    if args.run_api_worktree is not None:
+        if args.source_repo_path is None:
+            raise SystemExit("--source-repo-path is required with --run-api-worktree")
+        if not args.shell_command:
+            raise SystemExit("--shell-command is required with --run-api-worktree")
+        run_api_worktree_shell_command(
+            args.run_api_worktree,
+            args.source_repo_path,
+            args.shell_command,
+            db_path=args.db_path,
+        )
+        return 0
 
     repo_specs = build_repo_specs(args.workspace_root)
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1087,7 +1087,7 @@ def run_api_worktree_shell_command(
         command_env["POLYSCOPE_DB_PATH"] = str(db_path)
 
     os.chdir(worktree_path)
-    os.execvpe("bash", ["bash", "-lc", f"set -euo pipefail; exec {shell_command}"], command_env)
+    os.execvpe("bash", ["bash", "-c", f"set -euo pipefail; exec {shell_command}"], command_env)
 
 
 def cleanup_removed_api_preview_databases(

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -707,14 +707,42 @@ grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polys
 grep -q 'AGENTS.md' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --bootstrap-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
-grep -qF 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600' "$workspace_root/api/polyscope.local.json"
+grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600'" "$workspace_root/api/polyscope.local.json"
 grep -qF '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json"
-grep -qF '"command": "php artisan schedule:work"' "$workspace_root/api/polyscope.local.json"
+grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan schedule:work'" "$workspace_root/api/polyscope.local.json"
+grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan pail --timeout=0'" "$workspace_root/api/polyscope.local.json"
 grep -A3 '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json" | grep -qF '"autostart": true'
 if grep -qF 'php artisan queue:listen --tries=1' "$workspace_root/api/polyscope.local.json"; then
     echo "preview API queue worker must use combined queue:work and not queue:listen" >&2
     exit 1
 fi
+if grep -qF '"command": "php artisan schedule:work"' "$workspace_root/api/polyscope.local.json"; then
+    echo "preview API scheduler must run through the rollout runtime env wrapper" >&2
+    exit 1
+fi
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace_root"
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace_root = pathlib.Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+api_run_actions = module.REPO_SETTINGS["api"]["local_config"]["scripts"]["run"]
+api_run_actions[0]["label"] = "Background Queue"
+api_run_actions[1]["label"] = "Cron Loop"
+api_run_actions[2]["label"] = "Log Tail"
+api_spec = module.build_repo_specs(workspace_root)["api"]
+runtime_commands = [
+    action["command"]
+    for action in api_spec["local_config"]["scripts"]["run"][:3]
+]
+assert all("--run-api-worktree" in command for command in runtime_commands), runtime_commands
+PY
 grep -qF 'Preview Only: Refresh DB + E2E User' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --refresh-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF '"label": "All Checks"' "$workspace_root/api/polyscope.local.json"
@@ -2137,6 +2165,86 @@ assert calls == [
         api_worktree,
         "source-only-password",
         "source-only-password",
+    ),
+], calls
+PY
+
+# run_api_worktree_shell_command must reuse the transient runtime DB password
+# injection for long-running preview actions such as the queue worker and scheduler.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "run-transient-pgsql-password-fixture" / "source-api"
+api_worktree = workspace / "run-transient-pgsql-password-fixture" / "clones" / "api12345" / "steady-hawk"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal__preview__steady_hawk\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=source-only-password\n"
+)
+api_worktree.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal__preview__steady_hawk\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+calls = []
+
+def fake_chdir(cwd):
+    calls.append(("chdir", cwd))
+
+def fake_execvpe(file, args, env):
+    calls.append(
+        (
+            "execvpe",
+            file,
+            tuple(args),
+            env["DB_PASSWORD"],
+            env["PGPASSWORD"],
+            env["POLYSCOPE_DB_PATH"],
+        )
+    )
+    raise SystemExit(0)
+
+module.os.chdir = fake_chdir
+module.os.execvpe = fake_execvpe
+
+db_path = workspace / "runtime-polyscope.db"
+try:
+    module.run_api_worktree_shell_command(
+        api_worktree,
+        source_api,
+        "php artisan schedule:work",
+        db_path=db_path,
+    )
+except SystemExit as error:
+    assert error.code == 0, error
+
+assert calls == [
+    ("chdir", api_worktree),
+    (
+        "execvpe",
+        "bash",
+        ("bash", "-lc", "set -euo pipefail; exec php artisan schedule:work"),
+        "source-only-password",
+        "source-only-password",
+        str(db_path),
     ),
 ], calls
 PY

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2241,7 +2241,7 @@ assert calls == [
     (
         "execvpe",
         "bash",
-        ("bash", "-lc", "set -euo pipefail; exec php artisan schedule:work"),
+        ("bash", "-c", "set -euo pipefail; exec php artisan schedule:work"),
         "source-only-password",
         "source-only-password",
         str(db_path),


### PR DESCRIPTION
## Defect

`tests/polyscope-rollout.sh` now proves generated API preview runtime actions for `queue:work`, `schedule:work`, and `pail` must run through the rollout wrapper instead of direct `php artisan` commands. The previous generated commands bypassed the transient PostgreSQL password injection used by API bootstrap and refresh paths, so long-running preview processes could start without the runtime `DB_PASSWORD` and `PGPASSWORD` values they need.

## TDD / Validate-First Evidence

- Failing proof before implementation: the pre-fix generated `api/polyscope.local.json` run actions used direct `php artisan queue:work`, `php artisan schedule:work`, and `php artisan pail --timeout=0` commands, so the new regression checks added in `tests/polyscope-rollout.sh` would fail because those runtime actions were not wrapped through `scripts/polyscope-rollout.py --run-api-worktree` and therefore could not inherit the transient runtime `DB_PASSWORD` / `PGPASSWORD` injection.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` passes with the generated runtime commands wrapped through `--run-api-worktree`, including the new assertions for wrapper generation, label-independent wrapping, transient password propagation, and `exec` handoff.
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`

## Change

- Route generated API preview runtime commands through `scripts/polyscope-rollout.py --run-api-worktree`.
- Reuse the existing API worktree command environment builder for long-running runtime actions.
- Hand off the runtime shell through `exec` so replacement and stop behavior applies to the artisan process itself.
- Add regression coverage for wrapper generation, label-independent command wrapping, transient password propagation, and `exec` handoff.
- Update `CHANGELOG.md`.

## Validation

- `bash tests/polyscope-rollout.sh`
- `git diff --check`
- `./scripts/preflight.sh`
- Commit signature verified with `git log --show-signature --oneline -1`

## Open Checks Before Ready

- Keep this PR as draft until GitHub CI completes.
- Complete the final PR-view self-review before marking ready.
- Linked workspace context: `SecPal/frontend` at `/home/secpal/.polyscope/clones/b6624c93/inspect-preview-provision` was available for context only; no changes were made there.