### PR TITLE
Fix stale Polyscope preview tenant keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- recovered isolated API previews whose seeded tenant envelope keys no longer match their per-worktree KEK: provisioning now recognizes the precise `TenantKey::loadKek()` / `unwrapDek()` seed failure, removes only the preview-local KEK, resets only that preview database, and retries seeding once; unrelated seed failures still surface normally
+- recovered isolated API previews whose seeded tenant envelope keys no longer match their per-worktree KEK: provisioning now requires the precise `TenantKey::loadKek()` / `unwrapDek()` stack and `Failed to unwrap DEK` error, removes only the preview-local KEK, resets only that preview database or schema, and retries seeding once; unrelated seed failures still surface normally
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-12 - Recover Stale Polyscope Preview Tenant Keys
+
+**Fixed:**
+
+- recovered isolated API previews whose seeded tenant envelope keys no longer match their per-worktree KEK: provisioning now recognizes the precise `TenantKey::loadKek()` / `unwrapDek()` seed failure, removes only the preview-local KEK, resets only that preview database, and retries seeding once; unrelated seed failures still surface normally
+
+---
+
 ## 2026-07-10 - Canonicalize Polyscope Preview Hosts
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1078,7 +1078,14 @@ def is_recoverable_preview_tenant_key_failure(error: subprocess.CalledProcessErr
     if not isinstance(output, str):
         return False
 
-    return "App\\Models\\TenantKey::loadKek" in output and "App\\Models\\TenantKey::unwrapDek" in output
+    return all(
+        marker in output
+        for marker in (
+            "App\\Models\\TenantKey::loadKek",
+            "App\\Models\\TenantKey::unwrapDek",
+            "Failed to unwrap DEK",
+        )
+    )
 
 
 def discard_stale_preview_kek(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1057,7 +1057,47 @@ def run_api_worktree_bootstrap_command(
     *,
     command_env: dict[str, str],
 ) -> None:
-    subprocess.run(command, cwd=worktree_path, env=command_env, check=True)
+    result = subprocess.run(
+        command,
+        cwd=worktree_path,
+        env=command_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    result.check_returncode()
+
+
+def is_recoverable_preview_tenant_key_failure(error: subprocess.CalledProcessError) -> bool:
+    """Return whether seed output proves an isolated preview KEK mismatch."""
+    output = error.output
+    if isinstance(output, bytes):
+        output = output.decode(errors="replace")
+    if not isinstance(output, str):
+        return False
+
+    return "App\\Models\\TenantKey::loadKek" in output and "App\\Models\\TenantKey::unwrapDek" in output
+
+
+def discard_stale_preview_kek(
+    worktree_path: pathlib.Path,
+    env_values: dict[str, str],
+    preview_storage_target: str | None,
+) -> bool:
+    """Discard only a stale KEK belonging to an isolated API preview worktree."""
+    if preview_storage_target is None or "__preview__" not in preview_storage_target:
+        return False
+
+    configured_kek_path = env_values.get("KEK_PATH", "").strip()
+    expected_kek_path = pathlib.Path(build_api_preview_kek_path(worktree_path))
+    if not configured_kek_path or pathlib.Path(configured_kek_path).resolve() != expected_kek_path:
+        return False
+
+    if expected_kek_path.exists():
+        expected_kek_path.unlink()
+    return True
 
 
 def bootstrap_api_worktree(
@@ -1067,6 +1107,7 @@ def bootstrap_api_worktree(
     db_path: pathlib.Path | None = None,
     migration_command: list[str] | None = None,
     migration_label: str = "running migrations",
+    allow_tenant_key_recovery: bool = True,
 ) -> tuple[bool, str | None]:
     env_path = worktree_path / ".env"
     preview_storage_target: str | None = None
@@ -1110,11 +1151,29 @@ def bootstrap_api_worktree(
     )
 
     print(f"{prefix} seeding database")
-    run_api_worktree_bootstrap_command(
-        worktree_path,
-        ["php", "artisan", "db:seed", "--force"],
-        command_env=command_env,
-    )
+    try:
+        run_api_worktree_bootstrap_command(
+            worktree_path,
+            ["php", "artisan", "db:seed", "--force"],
+            command_env=command_env,
+        )
+    except subprocess.CalledProcessError as error:
+        if not (
+            allow_tenant_key_recovery
+            and is_recoverable_preview_tenant_key_failure(error)
+            and discard_stale_preview_kek(worktree_path, env_values, preview_storage_target)
+        ):
+            raise
+
+        print(f"{prefix} recovering stale preview tenant key material")
+        return bootstrap_api_worktree(
+            worktree_path,
+            source_repo_path,
+            db_path=db_path,
+            migration_command=["php", "artisan", "migrate:fresh", "--force"],
+            migration_label="resetting preview database after tenant key recovery",
+            allow_tenant_key_recovery=False,
+        )
 
     print(f"{prefix} normalizing preview test user")
     run_api_worktree_bootstrap_command(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1057,7 +1057,7 @@ def run_api_worktree_bootstrap_command(
     *,
     command_env: dict[str, str],
 ) -> None:
-    result = subprocess.run(
+    process = subprocess.Popen(
         command,
         cwd=worktree_path,
         env=command_env,
@@ -1065,9 +1065,17 @@ def run_api_worktree_bootstrap_command(
         stderr=subprocess.STDOUT,
         text=True,
     )
-    if result.stdout:
-        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
-    result.check_returncode()
+    if process.stdout is None:
+        raise RuntimeError("Failed to capture API bootstrap command output")
+
+    output_chunks: list[str] = []
+    for output_chunk in process.stdout:
+        print(output_chunk, end="")
+        output_chunks.append(output_chunk)
+
+    return_code = process.wait()
+    if return_code != 0:
+        raise subprocess.CalledProcessError(return_code, command, output="".join(output_chunks))
 
 
 def is_recoverable_preview_tenant_key_failure(error: subprocess.CalledProcessError) -> bool:
@@ -1094,7 +1102,7 @@ def discard_stale_preview_kek(
     preview_storage_target: str | None,
 ) -> bool:
     """Discard only a stale KEK belonging to an isolated API preview worktree."""
-    if preview_storage_target is None or "__preview__" not in preview_storage_target:
+    if preview_storage_target is None or POSTGRES_PREVIEW_DATABASE_SEPARATOR not in preview_storage_target:
         return False
 
     configured_kek_path = env_values.get("KEK_PATH", "").strip()

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2446,6 +2446,81 @@ assert "POLYSCOPE_DB_PASSWORD_SOURCE=source" in worktree_env, worktree_env
 assert "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256=" in worktree_env, worktree_env
 PY
 
+# A stale per-worktree KEK cannot unwrap tenant keys left in an isolated
+# preview database. Bootstrap must recognize that exact failure, discard only
+# the preview key material, and retry once from a fresh preview schema.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+source_api = workspace / "tenant-key-recovery-fixture" / "source-api"
+api_worktree = workspace / "tenant-key-recovery-fixture" / "clones" / "api12345" / "coral-crow-d6cd6a1f"
+source_api.mkdir(parents=True, exist_ok=True)
+api_worktree.mkdir(parents=True, exist_ok=True)
+source_api.joinpath(".env").write_text("DB_CONNECTION=sqlite\n")
+kek_path = api_worktree / "storage" / "app" / "keys" / "kek.key"
+kek_path.parent.mkdir(parents=True)
+kek_path.write_bytes(b"stale-preview-kek")
+api_worktree.joinpath(".env").write_text(
+    "APP_KEY=base64:preview\n"
+    f"KEK_PATH={kek_path}\n"
+    "POLYSCOPE_PREVIEW_STORAGE_MODE=database\n"
+    "DB_DATABASE=secpal__preview__coral_crow\n"
+)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+calls = []
+seed_attempts = [0]
+
+def fake_run_api_worktree_bootstrap_command(worktree_path, command, *, command_env):
+    seed_attempts[0] += 1 if command == ["php", "artisan", "db:seed", "--force"] else 0
+    calls.append(tuple(command))
+    if command == ["php", "artisan", "db:seed", "--force"] and seed_attempts[0] == 1:
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            output=(
+                "App\\Models\\TenantKey::loadKek()\n"
+                "App\\Models\\TenantKey::unwrapDek()\n"
+                "Failed to unwrap DEK\n"
+            ),
+        )
+module.run_api_worktree_bootstrap_command = fake_run_api_worktree_bootstrap_command
+
+ready, target = module.bootstrap_api_worktree(api_worktree, source_api)
+assert ready is True
+assert target == "database:secpal__preview__coral_crow", target
+assert not kek_path.exists(), "recovery must remove the stale isolated-preview KEK"
+assert calls == [
+    ("php", "artisan", "config:clear"),
+    ("php", "artisan", "migrate", "--force"),
+    ("php", "artisan", "db:seed", "--force"),
+    ("php", "artisan", "config:clear"),
+    ("php", "artisan", "migrate:fresh", "--force"),
+    ("php", "artisan", "db:seed", "--force"),
+    ("php", "artisan", "tinker", f"--execute={module.build_api_preview_test_user_tinker_script()}"),
+], calls
+
+assert not module.is_recoverable_preview_tenant_key_failure(
+    subprocess.CalledProcessError(1, ["php", "artisan", "db:seed", "--force"], output="ordinary seeder failure")
+)
+kek_path.write_bytes(b"must-not-delete")
+assert not module.discard_stale_preview_kek(
+    api_worktree,
+    module.load_env_assignments(api_worktree / ".env"),
+    "database:secpal",
+)
+assert kek_path.exists(), "recovery must not reset an unisolated database"
+PY
+
 # run_api_worktree_shell_command must reuse the transient runtime DB password
 # injection for long-running preview actions such as the queue worker and scheduler.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2446,9 +2446,58 @@ assert "POLYSCOPE_DB_PASSWORD_SOURCE=source" in worktree_env, worktree_env
 assert "POLYSCOPE_DB_PASSWORD_SOURCE_SHA256=" in worktree_env, worktree_env
 PY
 
+# Bootstrap output must remain visible while a command is running, while its
+# complete transcript remains available to classify a failed seed command.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import builtins
+import importlib.util
+import pathlib
+import subprocess
+import sys
+from unittest.mock import patch
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+emitted = []
+popen_calls = []
+
+class FakeProcess:
+    stdout = ["first line\n", "second line\n"]
+
+    def wait(self):
+        assert emitted == ["first line\n", "second line\n"], emitted
+        return 1
+
+def fake_popen(*args, **kwargs):
+    popen_calls.append((args, kwargs))
+    return FakeProcess()
+
+with patch.object(module.subprocess, "Popen", side_effect=fake_popen):
+    with patch.object(builtins, "print", side_effect=lambda value="", end="\n": emitted.append(value)):
+        try:
+            module.run_api_worktree_bootstrap_command(
+                workspace,
+                ["php", "artisan", "db:seed", "--force"],
+                command_env={},
+            )
+        except subprocess.CalledProcessError as error:
+            assert error.output == "first line\nsecond line\n", error.output
+        else:
+            raise AssertionError("expected streamed bootstrap failure")
+
+assert len(popen_calls) == 1, popen_calls
+assert popen_calls[0][1]["stdout"] is subprocess.PIPE, popen_calls
+assert popen_calls[0][1]["stderr"] is subprocess.STDOUT, popen_calls
+PY
+
 # A stale per-worktree KEK cannot unwrap tenant keys left in an isolated
 # preview database. Bootstrap must recognize that exact failure, discard only
-# the preview key material, and retry once from a fresh preview schema.
+# the preview key material, and retry once from a fresh preview database.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2512,6 +2512,17 @@ assert calls == [
 assert not module.is_recoverable_preview_tenant_key_failure(
     subprocess.CalledProcessError(1, ["php", "artisan", "db:seed", "--force"], output="ordinary seeder failure")
 )
+assert not module.is_recoverable_preview_tenant_key_failure(
+    subprocess.CalledProcessError(
+        1,
+        ["php", "artisan", "db:seed", "--force"],
+        output=(
+            "App\\Models\\TenantKey::loadKek()\n"
+            "App\\Models\\TenantKey::unwrapDek()\n"
+            "Unrelated tenant key failure\n"
+        ),
+    )
+), "stack frames alone must not authorize destructive preview recovery"
 kek_path.write_bytes(b"must-not-delete")
 assert not module.discard_stale_preview_kek(
     api_worktree,
@@ -2519,6 +2530,21 @@ assert not module.discard_stale_preview_kek(
     "database:secpal",
 )
 assert kek_path.exists(), "recovery must not reset an unisolated database"
+
+api_worktree.joinpath(".env").write_text(
+    "APP_KEY=base64:preview\n"
+    f"KEK_PATH={kek_path}\n"
+    "POLYSCOPE_PREVIEW_STORAGE_MODE=schema\n"
+    "POLYSCOPE_PREVIEW_DATABASE_BASE=secpal\n"
+    "POLYSCOPE_PREVIEW_SCHEMA=secpal__preview__coral_crow\n"
+    "DB_DATABASE=secpal\n"
+)
+assert module.discard_stale_preview_kek(
+    api_worktree,
+    module.load_env_assignments(api_worktree / ".env"),
+    "schema:secpal:secpal__preview__coral_crow",
+)
+assert not kek_path.exists(), "schema previews must permit the same isolated KEK recovery"
 PY
 
 # run_api_worktree_shell_command must reuse the transient runtime DB password


### PR DESCRIPTION
## Reproduced defect

`php artisan db:seed --force` failed repeatedly for an API preview when its tenant envelope keys were wrapped by an older per-worktree KEK. The failure trace included both `App\Models\TenantKey::loadKek()` and `App\Models\TenantKey::unwrapDek()`, leaving the worktree in every automatic provisioning failure set.

Closes #549

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` failed when the simulated `TenantKey::loadKek()` / `unwrapDek()` seed trace raised `CalledProcessError` instead of recovering the isolated preview.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` passes with the one-time `migrate:fresh` retry and the negative guards for ordinary seed failures and unisolated databases.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Change

- capture bootstrap command output so the provisioner can classify the observed failure
- recover only when both tenant-key stack markers are present, the KEK path is the expected worktree-local path, and the target is an isolated preview database or schema
- remove that stale KEK, reset the isolated preview database with `migrate:fresh`, and retry seeding once
- preserve normal failures for unrelated seed errors and non-preview targets

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`

The regression starts with the failing tenant-key seed trace, then verifies the fresh-database retry and negative guards for ordinary seed failures and an unisolated database.

## Linked workspaces and follow-up

No linked-workspace changes are required. CI checks are in progress; final PR review and completed checks are required before this draft can be marked ready.
