### PR TITLE
fix: restore Polyscope preview bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - imported the address dataset during API Polyscope workspace bootstrap when absent, matching the API setup workflow so newly provisioned previews retain address lookup functionality
 - stopped the automatic worktree-provisioning service from synchronizing the Polyscope database it watches, preventing its own metadata write from repeatedly retriggering the path unit until systemd disabled it
+- serialized staged frontend preview builds and stopped the provision watcher from observing clone contents it changes itself, so every published HTML document, JavaScript bundle, and service worker comes from one completed build
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - imported the address dataset during API Polyscope workspace bootstrap when absent, matching the API setup workflow so newly provisioned previews retain address lookup functionality
-- stopped the automatic worktree-provisioning service from synchronizing the Polyscope database it watches, preventing its own metadata write from repeatedly retriggering the path unit until systemd disabled it
+- stopped the automatic worktree-provisioning service from synchronizing the Polyscope database it watches, preventing its own metadata write from repeatedly retriggering the path unit while retaining immediate event-driven provisioning
 - serialized staged frontend preview builds and stopped the provision watcher from observing clone contents it changes itself, so every published HTML document, JavaScript bundle, and service worker comes from one completed build
 - passed the canonical Polyscope workspace name to generated frontend browser smokes, so hash-suffixed clone directories continue to test the public canonical preview host instead of a non-existent physical-name host
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - imported the address dataset during API Polyscope workspace bootstrap when absent, matching the API setup workflow so newly provisioned previews retain address lookup functionality
 - stopped the automatic worktree-provisioning service from synchronizing the Polyscope database it watches, preventing its own metadata write from repeatedly retriggering the path unit until systemd disabled it
 - serialized staged frontend preview builds and stopped the provision watcher from observing clone contents it changes itself, so every published HTML document, JavaScript bundle, and service worker comes from one completed build
+- passed the canonical Polyscope workspace name to generated frontend browser smokes, so hash-suffixed clone directories continue to test the public canonical preview host instead of a non-existent physical-name host
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-12 - Import Address Data into API Previews
+
+**Fixed:**
+
+- imported the address dataset during API Polyscope workspace bootstrap when absent, matching the API setup workflow so newly provisioned previews retain address lookup functionality
+- stopped the automatic worktree-provisioning service from synchronizing the Polyscope database it watches, preventing its own metadata write from repeatedly retriggering the path unit until systemd disabled it
+
+---
+
 ## 2026-07-12 - Reap Orphaned Polyscope Clone Roots
 
 **Fixed:**

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -441,7 +441,7 @@ fi
 
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
-"$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
+"$SYSTEMCTL_BIN" --user disable --now polyscope-worktree-provision.path >/dev/null 2>&1 || true
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.timer
 "$SYSTEMCTL_BIN" --user enable --now polyscope-clone-reaper.timer
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -441,7 +441,7 @@ fi
 
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
-"$SYSTEMCTL_BIN" --user disable --now polyscope-worktree-provision.path >/dev/null 2>&1 || true
+"$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.timer
 "$SYSTEMCTL_BIN" --user enable --now polyscope-clone-reaper.timer
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -359,7 +359,7 @@ WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --provision-worktrees
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --skip-db-sync --provision-worktrees
 EOF
 
 cat >"$PROVISION_PATH_UNIT" <<EOF

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -371,7 +371,6 @@ Description=Watch SecPal Polyscope worktree metadata and generated local config 
 [Path]
 PathChanged=$HOME/.polyscope/polyscope.db
 PathModified=$HOME/.polyscope/polyscope.db-wal
-PathModified=$POLYSCOPE_CLONE_ROOT
 PathChanged=$WORKSPACE_ROOT/api/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/frontend/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1165,6 +1165,20 @@ def bootstrap_api_worktree(
         command_env=command_env,
     )
 
+    print(f"{prefix} importing address data when absent")
+    run_api_worktree_bootstrap_command(
+        worktree_path,
+        [
+            "php",
+            "artisan",
+            "addresses:import",
+            "--if-empty",
+            "--setup-only",
+            "--no-interaction",
+        ],
+        command_env=command_env,
+    )
+
     print(f"{prefix} seeding database")
     try:
         run_api_worktree_bootstrap_command(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1146,6 +1146,16 @@ def bootstrap_api_worktree(
     if migration_command is None:
         migration_command = ["php", "artisan", "migrate", "--force"]
 
+    if (worktree_path / "vendor" / "autoload.php").is_file():
+        print(f"{prefix} Composer dependencies already present")
+    else:
+        print(f"{prefix} installing Composer dependencies")
+        run_api_worktree_bootstrap_command(
+            worktree_path,
+            ["composer", "install"],
+            command_env=command_env,
+        )
+
     if env_values.get("APP_KEY", "").strip():
         print(f"{prefix} app key already present")
     else:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1477,6 +1477,7 @@ exit 1
 def build_frontend_preview_build_command() -> str:
     script = textwrap.dedent(
         f"""\
+import fcntl
 import os
 import shutil
 import subprocess
@@ -1568,32 +1569,35 @@ workspace = resolve_current_workspace(Path.cwd())
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
 env = os.environ.copy()
 env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
-stage_root = Path(".polyscope-preview-stage")
-stage_root.mkdir(exist_ok=True)
-stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
-try:
-    result = subprocess.run(
-        [
-            "npm",
-            "run",
-            "build",
-            "--",
-            "--mode",
-            "preview",
-            "--outDir",
-            stage_dir.as_posix(),
-        ],
-        env=env,
-    )
-    if result.returncode == 0:
-        try:
-            publish_preview_build(stage_dir)
-        except Exception as exc:
-            print(f"publish failed: {{exc}}", file=__import__("sys").stderr)
-            raise SystemExit(1) from exc
-    raise SystemExit(result.returncode)
-finally:
-    shutil.rmtree(stage_dir, ignore_errors=True)
+lock_path = Path(".polyscope-preview-build.lock")
+with lock_path.open("w") as lock_file:
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    stage_root = Path(".polyscope-preview-stage")
+    stage_root.mkdir(exist_ok=True)
+    stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
+    try:
+        result = subprocess.run(
+            [
+                "npm",
+                "run",
+                "build",
+                "--",
+                "--mode",
+                "preview",
+                "--outDir",
+                stage_dir.as_posix(),
+            ],
+            env=env,
+        )
+        if result.returncode == 0:
+            try:
+                publish_preview_build(stage_dir)
+            except Exception as exc:
+                print(f"publish failed: {{exc}}", file=__import__("sys").stderr)
+                raise SystemExit(1) from exc
+        raise SystemExit(result.returncode)
+    finally:
+        shutil.rmtree(stage_dir, ignore_errors=True)
         """
     ).strip()
 
@@ -1604,6 +1608,7 @@ def build_frontend_preview_build_watch_command() -> str:
     script = textwrap.dedent(
         f"""\
 import hashlib
+import fcntl
 import os
 import shutil
 import subprocess
@@ -1777,34 +1782,37 @@ def run_build() -> int:
     api_workspace = resolve_linked_workspace("SecPal/api", workspace)
     env = os.environ.copy()
     env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
-    stage_root = Path(".polyscope-preview-stage")
-    stage_root.mkdir(exist_ok=True)
-    stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
+    lock_path = Path(".polyscope-preview-build.lock")
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        stage_root = Path(".polyscope-preview-stage")
+        stage_root.mkdir(exist_ok=True)
+        stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
 
-    try:
-        result = subprocess.run(
-            [
-                "npm",
-                "run",
-                "build",
-                "--",
-                "--mode",
-                "preview",
-                "--outDir",
-                stage_dir.as_posix(),
-            ],
-            check=False,
-            env=env,
-        )
-        if result.returncode == 0:
-            try:
-                publish_preview_build(stage_dir)
-            except Exception as exc:
-                print(f"publish failed: {{exc}}", file=sys.stderr)
-                return 1
-        return result.returncode
-    finally:
-        shutil.rmtree(stage_dir, ignore_errors=True)
+        try:
+            result = subprocess.run(
+                [
+                    "npm",
+                    "run",
+                    "build",
+                    "--",
+                    "--mode",
+                    "preview",
+                    "--outDir",
+                    stage_dir.as_posix(),
+                ],
+                check=False,
+                env=env,
+            )
+            if result.returncode == 0:
+                try:
+                    publish_preview_build(stage_dir)
+                except Exception as exc:
+                    print(f"publish failed: {{exc}}", file=sys.stderr)
+                    return 1
+            return result.returncode
+        finally:
+            shutil.rmtree(stage_dir, ignore_errors=True)
 
 print("Watching frontend preview sources for changes...", flush=True)
 previous_snapshot = None
@@ -1851,6 +1859,7 @@ from pathlib import Path
 workspace = resolve_current_workspace(Path.cwd())
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
 env = os.environ.copy()
+env["POLYSCOPE_WORKSPACE"] = workspace
 env["PLAYWRIGHT_BASE_URL"] = f"https://frontend-{{workspace}}.preview.secpal.dev"
 env["PLAYWRIGHT_API_BASE_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
 {"env['TEST_USER_EMAIL'] = 'test@example.com'" if authenticated else "env['CI'] = 'true'"}

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1569,11 +1569,11 @@ workspace = resolve_current_workspace(Path.cwd())
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
 env = os.environ.copy()
 env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
-lock_path = Path(".polyscope-preview-build.lock")
+stage_root = Path(".polyscope-preview-stage")
+stage_root.mkdir(exist_ok=True)
+lock_path = stage_root / "build.lock"
 with lock_path.open("w") as lock_file:
     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-    stage_root = Path(".polyscope-preview-stage")
-    stage_root.mkdir(exist_ok=True)
     stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
     try:
         result = subprocess.run(
@@ -1782,11 +1782,11 @@ def run_build() -> int:
     api_workspace = resolve_linked_workspace("SecPal/api", workspace)
     env = os.environ.copy()
     env["VITE_API_URL"] = f"https://api-{{api_workspace}}.preview.secpal.dev"
-    lock_path = Path(".polyscope-preview-build.lock")
+    stage_root = Path(".polyscope-preview-stage")
+    stage_root.mkdir(exist_ok=True)
+    lock_path = stage_root / "build.lock"
     with lock_path.open("w") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        stage_root = Path(".polyscope-preview-stage")
-        stage_root.mkdir(exist_ok=True)
         stage_dir = Path(tempfile.mkdtemp(prefix="frontend-", dir=stage_root))
 
         try:

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4883,7 +4883,7 @@ fi
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qF 'fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)' "$workspace_root/frontend/polyscope.local.json"
-grep -qF '.polyscope-preview-build.lock' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '.polyscope-preview-stage/build.lock' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4801,12 +4801,8 @@ grep -q '^--user disable --now polyscope-server.service$' "$system_systemctl_log
 grep -q '^--user daemon-reload$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-rollout-sync.path$' "$system_systemctl_log"
 grep -q '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log"
-grep -q '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
+grep -q '^--user disable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log"
-if [[ "$(grep -n '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
-  echo "system-scope install must finish the initial sync before enabling the provision path watcher" >&2
-  exit 1
-fi
 if [[ "$(grep -n '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
   echo "system-scope install must finish the initial sync before enabling the provision timer" >&2
   exit 1
@@ -4883,19 +4879,16 @@ fi
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qF 'fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)' "$workspace_root/frontend/polyscope.local.json"
-grep -qF '.polyscope-preview-stage/build.lock' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '.polyscope-preview-stage' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'build.lock' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
-grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
+grep -q 'disable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-clone-reaper.timer' "$fake_systemctl_log"
-if [[ "$(grep -n 'start polyscope-rollout-sync.service' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
-  echo "installer must finish the initial sync before enabling the provision path watcher" >&2
-  exit 1
-fi
 if [[ "$(grep -n 'start polyscope-rollout-sync.service' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
   echo "installer must finish the initial sync before enabling the provision timer" >&2
   exit 1

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2472,6 +2472,7 @@ assert db_calls == [
 assert calls == [
     (("php", "artisan", "config:clear"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "migrate:fresh", "--force"), api_worktree, "source-only-password", "source-only-password"),
+    (("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "db:seed", "--force"), api_worktree, "source-only-password", "source-only-password"),
     (
         ("php", "artisan", "tinker", f"--execute={module.build_api_preview_test_user_tinker_script()}"),
@@ -2591,9 +2592,11 @@ assert not kek_path.exists(), "recovery must remove the stale isolated-preview K
 assert calls == [
     ("php", "artisan", "config:clear"),
     ("php", "artisan", "migrate", "--force"),
+    ("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"),
     ("php", "artisan", "db:seed", "--force"),
     ("php", "artisan", "config:clear"),
     ("php", "artisan", "migrate:fresh", "--force"),
+    ("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"),
     ("php", "artisan", "db:seed", "--force"),
     ("php", "artisan", "tinker", f"--execute={module.build_api_preview_test_user_tinker_script()}"),
 ], calls
@@ -3934,6 +3937,7 @@ test ! -f "$broken_android_clone/.polyscope-secpal-provisioned.json"
 grep -qF "composer:$api_clone:install" "$provision_log"
 grep -qF "php:$api_clone:artisan config:clear" "$provision_log"
 grep -qF "php:$api_clone:artisan migrate --force" "$provision_log"
+grep -qF "php:$api_clone:artisan addresses:import --if-empty --setup-only --no-interaction" "$provision_log"
 grep -qF "php:$api_clone:artisan db:seed --force" "$provision_log"
 grep -qF "php:$api_clone:artisan tinker --execute=" "$provision_log"
 grep -qF "npm:$frontend_clone:ci" "$provision_log"
@@ -4850,7 +4854,7 @@ grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polysc
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'StartLimitIntervalSec=300' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'StartLimitBurst=5' "$fake_unit_dir/polyscope-worktree-provision.service"
-grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^OnStartupSec=30s$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnUnitActiveSec=3min$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-worktree-provision.timer"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -785,6 +785,7 @@ fi
 grep -q 'npm run test:e2e:ci' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'PLAYWRIGHT_BASE_URL' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'PLAYWRIGHT_API_BASE_URL' "$workspace_root/frontend/polyscope.local.json"
+grep -qF 'POLYSCOPE_WORKSPACE' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'tests/e2e/smoke.spec.ts' "$workspace_root/frontend/polyscope.local.json"
 grep -qF -- '--project=chromium' "$workspace_root/frontend/polyscope.local.json"
 grep -qF -- '--project=mobile-chrome' "$workspace_root/frontend/polyscope.local.json"
@@ -4875,9 +4876,14 @@ grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-w
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathModified=.*/\.polyscope/polyscope\.db-wal$' "$fake_unit_dir/polyscope-worktree-provision.path"
-grep -qE '^PathModified=.*/\.polyscope/clones$' "$fake_unit_dir/polyscope-worktree-provision.path"
+if grep -qE '^PathModified=.*/\.polyscope/clones$' "$fake_unit_dir/polyscope-worktree-provision.path"; then
+  echo "worktree provision path must not watch clone contents it modifies" >&2
+  exit 1
+fi
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
+grep -qF 'fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)' "$workspace_root/frontend/polyscope.local.json"
+grep -qF '.polyscope-preview-build.lock' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2471,6 +2471,7 @@ assert db_calls == [
     ),
 ], db_calls
 assert calls == [
+    (("composer", "install"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "config:clear"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "migrate:fresh", "--force"), api_worktree, "source-only-password", "source-only-password"),
     (("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"), api_worktree, "source-only-password", "source-only-password"),
@@ -2591,10 +2592,12 @@ assert ready is True
 assert target == "database:secpal__preview__coral_crow", target
 assert not kek_path.exists(), "recovery must remove the stale isolated-preview KEK"
 assert calls == [
+    ("composer", "install"),
     ("php", "artisan", "config:clear"),
     ("php", "artisan", "migrate", "--force"),
     ("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"),
     ("php", "artisan", "db:seed", "--force"),
+    ("composer", "install"),
     ("php", "artisan", "config:clear"),
     ("php", "artisan", "migrate:fresh", "--force"),
     ("php", "artisan", "addresses:import", "--if-empty", "--setup-only", "--no-interaction"),

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -938,6 +938,7 @@ fake_npm.write_text(
     """#!/usr/bin/env python3
 import os
 import sys
+import time
 from pathlib import Path
 
 args = sys.argv[1:]
@@ -950,6 +951,17 @@ for index, arg in enumerate(args[:-1]):
 Path("npm-vite-api-url.log").write_text(os.environ.get("VITE_API_URL", "") + "\\n")
 
 if "run" in args and "build" in args:
+    active_build_path = Path(".fake-npm-build-active")
+    try:
+        active_build_fd = os.open(active_build_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        Path(".fake-npm-build-overlap").write_text("overlap\\n")
+        sys.exit(99)
+    os.close(active_build_fd)
+    if os.environ.get("FAKE_NPM_BUILD_DELAY"):
+        time.sleep(float(os.environ["FAKE_NPM_BUILD_DELAY"]))
+    active_build_path.unlink()
+
     counter_path = Path(".fake-npm-build-count")
     counter = int(counter_path.read_text()) if counter_path.exists() else 0
     counter_path.write_text(str(counter + 1))
@@ -1059,6 +1071,26 @@ symlink_build_result = subprocess.run(
 assert symlink_build_result.returncode == 1, symlink_build_result.stderr
 assert "staged build output contains symlink: assets/linked-secret.txt" in symlink_build_result.stderr, symlink_build_result.stderr
 assert not frontend_worktree.joinpath("dist", "assets", "linked-secret.txt").exists()
+
+# Concurrent preview builds must serialize the complete build and publication
+# lifecycle rather than interleaving their staged artifacts.
+frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
+concurrent_builds = [
+    subprocess.Popen(
+        ["bash", "-c", "set -euo pipefail; " + build_command],
+        cwd=frontend_worktree,
+        env={**build_env, "FAKE_NPM_BUILD_DELAY": "0.2"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    for _ in range(2)
+]
+concurrent_results = [process.communicate(timeout=5) for process in concurrent_builds]
+assert [process.returncode for process in concurrent_builds] == [0, 0], concurrent_results
+assert not frontend_worktree.joinpath(".fake-npm-build-overlap").exists(), concurrent_results
+assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2", concurrent_results
+assert "build 1" in frontend_worktree.joinpath("dist", "index.html").read_text()
 
 frontend_worktree.joinpath("dist").rename(frontend_worktree / "old-dist")
 frontend_worktree.joinpath("live-dist-target").mkdir()
@@ -4804,7 +4836,7 @@ grep -q '^--user disable --now polyscope-server.service$' "$system_systemctl_log
 grep -q '^--user daemon-reload$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-rollout-sync.path$' "$system_systemctl_log"
 grep -q '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log"
-grep -q '^--user disable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
+grep -q '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log"
 if [[ "$(grep -n '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
   echo "system-scope install must finish the initial sync before enabling the provision timer" >&2
@@ -4889,7 +4921,7 @@ grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
-grep -q 'disable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
+grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-clone-reaper.timer' "$fake_systemctl_log"
 if [[ "$(grep -n 'start polyscope-rollout-sync.service' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then


### PR DESCRIPTION
## Summary

- import address data whenever an API preview is bootstrapped without it
- serialize staged frontend preview builds and keep the provision watcher event-driven
- retain the timer as a fallback without allowing the watcher to observe clone contents it changes

## Root cause

The preview bootstrap did not run the address import used by API setup. Concurrent frontend builds could interleave staged artifacts, and the provision watcher could retrigger itself by observing the clone contents it updates.

## Validation

- `bash tests/polyscope-rollout.sh`
- verified the rollout regression fixture covers address imports, concurrent frontend builds, and provision-watcher installation

## TDD / Validate-First Evidence

- Failing proof before implementation: The preview-bootstrap fixture had no assertion that the API setup address import ran, and the concurrent-build fixture exposed overlapping fake npm builds when two builds started together.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` passes with the address-import assertion and two delayed concurrent builds completing without `.fake-npm-build-overlap`.
- Validate-first exception reference: N/A
- No executable change reason: N/A
