### PR TITLE
Fix Dependabot auto-merge self-reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,8 +204,10 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
 - Consume them via:
 
   ```yaml
-  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@main
+  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@<trusted-commit-sha>
   ```
+
+- For cross-repository callers, prefer a reviewed immutable commit SHA over a branch ref. A moving branch or stale tag can silently change or preserve behavior outside the caller's own change set.
 
 - Check `EXAMPLE_workflow_for_other_repos.yml` for reference patterns before writing a new workflow
 

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -49,8 +49,10 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
 - Consume them via:
 
   ```yaml
-  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@main
+  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@<trusted-commit-sha>
   ```
+
+- For cross-repository callers, prefer a reviewed immutable commit SHA over a branch ref. A moving branch or stale tag can silently change or preserve behavior outside the caller's own change set.
 
 - Check `EXAMPLE_workflow_for_other_repos.yml` for reference patterns before writing a new workflow
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,11 +1,15 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Reusable Workflows
 
 This directory contains reusable GitHub Actions workflows that can be used across all SecPal repositories.
+
+For cross-repository callers, pin reusable workflows to a reviewed immutable
+commit SHA such as `@<trusted-commit-sha>`. Do not copy moving branch refs such
+as `@main` into consumer repositories.
 
 ## Available Workflows
 
@@ -20,7 +24,7 @@ Checks REUSE 3.3 compliance for copyright and licensing information.
 ```yaml
 jobs:
   reuse:
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@<trusted-commit-sha>
 ```
 
 #### `reusable-license-compatibility.yml`
@@ -32,7 +36,7 @@ Checks that all licenses are compatible with AGPL-3.0-or-later.
 ```yaml
 jobs:
   license-check:
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@<trusted-commit-sha>
 ```
 
 #### `reusable-prettier.yml`
@@ -46,7 +50,7 @@ When a repository has a `package.json`, the workflow uses `npm ci` by default an
 ```yaml
 jobs:
   prettier:
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@<trusted-commit-sha>
     with:
       node-version: "22.x" # optional, default: '22.x'
       files: "**/*.{md,yml,yaml,json}" # optional
@@ -62,7 +66,7 @@ Lints Markdown files.
 ```yaml
 jobs:
   markdown-lint:
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@<trusted-commit-sha>
 ```
 
 ### Frontend Workflows (Node.js/React)
@@ -76,7 +80,7 @@ Runs Node.js tests.
 ```yaml
 jobs:
   test:
-    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@<trusted-commit-sha>
     with:
       node-version: "22.x" # optional, default: '22.x'
       install-command: "npm ci" # optional
@@ -92,7 +96,7 @@ Runs Node.js linting (ESLint).
 ```yaml
 jobs:
   lint:
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@<trusted-commit-sha>
     with:
       node-version: "22.x" # optional, default: '22.x'
       lint-command: "npm run lint" # optional
@@ -107,7 +111,7 @@ Builds Node.js project.
 ```yaml
 jobs:
   build:
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@<trusted-commit-sha>
     with:
       node-version: "22.x" # optional, default: '22.x'
       build-command: "npm run build" # optional
@@ -124,7 +128,7 @@ Runs PHP tests with PEST.
 ```yaml
 jobs:
   test:
-    uses: SecPal/.github/.github/workflows/reusable-php-test.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-test.yml@<trusted-commit-sha>
     with:
       php-version: "8.4" # optional, default: '8.4'
       test-command: "./vendor/bin/pest" # optional
@@ -139,7 +143,7 @@ Checks PHP code style with Laravel Pint.
 ```yaml
 jobs:
   pint:
-    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@<trusted-commit-sha>
     with:
       php-version: "8.4" # optional, default: '8.4'
       pint-command: "./vendor/bin/pint --test" # optional
@@ -154,7 +158,7 @@ Runs static analysis with PHPStan.
 ```yaml
 jobs:
   phpstan:
-    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@<trusted-commit-sha>
     with:
       php-version: "8.4" # optional, default: '8.4'
       phpstan-command: "./vendor/bin/phpstan analyse" # optional
@@ -173,7 +177,7 @@ When a repository has a `package.json`, the workflow uses `npm ci` by default an
 ```yaml
 jobs:
   openapi-lint:
-    uses: SecPal/.github/.github/workflows/reusable-openapi-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-openapi-lint.yml@<trusted-commit-sha>
     with:
       openapi-file: "openapi.yaml" # optional, default: 'openapi.yaml'
       node-version: "22.x" # optional, default: '22.x'
@@ -201,25 +205,25 @@ on:
 
 jobs:
   reuse:
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@<trusted-commit-sha>
 
   license-check:
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@<trusted-commit-sha>
 
   prettier:
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@<trusted-commit-sha>
 
   markdown-lint:
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@<trusted-commit-sha>
 
   lint:
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@<trusted-commit-sha>
 
   test:
-    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@<trusted-commit-sha>
 
   build:
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@<trusted-commit-sha>
 ```
 
 ## Example: Complete CI Workflow for Backend
@@ -237,19 +241,19 @@ on:
 
 jobs:
   reuse:
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@<trusted-commit-sha>
 
   license-check:
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@<trusted-commit-sha>
 
   pint:
-    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@<trusted-commit-sha>
 
   phpstan:
-    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@<trusted-commit-sha>
 
   test:
-    uses: SecPal/.github/.github/workflows/reusable-php-test.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-test.yml@<trusted-commit-sha>
 ```
 
 ### Workflow Linting
@@ -263,5 +267,5 @@ Lints GitHub Actions workflows with actionlint and shellcheck.
 ```yaml
 jobs:
   actionlint:
-    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@<trusted-commit-sha>
 ```

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,9 +33,9 @@ jobs:
     # skip auto-merge enrollment. See:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    # Reuse the local workflow file so same-repo fixes stay coherent inside one
-    # pull request instead of depending on a separately published tag.
-    uses: ./.github/workflows/reusable-dependabot-auto-merge.yml
+    # Keep auto-merge decisions on the reviewed main-branch workflow so
+    # Dependabot PRs cannot execute unreviewed policy changes from the same PR.
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
     with:
       # Phase 1: Only PATCH updates auto-merge
       phase: "1"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,7 +33,9 @@ jobs:
     # skip auto-merge enrollment. See:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
+    # Reuse the local workflow file so same-repo fixes stay coherent inside one
+    # pull request instead of depending on a separately published tag.
+    uses: ./.github/workflows/reusable-dependabot-auto-merge.yml
     with:
       # Phase 1: Only PATCH updates auto-merge
       phase: "1"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Note: This workflow uses inline jobs instead of calling reusable workflows

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,9 +4,10 @@
 # Note: This workflow uses inline jobs instead of calling reusable workflows
 # to avoid a chicken-and-egg problem: the reusable workflows are not yet
 # available on the main branch until this PR is merged.
-# Other repositories should use the reusable workflows via:
-#   uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
-#   uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+# Other repositories should use the reusable workflows via reviewed immutable
+# refs such as:
+#   uses: SecPal/.github/.github/workflows/reusable-prettier.yml@<trusted-commit-sha>
+#   uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@<trusted-commit-sha>
 
 name: Code Quality
 

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -12,8 +12,7 @@
 #         phase: "1"  # Optional: 1 (PATCH only), 2 or 3 (PATCH+MINOR)
 #
 # For cross-repository callers, pin to a reviewed immutable commit SHA. A
-# moved tag can lag behind the reusable workflow source and silently preserve
-# obsolete behavior.
+# moving branch ref or stale tag can silently preserve obsolete behavior.
 #
 # Strategy:
 #   Phase 1 (default): PATCH updates auto-merge ✅, MINOR/MAJOR require review

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -7,9 +7,13 @@
 # Usage in other repositories:
 #   jobs:
 #     auto-merge:
-#       uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
+#       uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@<trusted-commit-sha>
 #       with:
 #         phase: "1"  # Optional: 1 (PATCH only), 2 or 3 (PATCH+MINOR)
+#
+# For cross-repository callers, pin to a reviewed immutable commit SHA. A
+# moved tag can lag behind the reusable workflow source and silently preserve
+# obsolete behavior.
 #
 # Strategy:
 #   Phase 1 (default): PATCH updates auto-merge ✅, MINOR/MAJOR require review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,8 +201,10 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
 - Consume them via:
 
   ```yaml
-  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@main
+  uses: SecPal/.github/.github/workflows/reusable-<name>.yml@<trusted-commit-sha>
   ```
+
+- For cross-repository callers, prefer a reviewed immutable commit SHA over a branch ref. A moving branch or stale tag can silently change or preserve behavior outside the caller's own change set.
 
 - Check `EXAMPLE_workflow_for_other_repos.yml` for reference patterns before writing a new workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - updated `EXAMPLE_workflow_for_other_repos.yml` and extended `tests/dependabot-auto-merge.sh` so cross-repository reference patterns now use immutable commit SHA placeholders and the caller workflow cannot regress to a local reusable workflow path, stale `@v1` tag, or moving example refs
 - updated `.github/workflows/README.md` to align every cross-repository reusable workflow example with the immutable SHA-pinning guidance instead of moving `@main` refs, and refreshed the touched example file SPDX years
 - updated `docs/workflows/ROLLOUT_GUIDE.md` and the cross-repository guidance comments in `.github/workflows/quality.yml` so the remaining reusable workflow copy-paste examples no longer point consumers at moving `@main` refs
+- updated the rollout guide's later maintenance section so it now describes rotating reviewed commit SHAs instead of auto-tracking `@main` or pinning release tags, and refreshed the touched `quality.yml` SPDX year
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- switched `.github/workflows/dependabot-auto-merge.yml` to call `./.github/workflows/reusable-dependabot-auto-merge.yml` locally, so same-repo Dependabot workflow fixes no longer depend on whatever state the external `SecPal/.github@v1` tag happens to expose
+- switched `.github/workflows/dependabot-auto-merge.yml` from the stale `SecPal/.github@v1` tag to the reviewed `SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main` ref, so this repository no longer depends on an outdated published tag while keeping auto-merge decisions on reviewed workflow code
 - updated `.github/workflows/reusable-dependabot-auto-merge.yml`, `.github/instructions/github-workflows.instructions.md`, and `.github/copilot-instructions.md` to tell cross-repository callers to pin reusable workflows to a reviewed immutable commit SHA instead of `@main` or the stale `@v1` example
-- extended `tests/dependabot-auto-merge.sh` to fail if the caller workflow regresses to a self-reference through `@v1` or if the reusable workflow example stops documenting immutable SHA pinning for external callers
+- updated `EXAMPLE_workflow_for_other_repos.yml` and extended `tests/dependabot-auto-merge.sh` so cross-repository reference patterns now use immutable commit SHA placeholders and the caller workflow cannot regress to a local reusable workflow path, stale `@v1` tag, or moving example refs
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - updated `.github/workflows/reusable-dependabot-auto-merge.yml`, `.github/instructions/github-workflows.instructions.md`, and `.github/copilot-instructions.md` to tell cross-repository callers to pin reusable workflows to a reviewed immutable commit SHA instead of `@main` or the stale `@v1` example
 - updated `EXAMPLE_workflow_for_other_repos.yml` and extended `tests/dependabot-auto-merge.sh` so cross-repository reference patterns now use immutable commit SHA placeholders and the caller workflow cannot regress to a local reusable workflow path, stale `@v1` tag, or moving example refs
 - updated `.github/workflows/README.md` to align every cross-repository reusable workflow example with the immutable SHA-pinning guidance instead of moving `@main` refs, and refreshed the touched example file SPDX years
+- updated `docs/workflows/ROLLOUT_GUIDE.md` and the cross-repository guidance comments in `.github/workflows/quality.yml` so the remaining reusable workflow copy-paste examples no longer point consumers at moving `@main` refs
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - switched `.github/workflows/dependabot-auto-merge.yml` from the stale `SecPal/.github@v1` tag to the reviewed `SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main` ref, so this repository no longer depends on an outdated published tag while keeping auto-merge decisions on reviewed workflow code
 - updated `.github/workflows/reusable-dependabot-auto-merge.yml`, `.github/instructions/github-workflows.instructions.md`, and `.github/copilot-instructions.md` to tell cross-repository callers to pin reusable workflows to a reviewed immutable commit SHA instead of `@main` or the stale `@v1` example
 - updated `EXAMPLE_workflow_for_other_repos.yml` and extended `tests/dependabot-auto-merge.sh` so cross-repository reference patterns now use immutable commit SHA placeholders and the caller workflow cannot regress to a local reusable workflow path, stale `@v1` tag, or moving example refs
+- updated `.github/workflows/README.md` to align every cross-repository reusable workflow example with the immutable SHA-pinning guidance instead of moving `@main` refs, and refreshed the touched example file SPDX years
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-09 - Remove Dependabot Auto-Merge Self-Tag Drift
+
+**Fixed:**
+
+- switched `.github/workflows/dependabot-auto-merge.yml` to call `./.github/workflows/reusable-dependabot-auto-merge.yml` locally, so same-repo Dependabot workflow fixes no longer depend on whatever state the external `SecPal/.github@v1` tag happens to expose
+- updated `.github/workflows/reusable-dependabot-auto-merge.yml`, `.github/instructions/github-workflows.instructions.md`, and `.github/copilot-instructions.md` to tell cross-repository callers to pin reusable workflows to a reviewed immutable commit SHA instead of `@main` or the stale `@v1` example
+- extended `tests/dependabot-auto-merge.sh` to fail if the caller workflow regresses to a self-reference through `@v1` or if the reusable workflow example stops documenting immutable SHA pinning for external callers
+
+---
+
 ## 2026-07-08 - Harden Polyscope Workspace Provisioning Triggers
 
 **Fixed:**

--- a/EXAMPLE_workflow_for_other_repos.yml
+++ b/EXAMPLE_workflow_for_other_repos.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # This file shows how to use the reusable workflows from SecPal/.github

--- a/EXAMPLE_workflow_for_other_repos.yml
+++ b/EXAMPLE_workflow_for_other_repos.yml
@@ -6,6 +6,7 @@
 #              frontend/.github/workflows/project-automation.yml
 #              contracts/.github/workflows/project-automation.yml
 
+---
 name: Project Board Automation
 
 on:
@@ -26,10 +27,10 @@ on:
 jobs:
   # Automatic project board status updates
   project-automation:
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@<trusted-commit-sha>
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
 
   # Friendly reminder about draft PRs
   draft-reminder:
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@<trusted-commit-sha>

--- a/docs/workflows/ROLLOUT_GUIDE.md
+++ b/docs/workflows/ROLLOUT_GUIDE.md
@@ -303,16 +303,16 @@ After deployment, monitor:
 
 When the reusable workflow in `.github` is updated:
 
-1. **Automatic:** Workflows in other repos automatically use the latest version (because of `@main`)
-2. **No action needed** in consuming repositories
-3. **Testing:** Always test in `.github` repo first
+1. **Publish a reviewed ref:** capture the reviewed workflow commit SHA after testing in `.github`
+2. **Update consuming repositories:** replace the old pinned SHA with the new reviewed commit SHA
+3. **Testing:** always test the workflow in `.github` before rolling the new SHA into consumers
 
 ### Pinning to a Specific Version
 
-For stability, pin to a release tag:
+For stability, pin to the reviewed workflow commit SHA:
 
 ```yaml
-uses: SecPal/.github/.github/workflows/project-automation-v2.yml@v1.0.0
+uses: SecPal/.github/.github/workflows/project-automation-v2.yml@<trusted-commit-sha>
 ```
 
 ## 📝 Documentation Updates

--- a/docs/workflows/ROLLOUT_GUIDE.md
+++ b/docs/workflows/ROLLOUT_GUIDE.md
@@ -46,7 +46,7 @@ on:
 
 jobs:
   automate:
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@<trusted-commit-sha>
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
 ```
@@ -206,7 +206,7 @@ If your repository uses different labels, modify the workflow file:
 ```yaml
 jobs:
   automate:
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@<trusted-commit-sha>
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     # Note: Label mapping is in the reusable workflow

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -19,6 +19,7 @@ CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
 WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instructions.md"
 WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
+WORKFLOW_CATALOG_README="$REPO_ROOT/.github/workflows/README.md"
 
 for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   if [ ! -f "$workflow" ]; then
@@ -59,6 +60,11 @@ fi
 
 if [ ! -f "$WORKFLOW_EXAMPLE" ]; then
   echo "Expected workflow example was not found: $WORKFLOW_EXAMPLE" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKFLOW_CATALOG_README" ]; then
+  echo "Expected workflow catalog README was not found: $WORKFLOW_CATALOG_README" >&2
   exit 1
 fi
 
@@ -195,6 +201,16 @@ grep -q '^    uses: SecPal/\.github/\.github/workflows/project-automation-v2\.ym
 
 grep -q '^    uses: SecPal/\.github/\.github/workflows/draft-pr-reminder\.yml@<trusted-commit-sha>$' "$WORKFLOW_EXAMPLE" || {
   echo "Workflow example must pin draft PR reminder to a trusted commit SHA." >&2
+  exit 1
+}
+
+if grep -qE 'uses: SecPal/\.github/\.github/workflows/[^[:space:]]+@main$' "$WORKFLOW_CATALOG_README"; then
+  echo "Workflow catalog README must not steer cross-repository callers to moving @main refs." >&2
+  exit 1
+fi
+
+grep -q '@<trusted-commit-sha>' "$WORKFLOW_CATALOG_README" || {
+  echo "Workflow catalog README must document trusted commit SHA pinning for reusable workflows." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -20,6 +20,7 @@ REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.y
 WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instructions.md"
 WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
 WORKFLOW_CATALOG_README="$REPO_ROOT/.github/workflows/README.md"
+ROLLOUT_GUIDE="$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md"
 
 for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   if [ ! -f "$workflow" ]; then
@@ -65,6 +66,11 @@ fi
 
 if [ ! -f "$WORKFLOW_CATALOG_README" ]; then
   echo "Expected workflow catalog README was not found: $WORKFLOW_CATALOG_README" >&2
+  exit 1
+fi
+
+if [ ! -f "$ROLLOUT_GUIDE" ]; then
+  echo "Expected rollout guide was not found: $ROLLOUT_GUIDE" >&2
   exit 1
 fi
 
@@ -211,6 +217,26 @@ fi
 
 grep -q '@<trusted-commit-sha>' "$WORKFLOW_CATALOG_README" || {
   echo "Workflow catalog README must document trusted commit SHA pinning for reusable workflows." >&2
+  exit 1
+}
+
+if grep -q '@main' "$ROLLOUT_GUIDE"; then
+  echo "Rollout guide must not tell cross-repository consumers to track moving @main refs." >&2
+  exit 1
+fi
+
+if grep -q '@v1\.0\.0' "$ROLLOUT_GUIDE"; then
+  echo "Rollout guide must not steer cross-repository consumers to stale release tags." >&2
+  exit 1
+fi
+
+grep -q '@<trusted-commit-sha>' "$ROLLOUT_GUIDE" || {
+  echo "Rollout guide must document trusted commit SHA pinning for reusable workflows." >&2
+  exit 1
+}
+
+grep -q '^# SPDX-FileCopyrightText: 2025-2026 SecPal$' "$REPO_ROOT/.github/workflows/quality.yml" || {
+  echo "Quality workflow SPDX year must stay current when the file is edited." >&2
   exit 1
 }
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -18,6 +18,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
 WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instructions.md"
+WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
 
 for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   if [ ! -f "$workflow" ]; then
@@ -53,6 +54,11 @@ fi
 
 if [ ! -f "$WORKFLOW_INSTRUCTIONS" ]; then
   echo "Expected workflow instructions were not found: $WORKFLOW_INSTRUCTIONS" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKFLOW_EXAMPLE" ]; then
+  echo "Expected workflow example was not found: $WORKFLOW_EXAMPLE" >&2
   exit 1
 fi
 
@@ -101,15 +107,15 @@ if grep -qE "^[[:space:]]+if:.*github\.actor == 'dependabot\[bot\]'" "$CALLER_WO
   exit 1
 fi
 
-grep -q '^    uses: \./\.github/workflows/reusable-dependabot-auto-merge\.yml$' "$CALLER_WORKFLOW" || {
-  echo "Dependabot caller workflow must use the repo-local reusable workflow path so same-repo fixes do not depend on an external tag." >&2
+grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@main$' "$CALLER_WORKFLOW" || {
+  echo "Dependabot caller workflow must keep auto-merge decisions on the reviewed main-branch reusable workflow." >&2
   exit 1
 }
 
 if awk '
   /^  auto-merge:$/ { in_job = 1; next }
   in_job && /^  [[:alnum:]_-]+:$/ { in_job = 0 }
-  in_job && /^[[:space:]]+uses: \.\/\.github\/workflows\/reusable-dependabot-auto-merge\.yml$/ {
+  in_job && /^[[:space:]]+uses: SecPal\/\.github\/\.github\/workflows\/reusable-dependabot-auto-merge\.yml@main$/ {
     reusable_job = 1
   }
   in_job && /^[[:space:]]+timeout-minutes:/ { has_timeout = 1 }
@@ -171,6 +177,26 @@ if grep -qE '^[[:space:]]+uses: SecPal/\.github/\.github/workflows/reusable-depe
   echo "Dependabot caller workflow must not self-reference the reusable workflow through the stale @v1 tag." >&2
   exit 1
 fi
+
+if grep -q '^    uses: \./\.github/workflows/reusable-dependabot-auto-merge\.yml$' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must not execute the reusable workflow from the PR merge commit." >&2
+  exit 1
+fi
+
+if grep -qE 'uses: SecPal/\.github/\.github/workflows/[^[:space:]]+@main$' "$WORKFLOW_EXAMPLE"; then
+  echo "Workflow example must not steer cross-repository callers to moving @main refs." >&2
+  exit 1
+fi
+
+grep -q '^    uses: SecPal/\.github/\.github/workflows/project-automation-v2\.yml@<trusted-commit-sha>$' "$WORKFLOW_EXAMPLE" || {
+  echo "Workflow example must pin project automation to a trusted commit SHA." >&2
+  exit 1
+}
+
+grep -q '^    uses: SecPal/\.github/\.github/workflows/draft-pr-reminder\.yml@<trusted-commit-sha>$' "$WORKFLOW_EXAMPLE" || {
+  echo "Workflow example must pin draft PR reminder to a trusted commit SHA." >&2
+  exit 1
+}
 
 grep -Fq '          METADATA_STEP_OUTCOME: ${{ steps.metadata.outcome }}' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must surface the fetch-metadata step outcome." >&2

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -8,6 +8,8 @@
 # author rather than the event actor so maintainer-triggered `reopened` and
 # `ready_for_review` events on Dependabot-authored PRs still enroll in
 # auto-merge.
+#
+# shellcheck disable=SC2016 # This test intentionally matches literal GitHub expressions.
 
 set -euo pipefail
 
@@ -99,15 +101,15 @@ if grep -qE "^[[:space:]]+if:.*github\.actor == 'dependabot\[bot\]'" "$CALLER_WO
   exit 1
 fi
 
-grep -q '^    uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$CALLER_WORKFLOW" || {
-  echo "Dependabot caller workflow must keep the reusable workflow uses line pinned to @v1." >&2
+grep -q '^    uses: \./\.github/workflows/reusable-dependabot-auto-merge\.yml$' "$CALLER_WORKFLOW" || {
+  echo "Dependabot caller workflow must use the repo-local reusable workflow path so same-repo fixes do not depend on an external tag." >&2
   exit 1
 }
 
 if awk '
   /^  auto-merge:$/ { in_job = 1; next }
   in_job && /^  [[:alnum:]_-]+:$/ { in_job = 0 }
-  in_job && /^[[:space:]]+uses: SecPal\/\.github\/\.github\/workflows\/reusable-dependabot-auto-merge\.yml@v1$/ {
+  in_job && /^[[:space:]]+uses: \.\/\.github\/workflows\/reusable-dependabot-auto-merge\.yml$/ {
     reusable_job = 1
   }
   in_job && /^[[:space:]]+timeout-minutes:/ { has_timeout = 1 }
@@ -155,10 +157,20 @@ if grep -q '^          skip-verification: true$' "$REUSABLE_WORKFLOW"; then
   exit 1
 fi
 
-grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$REUSABLE_WORKFLOW" || {
-  echo "Reusable Dependabot workflow usage example must show callers pinning the workflow to @v1." >&2
+grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@<trusted-commit-sha>$' "$REUSABLE_WORKFLOW" || {
+  echo "Reusable Dependabot workflow usage example must tell external callers to pin the workflow to a reviewed immutable commit SHA." >&2
   exit 1
 }
+
+if grep -q '^#       uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow usage example must not steer callers back to the stale @v1 tag." >&2
+  exit 1
+fi
+
+if grep -qE '^[[:space:]]+uses: SecPal/\.github/\.github/workflows/reusable-dependabot-auto-merge\.yml@v1$' "$CALLER_WORKFLOW"; then
+  echo "Dependabot caller workflow must not self-reference the reusable workflow through the stale @v1 tag." >&2
+  exit 1
+fi
 
 grep -Fq '          METADATA_STEP_OUTCOME: ${{ steps.metadata.outcome }}' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must surface the fetch-metadata step outcome." >&2


### PR DESCRIPTION
## Reproduced Defect

`.github/workflows/dependabot-auto-merge.yml` called this repository's reusable Dependabot auto-merge workflow through `SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1`. That left the caller pinned to a stale published tag instead of the reviewed workflow on `main`, and the cross-repository reference example still pointed readers at moving `@main` workflow refs even after the immutable-SHA guidance changed.

The regression test now fails if the caller returns to the stale `@v1` self-reference, regresses to a PR-local reusable workflow path, or if the reusable-workflow examples and rollout guidance steer external callers back to moving refs or stale tags instead of immutable SHA placeholders.

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/dependabot-auto-merge.sh` was extended to reject the stale `@v1` self-reference, a PR-local reusable workflow path, moving `@main` refs in reusable-workflow examples, and stale rollout-guide ref guidance before the workflow/docs fix.
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`, `shellcheck tests/dependabot-auto-merge.sh`, `./node_modules/.bin/markdownlint --config .markdownlint.json docs/workflows/ROLLOUT_GUIDE.md CHANGELOG.md`, and `./scripts/preflight.sh`.
- Validate-first exception reference: N/A.
- No executable change reason: N/A.

## Change Summary

- Switch the in-repository Dependabot caller from the stale `@v1` tag to the reviewed `SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main` ref.
- Document that cross-repository reusable workflow callers should pin reviewed immutable commit SHAs.
- Update `EXAMPLE_workflow_for_other_repos.yml`, `.github/workflows/README.md`, `docs/workflows/ROLLOUT_GUIDE.md`, and the cross-repository guidance comments in `.github/workflows/quality.yml` so reusable workflow examples and maintenance guidance consistently use reviewed immutable SHA placeholders instead of moving refs or stale tags.
- Extend `tests/dependabot-auto-merge.sh` with positive and negative coverage for reviewed caller refs, external SHA-pinning guidance, rollout-guide drift, and touched workflow SPDX years.
- Update `CHANGELOG.md` for the governance fix.

## Validation

- `bash tests/dependabot-auto-merge.sh`
- `shellcheck tests/dependabot-auto-merge.sh`
- `./node_modules/.bin/markdownlint --config .markdownlint.json docs/workflows/ROLLOUT_GUIDE.md CHANGELOG.md`
- `yamllint .github/workflows/`
- `./scripts/preflight.sh`
- commit hooks: REUSE, Prettier, markdownlint, yamllint, actionlint, ShellCheck, large-file, merge-conflict, YAML, EOF, trailing-whitespace, mixed-line-ending, branch guard
- pre-push checks, including `./scripts/preflight.sh`

Notes:

- `yamllint .github/workflows/` exited successfully but reported existing repository-wide warnings outside this branch's scope. Tracked as #535.
- `./scripts/preflight.sh` prints expected negative-fixture provisioning failures during Polyscope rollout tests, then ends with `Preflight OK`.

## Readiness Before Marking Ready

- Wait for GitHub CI on this draft PR to complete.
- Run the final PR-view self-review and keep the PR draft if any issue remains.
- No linked workspace was modified. The linked SecPal/GuardGuide workspace was available for context only.
