### PR TITLE
Version reusable workflow releases

### DIFF
--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -54,6 +54,12 @@ Applies when editing GitHub Actions workflows, Dependabot configs, and YAML conf
 
 - For cross-repository callers, prefer a reviewed immutable commit SHA over a branch ref. A moving branch or stale tag can silently change or preserve behavior outside the caller's own change set.
 
+- Published reusable workflows may instead use a complete immutable semantic
+  release tag such as `@v2.0.0`. This makes Dependabot version classification
+  available. Before merging an update, verify the tag against the release's
+  recorded resolved commit SHA. Never use major-only tags such as `@v1`.
+  See `docs/workflows/REUSABLE_WORKFLOW_RELEASES.md` for the release contract.
+
 - Check `EXAMPLE_workflow_for_other_repos.yml` for reference patterns before writing a new workflow
 
 ## `continue-on-error`

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -11,8 +11,10 @@
 #       with:
 #         phase: "1"  # Optional: 1 (PATCH only), 2 or 3 (PATCH+MINOR)
 #
-# For cross-repository callers, pin to a reviewed immutable commit SHA. A
-# moving branch ref or stale tag can silently preserve obsolete behavior.
+# For cross-repository callers, use a reviewed immutable commit SHA or a
+# published immutable semantic release tag. The latter lets Dependabot classify
+# numeric updates; verify its resolved commit SHA before merging.
+# See docs/workflows/REUSABLE_WORKFLOW_RELEASES.md for the release contract.
 #
 # Strategy:
 #   Phase 1 (default): PATCH updates auto-merge ✅, MINOR/MAJOR require review

--- a/.github/workflows/validate-reusable-workflow-release.yml
+++ b/.github/workflows/validate-reusable-workflow-release.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+---
+name: Validate Reusable Workflow Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate immutable semantic release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      resolved-commit-sha: ${{ steps.validate.outputs.resolved-commit-sha }}
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Validate release contract
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          TAG="${RELEASE_TAG:?Release tag is required}"
+
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be a complete semantic version: ${TAG}" >&2
+            exit 1
+          fi
+
+          if [[ "$(git cat-file -t "refs/tags/${TAG}")" != "tag" ]]; then
+            echo "Release tag must be annotated: ${TAG}" >&2
+            exit 1
+          fi
+
+          RESOLVED_COMMIT_SHA="$(git rev-parse "${TAG}^{commit}")"
+          IS_IMMUTABLE="$(gh release view "${TAG}" --json isImmutable --jq '.isImmutable')"
+          RELEASE_BODY="$(gh release view "${TAG}" --json body --jq '.body')"
+
+          if [[ "${IS_IMMUTABLE}" != "true" ]]; then
+            echo "Release must be immutable: ${TAG}" >&2
+            exit 1
+          fi
+
+          if ! grep -Fq "${RESOLVED_COMMIT_SHA}" <<<"${RELEASE_BODY}"; then
+            echo "Release notes must record the resolved commit SHA: ${TAG}" >&2
+            exit 1
+          fi
+
+          echo "resolved-commit-sha=${RESOLVED_COMMIT_SHA}" >> "${GITHUB_OUTPUT}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@
 
 Log of notable changes to SecPal organization defaults (newest first).
 
-**Note:** This repository contains organization-wide configuration and is NOT versioned. For versioned releases, see individual project repositories (`api/`, `frontend/`, `contracts/`).
+**Note:** This repository contains organization-wide configuration and is NOT
+versioned as an application. Its reusable workflows are a separately versioned
+integration surface; see `docs/workflows/REUSABLE_WORKFLOW_RELEASES.md`.
+
+---
+
+## 2026-07-10 - Version Reusable Workflow Releases
+
+**Added:**
+
+- defined immutable semantic releases for reusable workflows, including
+  full-version tags, signed annotated tags, immutable GitHub Releases, and a
+  recorded resolved commit SHA for auditability
+- documented consumer usage of complete immutable semantic tags so Dependabot
+  can classify numeric updates without accepting moving refs or the stale
+  legacy `v1` tag
 
 ---
 

--- a/docs/workflows/REUSABLE_WORKFLOW_RELEASES.md
+++ b/docs/workflows/REUSABLE_WORKFLOW_RELEASES.md
@@ -1,0 +1,44 @@
+<!-- SPDX-FileCopyrightText: 2026 SecPal Contributors -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Reusable Workflow Releases
+
+The reusable workflows in this repository are a versioned integration surface.
+Each published release uses one complete semantic-version tag in the form
+`v<major>.<minor>.<patch>`.
+
+## Release Contract
+
+- Publish every reusable-workflow release as an immutable GitHub Release.
+  Repository administrators must enable immutable releases before publishing.
+- Create only annotated, signed tags. Never move, delete, or reuse a published
+  tag.
+- Record the release tag's resolved commit SHA in the release notes. Reviewers
+  use that SHA to audit the exact workflow code selected by the tag.
+- Do not use major-only tags such as `v1`, branch names, or other moving refs
+  for cross-repository workflow calls.
+- Increment the major version for incompatible caller contracts, the minor
+  version for backward-compatible behavior or inputs, and the patch version
+  for backward-compatible fixes.
+
+## Consumer Usage
+
+Use a published immutable release tag in the `uses:` reference so Dependabot
+can determine the numeric update type:
+
+```yaml
+jobs:
+  quality:
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@v2.0.0
+```
+
+Before merging a Dependabot update, verify that the tag resolves to the
+resolved commit SHA recorded in the upstream immutable release. A release tag
+is therefore both machine-readable for Dependabot and auditable as a specific
+immutable commit.
+
+## Initial Migration
+
+The legacy `v1` tag is stale and must not be reused. Publish the first current
+release as `v2.0.0`, then migrate every consumer repository in its own pull
+request. Do not mix that migration with unrelated dependency changes.

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -21,6 +21,8 @@ WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instruct
 WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
 WORKFLOW_CATALOG_README="$REPO_ROOT/.github/workflows/README.md"
 ROLLOUT_GUIDE="$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md"
+RELEASE_GUIDE="$REPO_ROOT/docs/workflows/REUSABLE_WORKFLOW_RELEASES.md"
+RELEASE_VALIDATION_WORKFLOW="$REPO_ROOT/.github/workflows/validate-reusable-workflow-release.yml"
 
 for workflow in "$CALLER_WORKFLOW" "$REUSABLE_WORKFLOW"; do
   if [ ! -f "$workflow" ]; then
@@ -73,6 +75,56 @@ if [ ! -f "$ROLLOUT_GUIDE" ]; then
   echo "Expected rollout guide was not found: $ROLLOUT_GUIDE" >&2
   exit 1
 fi
+
+if [ ! -f "$RELEASE_GUIDE" ]; then
+  echo "Expected reusable workflow release guide was not found: $RELEASE_GUIDE" >&2
+  exit 1
+fi
+
+grep -Fq 'v<major>.<minor>.<patch>' "$RELEASE_GUIDE" || {
+  echo "Reusable workflow releases must use complete semantic version tags." >&2
+  exit 1
+}
+
+grep -Fq 'immutable GitHub Release' "$RELEASE_GUIDE" || {
+  echo "Reusable workflow release tags must be immutable." >&2
+  exit 1
+}
+
+grep -Fq 'resolved commit SHA' "$RELEASE_GUIDE" || {
+  echo "Reusable workflow releases must record their resolved commit SHA." >&2
+  exit 1
+}
+
+if [ ! -f "$RELEASE_VALIDATION_WORKFLOW" ]; then
+  echo "Expected reusable workflow release validation workflow was not found: $RELEASE_VALIDATION_WORKFLOW" >&2
+  exit 1
+fi
+
+grep -Fq 'types: [published]' "$RELEASE_VALIDATION_WORKFLOW" || {
+  echo "Reusable workflow releases must be validated when published." >&2
+  exit 1
+}
+
+grep -Fq '^v[0-9]+\.[0-9]+\.[0-9]+$' "$RELEASE_VALIDATION_WORKFLOW" || {
+  echo "Reusable workflow releases must reject incomplete semantic version tags." >&2
+  exit 1
+}
+
+grep -Fq 'isImmutable' "$RELEASE_VALIDATION_WORKFLOW" || {
+  echo "Reusable workflow releases must verify GitHub Release immutability." >&2
+  exit 1
+}
+
+grep -Fq 'git cat-file -t "refs/tags/${TAG}"' "$RELEASE_VALIDATION_WORKFLOW" || {
+  echo "Reusable workflow releases must require annotated tags." >&2
+  exit 1
+}
+
+grep -Fq 'RELEASE_BODY' "$RELEASE_VALIDATION_WORKFLOW" || {
+  echo "Reusable workflow releases must verify the release notes record the commit SHA." >&2
+  exit 1
+}
 
 if ! awk '
   /^---$/ { document_start_markers++ }


### PR DESCRIPTION
## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/dependabot-auto-merge.sh` covers the reusable-workflow release contract regressions before accepting the workflow release validator.
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`, `yamllint .github/workflows/validate-reusable-workflow-release.yml`, and `./scripts/preflight.sh` pass locally.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

`bash tests/dependabot-auto-merge.sh` passes with regression coverage for the reusable-workflow release contract. `yamllint .github/workflows/validate-reusable-workflow-release.yml` and `./scripts/preflight.sh` also pass.

## Summary

- define immutable, complete semantic-version releases for reusable workflows
- validate published releases for annotated tags, immutability, and a recorded resolved commit SHA
- document consumer pinning and Dependabot update classification

## Review status

The local four-pass review found no issues. The linked GuardGuide workspace was not changed. Repository CI checks are pending and must pass before the final PR-view self-review and any ready-for-review transition; retain draft status until then.
