### PR TITLE
Fix invalid direct deploy repo name

### DIFF
--- a/.github/workflows/reusable-deploy-main.yml
+++ b/.github/workflows/reusable-deploy-main.yml
@@ -51,11 +51,10 @@ jobs:
           printf '%s\n' "$VPS_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-          quote_remote_word() {
-            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
-          }
-
-          REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"
+          if ! printf '%s\n' "$REPO_NAME" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "Repository name is unsafe for direct deploy invocation: $REPO_NAME" >&2
+            exit 1
+          fi
 
           ssh \
             -i ~/.ssh/vps_key \
@@ -63,4 +62,4 @@ jobs:
             -o UserKnownHostsFile=~/.ssh/known_hosts \
             -p "$VPS_PORT" \
             "$VPS_USER@$VPS_HOST" \
-            "deploy $REMOTE_REPO_NAME"
+            "deploy $REPO_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-07 - Fix Direct Deploy Repo Name Validation
+
+**Fixed:**
+
+- removed shell-style quoting from `.github/workflows/reusable-deploy-main.yml` when calling the VPS `deploy <repo>` wrapper, because the forced command receives those quotes literally and rejects names such as `'.github'` as invalid
+- validated `github.event.repository.name` locally against the deploy host's allowed `^[A-Za-z0-9._-]+$` contract before invoking the direct `deploy <repo>` command
+- updated `tests/deploy-main-workflow.sh` so regression coverage now checks direct validated repo-name handoff instead of shell-quoted wrapper arguments
+
+---
+
 ## 2026-07-07 - Fix VPS Deploy Wrapper Command
 
 **Fixed:**

--- a/tests/deploy-main-workflow.sh
+++ b/tests/deploy-main-workflow.sh
@@ -137,42 +137,47 @@ grep -Fq 'trap '\''rm -f ~/.ssh/vps_key ~/.ssh/known_hosts'\'' EXIT' "$REUSABLE_
   exit 1
 }
 
-grep -Fq 'quote_remote_word() {' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable deploy workflow must shell-quote the repository name for the remote shell." >&2
+if grep -Fq 'quote_remote_word() {' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable deploy workflow must not shell-quote the repository name into SSH_ORIGINAL_COMMAND." >&2
+  exit 1
+fi
+
+if grep -Fq 'REMOTE_REPO_NAME=' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable deploy workflow must not build a separately quoted remote repository name." >&2
+  exit 1
+fi
+
+grep -Fq 'grep -Eq '\''^[A-Za-z0-9._-]+$'\''' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must validate the repository name before the direct deploy invocation." >&2
   exit 1
 }
 
-grep -Fq 'REMOTE_REPO_NAME="$(quote_remote_word "$REPO_NAME")"' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable deploy workflow must prepare a shell-quoted repository name." >&2
+grep -Fq '"deploy $REPO_NAME"' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable deploy workflow must invoke the remote deploy wrapper directly with the validated repository name." >&2
   exit 1
 }
 
-grep -Fq '"deploy $REMOTE_REPO_NAME"' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable deploy workflow must invoke the remote deploy wrapper directly with the quoted repository name." >&2
+if grep -Fq '"deploy $REMOTE_REPO_NAME"' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable deploy workflow must not quote the repository name into the direct deploy command." >&2
   exit 1
-}
+fi
 
 if grep -Fq '"sh -c '\''deploy \"\$1\"'\'' deploy $REMOTE_REPO_NAME"' "$REUSABLE_WORKFLOW"; then
   echo "Reusable deploy workflow must not wrap the remote deploy command in sh -c." >&2
   exit 1
 fi
 
-simulate_remote_allowlist() {
-  printf '%s\n' "$1" | grep -Eq "^deploy '([^']|'\\\\''*)+'$"
+repo_name_is_safe() {
+  printf '%s\n' "$1" | grep -Eq '^[A-Za-z0-9._-]+$'
 }
 
-if ! simulate_remote_allowlist "deploy 'shiny-pelican'"; then
-  echo "Reusable deploy workflow remote command must match the VPS deploy allowlist shape." >&2
+if ! repo_name_is_safe '.github'; then
+  echo "Reusable deploy workflow must allow repository names that match the VPS deploy contract." >&2
   exit 1
 fi
 
-quote_remote_word() {
-  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
-}
-
-quoted_repo_name="$(quote_remote_word "shiny' pelican; echo bad")"
-if ! simulate_remote_allowlist "deploy $quoted_repo_name"; then
-  echo "Reusable deploy workflow remote repository-name quoting must preserve the direct deploy allowlist shape." >&2
+if repo_name_is_safe "shiny' pelican; echo bad"; then
+  echo "Reusable deploy workflow must reject repository names that are unsafe for direct deploy invocation." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- removed shell-style quoting from the direct `deploy <repo>` SSH command in `.github/workflows/reusable-deploy-main.yml`
- validated the repository name locally against the deploy host's accepted `^[A-Za-z0-9._-]+$` contract before invoking the wrapper
- updated `tests/deploy-main-workflow.sh` so regression coverage checks direct validated repo-name handoff instead of quoted wrapper arguments
- updated `CHANGELOG.md`

## TDD / Validate-First Evidence

- Failing proof before implementation: GitHub Actions run `28880506911`, job `85667134129`, failed on `main` with `Invalid repo name` because the workflow sent `deploy '.github'` and the VPS wrapper received the quotes literally.
- Passing proof after implementation: `bash tests/deploy-main-workflow.sh`; `yamllint .github/workflows/reusable-deploy-main.yml .github/workflows/deploy-main.yml`; `reuse lint`; `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

Already run locally:

- `bash tests/deploy-main-workflow.sh`
- `yamllint .github/workflows/reusable-deploy-main.yml .github/workflows/deploy-main.yml`
- `reuse lint`
- `./scripts/preflight.sh`

## Follow-up Before Ready

- no linked workspaces
- remaining checks are the GitHub Actions runs on this draft PR and the final PR-view self-review before marking the PR ready
