### PR TITLE
fix(polyscope): gate API preview readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint returns a 2xx response, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404` or a redirect; the default wait window exceeds the three-minute provisioning fallback, while static previews retain their immediate announcement behavior
+- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint returns a 2xx response, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404` or a redirect; the ten-minute default wait window covers provisioning after the three-minute fallback timer, while static previews retain their immediate announcement behavior
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-10 - Gate API Preview Readiness
+
+**Fixed:**
+
+- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint responds successfully, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404`; static previews retain their immediate announcement behavior
+
+---
+
 ## 2026-07-10 - Restrict Reusable Workflow Token Permissions
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint responds successfully, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404`; static previews retain their immediate announcement behavior
+- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint responds successfully, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404`; the default wait window exceeds the three-minute provisioning fallback, while static previews retain their immediate announcement behavior
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint responds successfully, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404`; the default wait window exceeds the three-minute provisioning fallback, while static previews retain their immediate announcement behavior
+- delayed the API preview tunnel's ready announcement until its public `/health/ready` endpoint returns a 2xx response, so Polyscope does not present an API preview as ready while nginx or Laravel provisioning still returns a generic `404` or a redirect; the default wait window exceeds the three-minute provisioning fallback, while static previews retain their immediate announcement behavior
 
 ---
 

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -42,6 +42,39 @@ normalize_preview_url() {
 	printf '\n'
 }
 
+is_api_preview_url() {
+	local direct_url="$1"
+
+	[[ "$direct_url" =~ ^https://api-[A-Za-z0-9-]+\.preview\.secpal\.dev$ ]]
+}
+
+wait_for_api_preview_readiness() {
+	local direct_url="$1"
+	local readiness_url="${direct_url}/health/ready"
+	local retry_seconds="${POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-2}"
+	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-60}"
+	local attempt
+
+	if [[ ! "$retry_seconds" =~ ^[0-9]+$ || ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+		echo "Error: preview readiness retry settings must be non-negative seconds and positive attempts" >&2
+		return 1
+	fi
+
+	for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+		if curl -fsS --max-time 3 "$readiness_url" >/dev/null; then
+			return 0
+		fi
+
+		printf 'Waiting for API preview readiness (%s, attempt %s)\n' "$readiness_url" "$attempt" >&2
+		if ((attempt < max_attempts)); then
+			sleep "$retry_seconds"
+		fi
+	done
+
+	echo "Error: API preview did not become ready after $max_attempts attempts" >&2
+	return 1
+}
+
 announce_direct_preview() {
 	local shared_site="$1"
 	local direct_url="$2"
@@ -64,6 +97,9 @@ announce_direct_preview() {
 if [[ $# -ge 2 && "$1" == "share" ]]; then
 	direct_preview_url="$(normalize_preview_url "$2" || true)"
 	if [[ -n "$direct_preview_url" ]]; then
+		if is_api_preview_url "$direct_preview_url"; then
+			wait_for_api_preview_readiness "$direct_preview_url"
+		fi
 		announce_direct_preview "$2" "$direct_preview_url"
 	fi
 fi

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -58,7 +58,7 @@ wait_for_api_preview_readiness() {
 	local direct_url="$1"
 	local readiness_url="${direct_url}/health/ready"
 	local retry_seconds="${POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-2}"
-	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-60}"
+	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-92}"
 	local attempt
 
 	if [[ ! "$retry_seconds" =~ ^[0-9]+$ || ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -42,10 +42,16 @@ normalize_preview_url() {
 	printf '\n'
 }
 
-is_api_preview_url() {
+api_preview_origin() {
 	local direct_url="$1"
+	local host_and_path host
 
-	[[ "$direct_url" =~ ^https://api-[A-Za-z0-9-]+\.preview\.secpal\.dev$ ]]
+	[[ "$direct_url" == https://* ]] || return 1
+	host_and_path="${direct_url#https://}"
+	host="${host_and_path%%/*}"
+	[[ "$host" =~ ^api-[A-Za-z0-9-]+\.preview\.secpal\.dev$ ]] || return 1
+
+	printf 'https://%s\n' "$host"
 }
 
 wait_for_api_preview_readiness() {
@@ -97,8 +103,9 @@ announce_direct_preview() {
 if [[ $# -ge 2 && "$1" == "share" ]]; then
 	direct_preview_url="$(normalize_preview_url "$2" || true)"
 	if [[ -n "$direct_preview_url" ]]; then
-		if is_api_preview_url "$direct_preview_url"; then
-			wait_for_api_preview_readiness "$direct_preview_url"
+		api_preview_url="$(api_preview_origin "$direct_preview_url" || true)"
+		if [[ -n "$api_preview_url" ]]; then
+			wait_for_api_preview_readiness "$api_preview_url"
 		fi
 		announce_direct_preview "$2" "$direct_preview_url"
 	fi

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -59,7 +59,7 @@ wait_for_api_preview_readiness() {
 	local readiness_url="${direct_url}/health/ready"
 	local retry_seconds="${POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-2}"
 	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-92}"
-	local attempt
+	local attempt status_code
 
 	if [[ ! "$retry_seconds" =~ ^[0-9]+$ || ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
 		echo "Error: preview readiness retry settings must be non-negative seconds and positive attempts" >&2
@@ -67,7 +67,8 @@ wait_for_api_preview_readiness() {
 	fi
 
 	for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-		if curl -fsS --max-time 3 "$readiness_url" >/dev/null; then
+		if status_code="$(curl -fsS --max-time 3 -o /dev/null -w '%{http_code}' "$readiness_url")" \
+			&& [[ "$status_code" =~ ^2[0-9][0-9]$ ]]; then
 			return 0
 		fi
 

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -58,7 +58,7 @@ wait_for_api_preview_readiness() {
 	local direct_url="$1"
 	local readiness_url="${direct_url}/health/ready"
 	local retry_seconds="${POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-2}"
-	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-92}"
+	local max_attempts="${POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-302}"
 	local attempt status_code
 
 	if [[ ! "$retry_seconds" =~ ^[0-9]+$ || ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4627,6 +4627,8 @@ printf '%s\n' "$attempt" > "$FAKE_CURL_ATTEMPT_FILE"
 if [[ "${FAKE_CURL_ALWAYS_FAIL:-0}" == "1" || "$attempt" -lt 2 ]]; then
     exit 1
 fi
+
+printf '%s' "${FAKE_CURL_HTTP_STATUS:-200}"
 STUB
 chmod +x "$fake_curl_bin"
 
@@ -4641,7 +4643,7 @@ env HOME="$home_dir" \
 grep -q 'Shared site              https://api-auto-hawk.preview.secpal.dev:443' "$preview_wrapper_out"
 grep -q 'Public URL               https://api-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
 test "$(cat "$fake_curl_attempt_file")" = "2"
-grep -qx -- '-fsS --max-time 3 https://api-auto-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
+grep -qx -- '-fsS --max-time 3 -o /dev/null -w %{http_code} https://api-auto-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
 
 path_preview_wrapper_out="$workspace/expose-wrapper-path-preview.out"
 env HOME="$home_dir" \
@@ -4680,6 +4682,24 @@ fi
 grep -q 'API preview did not become ready after 1 attempts' "$failed_preview_wrapper_out"
 if grep -q 'Public URL' "$failed_preview_wrapper_out"; then
     echo "unready API preview must not announce a public URL" >&2
+    exit 1
+fi
+
+redirect_preview_wrapper_out="$workspace/expose-wrapper-preview-redirect.out"
+if env HOME="$home_dir" \
+    PATH="$workspace/fake-tools:$PATH" \
+    FAKE_CURL_LOG="$fake_curl_log" \
+    FAKE_CURL_ATTEMPT_FILE="$fake_curl_attempt_file" \
+    FAKE_CURL_HTTP_STATUS=302 \
+    POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://api-redirect-hawk.preview.secpal.dev:443 >"$redirect_preview_wrapper_out" 2>&1; then
+    echo "redirecting API preview must not announce readiness" >&2
+    exit 1
+fi
+
+grep -q 'API preview did not become ready after 1 attempts' "$redirect_preview_wrapper_out"
+if grep -q 'Public URL' "$redirect_preview_wrapper_out"; then
+    echo "redirecting API preview must not announce a public URL" >&2
     exit 1
 fi
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4483,6 +4483,14 @@ grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscop
 grep -q '^OnStartupSec=30s$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnUnitActiveSec=3min$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-worktree-provision.timer"
+
+default_readiness_retry_seconds="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
+default_readiness_max_attempts="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
+if (( (default_readiness_max_attempts - 1) * default_readiness_retry_seconds <= 180 )); then
+    echo "API preview readiness wait must exceed the three-minute provisioning fallback" >&2
+    exit 1
+fi
+
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4486,8 +4486,8 @@ grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 
 default_readiness_retry_seconds="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
 default_readiness_max_attempts="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
-if (( (default_readiness_max_attempts - 1) * default_readiness_retry_seconds <= 180 )); then
-    echo "API preview readiness wait must exceed the three-minute provisioning fallback" >&2
+if (( (default_readiness_max_attempts - 1) * default_readiness_retry_seconds < 600 )); then
+    echo "API preview readiness wait must cover fallback provisioning after the three-minute timer" >&2
     exit 1
 fi
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4635,6 +4635,19 @@ grep -q 'Public URL               https://api-auto-hawk.preview.secpal.dev' "$pr
 test "$(cat "$fake_curl_attempt_file")" = "2"
 grep -qx -- '-fsS --max-time 3 https://api-auto-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
 
+path_preview_wrapper_out="$workspace/expose-wrapper-path-preview.out"
+env HOME="$home_dir" \
+    PATH="$workspace/fake-tools:$PATH" \
+    FAKE_CURL_LOG="$fake_curl_log" \
+    FAKE_CURL_ATTEMPT_FILE="$fake_curl_attempt_file" \
+    POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS=0 \
+    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://api-path-hawk.preview.secpal.dev/some/path >"$path_preview_wrapper_out"
+
+grep -q 'Public URL               https://api-path-hawk.preview.secpal.dev/some/path' "$path_preview_wrapper_out"
+test "$(cat "$fake_curl_attempt_file")" = "3"
+grep -qx -- '-fsS --max-time 3 https://api-path-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
+
 env HOME="$home_dir" \
     PATH="$workspace/fake-tools:$PATH" \
     FAKE_CURL_LOG="$fake_curl_log" \
@@ -4642,7 +4655,7 @@ env HOME="$home_dir" \
     POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
     "$fake_polyscope_bin_dir/expose-linux-x64" share https://frontend-auto-hawk.preview.secpal.dev:443 >/dev/null
 
-test "$(cat "$fake_curl_attempt_file")" = "2"
+test "$(cat "$fake_curl_attempt_file")" = "3"
 
 failed_preview_wrapper_out="$workspace/expose-wrapper-preview-failed.out"
 if env HOME="$home_dir" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4656,7 +4656,7 @@ env HOME="$home_dir" \
 
 grep -q 'Public URL               https://api-path-hawk.preview.secpal.dev/some/path' "$path_preview_wrapper_out"
 test "$(cat "$fake_curl_attempt_file")" = "3"
-grep -qx -- '-fsS --max-time 3 https://api-path-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
+grep -qx -- '-fsS --max-time 3 -o /dev/null -w %{http_code} https://api-path-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
 
 env HOME="$home_dir" \
     PATH="$workspace/fake-tools:$PATH" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4601,12 +4601,66 @@ if [[ "$no_gpg_sign_exit" -eq 0 ]]; then
 fi
 
 preview_wrapper_out="$workspace/expose-wrapper-preview.out"
-env HOME="$home_dir" \
-    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
-    "$fake_polyscope_bin_dir/expose-linux-x64" share https://frontend-auto-hawk.preview.secpal.dev:443 >"$preview_wrapper_out"
+fake_curl_bin="$workspace/fake-tools/curl"
+fake_curl_log="$workspace/fake-curl.log"
+fake_curl_attempt_file="$workspace/fake-curl-attempt"
+cat >"$fake_curl_bin" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
 
-grep -q 'Shared site              https://frontend-auto-hawk.preview.secpal.dev:443' "$preview_wrapper_out"
-grep -q 'Public URL               https://frontend-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
+printf '%s\n' "$*" >> "$FAKE_CURL_LOG"
+attempt=0
+if [[ -f "$FAKE_CURL_ATTEMPT_FILE" ]]; then
+    attempt="$(cat "$FAKE_CURL_ATTEMPT_FILE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$FAKE_CURL_ATTEMPT_FILE"
+
+if [[ "${FAKE_CURL_ALWAYS_FAIL:-0}" == "1" || "$attempt" -lt 2 ]]; then
+    exit 1
+fi
+STUB
+chmod +x "$fake_curl_bin"
+
+env HOME="$home_dir" \
+    PATH="$workspace/fake-tools:$PATH" \
+    FAKE_CURL_LOG="$fake_curl_log" \
+    FAKE_CURL_ATTEMPT_FILE="$fake_curl_attempt_file" \
+    POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS=0 \
+    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://api-auto-hawk.preview.secpal.dev:443 >"$preview_wrapper_out"
+
+grep -q 'Shared site              https://api-auto-hawk.preview.secpal.dev:443' "$preview_wrapper_out"
+grep -q 'Public URL               https://api-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
+test "$(cat "$fake_curl_attempt_file")" = "2"
+grep -qx -- '-fsS --max-time 3 https://api-auto-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
+
+env HOME="$home_dir" \
+    PATH="$workspace/fake-tools:$PATH" \
+    FAKE_CURL_LOG="$fake_curl_log" \
+    FAKE_CURL_ATTEMPT_FILE="$fake_curl_attempt_file" \
+    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://frontend-auto-hawk.preview.secpal.dev:443 >/dev/null
+
+test "$(cat "$fake_curl_attempt_file")" = "2"
+
+failed_preview_wrapper_out="$workspace/expose-wrapper-preview-failed.out"
+if env HOME="$home_dir" \
+    PATH="$workspace/fake-tools:$PATH" \
+    FAKE_CURL_LOG="$fake_curl_log" \
+    FAKE_CURL_ATTEMPT_FILE="$fake_curl_attempt_file" \
+    FAKE_CURL_ALWAYS_FAIL=1 \
+    POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" share https://api-failing-hawk.preview.secpal.dev:443 >"$failed_preview_wrapper_out" 2>&1; then
+    echo "unready API preview must fail instead of announcing readiness" >&2
+    exit 1
+fi
+
+grep -q 'API preview did not become ready after 1 attempts' "$failed_preview_wrapper_out"
+if grep -q 'Public URL' "$failed_preview_wrapper_out"; then
+    echo "unready API preview must not announce a public URL" >&2
+    exit 1
+fi
 
 if [[ -s "$fake_expose_real_log" ]]; then
     echo "preview-domain Expose wrapper must not invoke the real Expose binary" >&2


### PR DESCRIPTION
## Reproduced defect

Before this change, the Expose wrapper announced an API preview immediately after normalizing its URL. During nginx or Laravel provisioning, that URL can still return a generic `404`, so the ready announcement was premature.

## TDD / Validate-First Evidence

- Failing proof before implementation: An `api-*.preview.secpal.dev` URL took the direct announcement path without requesting `/health/ready`, violating the invariant that an announced API preview must be publicly ready; the endpoint could still return `404` during provisioning.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` verifies a failed readiness request is retried, a persistently unready preview exits without a public URL, and a static preview makes no readiness request.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Summary

- Gate `api-*.preview.secpal.dev` announcements on a public `/health/ready` 2xx response.
- Retry readiness checks with bounded, configurable attempt and delay settings; the ten-minute default window covers provisioning after the three-minute fallback and fails without announcing an unready preview.
- Preserve immediate announcements for static previews and cover retry, failure, and static-preview behavior in the rollout regression test.

## Validation

- `bash tests/polyscope-rollout.sh`
- `shellcheck scripts/polyscope-expose-wrapper.sh tests/polyscope-rollout.sh`
- `reuse lint`
- Push-time repository preflight

## Coordination and remaining checks

The linked `SecPal/api` workspace (`gate-preview-readiness`) is clean and has no pending local changes. No unresolved local checks remain. The updated-body evidence run passed, but the original failed evidence run remains in the aggregate check list; refresh that check with the next legitimate head update before marking this draft ready. This PR remains a draft.
