### PR TITLE
fix(polyscope): reap orphaned clone roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - added a daily, conservative Polyscope clone-root reaper that derives its allowlist from live `polyscope.db` worktree paths, waits a seven-day grace period, rejects paths outside the configured clone root, skips active processes and lock files, supports dry-run and JSON reporting, and reports reclaimed storage
 - added positive and negative fixtures covering registered roots, fresh roots, locks, active processes, dry runs, invalid clone roots, and actual deletion; rollout installation now enables the reaper timer
+- protected all registered repository roots and added transactional final revalidation plus atomic quarantine before deletion to prevent concurrent registration from racing cleanup
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-12 - Reap Orphaned Polyscope Clone Roots
+
+**Fixed:**
+
+- added a daily, conservative Polyscope clone-root reaper that derives its allowlist from live `polyscope.db` worktree paths, waits a seven-day grace period, rejects paths outside the configured clone root, skips active processes and lock files, supports dry-run and JSON reporting, and reports reclaimed storage
+- added positive and negative fixtures covering registered roots, fresh roots, locks, active processes, dry runs, invalid clone roots, and actual deletion; rollout installation now enables the reaper timer
+
+---
+
 ## 2026-07-12 - Recover Frontend Preview Watcher After Dependency Installation
 
 **Fixed:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -326,6 +326,28 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 - `1`: One or more findings detected
 - `2`: Usage error or missing dependency/state
 
+### `reap-polyscope-clones.py`
+
+Conservatively reclaims orphaned Polyscope repository clone roots. It derives
+its allowlist from worktree paths currently registered in `polyscope.db`, waits
+seven days by default, and skips clone roots with lock files or active
+processes. It only considers immediate real directories inside the configured
+clone root.
+
+**Usage:**
+
+```bash
+# Inspect eligible orphan roots and potential reclaimed space
+python3 scripts/reap-polyscope-clones.py --dry-run
+
+# Reap an isolated fixture or non-default Polyscope location
+python3 scripts/reap-polyscope-clones.py --polyscope-home /tmp/polyscope --clone-root /tmp/polyscope/clones --grace-period 14d
+```
+
+The rollout installer enables `polyscope-clone-reaper.timer`, which runs the
+reaper daily after startup. The reaper prints reclaimed bytes and supports
+`--json` for operational reporting.
+
 ### `install-polyscope-rollout.sh`
 
 Installs the SecPal Polyscope rollout systemd units that keep workspace clones,
@@ -346,7 +368,9 @@ and exits before writing service units when unattended access is unavailable.
 
 After installation, the user-level `polyscope-rollout-sync.service` and
 `polyscope-worktree-provision.service` units take care of provisioning new
-managed repositories automatically when the canonical repo list changes.
+managed repositories automatically when the canonical repo list changes. The
+paired daily `polyscope-clone-reaper.timer` removes only aged orphan clone
+roots after checking the live database allowlist, locks, and processes.
 
 ### `setup-hooks.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -328,11 +328,13 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 
 ### `reap-polyscope-clones.py`
 
-Conservatively reclaims orphaned Polyscope repository clone roots. It derives
-its allowlist from worktree paths currently registered in `polyscope.db`, waits
-seven days by default, and skips clone roots with lock files or active
-processes. It only considers immediate real directories inside the configured
-clone root.
+Conservatively reclaims orphaned Polyscope repository clone roots. It protects
+every repository and active worktree currently registered in `polyscope.db`,
+waits seven days by default, and skips clone roots with lock files or active
+processes. Immediately before deletion it revalidates the database while
+holding a write-reservation transaction and atomically detaches the candidate,
+so concurrent registration cannot expose a live root to recursive deletion. It
+only considers immediate real directories inside the configured clone root.
 
 **Usage:**
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_SCRIPT="$SCRIPT_DIR/polyscope-rollout.py"
+REAPER_SOURCE="$SCRIPT_DIR/reap-polyscope-clones.py"
 WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-expose-wrapper.sh"
 GIT_WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-git-wrapper.sh"
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/code/SecPal}"
@@ -65,6 +66,7 @@ if [[ -z "$SERVICE_PATH" ]]; then
 fi
 
 INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
+REAPER_TARGET="$BIN_DIR/reap-polyscope-clones.py"
 EXPOSE_WRAPPER_TARGET="$BIN_DIR/polyscope-expose-wrapper.sh"
 GIT_WRAPPER_TARGET="$BIN_DIR/polyscope-git-wrapper.sh"
 SERVER_UNIT="$UNIT_DIR/polyscope-server.service"
@@ -73,6 +75,8 @@ PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
 PROVISION_SERVICE_UNIT="$UNIT_DIR/polyscope-worktree-provision.service"
 PROVISION_PATH_UNIT="$UNIT_DIR/polyscope-worktree-provision.path"
 PROVISION_TIMER_UNIT="$UNIT_DIR/polyscope-worktree-provision.timer"
+REAPER_SERVICE_UNIT="$UNIT_DIR/polyscope-clone-reaper.service"
+REAPER_TIMER_UNIT="$UNIT_DIR/polyscope-clone-reaper.timer"
 ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
 detect_system_server_fragment_path() {
@@ -208,6 +212,7 @@ fi
 
 mkdir -p "$BIN_DIR" "$UNIT_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
+ln -sfn "$REAPER_SOURCE" "$REAPER_TARGET"
 ln -sfn "$WRAPPER_SOURCE" "$EXPOSE_WRAPPER_TARGET"
 ln -sfn "$GIT_WRAPPER_SOURCE" "$GIT_WRAPPER_TARGET"
 
@@ -395,6 +400,34 @@ Persistent=true
 WantedBy=timers.target
 EOF
 
+cat >"$REAPER_SERVICE_UNIT" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Reap orphaned SecPal Polyscope clone roots
+After=polyscope-worktree-provision.service
+
+[Service]
+Type=oneshot
+Environment=PATH=$SERVICE_PATH
+ExecStart=$REAPER_TARGET --polyscope-home $POLYSCOPE_HOME --clone-root $POLYSCOPE_CLONE_ROOT --grace-period 7d
+EOF
+
+cat >"$REAPER_TIMER_UNIT" <<EOF
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Schedule conservative Polyscope clone-root reaping
+
+[Timer]
+OnStartupSec=10min
+OnUnitActiveSec=1d
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
 "$SYSTEMCTL_BIN" --user daemon-reload
 
 if [[ "$server_scope" == "user" ]]; then
@@ -411,6 +444,7 @@ fi
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.timer
+"$SYSTEMCTL_BIN" --user enable --now polyscope-clone-reaper.timer
 
 echo "Installed $INSTALL_TARGET"
 echo "Installed $EXPOSE_WRAPPER_TARGET"
@@ -423,3 +457,5 @@ echo "Installed $PATH_UNIT"
 echo "Installed $PROVISION_SERVICE_UNIT"
 echo "Installed $PROVISION_PATH_UNIT"
 echo "Installed $PROVISION_TIMER_UNIT"
+echo "Installed $REAPER_SERVICE_UNIT"
+echo "Installed $REAPER_TIMER_UNIT"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -311,6 +311,15 @@ if [ -f tests/polyscope-state-audit.sh ]; then
   }
 fi
 
+if [ -f tests/polyscope-clone-reaper.sh ]; then
+  bash tests/polyscope-clone-reaper.sh || {
+    echo "" >&2
+    echo "❌ Polyscope clone reaper regression test failed!" >&2
+    echo "Keep scripts/reap-polyscope-clones.py conservative: database allowlist, grace period, locks, and live processes must all protect clone roots." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/polyscope-rollout.sh ]; then
   bash tests/polyscope-rollout.sh || {
     echo "" >&2

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -43,19 +43,12 @@ def resolved_absolute(path: Path, description: str) -> Path:
     return path.resolve()
 
 
-def active_clone_root_names(db_path: Path, clone_root: Path) -> set[str]:
-    if not db_path.is_file():
-        raise ValueError(f"Polyscope DB not found at {db_path}")
-    try:
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
-            paths = [
-                Path(row[0]).resolve()
-                for row in conn.execute("SELECT path FROM worktrees WHERE status = 'active'")
-            ]
-    except sqlite3.Error as exc:
-        raise ValueError(f"unable to read Polyscope DB: {exc}") from exc
-
-    names: set[str] = set()
+def protected_clone_root_names(conn: sqlite3.Connection, clone_root: Path) -> set[str]:
+    names = {str(row[0]) for row in conn.execute("SELECT id FROM repositories")}
+    paths = [
+        Path(row[0]).resolve()
+        for row in conn.execute("SELECT path FROM worktrees WHERE status = 'active'")
+    ]
     for path in paths:
         try:
             relative = path.relative_to(clone_root)
@@ -64,6 +57,35 @@ def active_clone_root_names(db_path: Path, clone_root: Path) -> set[str]:
         if len(relative.parts) >= 2:
             names.add(relative.parts[0])
     return names
+
+
+def load_protected_clone_root_names(db_path: Path, clone_root: Path) -> set[str]:
+    if not db_path.is_file():
+        raise ValueError(f"Polyscope DB not found at {db_path}")
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            return protected_clone_root_names(conn, clone_root)
+    except sqlite3.Error as exc:
+        raise ValueError(f"unable to read Polyscope DB: {exc}") from exc
+
+
+
+def quarantine_if_still_orphan(
+    db_path: Path, clone_root: Path, candidate: Path, cutoff: float
+) -> Path | None:
+    """Atomically detach a candidate while preventing database registrations."""
+    quarantine = clone_root / f".reaper-trash-{os.getpid()}-{candidate.name}"
+    try:
+        with sqlite3.connect(db_path, timeout=30) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            if candidate.name in protected_clone_root_names(conn, clone_root):
+                return None
+            if candidate.stat().st_mtime > cutoff or has_lock(candidate) or has_active_process(candidate):
+                return None
+            candidate.rename(quarantine)
+        return quarantine
+    except (OSError, sqlite3.Error):
+        return None
 
 
 def is_within(path: Path, parent: Path) -> bool:
@@ -133,7 +155,8 @@ def allocated_bytes(root: Path) -> int:
 def reap(args: argparse.Namespace) -> dict[str, Any]:
     home = resolved_absolute(Path(args.polyscope_home), "Polyscope home")
     clone_root = resolved_absolute(Path(args.clone_root) if args.clone_root else home / "clones", "clone root")
-    allowlist = active_clone_root_names(home / "polyscope.db", clone_root)
+    db_path = home / "polyscope.db"
+    allowlist = load_protected_clone_root_names(db_path, clone_root)
     report: dict[str, Any] = {
         "removed": [],
         "would_remove": [],
@@ -170,8 +193,12 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
             report["would_remove"].append(str(candidate))
             report["reclaimed_bytes"] += size
             continue
+        quarantined = quarantine_if_still_orphan(db_path, clone_root, candidate, cutoff)
+        if quarantined is None:
+            report["skipped"]["unsafe"].append(str(candidate))
+            continue
         try:
-            shutil.rmtree(candidate)
+            shutil.rmtree(quarantined)
         except OSError:
             report["skipped"]["unsafe"].append(str(candidate))
             continue

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -45,16 +45,18 @@ def resolved_absolute(path: Path, description: str) -> Path:
 
 def protected_clone_root_names(conn: sqlite3.Connection, clone_root: Path) -> set[str]:
     names = {str(row[0]) for row in conn.execute("SELECT id FROM repositories")}
-    paths = [
-        Path(row[0]).resolve()
-        for row in conn.execute("SELECT path FROM worktrees WHERE status = 'active'")
-    ]
+    worktree_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(worktrees)")}
+    worktree_query = "SELECT path FROM worktrees"
+    if "status" in worktree_columns:
+        worktree_query += " WHERE status = 'active'"
+    paths = [Path(row[0]).resolve() for row in conn.execute("SELECT path FROM repositories")]
+    paths.extend(Path(row[0]).resolve() for row in conn.execute(worktree_query))
     for path in paths:
         try:
             relative = path.relative_to(clone_root)
         except ValueError:
             continue
-        if len(relative.parts) >= 2:
+        if relative.parts:
             names.add(relative.parts[0])
     return names
 
@@ -102,10 +104,19 @@ def has_lock(root: Path) -> bool:
         # evidence of an in-progress operation. Git's lock files live inside
         # a worktree's .git directory and protect exactly the metadata that a
         # clone-root deletion must not race.
-        return any(
-            ".git" in path.relative_to(root).parts and path.is_file()
-            for path in root.rglob("*.lock")
+        metadata_paths = [root / ".git"]
+        metadata_paths.extend(
+            child / ".git" for child in root.iterdir() if child.is_dir() and not child.is_symlink()
         )
+        for metadata in metadata_paths:
+            if metadata.is_file():
+                contents = metadata.read_text(errors="replace").strip()
+                if contents.startswith("gitdir: "):
+                    git_dir = Path(contents.removeprefix("gitdir: "))
+                    metadata = (metadata.parent / git_dir).resolve() if not git_dir.is_absolute() else git_dir
+            if metadata.is_dir() and any(path.is_file() for path in metadata.rglob("*.lock")):
+                return True
+        return False
     except OSError:
         # An unreadable tree must never be a deletion candidate.
         return True

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+"""Conservatively remove stale Polyscope clone roots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def parse_duration(value: str) -> int:
+    units = {"s": 1, "m": 60, "h": 60 * 60, "d": 24 * 60 * 60}
+    if len(value) < 2 or value[-1] not in units or not value[:-1].isdigit():
+        raise argparse.ArgumentTypeError("grace period must be a whole number followed by s, m, h, or d")
+    seconds = int(value[:-1]) * units[value[-1]]
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("grace period must be greater than zero")
+    return seconds
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Remove orphaned Polyscope clone roots after a grace period.")
+    parser.add_argument("--polyscope-home", default=str(Path.home() / ".polyscope"))
+    parser.add_argument("--clone-root", help="Absolute clone root. Defaults to POLYSCOPE_HOME/clones.")
+    parser.add_argument("--grace-period", type=parse_duration, default=7 * 24 * 60 * 60)
+    parser.add_argument("--dry-run", action="store_true", help="Report eligible clone roots without removing them.")
+    parser.add_argument("--json", action="store_true", help="Print the report as JSON.")
+    return parser.parse_args()
+
+
+def resolved_absolute(path: Path, description: str) -> Path:
+    if not path.is_absolute():
+        raise ValueError(f"{description} must be absolute: {path}")
+    return path.resolve()
+
+
+def active_clone_root_names(db_path: Path, clone_root: Path) -> set[str]:
+    if not db_path.is_file():
+        raise ValueError(f"Polyscope DB not found at {db_path}")
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            paths = [
+                Path(row[0]).resolve()
+                for row in conn.execute("SELECT path FROM worktrees WHERE status = 'active'")
+            ]
+    except sqlite3.Error as exc:
+        raise ValueError(f"unable to read Polyscope DB: {exc}") from exc
+
+    names: set[str] = set()
+    for path in paths:
+        try:
+            relative = path.relative_to(clone_root)
+        except ValueError:
+            continue
+        if len(relative.parts) >= 2:
+            names.add(relative.parts[0])
+    return names
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def has_lock(root: Path) -> bool:
+    try:
+        # Dependency manifests such as yarn.lock are durable source files, not
+        # evidence of an in-progress operation. Git's lock files live inside
+        # a worktree's .git directory and protect exactly the metadata that a
+        # clone-root deletion must not race.
+        return any(
+            ".git" in path.relative_to(root).parts and path.is_file()
+            for path in root.rglob("*.lock")
+        )
+    except OSError:
+        # An unreadable tree must never be a deletion candidate.
+        return True
+
+
+def has_active_process(root: Path) -> bool:
+    proc = Path("/proc")
+    if not proc.is_dir():
+        # Without portable process inspection, skip rather than risk deleting a live tree.
+        return True
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        for location in (entry / "cwd", entry / "exe"):
+            try:
+                if is_within(Path(os.readlink(location)), root):
+                    return True
+            except OSError:
+                pass
+        fd_dir = entry / "fd"
+        try:
+            fds = list(fd_dir.iterdir())
+        except OSError:
+            continue
+        for fd in fds:
+            try:
+                target = os.readlink(fd).removesuffix(" (deleted)")
+                if target.startswith("/") and is_within(Path(target), root):
+                    return True
+            except OSError:
+                pass
+    return False
+
+
+def allocated_bytes(root: Path) -> int:
+    total = 0
+    try:
+        for path in [root, *root.rglob("*")]:
+            total += path.lstat().st_blocks * 512
+    except OSError:
+        return 0
+    return total
+
+
+def reap(args: argparse.Namespace) -> dict[str, Any]:
+    home = resolved_absolute(Path(args.polyscope_home), "Polyscope home")
+    clone_root = resolved_absolute(Path(args.clone_root) if args.clone_root else home / "clones", "clone root")
+    allowlist = active_clone_root_names(home / "polyscope.db", clone_root)
+    report: dict[str, Any] = {
+        "removed": [],
+        "would_remove": [],
+        "reclaimed_bytes": 0,
+        "skipped": {"active": [], "grace_period": [], "lock": [], "process": [], "unsafe": []},
+    }
+    if not clone_root.is_dir():
+        return report
+
+    cutoff = time.time() - args.grace_period
+    for candidate in sorted(clone_root.iterdir()):
+        # Only immediate, real directories under the configured clone root are eligible.
+        if candidate.is_symlink() or not candidate.is_dir() or not is_within(candidate.resolve(), clone_root):
+            report["skipped"]["unsafe"].append(str(candidate))
+            continue
+        if candidate.name in allowlist:
+            report["skipped"]["active"].append(str(candidate))
+            continue
+        try:
+            if candidate.stat().st_mtime > cutoff:
+                report["skipped"]["grace_period"].append(str(candidate))
+                continue
+        except OSError:
+            report["skipped"]["unsafe"].append(str(candidate))
+            continue
+        if has_lock(candidate):
+            report["skipped"]["lock"].append(str(candidate))
+            continue
+        if has_active_process(candidate):
+            report["skipped"]["process"].append(str(candidate))
+            continue
+        size = allocated_bytes(candidate)
+        if args.dry_run:
+            report["would_remove"].append(str(candidate))
+            report["reclaimed_bytes"] += size
+            continue
+        try:
+            shutil.rmtree(candidate)
+        except OSError:
+            report["skipped"]["unsafe"].append(str(candidate))
+            continue
+        report["removed"].append(str(candidate))
+        report["reclaimed_bytes"] += size
+    return report
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = reap(args)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        action = "Would reclaim" if args.dry_run else "Reclaimed"
+        print(f"{action} {report['reclaimed_bytes']} bytes from {len(report['would_remove']) or len(report['removed'])} clone roots.")
+        for reason, paths in report["skipped"].items():
+            for path in paths:
+                print(f"Skipped ({reason}): {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -102,7 +102,8 @@ def has_active_process(root: Path) -> bool:
                 if is_within(Path(os.readlink(location)), root):
                     return True
             except OSError:
-                pass
+                # The process may exit or hide this link while it is scanned.
+                continue
         fd_dir = entry / "fd"
         try:
             fds = list(fd_dir.iterdir())
@@ -114,7 +115,8 @@ def has_active_process(root: Path) -> bool:
                 if target.startswith("/") and is_within(Path(target), root):
                     return True
             except OSError:
-                pass
+                # File descriptors can close between directory listing and lookup.
+                continue
     return False
 
 

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -82,7 +82,8 @@ def quarantine_if_still_orphan(
             conn.execute("BEGIN IMMEDIATE")
             if candidate.name in protected_clone_root_names(conn, clone_root):
                 return None
-            if candidate.stat().st_mtime > cutoff or has_lock(candidate) or has_active_process(candidate):
+            newest_mtime = newest_tree_mtime(candidate)
+            if newest_mtime is None or newest_mtime > cutoff or has_lock(candidate) or has_active_process(candidate):
                 return None
             candidate.rename(quarantine)
         return quarantine
@@ -163,6 +164,13 @@ def allocated_bytes(root: Path) -> int:
     return total
 
 
+def newest_tree_mtime(root: Path) -> float | None:
+    try:
+        return max(path.lstat().st_mtime for path in [root, *root.rglob("*")])
+    except OSError:
+        return None
+
+
 def reap(args: argparse.Namespace) -> dict[str, Any]:
     home = resolved_absolute(Path(args.polyscope_home), "Polyscope home")
     clone_root = resolved_absolute(Path(args.clone_root) if args.clone_root else home / "clones", "clone root")
@@ -187,7 +195,11 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
             report["skipped"]["active"].append(str(candidate))
             continue
         try:
-            if candidate.stat().st_mtime > cutoff:
+            newest_mtime = newest_tree_mtime(candidate)
+            if newest_mtime is None:
+                report["skipped"]["unsafe"].append(str(candidate))
+                continue
+            if newest_mtime > cutoff:
                 report["skipped"]["grace_period"].append(str(candidate))
                 continue
         except OSError:

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -25,8 +25,11 @@ home = Path(sys.argv[1])
 clones = Path(sys.argv[2])
 conn = sqlite3.connect(home / 'polyscope.db')
 conn.executescript('''
+CREATE TABLE repositories (id TEXT PRIMARY KEY, name TEXT NOT NULL, path TEXT NOT NULL);
 CREATE TABLE worktrees (id TEXT PRIMARY KEY, repo_id TEXT NOT NULL, branch TEXT NOT NULL, path TEXT NOT NULL, status TEXT NOT NULL);
 ''')
+conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('active-repo', 'active', '/tmp/active'))
+conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('inactive-repo', 'inactive', '/tmp/inactive'))
 active = clones / 'active-repo' / 'workspace'
 active.mkdir(parents=True)
 conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('active', 'active-repo', 'main', str(active), 'active'))
@@ -59,8 +62,8 @@ from pathlib import Path
 report = json.loads(sys.argv[1])
 clones = Path(sys.argv[2])
 assert report['removed'] == []
-assert report['would_remove'] == [str(clones / 'inactive-repo'), str(clones / 'orphan-old')]
-assert report['skipped']['active'] == [str(clones / 'active-repo')]
+assert report['would_remove'] == [str(clones / 'orphan-old')]
+assert report['skipped']['active'] == [str(clones / 'active-repo'), str(clones / 'inactive-repo')]
 assert report['skipped']['grace_period'] == [str(clones / 'orphan-young')]
 assert report['skipped']['lock'] == [str(clones / 'orphan-lock')]
 assert report['skipped']['process'] == [str(clones / 'orphan-busy')]
@@ -78,16 +81,52 @@ from pathlib import Path
 
 report = json.loads(sys.argv[1])
 clones = Path(sys.argv[2])
-assert report['removed'] == [str(clones / 'inactive-repo'), str(clones / 'orphan-old')]
+assert report['removed'] == [str(clones / 'orphan-old')]
 assert report['would_remove'] == []
 assert report['reclaimed_bytes'] > 0
 PY
 
-[[ ! -e "$clone_root/orphan-old" && ! -e "$clone_root/inactive-repo" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
-[[ -d "$clone_root/active-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$outside_root" ]] || {
+[[ ! -e "$clone_root/orphan-old" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
+[[ -d "$clone_root/active-repo" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$outside_root" ]] || {
     echo 'reaper removed a protected clone root' >&2
     exit 1
 }
+
+# A repository registered after the initial allowlist read must still prevent
+# deletion at the final destructive boundary.
+mkdir -p "$clone_root/racing-repo/workspace"
+touch -d '10 days ago' "$clone_root/racing-repo"
+python3 - <<'PY' "$REAPER" "$polyscope_home" "$clone_root"
+import argparse
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('clone_reaper', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+home = Path(sys.argv[2])
+clones = Path(sys.argv[3])
+original_process_check = module.has_active_process
+registered = False
+
+def register_during_scan(root):
+    global registered
+    if root.name == 'racing-repo' and not registered:
+        with sqlite3.connect(home / 'polyscope.db') as conn:
+            conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('racing-repo', 'racing', '/tmp/racing'))
+        registered = True
+    return original_process_check(root)
+
+module.has_active_process = register_during_scan
+report = module.reap(argparse.Namespace(
+    polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
+    dry_run=False, json=True,
+))
+assert (clones / 'racing-repo').is_dir(), report
+assert str(clones / 'racing-repo') not in report['removed'], report
+PY
 
 # A configured clone root must be absolute and must not permit cleanup elsewhere.
 set +e

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -44,14 +44,15 @@ conn.commit()
 conn.close()
 PY
 
-mkdir -p "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-young" "$clone_root/orphan-lock/.git" "$clone_root/orphan-busy"
+mkdir -p "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-recent/cache" "$clone_root/orphan-young" "$clone_root/orphan-lock/.git" "$clone_root/orphan-busy"
 mkdir -p "$clone_root/registered-path-root"
 outside_root="$workspace/outside-clone-root"
 mkdir -p "$outside_root"
 ln -s "$outside_root" "$clone_root/external-link"
 printf 'payload\n' > "$clone_root/orphan-old/node_modules/cache/file"
 touch "$clone_root/orphan-old/yarn.lock"
-python3 - <<'PY' "$clone_root/orphan-old" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-busy" "$clone_root/registered-path-root" "$clone_root/direct-worktree"
+touch "$clone_root/orphan-lock/.git/index.lock"
+python3 - <<'PY' "$clone_root/orphan-old" "$clone_root/orphan-old/node_modules" "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-old/node_modules/cache/file" "$clone_root/orphan-old/yarn.lock" "$clone_root/orphan-recent" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-lock/.git" "$clone_root/orphan-lock/.git/index.lock" "$clone_root/orphan-busy" "$clone_root/registered-path-root" "$clone_root/direct-worktree"
 import os
 import sys
 import time
@@ -60,7 +61,6 @@ mtime = time.time() - 10 * 24 * 60 * 60
 for value in sys.argv[1:]:
     os.utime(value, (mtime, mtime))
 PY
-touch "$clone_root/orphan-lock/.git/index.lock"
 
 # A process whose current directory is inside a candidate must prevent deletion.
 (cd "$clone_root/orphan-busy" && sleep 30) &
@@ -82,7 +82,7 @@ assert report['skipped']['active'] == [
     str(clones / 'inactive-repo'),
     str(clones / 'registered-path-root'),
 ]
-assert report['skipped']['grace_period'] == [str(clones / 'orphan-young')]
+assert report['skipped']['grace_period'] == [str(clones / 'orphan-recent'), str(clones / 'orphan-young')]
 assert report['skipped']['lock'] == [str(clones / 'orphan-lock')]
 assert report['skipped']['process'] == [str(clones / 'orphan-busy')]
 assert report['skipped']['unsafe'] == [str(clones / 'external-link')]
@@ -105,7 +105,7 @@ assert report['reclaimed_bytes'] > 0
 PY
 
 [[ ! -e "$clone_root/orphan-old" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
-[[ -d "$clone_root/active-repo" && -d "$clone_root/direct-worktree" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$clone_root/registered-path-root" && -d "$outside_root" ]] || {
+[[ -d "$clone_root/active-repo" && -d "$clone_root/direct-worktree" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-recent" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$clone_root/registered-path-root" && -d "$outside_root" ]] || {
     echo 'reaper removed a protected clone root' >&2
     exit 1
 }

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -30,23 +30,36 @@ CREATE TABLE worktrees (id TEXT PRIMARY KEY, repo_id TEXT NOT NULL, branch TEXT 
 ''')
 conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('active-repo', 'active', '/tmp/active'))
 conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('inactive-repo', 'inactive', '/tmp/inactive'))
+conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('path-id', 'path', str(clones / 'registered-path-root')))
 active = clones / 'active-repo' / 'workspace'
 active.mkdir(parents=True)
 conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('active', 'active-repo', 'main', str(active), 'active'))
 inactive = clones / 'inactive-repo' / 'workspace'
 inactive.mkdir(parents=True)
 conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('inactive', 'inactive-repo', 'old', str(inactive), 'removed'))
+direct = clones / 'direct-worktree'
+direct.mkdir()
+conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('direct', 'active-repo', 'direct', str(direct), 'active'))
 conn.commit()
 conn.close()
 PY
 
 mkdir -p "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-young" "$clone_root/orphan-lock/.git" "$clone_root/orphan-busy"
+mkdir -p "$clone_root/registered-path-root"
 outside_root="$workspace/outside-clone-root"
 mkdir -p "$outside_root"
 ln -s "$outside_root" "$clone_root/external-link"
 printf 'payload\n' > "$clone_root/orphan-old/node_modules/cache/file"
 touch "$clone_root/orphan-old/yarn.lock"
-touch -d '10 days ago' "$clone_root/orphan-old" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-busy"
+python3 - <<'PY' "$clone_root/orphan-old" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-busy" "$clone_root/registered-path-root" "$clone_root/direct-worktree"
+import os
+import sys
+import time
+
+mtime = time.time() - 10 * 24 * 60 * 60
+for value in sys.argv[1:]:
+    os.utime(value, (mtime, mtime))
+PY
 touch "$clone_root/orphan-lock/.git/index.lock"
 
 # A process whose current directory is inside a candidate must prevent deletion.
@@ -63,7 +76,12 @@ report = json.loads(sys.argv[1])
 clones = Path(sys.argv[2])
 assert report['removed'] == []
 assert report['would_remove'] == [str(clones / 'orphan-old')]
-assert report['skipped']['active'] == [str(clones / 'active-repo'), str(clones / 'inactive-repo')]
+assert report['skipped']['active'] == [
+    str(clones / 'active-repo'),
+    str(clones / 'direct-worktree'),
+    str(clones / 'inactive-repo'),
+    str(clones / 'registered-path-root'),
+]
 assert report['skipped']['grace_period'] == [str(clones / 'orphan-young')]
 assert report['skipped']['lock'] == [str(clones / 'orphan-lock')]
 assert report['skipped']['process'] == [str(clones / 'orphan-busy')]
@@ -87,7 +105,7 @@ assert report['reclaimed_bytes'] > 0
 PY
 
 [[ ! -e "$clone_root/orphan-old" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
-[[ -d "$clone_root/active-repo" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$outside_root" ]] || {
+[[ -d "$clone_root/active-repo" && -d "$clone_root/direct-worktree" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$clone_root/registered-path-root" && -d "$outside_root" ]] || {
     echo 'reaper removed a protected clone root' >&2
     exit 1
 }
@@ -95,7 +113,14 @@ PY
 # A repository registered after the initial allowlist read must still prevent
 # deletion at the final destructive boundary.
 mkdir -p "$clone_root/racing-repo/workspace"
-touch -d '10 days ago' "$clone_root/racing-repo"
+python3 - <<'PY' "$clone_root/racing-repo"
+import os
+import sys
+import time
+
+mtime = time.time() - 10 * 24 * 60 * 60
+os.utime(sys.argv[1], (mtime, mtime))
+PY
 python3 - <<'PY' "$REAPER" "$polyscope_home" "$clone_root"
 import argparse
 import importlib.util
@@ -126,6 +151,45 @@ report = module.reap(argparse.Namespace(
 ))
 assert (clones / 'racing-repo').is_dir(), report
 assert str(clones / 'racing-repo') not in report['removed'], report
+PY
+
+# Older Polyscope databases have no worktree status column. Their registered
+# worktrees must still be protected instead of disabling scheduled cleanup.
+legacy_home="$workspace/legacy/.polyscope"
+legacy_root="$legacy_home/clones"
+mkdir -p "$legacy_root/legacy-worktree" "$legacy_root/legacy-orphan"
+python3 - <<'PY' "$legacy_home" "$legacy_root"
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+root = Path(sys.argv[2])
+conn = sqlite3.connect(home / 'polyscope.db')
+conn.executescript('''
+CREATE TABLE repositories (id TEXT PRIMARY KEY, name TEXT NOT NULL, path TEXT NOT NULL);
+CREATE TABLE worktrees (id TEXT PRIMARY KEY, repo_id TEXT NOT NULL, branch TEXT NOT NULL, path TEXT NOT NULL);
+''')
+conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('legacy-repo', 'legacy', '/tmp/legacy'))
+conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?)', ('legacy', 'legacy-repo', 'main', str(root / 'legacy-worktree')))
+conn.commit()
+conn.close()
+mtime = time.time() - 10 * 24 * 60 * 60
+for path in (root / 'legacy-worktree', root / 'legacy-orphan'):
+    os.utime(path, (mtime, mtime))
+PY
+legacy_output="$(python3 "$REAPER" --polyscope-home "$legacy_home" --dry-run --json)"
+python3 - <<'PY' "$legacy_output" "$legacy_root"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+root = Path(sys.argv[2])
+assert report['skipped']['active'] == [str(root / 'legacy-worktree')]
+assert report['would_remove'] == [str(root / 'legacy-orphan')]
 PY
 
 # A configured clone root must be absolute and must not permit cleanup elsewhere.

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REAPER="$REPO_ROOT/scripts/reap-polyscope-clones.py"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-clone-reaper.XXXXXX")"
+active_pid=""
+trap '[[ -z "$active_pid" ]] || kill "$active_pid" 2>/dev/null || true; rm -rf "$workspace"' EXIT
+
+polyscope_home="$workspace/.polyscope"
+clone_root="$polyscope_home/clones"
+mkdir -p "$clone_root"
+
+python3 - <<'PY' "$polyscope_home" "$clone_root"
+import sqlite3
+import sys
+from pathlib import Path
+
+home = Path(sys.argv[1])
+clones = Path(sys.argv[2])
+conn = sqlite3.connect(home / 'polyscope.db')
+conn.executescript('''
+CREATE TABLE worktrees (id TEXT PRIMARY KEY, repo_id TEXT NOT NULL, branch TEXT NOT NULL, path TEXT NOT NULL, status TEXT NOT NULL);
+''')
+active = clones / 'active-repo' / 'workspace'
+active.mkdir(parents=True)
+conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('active', 'active-repo', 'main', str(active), 'active'))
+inactive = clones / 'inactive-repo' / 'workspace'
+inactive.mkdir(parents=True)
+conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('inactive', 'inactive-repo', 'old', str(inactive), 'removed'))
+conn.commit()
+conn.close()
+PY
+
+mkdir -p "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-young" "$clone_root/orphan-lock/.git" "$clone_root/orphan-busy"
+outside_root="$workspace/outside-clone-root"
+mkdir -p "$outside_root"
+ln -s "$outside_root" "$clone_root/external-link"
+printf 'payload\n' > "$clone_root/orphan-old/node_modules/cache/file"
+touch "$clone_root/orphan-old/yarn.lock"
+touch -d '10 days ago' "$clone_root/orphan-old" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-busy"
+touch "$clone_root/orphan-lock/.git/index.lock"
+
+# A process whose current directory is inside a candidate must prevent deletion.
+(cd "$clone_root/orphan-busy" && sleep 30) &
+active_pid=$!
+
+dry_run_output="$(python3 "$REAPER" --polyscope-home "$polyscope_home" --grace-period 7d --dry-run --json)"
+python3 - <<'PY' "$dry_run_output" "$clone_root"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+clones = Path(sys.argv[2])
+assert report['removed'] == []
+assert report['would_remove'] == [str(clones / 'inactive-repo'), str(clones / 'orphan-old')]
+assert report['skipped']['active'] == [str(clones / 'active-repo')]
+assert report['skipped']['grace_period'] == [str(clones / 'orphan-young')]
+assert report['skipped']['lock'] == [str(clones / 'orphan-lock')]
+assert report['skipped']['process'] == [str(clones / 'orphan-busy')]
+assert report['skipped']['unsafe'] == [str(clones / 'external-link')]
+assert report['reclaimed_bytes'] > 0
+PY
+
+[[ -d "$clone_root/orphan-old" ]] || { echo 'dry run removed a clone root' >&2; exit 1; }
+
+run_output="$(python3 "$REAPER" --polyscope-home "$polyscope_home" --grace-period 7d --json)"
+python3 - <<'PY' "$run_output" "$clone_root"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(sys.argv[1])
+clones = Path(sys.argv[2])
+assert report['removed'] == [str(clones / 'inactive-repo'), str(clones / 'orphan-old')]
+assert report['would_remove'] == []
+assert report['reclaimed_bytes'] > 0
+PY
+
+[[ ! -e "$clone_root/orphan-old" && ! -e "$clone_root/inactive-repo" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
+[[ -d "$clone_root/active-repo" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$outside_root" ]] || {
+    echo 'reaper removed a protected clone root' >&2
+    exit 1
+}
+
+# A configured clone root must be absolute and must not permit cleanup elsewhere.
+set +e
+outside_output="$(python3 "$REAPER" --polyscope-home "$polyscope_home" --clone-root relative --dry-run 2>&1)"
+outside_status=$?
+set -e
+[[ $outside_status -eq 2 ]] || { echo "expected invalid clone root to fail: $outside_output" >&2; exit 1; }

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4675,6 +4675,8 @@ env HOME="$home_dir" \
 
 test -L "$fake_bin_dir/polyscope-secpal-rollout.py"
 test -x "$fake_bin_dir/polyscope-secpal-rollout.py"
+test -L "$fake_bin_dir/reap-polyscope-clones.py"
+test -x "$fake_bin_dir/reap-polyscope-clones.py"
 test -L "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -x "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -L "$fake_bin_dir/polyscope-git-wrapper.sh"
@@ -4852,6 +4854,10 @@ grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscop
 grep -q '^OnStartupSec=30s$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnUnitActiveSec=3min$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-worktree-provision.timer"
+grep -q 'ExecStart=.*/reap-polyscope-clones.py --polyscope-home .* --clone-root .* --grace-period 7d' "$fake_unit_dir/polyscope-clone-reaper.service"
+grep -q '^OnStartupSec=10min$' "$fake_unit_dir/polyscope-clone-reaper.timer"
+grep -q '^OnUnitActiveSec=1d$' "$fake_unit_dir/polyscope-clone-reaper.timer"
+grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-clone-reaper.timer"
 
 default_readiness_retry_seconds="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_RETRY_SECONDS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
 default_readiness_max_attempts="$(sed -nE 's/.*POLYSCOPE_EXPOSE_WRAPPER_MAX_ATTEMPTS:-([0-9]+).*/\1/p' "$REPO_ROOT/scripts/polyscope-expose-wrapper.sh")"
@@ -4875,6 +4881,7 @@ grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log"
+grep -q 'enable --now polyscope-clone-reaper.timer' "$fake_systemctl_log"
 if [[ "$(grep -n 'start polyscope-rollout-sync.service' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
   echo "installer must finish the initial sync before enabling the provision path watcher" >&2
   exit 1


### PR DESCRIPTION
## Reproduced defect

`audit-polyscope-state.py` reports orphan clone roots, but the rollout installs
no lifecycle job to remove them. Deleted workspace roots can therefore retain
their `node_modules` and build caches indefinitely.

Closes #556

## Change

- add a conservative clone-root reaper backed by the active `polyscope.db`
  worktree allowlist and a seven-day grace period
- skip unsafe paths, Git locks, and roots with active processes; provide
  dry-run, JSON, and reclaimed-space reporting
- install and enable a daily user-systemd reaper timer
- add positive and negative fixtures and document the operational behavior

## Validation

- `bash scripts/preflight.sh`
- `tests/polyscope-clone-reaper.sh`
- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-state-audit.sh`
- `python3 -m py_compile scripts/reap-polyscope-clones.py`
- `reuse lint`

## TDD / Validate-First Evidence

- Failing proof before implementation: `tests/polyscope-clone-reaper.sh` failed because `scripts/reap-polyscope-clones.py` did not exist.
- Passing proof after implementation: `bash scripts/preflight.sh`

## Follow-up before ready

Linked workspaces: none.

Unresolved checks: CI and the final PR-view self-review remain. Keep this PR
as a draft until both are clean.
