### PR TITLE
Fix Polyscope worktree provisioning WAL watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- updated `scripts/install-polyscope-rollout.sh` so the installed `polyscope-worktree-provision.path` also watches `~/.polyscope/polyscope.db-wal`, ensuring fresh workspace creation still triggers automatic SecPal worktree provisioning when Polyscope records new worktrees in SQLite's WAL file instead of rewriting `polyscope.db` directly
-- extended `tests/polyscope-rollout.sh` to fail if the installed `polyscope-worktree-provision.path` ever drops the `polyscope.db-wal` watch again
+- updated `scripts/install-polyscope-rollout.sh` so the installed `polyscope-worktree-provision.path` watches `~/.polyscope/polyscope.db-wal` with `PathModified=`, ensuring fresh workspace creation triggers automatic SecPal worktree provisioning on WAL appends instead of waiting for the SQLite writer to close `polyscope.db`
+- extended `tests/polyscope-rollout.sh` to fail if the installed `polyscope-worktree-provision.path` ever drops the `PathModified=` watch for `polyscope.db-wal`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-08 - Trigger Provisioning On SQLite WAL Writes
+
+**Fixed:**
+
+- updated `scripts/install-polyscope-rollout.sh` so the installed `polyscope-worktree-provision.path` also watches `~/.polyscope/polyscope.db-wal`, ensuring fresh workspace creation still triggers automatic SecPal worktree provisioning when Polyscope records new worktrees in SQLite's WAL file instead of rewriting `polyscope.db` directly
+- extended `tests/polyscope-rollout.sh` to fail if the installed `polyscope-worktree-provision.path` ever drops the `polyscope.db-wal` watch again
+
+---
+
 ## 2026-07-07 - Fix Direct Deploy Repo Name Validation
 
 **Fixed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -360,7 +360,7 @@ Description=Watch SecPal Polyscope worktree metadata and generated local config 
 
 [Path]
 PathChanged=$HOME/.polyscope/polyscope.db
-PathChanged=$HOME/.polyscope/polyscope.db-wal
+PathModified=$HOME/.polyscope/polyscope.db-wal
 PathChanged=$WORKSPACE_ROOT/api/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/frontend/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -360,6 +360,7 @@ Description=Watch SecPal Polyscope worktree metadata and generated local config 
 
 [Path]
 PathChanged=$HOME/.polyscope/polyscope.db
+PathChanged=$HOME/.polyscope/polyscope.db-wal
 PathChanged=$WORKSPACE_ROOT/api/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/frontend/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4225,6 +4225,7 @@ grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db$' "$fake_unit_dir/polyscope-worktree-provision.path"
+grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db-wal$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -q 'daemon-reload' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4225,7 +4225,7 @@ grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db$' "$fake_unit_dir/polyscope-worktree-provision.path"
-grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db-wal$' "$fake_unit_dir/polyscope-worktree-provision.path"
+grep -qE '^PathModified=.*/\.polyscope/polyscope\.db-wal$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -q 'daemon-reload' "$fake_systemctl_log"


### PR DESCRIPTION
## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/polyscope-rollout.sh` now asserts that the installed `polyscope-worktree-provision.path` includes `PathChanged=.../.polyscope/polyscope.db-wal`; that assertion fails against the previous installer output because only `polyscope.db` was watched.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Defect Evidence

Polyscope can record fresh worktree metadata through SQLite's WAL file without rewriting `~/.polyscope/polyscope.db` directly. The installed `polyscope-worktree-provision.path` only watched `polyscope.db`, so automatic SecPal worktree provisioning could miss new workspace creation when the write landed in `polyscope.db-wal`.

The regression in `tests/polyscope-rollout.sh` now fails if the installed path unit does not include a `PathChanged=` entry for `~/.polyscope/polyscope.db-wal`.

## Change Summary

- Add `~/.polyscope/polyscope.db-wal` to the generated `polyscope-worktree-provision.path` watch list.
- Extend the rollout installer regression to assert the WAL watch is installed.
- Record the fix in `CHANGELOG.md`.

## Validation

- `git diff --check`
- `bash tests/polyscope-rollout.sh`
- `reuse lint`
- Local review completed: correctness/tests/docs, domain and licensing policy, repository hygiene, and security-sensitive automation behavior.
- Commit signature verified locally with `git log --show-signature --oneline -1`.

## Draft Status

- CI has not run yet on the pushed branch.
- Final PR-view self-review is still pending; keep this PR in draft until that review finds zero issues.
- Linked workspace context: `SecPal/frontend (inspect-preview-staleness)` was available but not needed for this repo-local installer fix.
