### PR TITLE
fix(polyscope): canonicalize preview hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - canonicalized physical hash-suffixed Polyscope preview hosts by resolving provision markers from the clone root rather than relying on the Expose process working directory, and emit only the canonical host in both successful announcement fields so clone storage names such as `misty-vulture-26c1f2f1` cannot leak into the displayed preview URL; if canonical provisioning metadata is unavailable, the wrapper fails closed instead of publishing the suffixed host
 - made the rollout sync install and reload its rendered nginx configuration, preventing removed routing guards from remaining active on the preview host after the provisioning source has been updated
-- made automatic nginx installation transactional and safe for unattended rollout: installations fail before service setup when non-interactive privileges are unavailable, privileged commands cannot prompt inside the user service, unchanged configurations skip backup and reload, and validation or reload failures restore and revalidate the previous configuration
+- made automatic nginx installation transactional and safe for unattended rollout: installations fail before service setup when non-interactive privileges are unavailable, privileged commands cannot prompt inside the user service, root execution does not require a sudo binary, unchanged configurations skip backup and reload, and validation or reload failures restore and revalidate the previous configuration
 - made the autostarted frontend build watcher retry after setup-time dependency installation by tracking npm metadata, `cross-env`, and Vite rather than waiting for an unrelated source edit
 
 ## 2026-07-10 - Gate API Preview Readiness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-10 - Canonicalize Polyscope Preview Hosts
+
+**Fixed:**
+
+- canonicalized physical hash-suffixed Polyscope preview hosts by resolving provision markers from the clone root rather than relying on the Expose process working directory, and emit only the canonical host in both successful announcement fields so clone storage names such as `misty-vulture-26c1f2f1` cannot leak into the displayed preview URL; if canonical provisioning metadata is unavailable, the wrapper fails closed instead of publishing the suffixed host
+- made the rollout sync install and reload its rendered nginx configuration, preventing removed routing guards from remaining active on the preview host after the provisioning source has been updated
+- made automatic nginx installation transactional: unchanged configurations skip backup and reload, while validation or reload failures restore and revalidate the previous configuration
+- made the autostarted frontend build watcher track npm's installed lock metadata and the `cross-env` binary, allowing it to recover when it races the setup-time replacement of `node_modules` without either waiting for an unrelated source edit or retrying a permanently missing dependency in a tight loop
+
 ## 2026-07-10 - Gate API Preview Readiness
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - canonicalized physical hash-suffixed Polyscope preview hosts by resolving provision markers from the clone root rather than relying on the Expose process working directory, and emit only the canonical host in both successful announcement fields so clone storage names such as `misty-vulture-26c1f2f1` cannot leak into the displayed preview URL; if canonical provisioning metadata is unavailable, the wrapper fails closed instead of publishing the suffixed host
 - made the rollout sync install and reload its rendered nginx configuration, preventing removed routing guards from remaining active on the preview host after the provisioning source has been updated
 - made automatic nginx installation transactional and safe for unattended rollout: installations fail before service setup when non-interactive privileges are unavailable, privileged commands cannot prompt inside the user service, unchanged configurations skip backup and reload, and validation or reload failures restore and revalidate the previous configuration
+- made the autostarted frontend build watcher retry after setup-time dependency installation by tracking npm metadata, `cross-env`, and Vite rather than waiting for an unrelated source edit
 
 ## 2026-07-10 - Gate API Preview Readiness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - canonicalized physical hash-suffixed Polyscope preview hosts by resolving provision markers from the clone root rather than relying on the Expose process working directory, and emit only the canonical host in both successful announcement fields so clone storage names such as `misty-vulture-26c1f2f1` cannot leak into the displayed preview URL; if canonical provisioning metadata is unavailable, the wrapper fails closed instead of publishing the suffixed host
 - made the rollout sync install and reload its rendered nginx configuration, preventing removed routing guards from remaining active on the preview host after the provisioning source has been updated
-- made automatic nginx installation transactional: unchanged configurations skip backup and reload, while validation or reload failures restore and revalidate the previous configuration
-- made the autostarted frontend build watcher track npm's installed lock metadata and the `cross-env` binary, allowing it to recover when it races the setup-time replacement of `node_modules` without either waiting for an unrelated source edit or retrying a permanently missing dependency in a tight loop
+- made automatic nginx installation transactional and safe for unattended rollout: installations fail before service setup when non-interactive privileges are unavailable, privileged commands cannot prompt inside the user service, unchanged configurations skip backup and reload, and validation or reload failures restore and revalidate the previous configuration
 
 ## 2026-07-10 - Gate API Preview Readiness
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -339,6 +339,11 @@ the rollout-managed workspace can sync back to the expected repository set.
 bash .github/scripts/install-polyscope-rollout.sh
 ```
 
+Automatic nginx deployment runs from a user systemd service and therefore
+requires either root execution or passwordless, non-interactive `sudo`. The
+installer invalidates cached sudo credentials while checking this prerequisite
+and exits before writing service units when unattended access is unavailable.
+
 After installation, the user-level `polyscope-rollout-sync.service` and
 `polyscope-worktree-provision.service` units take care of provisioning new
 managed repositories automatically when the canonical repo list changes.

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -288,7 +288,7 @@ WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --install-nginx
 EOF
 
 cat >"$PATH_UNIT" <<EOF

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -131,7 +131,9 @@ can_run_privileged_commands() {
         return 0
     fi
 
-    "$SUDO_BIN" -n true >/dev/null 2>&1
+    # Invalidate cached credentials so success proves the future user service
+    # can authenticate without a terminal, not merely reuse this shell's ticket.
+    "$SUDO_BIN" -n -k true >/dev/null 2>&1
 }
 
 run_privileged() {
@@ -198,9 +200,9 @@ if [[ "$server_scope" == "system" ]] && [[ -z "$system_server_fragment_path" ]];
     exit 1
 fi
 
-if [[ "$server_scope" == "system" ]] && ! can_run_privileged_commands; then
-    echo "Error: detected existing system $POLYSCOPE_SYSTEM_SERVER_UNIT at ${system_server_fragment_path:-<unknown>}, but non-interactive sudo or root access is unavailable." >&2
-    echo "Refusing to create a competing user polyscope-server.service on port 4321." >&2
+if ! can_run_privileged_commands; then
+    echo "Error: automatic nginx rollout requires non-interactive sudo or root access." >&2
+    echo "Refusing to install a rollout service that cannot update and reload nginx unattended." >&2
     exit 1
 fi
 
@@ -288,6 +290,7 @@ WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
+Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN
 ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --install-nginx
 EOF
 

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -182,7 +182,7 @@ if [[ $# -ge 2 && "$1" == "share" ]]; then
 		canonical_preview_url=""
 		if canonical_preview_url="$(canonicalize_preview_url_from_marker "$direct_preview_url")"; then
 			direct_preview_url="$canonical_preview_url"
-		elif [[ "$direct_preview_url" =~ ^https://[A-Za-z0-9-]+-[0-9a-fA-F]{8}\.preview\.secpal\.dev(/|$) ]]; then
+		elif [[ "$direct_preview_url" =~ ^https://(api|frontend|guardguide-de|guardguide|secpal-app|changelog)-[A-Za-z0-9-]+-[0-9a-fA-F]{8}\.preview\.secpal\.dev(/|$) ]]; then
 			echo "Error: refusing to announce physical hash-suffixed preview URL without a canonical workspace host: $direct_preview_url" >&2
 			exit 1
 		fi

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -42,6 +42,81 @@ normalize_preview_url() {
 	printf '\n'
 }
 
+canonicalize_preview_url_from_marker() {
+	local direct_url="$1"
+	local marker_path="${POLYSCOPE_PROVISION_MARKER_PATH:-$PWD/.polyscope-secpal-provisioned.json}"
+	local clone_root="${POLYSCOPE_CLONE_ROOT:-$HOME/.polyscope/clones}"
+
+	python3 - "$direct_url" "$marker_path" "$clone_root" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+direct_url = sys.argv[1]
+marker_path = Path(sys.argv[2])
+clone_root = Path(sys.argv[3])
+
+repo_prefixes = {
+    "api": "api",
+    "frontend": "frontend",
+    "GuardGuide": "guardguide",
+    "guardguide.de": "guardguide-de",
+    "secpal.app": "secpal-app",
+    "changelog": "changelog",
+}
+url = urlsplit(direct_url)
+host_match = re.fullmatch(
+    r"(api|frontend|guardguide-de|guardguide|secpal-app|changelog)-([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev",
+    url.hostname or "",
+)
+if host_match is None:
+    raise SystemExit(1)
+
+prefix, physical_workspace = host_match.groups()
+marker_paths = []
+if marker_path.is_file():
+    marker_paths.append(marker_path)
+if clone_root.is_dir():
+    marker_paths.extend(clone_root.glob(f"*/{physical_workspace}/.polyscope-secpal-provisioned.json"))
+
+canonical_urls = set()
+seen_marker_paths = set()
+for candidate in marker_paths:
+    try:
+        resolved_candidate = candidate.resolve()
+    except OSError:
+        resolved_candidate = candidate
+    if resolved_candidate in seen_marker_paths:
+        continue
+    seen_marker_paths.add(resolved_candidate)
+
+    try:
+        marker = json.loads(candidate.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        continue
+    if not isinstance(marker, dict):
+        continue
+
+    repo = marker.get("repo")
+    workspace = marker.get("workspace")
+    marker_physical_workspace = marker.get("physical_workspace")
+    if repo_prefixes.get(repo) != prefix or marker_physical_workspace != physical_workspace:
+        continue
+    if not isinstance(workspace, str) or not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", workspace):
+        continue
+
+    canonical_host = f"{prefix}-{workspace}.preview.secpal.dev"
+    canonical_urls.add(urlunsplit((url.scheme, canonical_host, url.path, url.query, url.fragment)))
+
+if len(canonical_urls) != 1:
+    raise SystemExit(1)
+
+print(canonical_urls.pop())
+PY
+}
+
 api_preview_origin() {
 	local direct_url="$1"
 	local host_and_path host
@@ -104,11 +179,18 @@ announce_direct_preview() {
 if [[ $# -ge 2 && "$1" == "share" ]]; then
 	direct_preview_url="$(normalize_preview_url "$2" || true)"
 	if [[ -n "$direct_preview_url" ]]; then
+		canonical_preview_url=""
+		if canonical_preview_url="$(canonicalize_preview_url_from_marker "$direct_preview_url")"; then
+			direct_preview_url="$canonical_preview_url"
+		elif [[ "$direct_preview_url" =~ ^https://[A-Za-z0-9-]+-[0-9a-fA-F]{8}\.preview\.secpal\.dev(/|$) ]]; then
+			echo "Error: refusing to announce physical hash-suffixed preview URL without a canonical workspace host: $direct_preview_url" >&2
+			exit 1
+		fi
 		api_preview_url="$(api_preview_origin "$direct_preview_url" || true)"
 		if [[ -n "$api_preview_url" ]]; then
 			wait_for_api_preview_readiness "$api_preview_url"
 		fi
-		announce_direct_preview "$2" "$direct_preview_url"
+		announce_direct_preview "$direct_preview_url" "$direct_preview_url"
 	fi
 fi
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1538,6 +1538,9 @@ watch_files = [
             Path(".env.local"),
             Path(".env.preview.local"),
             Path(".env.production.local"),
+            Path("node_modules/.package-lock.json"),
+            Path("node_modules/.bin/cross-env"),
+            Path("node_modules/.bin/vite"),
 ]
 watch_suffixes = {
             ".css",
@@ -1726,11 +1729,18 @@ while True:
         previous_snapshot = current_snapshot
         exit_code = run_build()
         if exit_code != 0:
-            print(
-                f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
-                file=sys.stderr,
-                flush=True,
-            )
+            if exit_code == 127:
+                print(
+                    "Preview build dependencies were unavailable; waiting for dependency installation or a source change.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            else:
+                print(
+                    f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
     time.sleep(1)
         """

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1538,6 +1538,8 @@ watch_files = [
             Path(".env.local"),
             Path(".env.preview.local"),
             Path(".env.production.local"),
+            Path("node_modules/.package-lock.json"),
+            Path("node_modules/.bin/cross-env"),
 ]
 watch_suffixes = {
             ".css",
@@ -1726,11 +1728,18 @@ while True:
         previous_snapshot = current_snapshot
         exit_code = run_build()
         if exit_code != 0:
-            print(
-                f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
-                file=sys.stderr,
-                flush=True,
-            )
+            if exit_code == 127:
+                print(
+                    "Preview build dependencies were unavailable; waiting for dependency installation or a source change.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            else:
+                print(
+                    f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
     time.sleep(1)
         """
@@ -3980,13 +3989,52 @@ def build_summary(
     return summary
 
 
-def install_nginx_config(nginx_output: pathlib.Path) -> None:
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    backup_target = f"/etc/nginx/sites-available/preview.secpal.dev.bak-{timestamp}"
-    subprocess.run(["sudo", "cp", "/etc/nginx/sites-available/preview.secpal.dev", backup_target], check=True)
-    subprocess.run(["sudo", "install", "-m", "644", str(nginx_output), "/etc/nginx/sites-available/preview.secpal.dev"], check=True)
-    subprocess.run(["sudo", "nginx", "-t"], check=True)
-    subprocess.run(["sudo", "systemctl", "reload", "nginx"], check=True)
+def install_nginx_config(
+    nginx_output: pathlib.Path,
+    *,
+    target: pathlib.Path = pathlib.Path("/etc/nginx/sites-available/preview.secpal.dev"),
+    sudo_bin: str = "sudo",
+    nginx_bin: str = "nginx",
+    systemctl_bin: str = "systemctl",
+) -> None:
+    target_exists = subprocess.run(
+        [sudo_bin, "test", "-f", str(target)],
+        check=False,
+    ).returncode == 0
+    if target_exists:
+        unchanged = subprocess.run(
+            [sudo_bin, "cmp", "-s", str(nginx_output), str(target)],
+            check=False,
+        ).returncode == 0
+        if unchanged:
+            return
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_target = target.with_name(f"{target.name}.bak-{timestamp}")
+    if target_exists:
+        subprocess.run([sudo_bin, "cp", str(target), str(backup_target)], check=True)
+
+    def restore_previous_config() -> None:
+        if target_exists:
+            subprocess.run([sudo_bin, "cp", str(backup_target), str(target)], check=True)
+        else:
+            subprocess.run([sudo_bin, "rm", "-f", str(target)], check=True)
+
+    subprocess.run([sudo_bin, "install", "-m", "644", str(nginx_output), str(target)], check=True)
+    try:
+        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
+    except subprocess.CalledProcessError:
+        restore_previous_config()
+        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
+        raise
+
+    try:
+        subprocess.run([sudo_bin, systemctl_bin, "reload", "nginx"], check=True)
+    except subprocess.CalledProcessError:
+        restore_previous_config()
+        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
+        subprocess.run([sudo_bin, systemctl_bin, "reload", "nginx"], check=True)
+        raise
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4001,6 +4001,8 @@ def install_nginx_config(
     sudo_bin = sudo_bin or os.environ.get("POLYSCOPE_SUDO_BIN", "sudo")
 
     def sudo_command(*command: str) -> list[str]:
+        if os.geteuid() == 0:
+            return list(command)
         return [sudo_bin, "-n", *command]
 
     target_exists = subprocess.run(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1538,8 +1538,6 @@ watch_files = [
             Path(".env.local"),
             Path(".env.preview.local"),
             Path(".env.production.local"),
-            Path("node_modules/.package-lock.json"),
-            Path("node_modules/.bin/cross-env"),
 ]
 watch_suffixes = {
             ".css",
@@ -1728,18 +1726,11 @@ while True:
         previous_snapshot = current_snapshot
         exit_code = run_build()
         if exit_code != 0:
-            if exit_code == 127:
-                print(
-                    "Preview build dependencies were unavailable; waiting for dependency installation or a source change.",
-                    file=sys.stderr,
-                    flush=True,
-                )
-            else:
-                print(
-                    f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
-                    file=sys.stderr,
-                    flush=True,
-                )
+            print(
+                f"Preview rebuild failed with exit code {{exit_code}}; waiting for the next change before retrying.",
+                file=sys.stderr,
+                flush=True,
+            )
 
     time.sleep(1)
         """
@@ -3993,17 +3984,22 @@ def install_nginx_config(
     nginx_output: pathlib.Path,
     *,
     target: pathlib.Path = pathlib.Path("/etc/nginx/sites-available/preview.secpal.dev"),
-    sudo_bin: str = "sudo",
+    sudo_bin: str | None = None,
     nginx_bin: str = "nginx",
     systemctl_bin: str = "systemctl",
 ) -> None:
+    sudo_bin = sudo_bin or os.environ.get("POLYSCOPE_SUDO_BIN", "sudo")
+
+    def sudo_command(*command: str) -> list[str]:
+        return [sudo_bin, "-n", *command]
+
     target_exists = subprocess.run(
-        [sudo_bin, "test", "-f", str(target)],
+        sudo_command("test", "-f", str(target)),
         check=False,
     ).returncode == 0
     if target_exists:
         unchanged = subprocess.run(
-            [sudo_bin, "cmp", "-s", str(nginx_output), str(target)],
+            sudo_command("cmp", "-s", str(nginx_output), str(target)),
             check=False,
         ).returncode == 0
         if unchanged:
@@ -4012,28 +4008,28 @@ def install_nginx_config(
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     backup_target = target.with_name(f"{target.name}.bak-{timestamp}")
     if target_exists:
-        subprocess.run([sudo_bin, "cp", str(target), str(backup_target)], check=True)
+        subprocess.run(sudo_command("cp", str(target), str(backup_target)), check=True)
 
     def restore_previous_config() -> None:
         if target_exists:
-            subprocess.run([sudo_bin, "cp", str(backup_target), str(target)], check=True)
+            subprocess.run(sudo_command("cp", str(backup_target), str(target)), check=True)
         else:
-            subprocess.run([sudo_bin, "rm", "-f", str(target)], check=True)
+            subprocess.run(sudo_command("rm", "-f", str(target)), check=True)
 
-    subprocess.run([sudo_bin, "install", "-m", "644", str(nginx_output), str(target)], check=True)
+    subprocess.run(sudo_command("install", "-m", "644", str(nginx_output), str(target)), check=True)
     try:
-        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
+        subprocess.run(sudo_command(nginx_bin, "-t"), check=True)
     except subprocess.CalledProcessError:
         restore_previous_config()
-        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
+        subprocess.run(sudo_command(nginx_bin, "-t"), check=True)
         raise
 
     try:
-        subprocess.run([sudo_bin, systemctl_bin, "reload", "nginx"], check=True)
+        subprocess.run(sudo_command(systemctl_bin, "reload", "nginx"), check=True)
     except subprocess.CalledProcessError:
         restore_previous_config()
-        subprocess.run([sudo_bin, nginx_bin, "-t"], check=True)
-        subprocess.run([sudo_bin, systemctl_bin, "reload", "nginx"], check=True)
+        subprocess.run(sudo_command(nginx_bin, "-t"), check=True)
+        subprocess.run(sudo_command(systemctl_bin, "reload", "nginx"), check=True)
         raise
 
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -951,6 +951,12 @@ if "run" in args and "build" in args:
     counter = int(counter_path.read_text()) if counter_path.exists() else 0
     counter_path.write_text(str(counter + 1))
 
+    if os.environ.get("FAKE_NPM_FAIL_FIRST_BUILD_127") == "1" and counter == 0:
+        Path("node_modules/.bin").mkdir(parents=True, exist_ok=True)
+        Path("node_modules/.bin/cross-env").write_text("ready\\n")
+        Path("node_modules/.package-lock.json").write_text("{}\\n")
+        sys.exit(127)
+
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "assets").mkdir(parents=True, exist_ok=True)
     (out_dir / "index.html").write_text(f"<!doctype html>build {counter}\\n")
@@ -1090,10 +1096,33 @@ assert 'api_workspace = resolve_linked_workspace("SecPal/api", workspace)' in ru
 assert '--outDir' in run_build_source, run_build_source
 assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
 assert 'Path("dist")' in watch_script, watch_script
+assert 'Path("node_modules/.bin/cross-env")' in watch_script, watch_script
+assert 'Path("node_modules/.package-lock.json")' in watch_script, watch_script
 assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
+
+# The autostarted watcher can race the setup-time npm ci, which temporarily
+# removes node_modules/.bin. Exit 127 must therefore retry without requiring a
+# source edit after dependency installation finishes.
+frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
+bounded_watch_script = watch_script.replace("while True:\n", "for _watch_iteration in range(3):\n", 1).replace(
+    "    time.sleep(1)\n",
+    "    time.sleep(0.05)\n",
+    1,
+)
+watch_retry_result = subprocess.run(
+    ["python3", "-c", bounded_watch_script],
+    cwd=frontend_worktree,
+    env={**build_env, "FAKE_NPM_FAIL_FIRST_BUILD_127": "1"},
+    capture_output=True,
+    text=True,
+    timeout=5,
+)
+assert watch_retry_result.returncode == 0, watch_retry_result.stderr
+assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2", watch_retry_result.stderr
+assert "waiting for dependency installation or a source change" in watch_retry_result.stderr, watch_retry_result.stderr
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""
@@ -3013,6 +3042,81 @@ except ValueError:
 else:
     raise SystemExit("unsupported nginx HTTP/2 syntax must fail before rendering")
 PY
+
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "nginx-install-rollback-fixture"
+fixture.mkdir()
+target = fixture / "preview.secpal.dev"
+candidate = fixture / "candidate.conf"
+systemctl_log = fixture / "systemctl.log"
+fake_sudo = fixture / "sudo"
+fake_nginx = fixture / "nginx"
+fake_systemctl = fixture / "systemctl"
+
+target.write_text("valid-current\n")
+candidate.write_text("invalid-candidate\n")
+fake_sudo.write_text('#!/usr/bin/env bash\nexec "$@"\n')
+fake_nginx.write_text(
+    "#!/usr/bin/env bash\n"
+    f"grep -q '^invalid' {target!s} && exit 1\n"
+    "exit 0\n"
+)
+fake_systemctl.write_text(
+    "#!/usr/bin/env bash\n"
+    f"printf '%s\\n' \"$*\" >> {systemctl_log!s}\n"
+)
+for executable in (fake_sudo, fake_nginx, fake_systemctl):
+    executable.chmod(0o755)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+try:
+    module.install_nginx_config(
+        candidate,
+        target=target,
+        sudo_bin=str(fake_sudo),
+        nginx_bin=str(fake_nginx),
+        systemctl_bin=str(fake_systemctl),
+    )
+except subprocess.CalledProcessError:
+    pass
+else:
+    raise AssertionError("invalid nginx candidate must fail installation")
+
+assert target.read_text() == "valid-current\n", target.read_text()
+assert not systemctl_log.exists(), systemctl_log.read_text() if systemctl_log.exists() else ""
+
+candidate.write_text("valid-next\n")
+module.install_nginx_config(
+    candidate,
+    target=target,
+    sudo_bin=str(fake_sudo),
+    nginx_bin=str(fake_nginx),
+    systemctl_bin=str(fake_systemctl),
+)
+assert target.read_text() == "valid-next\n", target.read_text()
+assert systemctl_log.read_text().splitlines() == ["reload nginx"], systemctl_log.read_text()
+
+module.install_nginx_config(
+    candidate,
+    target=target,
+    sudo_bin=str(fake_sudo),
+    nginx_bin=str(fake_nginx),
+    systemctl_bin=str(fake_systemctl),
+)
+assert systemctl_log.read_text().splitlines() == ["reload nginx"], systemctl_log.read_text()
+PY
+
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
 grep -q "/home/secpal/.polyscope/clones/gg123456/\\\$workspace" "$nginx_output"
 grep -qF "if (\$repo = guardguide) {" "$nginx_output"
@@ -4469,6 +4573,7 @@ grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscop
 grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
 grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q 'ExecStart=.* --install-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-rollout-sync.service"
@@ -4640,7 +4745,7 @@ env HOME="$home_dir" \
     POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
     "$fake_polyscope_bin_dir/expose-linux-x64" share https://api-auto-hawk.preview.secpal.dev:443 >"$preview_wrapper_out"
 
-grep -q 'Shared site              https://api-auto-hawk.preview.secpal.dev:443' "$preview_wrapper_out"
+grep -q 'Shared site              https://api-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
 grep -q 'Public URL               https://api-auto-hawk.preview.secpal.dev' "$preview_wrapper_out"
 test "$(cat "$fake_curl_attempt_file")" = "2"
 grep -qx -- '-fsS --max-time 3 -o /dev/null -w %{http_code} https://api-auto-hawk.preview.secpal.dev/health/ready' "$fake_curl_log"
@@ -4666,6 +4771,78 @@ env HOME="$home_dir" \
     "$fake_polyscope_bin_dir/expose-linux-x64" share https://frontend-auto-hawk.preview.secpal.dev:443 >/dev/null
 
 test "$(cat "$fake_curl_attempt_file")" = "3"
+
+physical_preview_clone_root="$workspace/physical-preview-clones"
+physical_preview_worktree="$physical_preview_clone_root/fe123456/misty-vulture-26c1f2f1"
+physical_preview_wrapper_out="$workspace/expose-wrapper-physical-preview.out"
+mkdir -p "$physical_preview_worktree"
+cat >"$physical_preview_worktree/.polyscope-secpal-provisioned.json" <<'JSON'
+{
+  "repo": "frontend",
+  "workspace": "misty-vulture",
+  "physical_workspace": "misty-vulture-26c1f2f1"
+}
+JSON
+
+(
+    cd "$workspace"
+    env HOME="$home_dir" \
+        PATH="$workspace/fake-tools:$PATH" \
+        POLYSCOPE_CLONE_ROOT="$physical_preview_clone_root" \
+        POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+        "$fake_polyscope_bin_dir/expose-linux-x64" \
+        share https://frontend-misty-vulture-26c1f2f1.preview.secpal.dev:443
+) >"$physical_preview_wrapper_out"
+
+grep -q 'Shared site              https://frontend-misty-vulture.preview.secpal.dev' "$physical_preview_wrapper_out"
+grep -q 'Public URL               https://frontend-misty-vulture.preview.secpal.dev' "$physical_preview_wrapper_out"
+if grep -q 'misty-vulture-26c1f2f1' "$physical_preview_wrapper_out"; then
+    echo "successful preview announcement must not expose the physical hash-suffixed host" >&2
+    exit 1
+fi
+
+canonical_hash_workspace="$physical_preview_clone_root/fe123456/release-deadbeef"
+canonical_hash_wrapper_out="$workspace/expose-wrapper-canonical-hash-preview.out"
+mkdir -p "$canonical_hash_workspace"
+cat >"$canonical_hash_workspace/.polyscope-secpal-provisioned.json" <<'JSON'
+{
+  "repo": "frontend",
+  "workspace": "release-deadbeef",
+  "physical_workspace": "release-deadbeef"
+}
+JSON
+
+(
+    cd "$workspace"
+    env HOME="$home_dir" \
+        POLYSCOPE_CLONE_ROOT="$physical_preview_clone_root" \
+        POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+        "$fake_polyscope_bin_dir/expose-linux-x64" \
+        share https://frontend-release-deadbeef.preview.secpal.dev:443
+) >"$canonical_hash_wrapper_out"
+
+grep -q 'Public URL               https://frontend-release-deadbeef.preview.secpal.dev' "$canonical_hash_wrapper_out"
+
+unprovisioned_physical_worktree="$workspace/unprovisioned-physical-preview/misty-vulture-26c1f2f1"
+unprovisioned_clone_root="$workspace/unprovisioned-physical-clones"
+unprovisioned_physical_wrapper_out="$workspace/expose-wrapper-unprovisioned-physical-preview.out"
+mkdir -p "$unprovisioned_physical_worktree" "$unprovisioned_clone_root"
+if (
+    cd "$unprovisioned_physical_worktree"
+    env HOME="$home_dir" \
+        POLYSCOPE_CLONE_ROOT="$unprovisioned_clone_root" \
+        POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+        "$fake_polyscope_bin_dir/expose-linux-x64" \
+        share https://frontend-misty-vulture-26c1f2f1.preview.secpal.dev:443
+) >"$unprovisioned_physical_wrapper_out" 2>&1; then
+    echo "physical hash-suffixed preview must not be announced without canonical provisioning metadata" >&2
+    exit 1
+fi
+grep -q 'refusing to announce physical hash-suffixed preview URL' "$unprovisioned_physical_wrapper_out"
+if grep -q 'Public URL' "$unprovisioned_physical_wrapper_out"; then
+    echo "physical hash-suffixed preview must never be exposed as the public URL" >&2
+    exit 1
+fi
 
 failed_preview_wrapper_out="$workspace/expose-wrapper-preview-failed.out"
 if env HOME="$home_dir" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -951,6 +951,13 @@ if "run" in args and "build" in args:
     counter = int(counter_path.read_text()) if counter_path.exists() else 0
     counter_path.write_text(str(counter + 1))
 
+    if os.environ.get("FAKE_NPM_FAIL_FIRST_BUILD_127") == "1" and counter == 0:
+        Path("node_modules/.bin").mkdir(parents=True, exist_ok=True)
+        Path("node_modules/.bin/cross-env").write_text("ready\\n")
+        Path("node_modules/.package-lock.json").write_text("{}\\n")
+        Path("node_modules/.bin/vite").write_text("ready\\n")
+        sys.exit(127)
+
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "assets").mkdir(parents=True, exist_ok=True)
     (out_dir / "index.html").write_text(f"<!doctype html>build {counter}\\n")
@@ -1090,10 +1097,33 @@ assert 'api_workspace = resolve_linked_workspace("SecPal/api", workspace)' in ru
 assert '--outDir' in run_build_source, run_build_source
 assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
 assert 'Path("dist")' in watch_script, watch_script
+assert 'Path("node_modules/.bin/cross-env")' in watch_script, watch_script
+assert 'Path("node_modules/.bin/vite")' in watch_script, watch_script
+assert 'Path("node_modules/.package-lock.json")' in watch_script, watch_script
 assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
+
+# The watcher can race setup-time npm ci. It must retry once both the npm
+# metadata and all build binaries become available, including Vite.
+frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
+bounded_watch_script = watch_script.replace("while True:\n", "for _watch_iteration in range(3):\n", 1).replace(
+    "    time.sleep(1)",
+    "    time.sleep(0.05)",
+    1,
+)
+watch_retry_result = subprocess.run(
+    ["python3", "-c", bounded_watch_script],
+    cwd=frontend_worktree,
+    env={**build_env, "FAKE_NPM_FAIL_FIRST_BUILD_127": "1"},
+    capture_output=True,
+    text=True,
+    timeout=5,
+)
+assert watch_retry_result.returncode == 0, watch_retry_result.stderr
+assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2", watch_retry_result.stderr
+assert "waiting for dependency installation or a source change" in watch_retry_result.stderr, watch_retry_result.stderr
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""
@@ -4876,6 +4906,14 @@ JSON
 ) >"$canonical_hash_wrapper_out"
 
 grep -q 'Public URL               https://frontend-release-deadbeef.preview.secpal.dev' "$canonical_hash_wrapper_out"
+
+generic_hash_wrapper_out="$workspace/expose-wrapper-generic-hash-preview.out"
+env HOME="$home_dir" \
+    POLYSCOPE_CLONE_ROOT="$physical_preview_clone_root" \
+    POLYSCOPE_EXPOSE_WRAPPER_EXIT_AFTER_ANNOUNCE=1 \
+    "$fake_polyscope_bin_dir/expose-linux-x64" \
+    share https://release-deadbeef.preview.secpal.dev:443 >"$generic_hash_wrapper_out"
+grep -q 'Public URL               https://release-deadbeef.preview.secpal.dev' "$generic_hash_wrapper_out"
 
 unprovisioned_physical_worktree="$workspace/unprovisioned-physical-preview/misty-vulture-26c1f2f1"
 unprovisioned_clone_root="$workspace/unprovisioned-physical-clones"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -951,12 +951,6 @@ if "run" in args and "build" in args:
     counter = int(counter_path.read_text()) if counter_path.exists() else 0
     counter_path.write_text(str(counter + 1))
 
-    if os.environ.get("FAKE_NPM_FAIL_FIRST_BUILD_127") == "1" and counter == 0:
-        Path("node_modules/.bin").mkdir(parents=True, exist_ok=True)
-        Path("node_modules/.bin/cross-env").write_text("ready\\n")
-        Path("node_modules/.package-lock.json").write_text("{}\\n")
-        sys.exit(127)
-
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "assets").mkdir(parents=True, exist_ok=True)
     (out_dir / "index.html").write_text(f"<!doctype html>build {counter}\\n")
@@ -1096,33 +1090,10 @@ assert 'api_workspace = resolve_linked_workspace("SecPal/api", workspace)' in ru
 assert '--outDir' in run_build_source, run_build_source
 assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
 assert 'Path("dist")' in watch_script, watch_script
-assert 'Path("node_modules/.bin/cross-env")' in watch_script, watch_script
-assert 'Path("node_modules/.package-lock.json")' in watch_script, watch_script
 assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
-
-# The autostarted watcher can race the setup-time npm ci, which temporarily
-# removes node_modules/.bin. Exit 127 must therefore retry without requiring a
-# source edit after dependency installation finishes.
-frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
-bounded_watch_script = watch_script.replace("while True:\n", "for _watch_iteration in range(3):\n", 1).replace(
-    "    time.sleep(1)\n",
-    "    time.sleep(0.05)\n",
-    1,
-)
-watch_retry_result = subprocess.run(
-    ["python3", "-c", bounded_watch_script],
-    cwd=frontend_worktree,
-    env={**build_env, "FAKE_NPM_FAIL_FIRST_BUILD_127": "1"},
-    capture_output=True,
-    text=True,
-    timeout=5,
-)
-assert watch_retry_result.returncode == 0, watch_retry_result.stderr
-assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2", watch_retry_result.stderr
-assert "waiting for dependency installation or a source change" in watch_retry_result.stderr, watch_retry_result.stderr
 
 # build_frontend_preview_playwright_command: assert linked API workspace is used in PLAYWRIGHT_API_BASE_URL
 playwright_probe = _textwrap.dedent(f"""
@@ -3045,6 +3016,7 @@ PY
 
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
+import os
 import pathlib
 import subprocess
 import sys
@@ -3056,13 +3028,19 @@ fixture.mkdir()
 target = fixture / "preview.secpal.dev"
 candidate = fixture / "candidate.conf"
 systemctl_log = fixture / "systemctl.log"
+systemctl_failure_marker = fixture / "systemctl-failed-once"
 fake_sudo = fixture / "sudo"
 fake_nginx = fixture / "nginx"
 fake_systemctl = fixture / "systemctl"
 
 target.write_text("valid-current\n")
 candidate.write_text("invalid-candidate\n")
-fake_sudo.write_text('#!/usr/bin/env bash\nexec "$@"\n')
+fake_sudo.write_text(
+    "#!/usr/bin/env bash\n"
+    "[[ \"${1:-}\" == '-n' ]] || exit 97\n"
+    "shift\n"
+    "exec \"$@\"\n"
+)
 fake_nginx.write_text(
     "#!/usr/bin/env bash\n"
     f"grep -q '^invalid' {target!s} && exit 1\n"
@@ -3071,6 +3049,10 @@ fake_nginx.write_text(
 fake_systemctl.write_text(
     "#!/usr/bin/env bash\n"
     f"printf '%s\\n' \"$*\" >> {systemctl_log!s}\n"
+    f"if [[ \"${{FAIL_FIRST_SYSTEMCTL_RELOAD:-0}}\" == '1' && ! -e {systemctl_failure_marker!s} ]]; then\n"
+    f"  touch {systemctl_failure_marker!s}\n"
+    "  exit 1\n"
+    "fi\n"
 )
 for executable in (fake_sudo, fake_nginx, fake_systemctl):
     executable.chmod(0o755)
@@ -3107,6 +3089,32 @@ module.install_nginx_config(
 assert target.read_text() == "valid-next\n", target.read_text()
 assert systemctl_log.read_text().splitlines() == ["reload nginx"], systemctl_log.read_text()
 
+target.write_text("valid-current-before-reload-failure\n")
+candidate.write_text("valid-next-reload-failure\n")
+os.environ["FAIL_FIRST_SYSTEMCTL_RELOAD"] = "1"
+try:
+    module.install_nginx_config(
+        candidate,
+        target=target,
+        sudo_bin=str(fake_sudo),
+        nginx_bin=str(fake_nginx),
+        systemctl_bin=str(fake_systemctl),
+    )
+except subprocess.CalledProcessError:
+    pass
+else:
+    raise AssertionError("nginx reload failure must fail installation after restoring the previous config")
+finally:
+    os.environ.pop("FAIL_FIRST_SYSTEMCTL_RELOAD", None)
+
+assert target.read_text() == "valid-current-before-reload-failure\n", target.read_text()
+assert systemctl_log.read_text().splitlines() == [
+    "reload nginx",
+    "reload nginx",
+    "reload nginx",
+], systemctl_log.read_text()
+
+candidate.write_text("valid-current-before-reload-failure\n")
 module.install_nginx_config(
     candidate,
     target=target,
@@ -3114,7 +3122,11 @@ module.install_nginx_config(
     nginx_bin=str(fake_nginx),
     systemctl_bin=str(fake_systemctl),
 )
-assert systemctl_log.read_text().splitlines() == ["reload nginx"], systemctl_log.read_text()
+assert systemctl_log.read_text().splitlines() == [
+    "reload nginx",
+    "reload nginx",
+    "reload nginx",
+], systemctl_log.read_text()
 PY
 
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"
@@ -4396,12 +4408,15 @@ cat >"$fake_sudo_dir/sudo" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$SUDO_LOG"
 
-if [[ "${1:-}" == "-n" ]]; then
-    shift
+if [[ "${1:-}" == "-n" && "${2:-}" == "-k" && "${3:-}" == "true" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "-n" && "${2:-}" == "true" ]]; then
+    exit 98
 fi
 
-if [[ "${1:-}" == "true" ]]; then
-    exit 0
+if [[ "${1:-}" == "-n" ]]; then
+    shift
 fi
 
 exec "$@"
@@ -4412,6 +4427,8 @@ env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
     bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
@@ -4435,6 +4452,8 @@ env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
     bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
@@ -4448,6 +4467,8 @@ env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
     FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
     PATH="$fake_systemctl_dir:$PATH" \
     bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
@@ -4470,6 +4491,8 @@ env HOME="$home_dir" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
     POLYSCOPE_EXPOSE_BIN="$fake_guard_expose_bin" \
     POLYSCOPE_EXPOSE_REAL_BIN="$fake_guard_expose_real" \
     PATH="$fake_systemctl_dir:$PATH" \
@@ -4578,6 +4601,7 @@ grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
@@ -4668,6 +4692,36 @@ if [[ "$no_sudo_exit" -eq 0 ]]; then
     exit 1
 fi
 test ! -e "$no_sudo_unit_dir/polyscope-server.service"
+
+# The user-scoped rollout sync also installs nginx and must therefore reject
+# configurations that cannot obtain unattended privileges before writing units.
+no_sudo_user_home_dir="$workspace/no-sudo-user-home"
+no_sudo_user_bin_dir="$workspace/no-sudo-user-bin"
+no_sudo_user_unit_dir="$workspace/no-sudo-user-units"
+no_sudo_user_exit=0
+mkdir -p "$no_sudo_user_home_dir/.polyscope/bin"
+cat >"$no_sudo_user_home_dir/.polyscope/bin/expose-linux-x64" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$no_sudo_user_home_dir/.polyscope/bin/expose-linux-x64"
+env HOME="$no_sudo_user_home_dir" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$no_sudo_systemctl_log" \
+    SUDO_BIN="$no_sudo_sudo_dir/sudo" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" \
+        --bin-dir "$no_sudo_user_bin_dir" \
+        --unit-dir "$no_sudo_user_unit_dir" \
+        --polyscope-server-bin "$fake_server_bin" \
+        --polyscope-server-scope user \
+        2>/dev/null || no_sudo_user_exit=$?
+if [[ "$no_sudo_user_exit" -eq 0 ]]; then
+    echo "installer must refuse user scope when unattended nginx privileges are unavailable" >&2
+    exit 1
+fi
+test ! -e "$no_sudo_user_unit_dir/polyscope-rollout-sync.service"
 
 # installer must also refuse when --polyscope-server-scope system is forced but no unit exists
 no_unit_exit=0

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -3157,6 +3157,26 @@ assert systemctl_log.read_text().splitlines() == [
     "reload nginx",
     "reload nginx",
 ], systemctl_log.read_text()
+
+# Root execution must not depend on a sudo binary being installed.
+root_target = fixture / "root-preview.secpal.dev"
+root_candidate = fixture / "root-candidate.conf"
+root_target.write_text("valid-root-current\\n")
+root_candidate.write_text("valid-root-next\\n")
+original_geteuid = module.os.geteuid
+module.os.geteuid = lambda: 0
+try:
+    module.install_nginx_config(
+        root_candidate,
+        target=root_target,
+        sudo_bin=str(fixture / "missing-sudo"),
+        nginx_bin=str(fake_nginx),
+        systemctl_bin=str(fake_systemctl),
+    )
+finally:
+    module.os.geteuid = original_geteuid
+
+assert root_target.read_text() == "valid-root-next\\n", root_target.read_text()
 PY
 
 grep -q "/home/secpal/.polyscope/clones/api12345/\\\$workspace" "$nginx_output"


### PR DESCRIPTION
## TDD / Validate-First Evidence

- Failing proof before implementation: `./tests/polyscope-rollout.sh` initially failed with permission denied because the test file is not executable; `bash tests/polyscope-rollout.sh` then exercised the fail-first regression coverage for hash-suffixed physical preview hosts, unprovisioned suffixed hosts, watcher recovery after exit 127, and nginx rollback before implementation was committed.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `./scripts/preflight.sh` passed.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/polyscope-rollout.sh` passed. Its regression cases reproduce hash-suffixed physical preview hosts, confirm canonical public output, reject unprovisioned suffixed hosts, cover watcher recovery after exit 127, and verify nginx rollback.
- `./scripts/preflight.sh` passed, including REUSE and domain-policy checks.
- Commit `c48cdc2` is GPG-signed; pre-commit checks passed (REUSE, formatting, Markdown lint, ShellCheck, conflict markers, and large-file checks).

## Summary

- Resolve preview host aliases from provisioning metadata before announcing them, failing closed when an unverifiable physical host would otherwise be public.
- Install and reload rendered nginx configuration during rollout sync, with transactional rollback for validation or reload failures.
- Let the frontend watcher observe dependency installation metadata so it recovers from an npm-install race.

## Scope and follow-up

- No linked workspace was used for this change.
- No unresolved checks or follow-up items remain. This PR remains a draft pending review.
