### PR TITLE
Add explicit reusable workflow permissions

### DIFF
--- a/.github/workflows/reusable-actionlint.yml
+++ b/.github/workflows/reusable-actionlint.yml
@@ -7,6 +7,10 @@ name: Reusable - actionlint
 on:
   workflow_call:
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   actionlint:
     name: Lint GitHub Actions Workflows

--- a/.github/workflows/reusable-node-build.yml
+++ b/.github/workflows/reusable-node-build.yml
@@ -23,6 +23,9 @@ on:
         type: string
         default: "npm run build"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Project

--- a/.github/workflows/reusable-node-lint.yml
+++ b/.github/workflows/reusable-node-lint.yml
@@ -23,6 +23,9 @@ on:
         type: string
         default: "npm run lint"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linter

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -23,6 +23,9 @@ on:
         type: string
         default: "npm test"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/reusable-php-lint.yml
+++ b/.github/workflows/reusable-php-lint.yml
@@ -18,6 +18,9 @@ on:
         type: string
         default: "./vendor/bin/pint --test"
 
+permissions:
+  contents: read
+
 jobs:
   pint:
     name: Check Code Style

--- a/.github/workflows/reusable-php-stan.yml
+++ b/.github/workflows/reusable-php-stan.yml
@@ -18,6 +18,9 @@ on:
         type: string
         default: "./vendor/bin/phpstan analyse"
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     name: Static Analysis

--- a/.github/workflows/reusable-php-test.yml
+++ b/.github/workflows/reusable-php-test.yml
@@ -23,6 +23,9 @@ on:
         type: string
         default: "./vendor/bin/pest"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -18,6 +18,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr-size:
     name: Check PR Size

--- a/.github/workflows/reusable-reuse.yml
+++ b/.github/workflows/reusable-reuse.yml
@@ -7,6 +7,9 @@ name: Reusable - REUSE Compliance
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   reuse:
     name: Check REUSE Compliance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-10 - Restrict Reusable Workflow Token Permissions
+
+**Fixed:**
+
+- added explicit least-privilege permission ceilings to the reusable actionlint, Node.js, PHP, PR-size, and REUSE workflows; actionlint can write checks, PR-size can read pull-request metadata, and the remaining audited workflows only read repository contents
+- extended the reusable-workflow policy regression test and preflight guidance so every reusable workflow must retain a top-level `permissions` block as well as job timeouts
+
+---
+
 ## 2026-07-09 - Clean Up Repository-Wide yamllint Warnings
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - added explicit least-privilege permission ceilings to the reusable actionlint, Node.js, PHP, PR-size, and REUSE workflows; actionlint can write checks, PR-size can read pull-request metadata, and the remaining audited workflows only read repository contents
-- extended the reusable-workflow policy regression test and preflight guidance so every reusable workflow must retain a top-level `permissions` block as well as job timeouts
+- extended the reusable-workflow policy regression test and preflight guidance so every `.yml` or `.yaml` reusable workflow must retain a valid, non-null top-level `permissions` block as well as job timeouts
+- added focused positive and negative fixtures for mapping and deny-all permissions, missing or null permissions, and missing timeouts so the policy scanner cannot silently lose coverage
 
 ---
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -122,6 +122,15 @@ if [ -f tests/reusable-workflow-timeouts.sh ]; then
   }
 fi
 
+if [ -f tests/reusable-workflow-policy.sh ]; then
+  bash tests/reusable-workflow-policy.sh || {
+    echo "" >&2
+    echo "❌ Reusable workflow policy regression fixtures failed!" >&2
+    echo "Keep .yml/.yaml discovery and positive/negative permission and timeout cases enforced." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/deploy-main-workflow.sh ]; then
   bash tests/deploy-main-workflow.sh || {
     echo "" >&2

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -116,8 +116,8 @@ fi
 if [ -f tests/reusable-workflow-timeouts.sh ]; then
   bash tests/reusable-workflow-timeouts.sh || {
     echo "" >&2
-    echo "❌ Reusable workflow timeout validation failed!" >&2
-    echo "Add timeout-minutes to every reusable workflow job before continuing." >&2
+    echo "❌ Reusable workflow policy validation failed!" >&2
+    echo "Add top-level permissions and timeout-minutes to every reusable workflow before continuing." >&2
     exit 1
   }
 fi

--- a/tests/reusable-workflow-policy.sh
+++ b/tests/reusable-workflow-policy.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR="$SCRIPT_DIR/reusable-workflow-timeouts.sh"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/reusable-workflow-policy.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/tests" "$workspace/.github/workflows"
+cp "$VALIDATOR" "$workspace/tests/reusable-workflow-timeouts.sh"
+
+run_validator() {
+  (
+    cd "$workspace"
+    bash tests/reusable-workflow-timeouts.sh
+  )
+}
+
+reset_workflows() {
+  rm -f "$workspace"/.github/workflows/reusable-*.yml
+  rm -f "$workspace"/.github/workflows/reusable-*.yaml
+}
+
+reset_workflows
+cat >"$workspace/.github/workflows/reusable-valid.yml" <<'YAML'
+---
+name: Valid mapping permissions
+on:
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: "true"
+YAML
+run_validator
+
+reset_workflows
+cat >"$workspace/.github/workflows/reusable-deny-all.yaml" <<'YAML'
+---
+name: Valid deny-all permissions
+on:
+  workflow_call:
+permissions: {} # Explicitly deny all token scopes.
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: "true"
+YAML
+run_validator
+
+reset_workflows
+cat >"$workspace/.github/workflows/reusable-missing-permissions.yaml" <<'YAML'
+---
+name: Missing permissions
+on:
+  workflow_call:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: "true"
+YAML
+if run_validator >/dev/null 2>&1; then
+  echo "Validator accepted a reusable .yaml workflow without top-level permissions." >&2
+  exit 1
+fi
+
+reset_workflows
+cat >"$workspace/.github/workflows/reusable-null-permissions.yml" <<'YAML'
+---
+name: Null permissions
+on:
+  workflow_call:
+permissions:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: "true"
+YAML
+if run_validator >/dev/null 2>&1; then
+  echo "Validator accepted a reusable workflow with null top-level permissions." >&2
+  exit 1
+fi
+
+reset_workflows
+cat >"$workspace/.github/workflows/reusable-missing-timeout.yaml" <<'YAML'
+---
+name: Missing timeout
+on:
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: "true"
+YAML
+if run_validator >/dev/null 2>&1; then
+  echo "Validator accepted a reusable .yaml workflow without a job timeout." >&2
+  exit 1
+fi

--- a/tests/reusable-workflow-policy.sh
+++ b/tests/reusable-workflow-policy.sh
@@ -42,6 +42,23 @@ YAML
 run_validator
 
 reset_workflows
+cat >"$workspace/.github/workflows/reusable-commented-late-permissions.yml" <<'YAML'
+---
+name: Valid late commented permissions
+on:
+  workflow_call:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: "true"
+permissions: # Explicit token-permission ceiling.
+  contents: read
+YAML
+run_validator
+
+reset_workflows
 cat >"$workspace/.github/workflows/reusable-deny-all.yaml" <<'YAML'
 ---
 name: Valid deny-all permissions

--- a/tests/reusable-workflow-timeouts.sh
+++ b/tests/reusable-workflow-timeouts.sh
@@ -17,10 +17,29 @@ fi
 failures=()
 permission_failures=()
 
+find_reusable_workflows() {
+  find .github/workflows -maxdepth 1 -type f \
+    \( -name 'reusable-*.yml' -o -name 'reusable-*.yaml' \) -print | sort
+}
+
 while IFS= read -r workflow; do
   if ! awk '
-    /^permissions:[[:space:]]*(\{\})?[[:space:]]*$/ {
+    /^permissions:[[:space:]]*\{\}[[:space:]]*(#.*)?$/ {
       found = 1
+      exit
+    }
+    /^permissions:[[:space:]]*(#.*)?$/ {
+      in_permissions = 1
+      next
+    }
+    in_permissions && /^[[:space:]]*($|#)/ {
+      next
+    }
+    in_permissions && /^[[:space:]]+[A-Za-z0-9_-]+:[[:space:]]*(read|write|none)[[:space:]]*(#.*)?$/ {
+      found = 1
+      exit
+    }
+    in_permissions {
       exit
     }
     /^jobs:[[:space:]]*$/ {
@@ -32,10 +51,10 @@ while IFS= read -r workflow; do
   ' "$workflow"; then
     permission_failures+=("$workflow")
   fi
-done < <(find .github/workflows -maxdepth 1 -type f -name 'reusable-*.yml' | sort)
+done < <(find_reusable_workflows)
 
 if [ ${#permission_failures[@]} -gt 0 ]; then
-  echo "Missing top-level permissions block on reusable workflows:" >&2
+  echo "Missing or invalid top-level permissions on reusable workflows:" >&2
   for workflow in "${permission_failures[@]}"; do
     echo "  - $workflow" >&2
   done
@@ -119,7 +138,7 @@ while IFS= read -r workflow; do
   if [ ${#current_failures[@]} -gt 0 ]; then
     failures+=("${current_failures[@]}")
   fi
-done < <(find .github/workflows -maxdepth 1 -type f -name 'reusable-*.yml' | sort)
+done < <(find_reusable_workflows)
 
 if [ ${#failures[@]} -gt 0 ]; then
   echo "Missing timeout-minutes on reusable workflow jobs:" >&2

--- a/tests/reusable-workflow-timeouts.sh
+++ b/tests/reusable-workflow-timeouts.sh
@@ -42,9 +42,6 @@ while IFS= read -r workflow; do
     in_permissions {
       exit
     }
-    /^jobs:[[:space:]]*$/ {
-      exit
-    }
     END {
       exit !found
     }

--- a/tests/reusable-workflow-timeouts.sh
+++ b/tests/reusable-workflow-timeouts.sh
@@ -15,6 +15,32 @@ if [ ! -d ".github/workflows" ]; then
 fi
 
 failures=()
+permission_failures=()
+
+while IFS= read -r workflow; do
+  if ! awk '
+    /^permissions:[[:space:]]*(\{\})?[[:space:]]*$/ {
+      found = 1
+      exit
+    }
+    /^jobs:[[:space:]]*$/ {
+      exit
+    }
+    END {
+      exit !found
+    }
+  ' "$workflow"; then
+    permission_failures+=("$workflow")
+  fi
+done < <(find .github/workflows -maxdepth 1 -type f -name 'reusable-*.yml' | sort)
+
+if [ ${#permission_failures[@]} -gt 0 ]; then
+  echo "Missing top-level permissions block on reusable workflows:" >&2
+  for workflow in "${permission_failures[@]}"; do
+    echo "  - $workflow" >&2
+  done
+  exit 1
+fi
 
 while IFS= read -r workflow; do
   current_failures=()


### PR DESCRIPTION
## Failing validation reproduced

Before the change, the reusable-workflow policy regression test failed because nine `reusable-*.yml` workflows had no top-level `permissions` block. That allowed reusable workflows to inherit broader caller token scopes without an explicit ceiling.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/reusable-workflow-timeouts.sh` failed and listed the nine reusable workflows without a top-level `permissions` block.
- Passing proof after implementation: `bash tests/reusable-workflow-timeouts.sh` passed after the audited workflows declared their minimal permissions.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary

- add least-privilege top-level permissions to the audited reusable workflows
- retain only `checks: write` for actionlint and `pull-requests: read` for the PR-size check; all other audited workflows use `contents: read`
- extend the reusable-workflow regression test and its preflight guidance to reject reusable workflows without a top-level permissions block
- update the changelog

## Validation

- `bash tests/reusable-workflow-timeouts.sh`
- `yamllint .github/workflows/`
- `actionlint` on the nine affected reusable workflows
- `./scripts/preflight.sh`
- `git diff --check`

## Follow-up

No linked workspaces or unresolved local checks. This PR remains a draft pending the final PR-view self-review and CI results before it can be marked ready.

Fixes #529
