### PR TITLE
Fix Polyscope preview database password persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - persisted source PostgreSQL `DB_PASSWORD` values back into generated API preview worktree `.env` files during `ensure_api_worktree_ready()` and refreshed them after source password rotation, so PHP-FPM runtime requests no longer fail with `fe_sendauth: no password supplied` after otherwise successful preview provisioning
+- tracked source-managed preview passwords with a hash snapshot so manual worktree `DB_PASSWORD` overrides are preserved, source-password removals clear stale preview secrets, and `refresh_api_worktree()` repairs existing `.env` files before rerunning artisan refresh steps
 - kept schema-mode preview `DB_URL` values password-free while still persisting `DB_PASSWORD` separately in the worktree `.env`, avoiding credential leaks in connection URLs
 - updated `scripts/install-polyscope-rollout.sh` so the installed `polyscope-worktree-provision.path` watches `~/.polyscope/polyscope.db-wal` with `PathModified=`, ensuring fresh workspace creation triggers automatic SecPal worktree provisioning on WAL appends instead of waiting for the SQLite writer to close `polyscope.db`
 - also watched `$POLYSCOPE_CLONE_ROOT` with `PathModified=` and installed a three-minute `polyscope-worktree-provision.timer` fallback so nested workspace-directory creation under existing repository clone roots is still provisioned when the non-recursive path unit cannot observe it directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
+- persisted source PostgreSQL `DB_PASSWORD` values back into generated API preview worktree `.env` files during `ensure_api_worktree_ready()` and refreshed them after source password rotation, so PHP-FPM runtime requests no longer fail with `fe_sendauth: no password supplied` after otherwise successful preview provisioning
+- kept schema-mode preview `DB_URL` values password-free while still persisting `DB_PASSWORD` separately in the worktree `.env`, avoiding credential leaks in connection URLs
 - updated `scripts/install-polyscope-rollout.sh` so the installed `polyscope-worktree-provision.path` watches `~/.polyscope/polyscope.db-wal` with `PathModified=`, ensuring fresh workspace creation triggers automatic SecPal worktree provisioning on WAL appends instead of waiting for the SQLite writer to close `polyscope.db`
 - also watched `$POLYSCOPE_CLONE_ROOT` with `PathModified=` and installed a three-minute `polyscope-worktree-provision.timer` fallback so nested workspace-directory creation under existing repository clone roots is still provisioned when the non-recursive path unit cannot observe it directly
 - stopped explicitly starting `polyscope-worktree-provision.service` during installation so the newly enabled timer and path units do not immediately stack duplicate provisioning runs on already-booted machines

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -527,7 +527,10 @@ def build_api_preview_runtime_shell_command(command: str, source_repo_path: path
 def decode_env_value(raw_value: str) -> str:
     value = raw_value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
-        return value[1:-1]
+        inner_value = value[1:-1]
+        if value[0] == "\"":
+            return inner_value.replace("\\\"", "\"").replace("\\\\", "\\")
+        return inner_value
     return value
 
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -31,6 +31,7 @@ ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
 DEFAULT_ANDROID_SDK_ROOT = pathlib.Path.home() / "Android" / "Sdk"
 PREVIEW_DATABASE_BASE_ENV_KEY = "POLYSCOPE_BASE_DB_DATABASE"
 PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY = "POLYSCOPE_DB_PASSWORD_SOURCE"
+PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY = "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256"
 PREVIEW_DB_PASSWORD_SOURCE_VALUE = "source"
 PREVIEW_SCHEMA_ENV_KEY = "POLYSCOPE_PREVIEW_SCHEMA"
 PREVIEW_STORAGE_MODE_ENV_KEY = "POLYSCOPE_PREVIEW_STORAGE_MODE"
@@ -795,21 +796,67 @@ def load_optional_env_assignments(env_path: pathlib.Path) -> dict[str, str]:
     return load_env_assignments(env_path)
 
 
-def should_use_source_db_password(
+def build_db_password_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def is_source_managed_db_password(
     worktree_env_values: dict[str, str],
     source_env_values: dict[str, str],
 ) -> bool:
-    source_db_password = source_env_values.get("DB_PASSWORD", "").strip()
+    if worktree_env_values.get("DB_CONNECTION", "").strip().lower() != "pgsql":
+        return False
+
+    worktree_db_password = worktree_env_values.get("DB_PASSWORD", "").strip()
+    if not worktree_db_password:
+        return True
+
     if (
-        worktree_env_values.get("DB_CONNECTION", "").strip().lower() != "pgsql"
-        or not source_db_password
+        worktree_env_values.get(PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY, "").strip()
+        != PREVIEW_DB_PASSWORD_SOURCE_VALUE
     ):
         return False
-    return (
-        not worktree_env_values.get("DB_PASSWORD", "").strip()
-        or worktree_env_values.get(PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY, "").strip()
-        == PREVIEW_DB_PASSWORD_SOURCE_VALUE
-    )
+
+    recorded_source_hash = worktree_env_values.get(
+        PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY,
+        "",
+    ).strip()
+    if recorded_source_hash:
+        return recorded_source_hash == build_db_password_sha256(worktree_db_password)
+
+    source_db_password = source_env_values.get("DB_PASSWORD", "").strip()
+    return bool(source_db_password) and worktree_db_password == source_db_password
+
+
+def build_source_db_password_tracking_updates(
+    worktree_env_values: dict[str, str],
+    source_env_values: dict[str, str],
+) -> dict[str, str]:
+    if is_source_managed_db_password(worktree_env_values, source_env_values):
+        source_db_password = source_env_values.get("DB_PASSWORD", "").strip()
+        if source_db_password:
+            return {
+                PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY: PREVIEW_DB_PASSWORD_SOURCE_VALUE,
+                PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY: build_db_password_sha256(source_db_password),
+            }
+        return {
+            PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY: "",
+            PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY: "",
+        }
+
+    if any(
+        worktree_env_values.get(key, "").strip()
+        for key in (
+            PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY,
+            PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY,
+        )
+    ):
+        return {
+            PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY: "",
+            PREVIEW_DB_PASSWORD_SOURCE_SHA256_ENV_KEY: "",
+        }
+
+    return {}
 
 
 def build_api_preview_env_updates(
@@ -865,8 +912,8 @@ def build_api_worktree_runtime_env(
     source_env_values: dict[str, str],
 ) -> dict[str, str]:
     runtime_env_values = dict(worktree_env_values)
-    if should_use_source_db_password(worktree_env_values, source_env_values):
-        runtime_env_values["DB_PASSWORD"] = source_env_values["DB_PASSWORD"].strip()
+    if is_source_managed_db_password(worktree_env_values, source_env_values):
+        runtime_env_values["DB_PASSWORD"] = source_env_values.get("DB_PASSWORD", "").strip()
     return runtime_env_values
 
 
@@ -959,14 +1006,14 @@ def ensure_api_worktree_ready(
         updated_values["APP_KEY"] = generate_laravel_app_key()
 
     if env_values.get("DB_CONNECTION", "").lower() == "pgsql":
-        using_source_db_password = should_use_source_db_password(env_values, source_env_values)
         if (
             env_values.get("DB_PASSWORD", "").strip()
             != runtime_env_values.get("DB_PASSWORD", "").strip()
         ):
             updated_values["DB_PASSWORD"] = runtime_env_values["DB_PASSWORD"]
-        if using_source_db_password:
-            updated_values[PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY] = PREVIEW_DB_PASSWORD_SOURCE_VALUE
+        updated_values.update(
+            build_source_db_password_tracking_updates(env_values, source_env_values)
+        )
         base_database = resolve_base_database_name(runtime_env_values, workspace)
         if not base_database:
             raise SystemExit(f"api worktree {worktree_path} is missing DB_DATABASE in .env")
@@ -1082,6 +1129,13 @@ def refresh_api_worktree(
     *,
     db_path: pathlib.Path | None = None,
 ) -> tuple[bool, str | None]:
+    ready, preview_storage_target = ensure_api_worktree_ready(
+        worktree_path,
+        source_repo_path,
+        db_path=db_path,
+    )
+    if not ready:
+        return ready, preview_storage_target
     return bootstrap_api_worktree(
         worktree_path,
         source_repo_path,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -30,6 +30,8 @@ PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
 ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
 DEFAULT_ANDROID_SDK_ROOT = pathlib.Path.home() / "Android" / "Sdk"
 PREVIEW_DATABASE_BASE_ENV_KEY = "POLYSCOPE_BASE_DB_DATABASE"
+PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY = "POLYSCOPE_DB_PASSWORD_SOURCE"
+PREVIEW_DB_PASSWORD_SOURCE_VALUE = "source"
 PREVIEW_SCHEMA_ENV_KEY = "POLYSCOPE_PREVIEW_SCHEMA"
 PREVIEW_STORAGE_MODE_ENV_KEY = "POLYSCOPE_PREVIEW_STORAGE_MODE"
 POSTGRES_PREVIEW_DATABASE_SEPARATOR = "__preview__"
@@ -793,6 +795,23 @@ def load_optional_env_assignments(env_path: pathlib.Path) -> dict[str, str]:
     return load_env_assignments(env_path)
 
 
+def should_use_source_db_password(
+    worktree_env_values: dict[str, str],
+    source_env_values: dict[str, str],
+) -> bool:
+    source_db_password = source_env_values.get("DB_PASSWORD", "").strip()
+    if (
+        worktree_env_values.get("DB_CONNECTION", "").strip().lower() != "pgsql"
+        or not source_db_password
+    ):
+        return False
+    return (
+        not worktree_env_values.get("DB_PASSWORD", "").strip()
+        or worktree_env_values.get(PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY, "").strip()
+        == PREVIEW_DB_PASSWORD_SOURCE_VALUE
+    )
+
+
 def build_api_preview_env_updates(
     workspace: str,
     frontend_workspace: str | None = None,
@@ -846,13 +865,8 @@ def build_api_worktree_runtime_env(
     source_env_values: dict[str, str],
 ) -> dict[str, str]:
     runtime_env_values = dict(worktree_env_values)
-    if (
-        runtime_env_values.get("DB_CONNECTION", "").strip().lower() == "pgsql"
-        and not runtime_env_values.get("DB_PASSWORD", "").strip()
-    ):
-        source_db_password = source_env_values.get("DB_PASSWORD", "").strip()
-        if source_db_password:
-            runtime_env_values["DB_PASSWORD"] = source_db_password
+    if should_use_source_db_password(worktree_env_values, source_env_values):
+        runtime_env_values["DB_PASSWORD"] = source_env_values["DB_PASSWORD"].strip()
     return runtime_env_values
 
 
@@ -945,6 +959,14 @@ def ensure_api_worktree_ready(
         updated_values["APP_KEY"] = generate_laravel_app_key()
 
     if env_values.get("DB_CONNECTION", "").lower() == "pgsql":
+        using_source_db_password = should_use_source_db_password(env_values, source_env_values)
+        if (
+            env_values.get("DB_PASSWORD", "").strip()
+            != runtime_env_values.get("DB_PASSWORD", "").strip()
+        ):
+            updated_values["DB_PASSWORD"] = runtime_env_values["DB_PASSWORD"]
+        if using_source_db_password:
+            updated_values[PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY] = PREVIEW_DB_PASSWORD_SOURCE_VALUE
         base_database = resolve_base_database_name(runtime_env_values, workspace)
         if not base_database:
             raise SystemExit(f"api worktree {worktree_path} is missing DB_DATABASE in .env")

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1946,12 +1946,13 @@ PY
 
 # upsert_env_assignments must preserve backslashes in replacement values instead
 # of letting re.sub interpret them as replacement escapes.
-python3 -B - <<'PY' "$PYTHON_SCRIPT"
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
 import sys
 
 script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
 spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
 module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
@@ -1962,6 +1963,11 @@ updated = module.upsert_env_assignments(
     {"DB_PASSWORD": r"secret\path\1"},
 )
 assert r"DB_PASSWORD=secret\path\1" in updated, updated
+
+round_trip_path = workspace / "roundtrip.env"
+round_trip_path.write_text('DB_PASSWORD="secret\\\\path\\\\1 #\\"quoted\\""\n')
+round_trip = module.load_env_assignments(round_trip_path)
+assert round_trip["DB_PASSWORD"] == 'secret\\path\\1 #"quoted"', round_trip
 PY
 
 # ensure_api_worktree_ready must persist the PostgreSQL password into preview
@@ -2044,6 +2050,71 @@ assert calls == [
 worktree_env = api_worktree.joinpath(".env").read_text()
 assert "DB_PASSWORD=rotated-source-password" in worktree_env, worktree_env
 assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
+PY
+
+# ensure_api_worktree_ready must preserve source-managed PostgreSQL passwords
+# that require quoted env encoding across later reruns.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "escaped-pgsql-password-fixture" / "source-api"
+api_worktree = workspace / "escaped-pgsql-password-fixture" / "clones" / "api12345" / "quiet-bear"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_password = 'secret\\path\\1 #"quoted"'
+escaped_source_password = source_password.replace("\\", "\\\\").replace('"', '\\"')
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    f'DB_PASSWORD="{escaped_source_password}"\n'
+)
+api_worktree.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+calls = []
+
+def fake_postgres_role_can_create_databases(env_values, base_database):
+    calls.append(("role", env_values["DB_PASSWORD"], base_database))
+    return True
+
+def fake_ensure_postgres_preview_database(env_values, base_database, preview_database):
+    calls.append(("create", env_values["DB_PASSWORD"], base_database, preview_database))
+
+module.postgres_role_can_create_databases = fake_postgres_role_can_create_databases
+module.ensure_postgres_preview_database = fake_ensure_postgres_preview_database
+
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__quiet_bear", target
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__quiet_bear", target
+assert calls == [
+    ("role", source_password, "secpal"),
+    ("create", source_password, "secpal", "secpal__preview__quiet_bear"),
+    ("role", source_password, "secpal"),
+    ("create", source_password, "secpal", "secpal__preview__quiet_bear"),
+], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert 'DB_PASSWORD="secret\\\\path\\\\1 #\\"quoted\\""' in worktree_env, worktree_env
 PY
 
 # ensure_api_worktree_ready must not overwrite an explicitly configured

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1964,9 +1964,10 @@ updated = module.upsert_env_assignments(
 assert r"DB_PASSWORD=secret\path\1" in updated, updated
 PY
 
-# ensure_api_worktree_ready must use a source-only PostgreSQL password
-# transiently for preview database provisioning without persisting it into the
-# generated worktree .env.
+# ensure_api_worktree_ready must persist the PostgreSQL password into preview
+# API worktree .env files so PHP-FPM runtime requests can connect after
+# provisioning, while still using that same password during preview database
+# provisioning.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -2022,12 +2023,90 @@ assert calls == [
     ("create", "source-only-password", "secpal", "secpal__preview__quiet_bear"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=rotated-source-password\n"
+)
+calls.clear()
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__quiet_bear", target
+assert calls == [
+    ("role", "rotated-source-password", "secpal"),
+    ("create", "rotated-source-password", "secpal", "secpal__preview__quiet_bear"),
+], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=rotated-source-password" in worktree_env, worktree_env
 assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
-assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
 PY
 
-# ensure_api_worktree_ready must not persist a source-only PostgreSQL password
-# into schema-mode preview .env values or DB_URL values.
+# ensure_api_worktree_ready must not overwrite an explicitly configured
+# worktree PostgreSQL password with the source checkout password.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "explicit-pgsql-password-fixture" / "source-api"
+api_worktree = workspace / "explicit-pgsql-password-fixture" / "clones" / "api12345" / "quiet-bear"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=source-password\n"
+)
+api_worktree.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=worktree-password\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+calls = []
+
+def fake_postgres_role_can_create_databases(env_values, base_database):
+    calls.append(("role", env_values["DB_PASSWORD"], base_database))
+    return True
+
+def fake_ensure_postgres_preview_database(env_values, base_database, preview_database):
+    calls.append(("create", env_values["DB_PASSWORD"], base_database, preview_database))
+
+module.postgres_role_can_create_databases = fake_postgres_role_can_create_databases
+module.ensure_postgres_preview_database = fake_ensure_postgres_preview_database
+
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__quiet_bear", target
+assert calls == [
+    ("role", "worktree-password", "secpal"),
+    ("create", "worktree-password", "secpal", "secpal__preview__quiet_bear"),
+], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=worktree-password" in worktree_env, worktree_env
+assert "DB_PASSWORD=source-password" not in worktree_env, worktree_env
+PY
+
+# ensure_api_worktree_ready must persist the PostgreSQL password into schema-mode
+# preview .env values without leaking it through generated DB_URL values.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -2083,8 +2162,7 @@ assert calls == [
     ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
-assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 
@@ -2097,8 +2175,7 @@ assert calls == [
     ("schema", "source-only-password", "secpal", "secpal__preview__careful_otter"),
 ], calls
 worktree_env = api_worktree.joinpath(".env").read_text()
-assert "DB_PASSWORD=source-only-password" not in worktree_env, worktree_env
-assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
 assert "source-only-password@" not in worktree_env, worktree_env
 assert "DB_URL=postgresql://secpal_app@127.0.0.1:5432/secpal?search_path=secpal__preview__careful_otter" in worktree_env, worktree_env
 PY

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2049,6 +2049,7 @@ PY
 # ensure_api_worktree_ready must not overwrite an explicitly configured
 # worktree PostgreSQL password with the source checkout password.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import hashlib
 import importlib.util
 import pathlib
 import sys
@@ -2074,6 +2075,8 @@ api_worktree.joinpath(".env").write_text(
     "DB_DATABASE=secpal\n"
     "DB_USERNAME=secpal_app\n"
     "DB_PASSWORD=worktree-password\n"
+    "POLYSCOPE_DB_PASSWORD_SOURCE=source\n"
+    f"POLYSCOPE_DB_PASSWORD_SOURCE_SHA256={hashlib.sha256('source-password'.encode('utf-8')).hexdigest()}\n"
 )
 
 spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
@@ -2103,6 +2106,72 @@ assert calls == [
 worktree_env = api_worktree.joinpath(".env").read_text()
 assert "DB_PASSWORD=worktree-password" in worktree_env, worktree_env
 assert "DB_PASSWORD=source-password" not in worktree_env, worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE=\n" in worktree_env or worktree_env.endswith("POLYSCOPE_DB_PASSWORD_SOURCE="), worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256=\n" in worktree_env or worktree_env.endswith("POLYSCOPE_DB_PASSWORD_SOURCE_SHA256="), worktree_env
+PY
+
+# ensure_api_worktree_ready must clear a source-managed worktree password when
+# the source checkout clears DB_PASSWORD.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import hashlib
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "cleared-source-pgsql-password-fixture" / "source-api"
+api_worktree = workspace / "cleared-source-pgsql-password-fixture" / "clones" / "api12345" / "quiet-bear"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=\n"
+)
+source_hash = hashlib.sha256("source-password".encode("utf-8")).hexdigest()
+api_worktree.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal_app\n"
+    "DB_PASSWORD=source-password\n"
+    "POLYSCOPE_DB_PASSWORD_SOURCE=source\n"
+    f"POLYSCOPE_DB_PASSWORD_SOURCE_SHA256={source_hash}\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+calls = []
+
+def fake_postgres_role_can_create_databases(env_values, base_database):
+    calls.append(("role", env_values["DB_PASSWORD"], base_database))
+    return True
+
+def fake_ensure_postgres_preview_database(env_values, base_database, preview_database):
+    calls.append(("create", env_values["DB_PASSWORD"], base_database, preview_database))
+
+module.postgres_role_can_create_databases = fake_postgres_role_can_create_databases
+module.ensure_postgres_preview_database = fake_ensure_postgres_preview_database
+
+ready, target = module.ensure_api_worktree_ready(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__quiet_bear", target
+assert calls == [
+    ("role", "", "secpal"),
+    ("create", "", "secpal", "secpal__preview__quiet_bear"),
+], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=\n" in worktree_env or worktree_env.endswith("DB_PASSWORD="), worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE=\n" in worktree_env or worktree_env.endswith("POLYSCOPE_DB_PASSWORD_SOURCE="), worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256=\n" in worktree_env or worktree_env.endswith("POLYSCOPE_DB_PASSWORD_SOURCE_SHA256="), worktree_env
 PY
 
 # ensure_api_worktree_ready must persist the PostgreSQL password into schema-mode
@@ -2217,6 +2286,14 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 calls = []
+db_calls = []
+
+def fake_postgres_role_can_create_databases(env_values, base_database):
+    db_calls.append(("role", env_values["DB_PASSWORD"], base_database))
+    return True
+
+def fake_ensure_postgres_preview_database(env_values, base_database, preview_database):
+    db_calls.append(("create", env_values["DB_PASSWORD"], base_database, preview_database))
 
 def fake_run_api_worktree_bootstrap_command(worktree_path, command, *, command_env):
     calls.append(
@@ -2228,11 +2305,22 @@ def fake_run_api_worktree_bootstrap_command(worktree_path, command, *, command_e
         )
     )
 
+module.postgres_role_can_create_databases = fake_postgres_role_can_create_databases
+module.ensure_postgres_preview_database = fake_ensure_postgres_preview_database
 module.run_api_worktree_bootstrap_command = fake_run_api_worktree_bootstrap_command
 
 ready, target = module.refresh_api_worktree(api_worktree, source_api)
 assert ready is True
 assert target == "database:secpal__preview__quiet_bear", target
+assert db_calls == [
+    ("role", "source-only-password", "secpal"),
+    (
+        "create",
+        "source-only-password",
+        "secpal",
+        "secpal__preview__quiet_bear",
+    ),
+], db_calls
 assert calls == [
     (("php", "artisan", "config:clear"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "migrate:fresh", "--force"), api_worktree, "source-only-password", "source-only-password"),
@@ -2244,6 +2332,10 @@ assert calls == [
         "source-only-password",
     ),
 ], calls
+worktree_env = api_worktree.joinpath(".env").read_text()
+assert "DB_PASSWORD=source-only-password" in worktree_env, worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE=source" in worktree_env, worktree_env
+assert "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256=" in worktree_env, worktree_env
 PY
 
 # run_api_worktree_shell_command must reuse the transient runtime DB password


### PR DESCRIPTION
Defect reproduced: API preview provisioning could use the source checkout PostgreSQL password to create or prepare preview storage, but the generated API preview worktree `.env` still kept `DB_PASSWORD` empty. That left later PHP-FPM runtime requests without a password and produced `fe_sendauth: no password supplied` after otherwise successful provisioning.

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/polyscope-rollout.sh` PostgreSQL preview password coverage was updated first to assert that generated API preview worktree `.env` files persist `DB_PASSWORD=source-only-password`; the pre-change implementation left `DB_PASSWORD` empty after provisioning.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `./scripts/preflight.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary

- Persist the source checkout `DB_PASSWORD` into generated PostgreSQL API preview worktree `.env` files when the worktree does not have an explicit password.
- Track source-derived worktree passwords with `POLYSCOPE_DB_PASSWORD_SOURCE=source` so later source password rotation refreshes the generated preview `.env`.
- Preserve explicitly configured worktree passwords instead of replacing them with the source checkout password.
- Keep schema-mode preview `DB_URL` values password-free while storing the runtime password separately as `DB_PASSWORD`.
- Add rollout regression coverage and update `CHANGELOG.md`.

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- `git diff --check`
- Signed commit verified with `git log --show-signature --oneline --max-count=1`

## Review Notes

- Local four-pass review completed: comprehensive, deep-dive, best-practices, and security.
- No out-of-scope findings were found that require a new issue.
- Linked workspace available for context: `SecPal/frontend` at `/home/secpal/.polyscope/clones/b6624c93/fix-preview-api-alias`; it was not modified for this change.
- Before marking this draft ready, GitHub Actions must finish successfully and the final PR-view self-review must still find zero issues.
