### PR TITLE
fix(polyscope): reap orphaned worktree directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - extended the scheduled Polyscope reaper to reclaim aged, unregistered immediate worktree directories below protected clone roots while preserving active `worktrees.path` records, clone-root worktrees, hidden metadata, locks, live processes, and paths outside the clone root
-- added positive and negative fixtures for nested worktree deletion, dry runs, active registrations, grace periods, locks, active processes, and symlink escapes
+- pinned final worktree detachment to non-symlink parent-directory handles and moved recoverable quarantines to the clone root, preventing parent-swap path escapes and stranded cleanup after interruptions
+- added positive and negative fixtures for nested worktree deletion, dry runs, active registrations, grace periods, locks, active processes, symlink escapes, parent swaps, and interrupted quarantine deletion
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-12 - Reap Orphaned Polyscope Worktree Directories
+
+**Fixed:**
+
+- extended the scheduled Polyscope reaper to reclaim aged, unregistered immediate worktree directories below protected clone roots while preserving active `worktrees.path` records, clone-root worktrees, hidden metadata, locks, live processes, and paths outside the clone root
+- added positive and negative fixtures for nested worktree deletion, dry runs, active registrations, grace periods, locks, active processes, and symlink escapes
+
+---
+
 ## 2026-07-12 - Import Address Data into API Previews
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - extended the scheduled Polyscope reaper to reclaim aged, unregistered immediate worktree directories below protected clone roots while preserving active `worktrees.path` records, clone-root worktrees, hidden metadata, locks, live processes, and paths outside the clone root
-- pinned final worktree detachment to non-symlink parent-directory handles and moved recoverable quarantines to the clone root, preventing parent-swap path escapes and stranded cleanup after interruptions
+- pinned final worktree detachment to non-symlink parent-directory handles, revalidated candidates after process scans before dry-run measurement, and moved recoverable quarantines to the clone root, preventing parent-swap path escapes and stranded cleanup after interruptions
 - added positive and negative fixtures for nested worktree deletion, dry runs, active registrations, grace periods, locks, active processes, symlink escapes, parent swaps, and interrupted quarantine deletion
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -335,9 +335,11 @@ by default, and skips candidates with lock files or active processes. An active
 worktree at a clone-root level is never scanned for children; otherwise, only
 its immediate non-hidden child directories can be worktree candidates.
 Immediately before deletion the reaper revalidates the database while holding a
-write-reservation transaction and atomically detaches the candidate, so
-concurrent registration cannot expose a live directory to recursive deletion.
-It rejects symlinks and paths outside the configured clone root.
+write-reservation transaction and atomically detaches the candidate through a
+pinned, non-symlink parent-directory handle, so concurrent registration or a
+parent-path replacement cannot redirect recursive deletion. Quarantines live at
+the clone-root level so a later run can finish cleanup after an interruption.
+The reaper rejects symlinks and paths outside the configured clone root.
 
 **Usage:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -339,7 +339,9 @@ write-reservation transaction and atomically detaches the candidate through a
 pinned, non-symlink parent-directory handle, so concurrent registration or a
 parent-path replacement cannot redirect recursive deletion. Quarantines live at
 the clone-root level so a later run can finish cleanup after an interruption.
-The reaper rejects symlinks and paths outside the configured clone root.
+The reaper revalidates candidates after process inspection before measuring
+dry-run storage, and rejects symlinks and paths outside the configured clone
+root.
 
 **Usage:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -328,13 +328,16 @@ python3 scripts/audit-polyscope-state.py --polyscope-home /tmp/test-polyscope --
 
 ### `reap-polyscope-clones.py`
 
-Conservatively reclaims orphaned Polyscope repository clone roots. It protects
-every repository and active worktree currently registered in `polyscope.db`,
-waits seven days by default, and skips clone roots with lock files or active
-processes. Immediately before deletion it revalidates the database while
-holding a write-reservation transaction and atomically detaches the candidate,
-so concurrent registration cannot expose a live root to recursive deletion. It
-only considers immediate real directories inside the configured clone root.
+Conservatively reclaims orphaned Polyscope repository clone roots and
+unregistered worktree directories. It protects every repository root and every
+active `worktrees.path` currently registered in `polyscope.db`, waits seven days
+by default, and skips candidates with lock files or active processes. An active
+worktree at a clone-root level is never scanned for children; otherwise, only
+its immediate non-hidden child directories can be worktree candidates.
+Immediately before deletion the reaper revalidates the database while holding a
+write-reservation transaction and atomically detaches the candidate, so
+concurrent registration cannot expose a live directory to recursive deletion.
+It rejects symlinks and paths outside the configured clone root.
 
 **Usage:**
 

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: MIT
 
-"""Conservatively remove stale Polyscope clone roots."""
+"""Conservatively remove stale Polyscope clone roots and worktrees."""
 
 from __future__ import annotations
 
@@ -43,14 +43,24 @@ def resolved_absolute(path: Path, description: str) -> Path:
     return path.resolve()
 
 
-def protected_clone_root_names(conn: sqlite3.Connection, clone_root: Path) -> set[str]:
-    names = {str(row[0]) for row in conn.execute("SELECT id FROM repositories")}
+def active_worktree_paths(conn: sqlite3.Connection, clone_root: Path) -> set[Path]:
+    """Return active registered worktrees physically contained by clone_root."""
     worktree_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(worktrees)")}
     worktree_query = "SELECT path FROM worktrees"
     if "status" in worktree_columns:
         worktree_query += " WHERE status = 'active'"
+    paths = set()
+    for row in conn.execute(worktree_query):
+        path = Path(row[0]).resolve()
+        if is_within(path, clone_root):
+            paths.add(path)
+    return paths
+
+
+def protected_clone_root_names(conn: sqlite3.Connection, clone_root: Path) -> set[str]:
+    names = {str(row[0]) for row in conn.execute("SELECT id FROM repositories")}
     paths = [Path(row[0]).resolve() for row in conn.execute("SELECT path FROM repositories")]
-    paths.extend(Path(row[0]).resolve() for row in conn.execute(worktree_query))
+    paths.extend(active_worktree_paths(conn, clone_root))
     for path in paths:
         try:
             relative = path.relative_to(clone_root)
@@ -61,26 +71,34 @@ def protected_clone_root_names(conn: sqlite3.Connection, clone_root: Path) -> se
     return names
 
 
-def load_protected_clone_root_names(db_path: Path, clone_root: Path) -> set[str]:
+def load_protected_paths(db_path: Path, clone_root: Path) -> tuple[set[str], set[Path]]:
     if not db_path.is_file():
         raise ValueError(f"Polyscope DB not found at {db_path}")
     try:
         with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
-            return protected_clone_root_names(conn, clone_root)
+            return protected_clone_root_names(conn, clone_root), active_worktree_paths(conn, clone_root)
     except sqlite3.Error as exc:
         raise ValueError(f"unable to read Polyscope DB: {exc}") from exc
 
 
 
+def is_registered_candidate(
+    conn: sqlite3.Connection, clone_root: Path, candidate: Path, is_worktree: bool
+) -> bool:
+    if is_worktree:
+        return protects_active_worktree(candidate, active_worktree_paths(conn, clone_root))
+    return candidate.name in protected_clone_root_names(conn, clone_root)
+
+
 def quarantine_if_still_orphan(
-    db_path: Path, clone_root: Path, candidate: Path, cutoff: float
+    db_path: Path, clone_root: Path, candidate: Path, cutoff: float, is_worktree: bool
 ) -> Path | None:
     """Atomically detach a candidate while preventing database registrations."""
-    quarantine = clone_root / f".reaper-trash-{os.getpid()}-{candidate.name}"
+    quarantine = candidate.parent / f".reaper-trash-{os.getpid()}-{candidate.name}"
     try:
         with sqlite3.connect(db_path, timeout=30) as conn:
             conn.execute("BEGIN IMMEDIATE")
-            if candidate.name in protected_clone_root_names(conn, clone_root):
+            if is_registered_candidate(conn, clone_root, candidate, is_worktree):
                 return None
             newest_mtime = newest_tree_mtime(candidate)
             if newest_mtime is None or newest_mtime > cutoff or has_lock(candidate) or has_active_process(candidate):
@@ -171,11 +189,43 @@ def newest_tree_mtime(root: Path) -> float | None:
         return None
 
 
+def protects_active_worktree(candidate: Path, active_worktrees: set[Path]) -> bool:
+    """Whether candidate is, or contains, an active registered worktree."""
+    candidate_path = candidate.resolve()
+    return any(is_within(worktree, candidate_path) for worktree in active_worktrees)
+
+
+def candidates(
+    clone_root: Path, protected_roots: set[str], protected_worktrees: set[Path]
+) -> list[tuple[Path, bool]]:
+    """Return root and safe-to-inspect child worktree candidates in path order."""
+    result: list[tuple[Path, bool]] = []
+    for root in clone_root.iterdir():
+        result.append((root, False))
+        try:
+            root_path = root.resolve()
+            # Only registered clone roots can contain individually managed
+            # worktrees. A registered worktree at the root has arbitrary
+            # source subdirectories, never worktree candidates.
+            if (
+                root.name not in protected_roots
+                or root.is_symlink()
+                or not root.is_dir()
+                or not is_within(root_path, clone_root)
+                or root_path in protected_worktrees
+            ):
+                continue
+            result.extend((child, True) for child in root.iterdir())
+        except OSError:
+            continue
+    return sorted(result, key=lambda item: str(item[0]))
+
+
 def reap(args: argparse.Namespace) -> dict[str, Any]:
     home = resolved_absolute(Path(args.polyscope_home), "Polyscope home")
     clone_root = resolved_absolute(Path(args.clone_root) if args.clone_root else home / "clones", "clone root")
     db_path = home / "polyscope.db"
-    allowlist = load_protected_clone_root_names(db_path, clone_root)
+    protected_roots, protected_worktrees = load_protected_paths(db_path, clone_root)
     report: dict[str, Any] = {
         "removed": [],
         "would_remove": [],
@@ -186,12 +236,24 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
         return report
 
     cutoff = time.time() - args.grace_period
-    for candidate in sorted(clone_root.iterdir()):
-        # Only immediate, real directories under the configured clone root are eligible.
-        if candidate.is_symlink() or not candidate.is_dir() or not is_within(candidate.resolve(), clone_root):
+    for candidate, is_worktree in candidates(clone_root, protected_roots, protected_worktrees):
+        parent = candidate.parent.resolve()
+        expected_parent = parent if is_worktree else clone_root
+        # Only real clone roots and immediate worktree children are eligible.
+        if (
+            (is_worktree and candidate.name.startswith("."))
+            or candidate.is_symlink()
+            or not candidate.is_dir()
+            or not is_within(candidate.resolve(), expected_parent)
+        ):
             report["skipped"]["unsafe"].append(str(candidate))
             continue
-        if candidate.name in allowlist:
+        protected = (
+            protects_active_worktree(candidate, protected_worktrees)
+            if is_worktree
+            else candidate.name in protected_roots
+        )
+        if protected:
             report["skipped"]["active"].append(str(candidate))
             continue
         try:
@@ -216,7 +278,7 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
             report["would_remove"].append(str(candidate))
             report["reclaimed_bytes"] += size
             continue
-        quarantined = quarantine_if_still_orphan(db_path, clone_root, candidate, cutoff)
+        quarantined = quarantine_if_still_orphan(db_path, clone_root, candidate, cutoff, is_worktree)
         if quarantined is None:
             report["skipped"]["unsafe"].append(str(candidate))
             continue
@@ -241,7 +303,7 @@ def main() -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         action = "Would reclaim" if args.dry_run else "Reclaimed"
-        print(f"{action} {report['reclaimed_bytes']} bytes from {len(report['would_remove']) or len(report['removed'])} clone roots.")
+        print(f"{action} {report['reclaimed_bytes']} bytes from {len(report['would_remove']) or len(report['removed'])} Polyscope directories.")
         for reason, paths in report["skipped"].items():
             for path in paths:
                 print(f"Skipped ({reason}): {path}")

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -142,6 +142,21 @@ def is_within(path: Path, parent: Path) -> bool:
         return False
 
 
+def is_safe_candidate(candidate: Path, clone_root: Path, is_worktree: bool) -> bool:
+    """Reject candidates whose lexical parent or resolved path escaped clone_root."""
+    if is_worktree and (
+        candidate.parent.parent != clone_root
+        or candidate.parent.is_symlink()
+        or not candidate.parent.is_dir()
+    ):
+        return False
+    return (
+        not candidate.is_symlink()
+        and candidate.is_dir()
+        and is_within(candidate.resolve(), clone_root)
+    )
+
+
 def has_lock(root: Path) -> bool:
     try:
         # Dependency manifests such as yarn.lock are durable source files, not
@@ -262,14 +277,10 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
 
     cutoff = time.time() - args.grace_period
     for candidate, is_worktree in candidates(clone_root, protected_roots, protected_worktrees):
-        parent = candidate.parent.resolve()
-        expected_parent = parent if is_worktree else clone_root
         # Only real clone roots and immediate worktree children are eligible.
         if (
             (is_worktree and candidate.name.startswith("."))
-            or candidate.is_symlink()
-            or not candidate.is_dir()
-            or not is_within(candidate.resolve(), expected_parent)
+            or not is_safe_candidate(candidate, clone_root, is_worktree)
         ):
             report["skipped"]["unsafe"].append(str(candidate))
             continue
@@ -298,8 +309,11 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
         if has_active_process(candidate):
             report["skipped"]["process"].append(str(candidate))
             continue
-        size = allocated_bytes(candidate)
+        if not is_safe_candidate(candidate, clone_root, is_worktree):
+            report["skipped"]["unsafe"].append(str(candidate))
+            continue
         if args.dry_run:
+            size = allocated_bytes(candidate)
             report["would_remove"].append(str(candidate))
             report["reclaimed_bytes"] += size
             continue
@@ -307,6 +321,7 @@ def reap(args: argparse.Namespace) -> dict[str, Any]:
         if quarantined is None:
             report["skipped"]["unsafe"].append(str(candidate))
             continue
+        size = allocated_bytes(quarantined)
         try:
             shutil.rmtree(quarantined)
         except OSError:

--- a/scripts/reap-polyscope-clones.py
+++ b/scripts/reap-polyscope-clones.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import time
 from pathlib import Path
@@ -94,19 +95,43 @@ def quarantine_if_still_orphan(
     db_path: Path, clone_root: Path, candidate: Path, cutoff: float, is_worktree: bool
 ) -> Path | None:
     """Atomically detach a candidate while preventing database registrations."""
-    quarantine = candidate.parent / f".reaper-trash-{os.getpid()}-{candidate.name}"
+    parent_name = candidate.parent.name if is_worktree else "root"
+    quarantine = clone_root / f".reaper-trash-{os.getpid()}-{parent_name}-{candidate.name}"
+    parent_fd = -1
+    clone_fd = -1
     try:
+        clone_fd = os.open(clone_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        if is_worktree:
+            if candidate.parent.parent != clone_root:
+                return None
+            parent_fd = os.open(candidate.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        else:
+            parent_fd = os.dup(clone_fd)
+        pinned_candidate = Path(f"/proc/self/fd/{parent_fd}") / candidate.name
+        candidate_stat = os.stat(candidate.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISDIR(candidate_stat.st_mode) or pinned_candidate.is_symlink():
+            return None
         with sqlite3.connect(db_path, timeout=30) as conn:
             conn.execute("BEGIN IMMEDIATE")
             if is_registered_candidate(conn, clone_root, candidate, is_worktree):
                 return None
-            newest_mtime = newest_tree_mtime(candidate)
-            if newest_mtime is None or newest_mtime > cutoff or has_lock(candidate) or has_active_process(candidate):
+            newest_mtime = newest_tree_mtime(pinned_candidate)
+            if (
+                newest_mtime is None
+                or newest_mtime > cutoff
+                or has_lock(pinned_candidate)
+                or has_active_process(pinned_candidate.resolve())
+            ):
                 return None
-            candidate.rename(quarantine)
+            os.rename(candidate.name, quarantine.name, src_dir_fd=parent_fd, dst_dir_fd=clone_fd)
         return quarantine
-    except (OSError, sqlite3.Error):
+    except (AttributeError, OSError, sqlite3.Error):
         return None
+    finally:
+        if parent_fd >= 0:
+            os.close(parent_fd)
+        if clone_fd >= 0:
+            os.close(clone_fd)
 
 
 def is_within(path: Path, parent: Path) -> bool:

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -10,7 +10,8 @@ REAPER="$REPO_ROOT/scripts/reap-polyscope-clones.py"
 
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-clone-reaper.XXXXXX")"
 active_pid=""
-trap '[[ -z "$active_pid" ]] || kill "$active_pid" 2>/dev/null || true; rm -rf "$workspace"' EXIT
+busy_pid=""
+trap '[[ -z "$active_pid" ]] || kill "$active_pid" 2>/dev/null || true; [[ -z "$busy_pid" ]] || kill "$busy_pid" 2>/dev/null || true; rm -rf "$workspace"' EXIT
 
 polyscope_home="$workspace/.polyscope"
 clone_root="$polyscope_home/clones"
@@ -34,6 +35,9 @@ conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('path-id', 'path', st
 active = clones / 'active-repo' / 'workspace'
 active.mkdir(parents=True)
 conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('active', 'active-repo', 'main', str(active), 'active'))
+contained_active = clones / 'active-repo' / 'contains-active' / 'registered-child'
+contained_active.mkdir(parents=True)
+conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('contained-active', 'active-repo', 'nested', str(contained_active), 'active'))
 inactive = clones / 'inactive-repo' / 'workspace'
 inactive.mkdir(parents=True)
 conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('inactive', 'inactive-repo', 'old', str(inactive), 'removed'))
@@ -45,14 +49,18 @@ conn.close()
 PY
 
 mkdir -p "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-recent/cache" "$clone_root/orphan-young" "$clone_root/orphan-lock/.git" "$clone_root/orphan-busy"
+mkdir -p "$clone_root/active-repo/.git" "$clone_root/active-repo/hungry-hawk-be808d44/cache" "$clone_root/active-repo/fresh-worktree" "$clone_root/active-repo/locked-worktree/.git" "$clone_root/active-repo/busy-worktree"
 mkdir -p "$clone_root/registered-path-root"
 outside_root="$workspace/outside-clone-root"
 mkdir -p "$outside_root"
 ln -s "$outside_root" "$clone_root/external-link"
+ln -s "$outside_root" "$clone_root/active-repo/external-worktree-link"
 printf 'payload\n' > "$clone_root/orphan-old/node_modules/cache/file"
+printf 'orphaned worktree payload\n' > "$clone_root/active-repo/hungry-hawk-be808d44/cache/file"
 touch "$clone_root/orphan-old/yarn.lock"
 touch "$clone_root/orphan-lock/.git/index.lock"
-python3 - <<'PY' "$clone_root/orphan-old" "$clone_root/orphan-old/node_modules" "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-old/node_modules/cache/file" "$clone_root/orphan-old/yarn.lock" "$clone_root/orphan-recent" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-lock/.git" "$clone_root/orphan-lock/.git/index.lock" "$clone_root/orphan-busy" "$clone_root/registered-path-root" "$clone_root/direct-worktree"
+touch "$clone_root/active-repo/locked-worktree/.git/index.lock"
+python3 - <<'PY' "$clone_root/orphan-old" "$clone_root/orphan-old/node_modules" "$clone_root/orphan-old/node_modules/cache" "$clone_root/orphan-old/node_modules/cache/file" "$clone_root/orphan-old/yarn.lock" "$clone_root/orphan-recent" "$clone_root/inactive-repo" "$clone_root/orphan-lock" "$clone_root/orphan-lock/.git" "$clone_root/orphan-lock/.git/index.lock" "$clone_root/orphan-busy" "$clone_root/registered-path-root" "$clone_root/direct-worktree" "$clone_root/active-repo/.git" "$clone_root/active-repo/contains-active" "$clone_root/active-repo/contains-active/registered-child" "$clone_root/active-repo/hungry-hawk-be808d44" "$clone_root/active-repo/hungry-hawk-be808d44/cache" "$clone_root/active-repo/hungry-hawk-be808d44/cache/file" "$clone_root/active-repo/locked-worktree" "$clone_root/active-repo/locked-worktree/.git" "$clone_root/active-repo/locked-worktree/.git/index.lock" "$clone_root/active-repo/busy-worktree"
 import os
 import sys
 import time
@@ -65,6 +73,8 @@ PY
 # A process whose current directory is inside a candidate must prevent deletion.
 (cd "$clone_root/orphan-busy" && sleep 30) &
 active_pid=$!
+(cd "$clone_root/active-repo/busy-worktree" && sleep 30) &
+busy_pid=$!
 
 dry_run_output="$(python3 "$REAPER" --polyscope-home "$polyscope_home" --grace-period 7d --dry-run --json)"
 python3 - <<'PY' "$dry_run_output" "$clone_root"
@@ -75,21 +85,27 @@ from pathlib import Path
 report = json.loads(sys.argv[1])
 clones = Path(sys.argv[2])
 assert report['removed'] == []
-assert report['would_remove'] == [str(clones / 'orphan-old')]
+assert report['would_remove'] == [
+    str(clones / 'active-repo' / 'hungry-hawk-be808d44'),
+    str(clones / 'orphan-old'),
+]
 assert report['skipped']['active'] == [
     str(clones / 'active-repo'),
+    str(clones / 'active-repo' / 'contains-active'),
+    str(clones / 'active-repo' / 'workspace'),
     str(clones / 'direct-worktree'),
     str(clones / 'inactive-repo'),
     str(clones / 'registered-path-root'),
 ]
-assert report['skipped']['grace_period'] == [str(clones / 'orphan-recent'), str(clones / 'orphan-young')]
-assert report['skipped']['lock'] == [str(clones / 'orphan-lock')]
-assert report['skipped']['process'] == [str(clones / 'orphan-busy')]
-assert report['skipped']['unsafe'] == [str(clones / 'external-link')]
+assert report['skipped']['grace_period'] == [str(clones / 'active-repo' / 'fresh-worktree'), str(clones / 'inactive-repo' / 'workspace'), str(clones / 'orphan-recent'), str(clones / 'orphan-young')]
+assert report['skipped']['lock'] == [str(clones / 'active-repo' / 'locked-worktree'), str(clones / 'orphan-lock')]
+assert report['skipped']['process'] == [str(clones / 'active-repo' / 'busy-worktree'), str(clones / 'orphan-busy')]
+assert report['skipped']['unsafe'] == [str(clones / 'active-repo' / '.git'), str(clones / 'active-repo' / 'external-worktree-link'), str(clones / 'external-link')]
 assert report['reclaimed_bytes'] > 0
 PY
 
 [[ -d "$clone_root/orphan-old" ]] || { echo 'dry run removed a clone root' >&2; exit 1; }
+[[ -d "$clone_root/active-repo/hungry-hawk-be808d44" ]] || { echo 'dry run removed a worktree directory' >&2; exit 1; }
 
 run_output="$(python3 "$REAPER" --polyscope-home "$polyscope_home" --grace-period 7d --json)"
 python3 - <<'PY' "$run_output" "$clone_root"
@@ -99,13 +115,17 @@ from pathlib import Path
 
 report = json.loads(sys.argv[1])
 clones = Path(sys.argv[2])
-assert report['removed'] == [str(clones / 'orphan-old')]
+assert report['removed'] == [
+    str(clones / 'active-repo' / 'hungry-hawk-be808d44'),
+    str(clones / 'orphan-old'),
+]
 assert report['would_remove'] == []
 assert report['reclaimed_bytes'] > 0
 PY
 
 [[ ! -e "$clone_root/orphan-old" ]] || { echo 'orphan clone root was not removed' >&2; exit 1; }
-[[ -d "$clone_root/active-repo" && -d "$clone_root/direct-worktree" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-recent" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$clone_root/registered-path-root" && -d "$outside_root" ]] || {
+[[ ! -e "$clone_root/active-repo/hungry-hawk-be808d44" ]] || { echo 'orphan worktree directory was not removed' >&2; exit 1; }
+[[ -d "$clone_root/active-repo" && -d "$clone_root/active-repo/.git" && -d "$clone_root/active-repo/contains-active/registered-child" && -d "$clone_root/active-repo/workspace" && -d "$clone_root/active-repo/fresh-worktree" && -d "$clone_root/active-repo/locked-worktree" && -d "$clone_root/active-repo/busy-worktree" && -L "$clone_root/active-repo/external-worktree-link" && -d "$clone_root/direct-worktree" && -d "$clone_root/inactive-repo" && -d "$clone_root/orphan-recent" && -d "$clone_root/orphan-young" && -d "$clone_root/orphan-lock" && -d "$clone_root/orphan-busy" && -d "$clone_root/registered-path-root" && -d "$outside_root" ]] || {
     echo 'reaper removed a protected clone root' >&2
     exit 1
 }
@@ -151,6 +171,56 @@ report = module.reap(argparse.Namespace(
 ))
 assert (clones / 'racing-repo').is_dir(), report
 assert str(clones / 'racing-repo') not in report['removed'], report
+PY
+
+# The same final database revalidation must protect a worktree child that is
+# registered while it is being inspected.
+mkdir -p "$clone_root/racing-worktree/workspace"
+python3 - <<'PY' "$polyscope_home" "$clone_root/racing-worktree/workspace"
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+worktree = Path(sys.argv[2])
+with sqlite3.connect(home / 'polyscope.db') as conn:
+    conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('racing-worktree', 'racing worktree', '/tmp/racing-worktree'))
+mtime = time.time() - 10 * 24 * 60 * 60
+os.utime(worktree, (mtime, mtime))
+PY
+python3 - <<'PY' "$REAPER" "$polyscope_home" "$clone_root"
+import argparse
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('clone_reaper', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+home = Path(sys.argv[2])
+clones = Path(sys.argv[3])
+original_process_check = module.has_active_process
+registered = False
+
+def register_during_scan(root):
+    global registered
+    if root.name == 'workspace' and root.parent.name == 'racing-worktree' and not registered:
+        with sqlite3.connect(home / 'polyscope.db') as conn:
+            conn.execute('INSERT INTO worktrees VALUES (?, ?, ?, ?, ?)', ('racing-worktree', 'racing-worktree', 'main', str(root), 'active'))
+        registered = True
+    return original_process_check(root)
+
+module.has_active_process = register_during_scan
+report = module.reap(argparse.Namespace(
+    polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
+    dry_run=False, json=True,
+))
+candidate = clones / 'racing-worktree' / 'workspace'
+assert candidate.is_dir(), report
+assert str(candidate) not in report['removed'], report
 PY
 
 # Older Polyscope databases have no worktree status column. Their registered

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -223,6 +223,110 @@ assert candidate.is_dir(), report
 assert str(candidate) not in report['removed'], report
 PY
 
+# Replacing a registered clone root with a symlink during inspection must not
+# redirect worktree cleanup outside the configured clone root.
+mkdir -p "$clone_root/swapped-parent/victim" "$workspace/swapped-parent-target/victim"
+printf 'outside data\n' > "$workspace/swapped-parent-target/victim/important"
+python3 - <<'PY' "$polyscope_home" "$clone_root/swapped-parent/victim" "$workspace/swapped-parent-target/victim"
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+with sqlite3.connect(home / 'polyscope.db') as conn:
+    conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('swapped-parent', 'swapped parent', '/tmp/swapped-parent'))
+mtime = time.time() - 10 * 24 * 60 * 60
+for value in sys.argv[2:]:
+    path = Path(value)
+    os.utime(path, (mtime, mtime))
+    for child in path.iterdir():
+        os.utime(child, (mtime, mtime))
+PY
+python3 - <<'PY' "$REAPER" "$polyscope_home" "$clone_root" "$workspace/swapped-parent-target"
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('clone_reaper', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+home = Path(sys.argv[2])
+clones = Path(sys.argv[3])
+outside = Path(sys.argv[4])
+original_process_check = module.has_active_process
+swapped = False
+
+def swap_parent_during_scan(root):
+    global swapped
+    if root == clones / 'swapped-parent' / 'victim' and not swapped:
+        root.parent.rename(clones / 'swapped-parent-detached')
+        root.parent.symlink_to(outside, target_is_directory=True)
+        swapped = True
+    return original_process_check(root)
+
+module.has_active_process = swap_parent_during_scan
+report = module.reap(argparse.Namespace(
+    polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
+    dry_run=False, json=True,
+))
+outside_file = outside / 'victim' / 'important'
+assert outside_file.is_file(), report
+assert str(clones / 'swapped-parent' / 'victim') not in report['removed'], report
+PY
+
+# A failed recursive deletion must leave a quarantine that a later run can
+# recognize and finish reclaiming.
+mkdir -p "$clone_root/quarantine-repo/old-worktree"
+printf 'payload\n' > "$clone_root/quarantine-repo/old-worktree/file"
+python3 - <<'PY' "$polyscope_home" "$clone_root/quarantine-repo/old-worktree"
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+candidate = Path(sys.argv[2])
+with sqlite3.connect(home / 'polyscope.db') as conn:
+    conn.execute('INSERT INTO repositories VALUES (?, ?, ?)', ('quarantine-repo', 'quarantine repo', '/tmp/quarantine-repo'))
+mtime = time.time() - 10 * 24 * 60 * 60
+for path in (candidate, candidate / 'file'):
+    os.utime(path, (mtime, mtime))
+PY
+python3 - <<'PY' "$REAPER" "$polyscope_home" "$clone_root"
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('clone_reaper', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+home = Path(sys.argv[2])
+clones = Path(sys.argv[3])
+original_rmtree = module.shutil.rmtree
+
+def fail_once(path):
+    module.shutil.rmtree = original_rmtree
+    raise OSError('simulated interruption')
+
+module.shutil.rmtree = fail_once
+module.reap(argparse.Namespace(
+    polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
+    dry_run=False, json=True,
+))
+quarantines = list(clones.glob('.reaper-trash-*-quarantine-repo-old-worktree'))
+assert len(quarantines) == 1, quarantines
+report = module.reap(argparse.Namespace(
+    polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
+    dry_run=False, json=True,
+))
+assert not quarantines[0].exists(), report
+PY
+
 # Older Polyscope databases have no worktree status column. Their registered
 # worktrees must still be protected instead of disabling scheduled cleanup.
 legacy_home="$workspace/legacy/.polyscope"

--- a/tests/polyscope-clone-reaper.sh
+++ b/tests/polyscope-clone-reaper.sh
@@ -257,6 +257,7 @@ home = Path(sys.argv[2])
 clones = Path(sys.argv[3])
 outside = Path(sys.argv[4])
 original_process_check = module.has_active_process
+original_allocated_bytes = module.allocated_bytes
 swapped = False
 
 def swap_parent_during_scan(root):
@@ -268,6 +269,12 @@ def swap_parent_during_scan(root):
     return original_process_check(root)
 
 module.has_active_process = swap_parent_during_scan
+
+def reject_outside_size_scan(root):
+    assert module.is_within(root.resolve(), clones), root
+    return original_allocated_bytes(root)
+
+module.allocated_bytes = reject_outside_size_scan
 report = module.reap(argparse.Namespace(
     polyscope_home=str(home), clone_root=str(clones), grace_period=7 * 24 * 60 * 60,
     dry_run=False, json=True,
@@ -275,6 +282,7 @@ report = module.reap(argparse.Namespace(
 outside_file = outside / 'victim' / 'important'
 assert outside_file.is_file(), report
 assert str(clones / 'swapped-parent' / 'victim') not in report['removed'], report
+assert str(clones / 'swapped-parent' / 'victim') in report['skipped']['unsafe'], report
 PY
 
 # A failed recursive deletion must leave a quarantine that a later run can


### PR DESCRIPTION
## Reproduction

The existing reaper protects active clone roots, so an aged unregistered child
worktree such as `hungry-hawk-be808d44` remains on disk after its
`worktrees.path` row is gone. The new nested-worktree fixture fails against the
previous implementation because that directory is absent from the dry-run
reclamation list.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-clone-reaper.sh` failed because the nested unregistered worktree was absent from `would_remove`.
- Passing proof after implementation: `bash tests/polyscope-clone-reaper.sh` passes with the nested worktree reclaimed and all protected fixtures retained.
- Validate-first exception reference: N/A
- No executable change reason: N/A

Closes #559

## Changes

- scan immediate non-hidden child directories only below protected clone roots
- protect active worktree paths and any candidate that contains an active path
- retain grace-period, lock, live-process, symlink, path-containment, and
  transactional revalidation safeguards
- report reclaimed bytes for both clone roots and worktree directories
- add positive and negative fixtures, including registration races

## Validation

- `bash tests/polyscope-clone-reaper.sh`
- `python3 -m py_compile scripts/reap-polyscope-clones.py`
- `git diff --check`
- `./scripts/preflight.sh`

## Follow-up before ready

- Review the draft diff and CI results in the PR view.
- No linked workspaces or unresolved local checks remain.
