### PR TITLE
fix(polyscope): autostart API queue worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- marked the generated API preview Queue Worker action as autostarted, so scheduled forensic jobs are consumed and readiness does not remain blocked by a missing worker heartbeat
+- marked the generated API preview Queue Worker action as autostarted and kept it running without a supervisor-dependent time limit, so scheduled forensic jobs continue to be consumed and readiness does not become blocked by a missing worker heartbeat
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-10 - Start API Preview Queue Workers Automatically
+
+**Fixed:**
+
+- marked the generated API preview Queue Worker action as autostarted, so scheduled forensic jobs are consumed and readiness does not remain blocked by a missing worker heartbeat
+
+---
+
 ## 2026-07-09 - Clean Up Repository-Wide yamllint Warnings
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-10 - Start API Preview Queue Workers Automatically
+
+**Fixed:**
+
+- marked the generated API preview Queue Worker action as autostarted, so scheduled forensic jobs are consumed and readiness does not remain blocked by a missing worker heartbeat
+
+---
+
 ## 2026-07-09 - Clean Up Repository-Wide yamllint Warnings
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2139,7 +2139,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,
                 ],
                 "run": [
-                    {"label": "Queue Worker", "command": API_QUEUE_WORKER_COMMAND, "runMode": "replace"},
+                    {"label": "Queue Worker", "command": API_QUEUE_WORKER_COMMAND, "autostart": True, "runMode": "replace"},
                     {"label": "Scheduler", "command": API_SCHEDULER_COMMAND, "autostart": True, "runMode": "replace"},
                     {"label": "Pail", "command": API_PAIL_COMMAND, "runMode": "replace"},
                     # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -63,7 +63,7 @@ API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_BOOTSTRAP_SETUP__"
 API_REFRESH_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_REFRESH__"
 API_QUEUE_WORKER_COMMAND = (
     "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default "
-    "--sleep=3 --tries=3 --max-time=3600"
+    "--sleep=3 --tries=3"
 )
 API_SCHEDULER_COMMAND = "php artisan schedule:work"
 API_PAIL_COMMAND = "php artisan pail --timeout=0"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -733,7 +733,11 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 api_run_actions = module.REPO_SETTINGS["api"]["local_config"]["scripts"]["run"]
-queue_worker_action = next(action for action in api_run_actions if action["label"] == "Queue Worker")
+queue_worker_action = next(
+    (action for action in api_run_actions if action["label"] == "Queue Worker"),
+    None,
+)
+assert queue_worker_action is not None, api_run_actions
 assert queue_worker_action.get("autostart") is True, queue_worker_action
 assert "--max-time" not in queue_worker_action["command"], queue_worker_action
 api_run_actions[0]["label"] = "Background Queue"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -707,7 +707,7 @@ grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polys
 grep -q 'AGENTS.md' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --bootstrap-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
-grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3 --max-time=3600'" "$workspace_root/api/polyscope.local.json"
+grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3'" "$workspace_root/api/polyscope.local.json"
 grep -qF '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan schedule:work'" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan pail --timeout=0'" "$workspace_root/api/polyscope.local.json"
@@ -735,6 +735,7 @@ spec.loader.exec_module(module)
 api_run_actions = module.REPO_SETTINGS["api"]["local_config"]["scripts"]["run"]
 queue_worker_action = next(action for action in api_run_actions if action["label"] == "Queue Worker")
 assert queue_worker_action.get("autostart") is True, queue_worker_action
+assert "--max-time" not in queue_worker_action["command"], queue_worker_action
 api_run_actions[0]["label"] = "Background Queue"
 api_run_actions[1]["label"] = "Cron Loop"
 api_run_actions[2]["label"] = "Log Tail"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -733,6 +733,8 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 api_run_actions = module.REPO_SETTINGS["api"]["local_config"]["scripts"]["run"]
+queue_worker_action = next(action for action in api_run_actions if action["label"] == "Queue Worker")
+assert queue_worker_action.get("autostart") is True, queue_worker_action
 api_run_actions[0]["label"] = "Background Queue"
 api_run_actions[1]["label"] = "Cron Loop"
 api_run_actions[2]["label"] = "Log Tail"


### PR DESCRIPTION
## Defect proof

The base configuration defines the API preview Queue Worker without `autostart`, while the Scheduler is autostarted. This leaves scheduled forensic jobs without a worker heartbeat and can block preview readiness. The regression assertion fails against the base configuration because the Queue Worker action has no `autostart: true` value.

## TDD / Validate-First Evidence

- Failing proof before implementation: `Queue Worker` action invariant against the base configuration — failed because `autostart` was absent.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` — passed with the Queue Worker `autostart` invariant.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Change

- autostart the generated API preview Queue Worker action
- add a focused configuration invariant test
- record the fix in the changelog

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- `reuse lint`
- `git diff --check`
- commit-time pre-commit checks
- push-time pre-push checks

## Follow-up before readiness

- Linked workspaces: none changed; the linked API workspace was not needed.
- Local preflight reports that `markdownlint` is absent from `node_modules` and recommends `npm ci`; the configured pre-commit markdownlint check passed. Re-run after dependency installation if independent local markdownlint confirmation is required.
