### PR TITLE
Add main VPS deploy workflow

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -12,47 +12,7 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: deploy-main-${{ github.event.repository.name }}
-  cancel-in-progress: false
-
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Deploy repository on VPS
-        env:
-          VPS_HOST: ${{ secrets.VPS_HOST }}
-          VPS_PORT: ${{ secrets.VPS_PORT }}
-          VPS_USER: ${{ secrets.VPS_USER }}
-          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
-          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          set -euo pipefail
-          trap 'rm -f ~/.ssh/vps_key ~/.ssh/known_hosts' EXIT
-
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-
-          printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/vps_key
-          chmod 600 ~/.ssh/vps_key
-
-          printf '%s\n' "$VPS_KNOWN_HOSTS" > ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
-
-          quote_remote_word() {
-            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
-          }
-
-          REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"
-
-          ssh \
-            -i ~/.ssh/vps_key \
-            -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile=~/.ssh/known_hosts \
-            -p "$VPS_PORT" \
-            "$VPS_USER@$VPS_HOST" \
-            "sh -lc 'deploy \"\$1\"' deploy $REMOTE_REPO_NAME"
+    uses: SecPal/.github/.github/workflows/reusable-deploy-main.yml@main
+    secrets: inherit

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -15,4 +15,9 @@ permissions:
 jobs:
   deploy:
     uses: SecPal/.github/.github/workflows/reusable-deploy-main.yml@main
-    secrets: inherit
+    secrets:
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      VPS_PORT: ${{ secrets.VPS_PORT }}
+      VPS_USER: ${{ secrets.VPS_USER }}
+      VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+      VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+name: Deploy main to VPS
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-main-${{ github.event.repository.name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Deploy repository on VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          trap 'rm -f ~/.ssh/vps_key ~/.ssh/known_hosts' EXIT
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+          printf '%s\n' "$VPS_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+          quote_remote_word() {
+            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+          }
+
+          REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"
+
+          ssh \
+            -i ~/.ssh/vps_key \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -p "$VPS_PORT" \
+            "$VPS_USER@$VPS_HOST" \
+            "sh -lc 'deploy \"\$1\"' deploy $REMOTE_REPO_NAME"

--- a/.github/workflows/reusable-deploy-main.yml
+++ b/.github/workflows/reusable-deploy-main.yml
@@ -18,6 +18,8 @@ on:
       VPS_KNOWN_HOSTS:
         required: true
 
+permissions: {}
+
 concurrency:
   group: deploy-main-${{ github.event.repository.name }}
   cancel-in-progress: false

--- a/.github/workflows/reusable-deploy-main.yml
+++ b/.github/workflows/reusable-deploy-main.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+name: Reusable Deploy to VPS
+
+on:
+  workflow_call:
+    secrets:
+      VPS_HOST:
+        required: true
+      VPS_PORT:
+        required: true
+      VPS_USER:
+        required: true
+      VPS_SSH_KEY:
+        required: true
+      VPS_KNOWN_HOSTS:
+        required: true
+
+concurrency:
+  group: deploy-main-${{ github.event.repository.name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Deploy repository on VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          trap 'rm -f ~/.ssh/vps_key ~/.ssh/known_hosts' EXIT
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+          printf '%s\n' "$VPS_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+          quote_remote_word() {
+            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+          }
+
+          REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"
+
+          ssh \
+            -i ~/.ssh/vps_key \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -p "$VPS_PORT" \
+            "$VPS_USER@$VPS_HOST" \
+            "sh -c 'deploy \"\$1\"' deploy $REMOTE_REPO_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Added:**
 
-- added `.github/workflows/deploy-main.yml` to deploy the pushed `main` branch repository to a VPS via the remote `deploy <repo>` command, with exact least-privilege permissions, job timeout coverage, SSH host verification, queued per-repository concurrency, and shell-quoted repository-name handoff
-- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future edits keep the workflow contract for headers, exact permissions, timeout, guarded SSH handling, queued deployment concurrency, and safe repository-name handoff under regression coverage
+- added `.github/workflows/deploy-main.yml` as the repo-local caller and `.github/workflows/reusable-deploy-main.yml` as the reusable VPS deploy workflow, so deployable repositories can invoke the same guarded `deploy <repo>` flow through `workflow_call`
+- kept the reusable deploy command on a non-login `sh -c` path with exact least-privilege permissions, job timeout coverage, SSH host verification, queued per-repository concurrency, declared workflow-call secrets, and shell-quoted repository-name handoff
+- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future edits keep the caller and reusable workflow contract for headers, permissions, timeout coverage, reusable invocation, guarded SSH handling, queued deployment concurrency, and safe repository-name handoff under regression coverage
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-07 - Add Main-Branch VPS Deploy Workflow
+
+**Added:**
+
+- added `.github/workflows/deploy-main.yml` to deploy the pushed `main` branch repository to a VPS via the remote `deploy <repo>` command, with exact least-privilege permissions, job timeout coverage, SSH host verification, queued per-repository concurrency, and shell-quoted repository-name handoff
+- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future edits keep the workflow contract for headers, exact permissions, timeout, guarded SSH handling, queued deployment concurrency, and safe repository-name handoff under regression coverage
+
+---
+
 ## 2026-07-06 - Restrict GitHub Actions Dependabot Fallback
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Added:**
 
 - added `.github/workflows/deploy-main.yml` as the repo-local caller and `.github/workflows/reusable-deploy-main.yml` as the reusable VPS deploy workflow, so deployable repositories can invoke the same guarded `deploy <repo>` flow through `workflow_call`
-- kept the reusable deploy command on a non-login `sh -c` path with exact least-privilege permissions, job timeout coverage, SSH host verification, queued per-repository concurrency, declared workflow-call secrets, and shell-quoted repository-name handoff
-- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future edits keep the caller and reusable workflow contract for headers, permissions, timeout coverage, reusable invocation, guarded SSH handling, queued deployment concurrency, and safe repository-name handoff under regression coverage
+- kept the reusable deploy command on a non-login `sh -c` path with exact least-privilege permissions, explicit empty reusable token permissions, SSH host verification, queued per-repository concurrency, declared workflow-call secrets, and shell-quoted repository-name handoff
+- mapped only the five required `VPS_*` secrets from the caller workflow into the reusable deploy workflow instead of inheriting every caller secret
+- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future edits keep the caller and reusable workflow contract for headers, permissions, timeout coverage, explicit secret mapping, reusable invocation, guarded SSH handling, queued deployment concurrency, and safe repository-name handoff under regression coverage
 
 ---
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -122,6 +122,15 @@ if [ -f tests/reusable-workflow-timeouts.sh ]; then
   }
 fi
 
+if [ -f tests/deploy-main-workflow.sh ]; then
+  bash tests/deploy-main-workflow.sh || {
+    echo "" >&2
+    echo "❌ Deploy-main workflow regression test failed!" >&2
+    echo "Restore the guarded main-branch VPS deployment workflow contract before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/copilot-review-memory.sh ]; then
   bash tests/copilot-review-memory.sh || {
     echo "" >&2

--- a/tests/deploy-main-workflow.sh
+++ b/tests/deploy-main-workflow.sh
@@ -59,6 +59,12 @@ if [ "$permissions_block" != "$expected_permissions_block" ]; then
   exit 1
 fi
 
+reusable_permissions_line="$(awk '/^permissions:/ { print; exit }' "$REUSABLE_WORKFLOW")"
+if [ "$reusable_permissions_line" != 'permissions: {}' ]; then
+  echo "Reusable deploy workflow must declare explicit empty token permissions." >&2
+  exit 1
+fi
+
 grep -q '^      - main$' "$CALLER_WORKFLOW" || {
   echo "Deploy caller workflow must trigger on pushes to main." >&2
   exit 1
@@ -84,10 +90,17 @@ grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-deploy-main\.yml
   exit 1
 }
 
-grep -q '^    secrets: inherit$' "$CALLER_WORKFLOW" || {
-  echo "Deploy caller workflow must inherit secrets into the reusable deploy workflow." >&2
+if grep -q '^    secrets: inherit$' "$CALLER_WORKFLOW"; then
+  echo "Deploy caller workflow must not inherit every caller secret into the reusable deploy workflow." >&2
   exit 1
-}
+fi
+
+for secret_name in VPS_HOST VPS_PORT VPS_USER VPS_SSH_KEY VPS_KNOWN_HOSTS; do
+  grep -q "^      ${secret_name}: \${{ secrets\.${secret_name} }}$" "$CALLER_WORKFLOW" || {
+    echo "Deploy caller workflow must map ${secret_name} explicitly into the reusable deploy workflow." >&2
+    exit 1
+  }
+done
 
 if awk '
   /^  deploy:$/ { in_job = 1; next }

--- a/tests/deploy-main-workflow.sh
+++ b/tests/deploy-main-workflow.sh
@@ -2,43 +2,46 @@
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 #
-# Regression checks for the main-branch VPS deployment workflow.
+# Regression checks for the main-branch VPS deployment workflows.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKFLOW="$REPO_ROOT/.github/workflows/deploy-main.yml"
+CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/deploy-main.yml"
+REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-deploy-main.yml"
 
-if [ ! -f "$WORKFLOW" ]; then
-  echo "Expected workflow was not found: $WORKFLOW" >&2
-  exit 1
-fi
+for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
+  if [ ! -f "$workflow" ]; then
+    echo "Expected workflow was not found: $workflow" >&2
+    exit 1
+  fi
 
-marker_count="$(grep -c '^---$' "$WORKFLOW")"
-if [ "$marker_count" -ne 1 ]; then
-  echo "Deploy workflow must contain exactly one YAML document marker." >&2
-  exit 1
-fi
+  marker_count="$(grep -c '^---$' "$workflow")"
+  if [ "$marker_count" -ne 1 ]; then
+    echo "Deploy workflow must contain exactly one YAML document marker: $workflow" >&2
+    exit 1
+  fi
+done
 
-if [ "$(sed -n '1p' "$WORKFLOW")" != '# SPDX-FileCopyrightText: 2026 SecPal' ]; then
-  echo "Deploy workflow must start with the SPDX copyright header." >&2
+if [ "$(sed -n '1p' "$CALLER_WORKFLOW")" != '# SPDX-FileCopyrightText: 2026 SecPal' ]; then
+  echo "Deploy caller workflow must start with the SPDX copyright header." >&2
   exit 1
 fi
 
 license_header_prefix='# SPDX-License'
-if [ "$(sed -n '2p' "$WORKFLOW")" != "${license_header_prefix}-Identifier: AGPL-3.0-or-later" ]; then
-  echo "Deploy workflow must declare the AGPL SPDX license header." >&2
+if [ "$(sed -n '2p' "$CALLER_WORKFLOW")" != "${license_header_prefix}-Identifier: AGPL-3.0-or-later" ]; then
+  echo "Deploy caller workflow must declare the AGPL SPDX license header." >&2
   exit 1
 fi
 
-grep -q '^name: Deploy main to VPS$' "$WORKFLOW" || {
-  echo "Deploy workflow must declare its workflow name." >&2
+grep -q '^name: Deploy main to VPS$' "$CALLER_WORKFLOW" || {
+  echo "Deploy caller workflow must declare its workflow name." >&2
   exit 1
 }
 
-grep -q '^permissions:$' "$WORKFLOW" || {
-  echo "Deploy workflow must declare explicit permissions." >&2
+grep -q '^name: Reusable Deploy to VPS$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must declare its workflow name." >&2
   exit 1
 }
 
@@ -46,78 +49,108 @@ permissions_block="$(awk '
   /^permissions:$/ { in_block = 1; print; next }
   in_block && /^[^[:space:]]/ { exit }
   in_block { print }
-' "$WORKFLOW")"
+' "$CALLER_WORKFLOW")"
 
 expected_permissions_block='permissions:
   contents: read'
 
 if [ "$permissions_block" != "$expected_permissions_block" ]; then
-  echo "Deploy workflow must keep exact least-privilege contents: read permissions." >&2
+  echo "Deploy caller workflow must keep exact least-privilege contents: read permissions." >&2
   exit 1
 fi
 
-grep -q '^    timeout-minutes: 10$' "$WORKFLOW" || {
-  echo "Deploy workflow must set timeout-minutes on the deploy job." >&2
+grep -q '^      - main$' "$CALLER_WORKFLOW" || {
+  echo "Deploy caller workflow must trigger on pushes to main." >&2
   exit 1
 }
 
-grep -q '^      - main$' "$WORKFLOW" || {
-  echo "Deploy workflow must trigger on pushes to main." >&2
+grep -q '^  workflow_call:$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must be callable via workflow_call." >&2
   exit 1
 }
 
-grep -q '^  group: deploy-main-\${{ github.event.repository.name }}$' "$WORKFLOW" || {
-  echo "Deploy workflow must scope concurrency by repository name." >&2
+grep -q '^  group: deploy-main-\${{ github.event.repository.name }}$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must scope concurrency by repository name." >&2
   exit 1
 }
 
-grep -q '^  cancel-in-progress: false$' "$WORKFLOW" || {
-  echo "Deploy workflow must queue newer deployments instead of canceling an active deployment." >&2
+grep -q '^  cancel-in-progress: false$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must queue newer deployments instead of canceling an active deployment." >&2
   exit 1
 }
 
-grep -q '^          VPS_HOST: \${{ secrets.VPS_HOST }}$' "$WORKFLOW" || {
-  echo "Deploy workflow must source VPS_HOST from GitHub secrets." >&2
+grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-deploy-main\.yml@main$' "$CALLER_WORKFLOW" || {
+  echo "Deploy caller workflow must invoke the reusable deploy workflow from @main." >&2
   exit 1
 }
 
-grep -q '^          VPS_KNOWN_HOSTS: \${{ secrets.VPS_KNOWN_HOSTS }}$' "$WORKFLOW" || {
-  echo "Deploy workflow must source VPS_KNOWN_HOSTS from GitHub secrets." >&2
+grep -q '^    secrets: inherit$' "$CALLER_WORKFLOW" || {
+  echo "Deploy caller workflow must inherit secrets into the reusable deploy workflow." >&2
   exit 1
 }
 
-grep -Fq 'trap '\''rm -f ~/.ssh/vps_key ~/.ssh/known_hosts'\'' EXIT' "$WORKFLOW" || {
-  echo "Deploy workflow must clean up the temporary SSH key material." >&2
+if awk '
+  /^  deploy:$/ { in_job = 1; next }
+  in_job && /^  [[:alnum:]_-]+:$/ { in_job = 0 }
+  in_job && /^[[:space:]]+uses: SecPal\/\.github\/\.github\/workflows\/reusable-deploy-main\.yml@main$/ {
+    reusable_job = 1
+  }
+  in_job && /^[[:space:]]+timeout-minutes:/ { has_timeout = 1 }
+  END { exit !(reusable_job && has_timeout) }
+' "$CALLER_WORKFLOW"; then
+  echo "Deploy caller workflow must not set timeout-minutes on a reusable workflow caller job." >&2
+  exit 1
+fi
+
+grep -q '^    timeout-minutes: 10$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must set timeout-minutes on the deploy job." >&2
   exit 1
 }
 
-grep -Fq 'ssh \' "$WORKFLOW" || {
-  echo "Deploy workflow must execute the remote deployment over SSH." >&2
+for secret_name in VPS_HOST VPS_PORT VPS_USER VPS_SSH_KEY VPS_KNOWN_HOSTS; do
+  grep -q "^      ${secret_name}:$" "$REUSABLE_WORKFLOW" || {
+    echo "Reusable deploy workflow must declare ${secret_name} as a workflow_call secret." >&2
+    exit 1
+  }
+
+  grep -q "^          ${secret_name}: \${{ secrets\.${secret_name} }}$" "$REUSABLE_WORKFLOW" || {
+    echo "Reusable deploy workflow must source ${secret_name} from GitHub secrets." >&2
+    exit 1
+  }
+done
+
+grep -Fq 'trap '\''rm -f ~/.ssh/vps_key ~/.ssh/known_hosts'\'' EXIT' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must clean up the temporary SSH key material." >&2
   exit 1
 }
 
-grep -Fq 'quote_remote_word() {' "$WORKFLOW" || {
-  echo "Deploy workflow must shell-quote the repository name for the remote shell." >&2
+grep -Fq 'quote_remote_word() {' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must shell-quote the repository name for the remote shell." >&2
   exit 1
 }
 
-grep -Fq 'REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"' "$WORKFLOW" || {
-  echo "Deploy workflow must prepare a shell-quoted repository name." >&2
+grep -Fq 'REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must prepare a shell-quoted repository name." >&2
   exit 1
 }
 
-grep -Fq '"sh -lc '\''deploy \"\$1\"'\'' deploy $REMOTE_REPO_NAME"' "$WORKFLOW" || {
-  echo "Deploy workflow must pass the repository name as a positional argument to the remote deploy command." >&2
+grep -Fq '"sh -c '\''deploy \"\$1\"'\'' deploy $REMOTE_REPO_NAME"' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must pass the repository name as a positional argument without using a login shell." >&2
   exit 1
 }
+
+if grep -Fq '"sh -lc '\''deploy \"\$1\"'\'' deploy $REMOTE_REPO_NAME"' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable deploy workflow must not use sh -lc for the remote deploy command." >&2
+  exit 1
+fi
 
 remote_output="$(
   env -i PATH="/usr/bin:/bin" \
-    sh -c "sh -lc 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy 'shiny-pelican'"
+    sh -c "sh -c 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy 'shiny-pelican'"
 )"
 
 if [ "$remote_output" != 'argc=1 arg1=shiny-pelican' ]; then
-  echo "Deploy workflow remote command must pass exactly one repository argument." >&2
+  echo "Reusable deploy workflow remote command must pass exactly one repository argument." >&2
   exit 1
 fi
 
@@ -128,12 +161,12 @@ quote_remote_word() {
 quoted_repo_name="$(quote_remote_word "shiny' pelican; echo bad")"
 quoted_remote_output="$(
   env -i PATH="/usr/bin:/bin" \
-    sh -c "sh -lc 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy $quoted_repo_name"
+    sh -c "sh -c 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy $quoted_repo_name"
 )"
 
 if [ "$quoted_remote_output" != "argc=1 arg1=shiny' pelican; echo bad" ]; then
-  echo "Deploy workflow remote repository-name quoting must preserve one argument." >&2
+  echo "Reusable deploy workflow remote repository-name quoting must preserve one argument." >&2
   exit 1
 fi
 
-echo "tests/deploy-main-workflow.sh: deploy-main workflow verified."
+echo "tests/deploy-main-workflow.sh: deploy-main workflows verified."

--- a/tests/deploy-main-workflow.sh
+++ b/tests/deploy-main-workflow.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+#
+# Regression checks for the main-branch VPS deployment workflow.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/deploy-main.yml"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+marker_count="$(grep -c '^---$' "$WORKFLOW")"
+if [ "$marker_count" -ne 1 ]; then
+  echo "Deploy workflow must contain exactly one YAML document marker." >&2
+  exit 1
+fi
+
+if [ "$(sed -n '1p' "$WORKFLOW")" != '# SPDX-FileCopyrightText: 2026 SecPal' ]; then
+  echo "Deploy workflow must start with the SPDX copyright header." >&2
+  exit 1
+fi
+
+license_header_prefix='# SPDX-License'
+if [ "$(sed -n '2p' "$WORKFLOW")" != "${license_header_prefix}-Identifier: AGPL-3.0-or-later" ]; then
+  echo "Deploy workflow must declare the AGPL SPDX license header." >&2
+  exit 1
+fi
+
+grep -q '^name: Deploy main to VPS$' "$WORKFLOW" || {
+  echo "Deploy workflow must declare its workflow name." >&2
+  exit 1
+}
+
+grep -q '^permissions:$' "$WORKFLOW" || {
+  echo "Deploy workflow must declare explicit permissions." >&2
+  exit 1
+}
+
+permissions_block="$(awk '
+  /^permissions:$/ { in_block = 1; print; next }
+  in_block && /^[^[:space:]]/ { exit }
+  in_block { print }
+' "$WORKFLOW")"
+
+expected_permissions_block='permissions:
+  contents: read'
+
+if [ "$permissions_block" != "$expected_permissions_block" ]; then
+  echo "Deploy workflow must keep exact least-privilege contents: read permissions." >&2
+  exit 1
+fi
+
+grep -q '^    timeout-minutes: 10$' "$WORKFLOW" || {
+  echo "Deploy workflow must set timeout-minutes on the deploy job." >&2
+  exit 1
+}
+
+grep -q '^      - main$' "$WORKFLOW" || {
+  echo "Deploy workflow must trigger on pushes to main." >&2
+  exit 1
+}
+
+grep -q '^  group: deploy-main-\${{ github.event.repository.name }}$' "$WORKFLOW" || {
+  echo "Deploy workflow must scope concurrency by repository name." >&2
+  exit 1
+}
+
+grep -q '^  cancel-in-progress: false$' "$WORKFLOW" || {
+  echo "Deploy workflow must queue newer deployments instead of canceling an active deployment." >&2
+  exit 1
+}
+
+grep -q '^          VPS_HOST: \${{ secrets.VPS_HOST }}$' "$WORKFLOW" || {
+  echo "Deploy workflow must source VPS_HOST from GitHub secrets." >&2
+  exit 1
+}
+
+grep -q '^          VPS_KNOWN_HOSTS: \${{ secrets.VPS_KNOWN_HOSTS }}$' "$WORKFLOW" || {
+  echo "Deploy workflow must source VPS_KNOWN_HOSTS from GitHub secrets." >&2
+  exit 1
+}
+
+grep -Fq 'trap '\''rm -f ~/.ssh/vps_key ~/.ssh/known_hosts'\'' EXIT' "$WORKFLOW" || {
+  echo "Deploy workflow must clean up the temporary SSH key material." >&2
+  exit 1
+}
+
+grep -Fq 'ssh \' "$WORKFLOW" || {
+  echo "Deploy workflow must execute the remote deployment over SSH." >&2
+  exit 1
+}
+
+grep -Fq 'quote_remote_word() {' "$WORKFLOW" || {
+  echo "Deploy workflow must shell-quote the repository name for the remote shell." >&2
+  exit 1
+}
+
+grep -Fq 'REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"' "$WORKFLOW" || {
+  echo "Deploy workflow must prepare a shell-quoted repository name." >&2
+  exit 1
+}
+
+grep -Fq '"sh -lc '\''deploy \"\$1\"'\'' deploy $REMOTE_REPO_NAME"' "$WORKFLOW" || {
+  echo "Deploy workflow must pass the repository name as a positional argument to the remote deploy command." >&2
+  exit 1
+}
+
+remote_output="$(
+  env -i PATH="/usr/bin:/bin" \
+    sh -c "sh -lc 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy 'shiny-pelican'"
+)"
+
+if [ "$remote_output" != 'argc=1 arg1=shiny-pelican' ]; then
+  echo "Deploy workflow remote command must pass exactly one repository argument." >&2
+  exit 1
+fi
+
+quote_remote_word() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+quoted_repo_name="$(quote_remote_word "shiny' pelican; echo bad")"
+quoted_remote_output="$(
+  env -i PATH="/usr/bin:/bin" \
+    sh -c "sh -lc 'printf \"argc=%s arg1=%s\\n\" \"\$#\" \"\$1\"' deploy $quoted_repo_name"
+)"
+
+if [ "$quoted_remote_output" != "argc=1 arg1=shiny' pelican; echo bad" ]; then
+  echo "Deploy workflow remote repository-name quoting must preserve one argument." >&2
+  exit 1
+fi
+
+echo "tests/deploy-main-workflow.sh: deploy-main workflow verified."


### PR DESCRIPTION
## Summary

- added `.github/workflows/reusable-deploy-main.yml` so deployable repositories can invoke the VPS `deploy <repo>` contract through `workflow_call`
- kept `.github/workflows/deploy-main.yml` as the repo-local caller on pushes to `main`
- removed the remote login-shell hop and kept the deploy command on a non-login `sh -c` path with SSH host verification and guarded repository-name handoff
- added `tests/deploy-main-workflow.sh` and wired it into `scripts/preflight.sh` so future workflow edits keep the caller and reusable workflow contract under regression coverage
- updated `CHANGELOG.md`

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/deploy-main-workflow.sh` failed because `.github/workflows/reusable-deploy-main.yml` did not exist yet.
- Passing proof after implementation: `bash tests/deploy-main-workflow.sh`; `yamllint .github/workflows/deploy-main.yml`; `reuse lint`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

Already run locally:

- `bash tests/deploy-main-workflow.sh`
- `yamllint .github/workflows/deploy-main.yml`
- `reuse lint`
- `./scripts/preflight.sh`

## Follow-up Before Ready

- rollout of caller workflows in deployable repositories is tracked in `SecPal/.github#528`
- remaining checks are the GitHub Actions runs on this draft PR and the final PR-view self-review before marking the PR ready
