### PR TITLE
Pin nested Dependabot workflow actions

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -217,7 +217,7 @@ jobs:
     steps:
       - name: Wait for CI checks
         id: wait-for-checks
-        uses: lewagon/wait-on-check-action@v1.8.1
+        uses: lewagon/wait-on-check-action@1d57e2c51a58d812d2765e036a028b6bdb5a6154
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -277,7 +277,7 @@ jobs:
           echo "✅ Auto-merge enabled! PR will merge when all checks pass."
 
       - name: Add comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const phase = '${{ inputs.phase }}';
@@ -325,7 +325,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Add comment for manual review
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const updateType = '${{ needs.check-eligibility.outputs.update-type }}';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-15 - Pin Nested Dependabot Workflow Actions
+
+**Fixed:**
+
+- pinned `lewagon/wait-on-check-action` and both `actions/github-script` invocations in `.github/workflows/reusable-dependabot-auto-merge.yml` to immutable commits, so callers pinned to a reviewed reusable-workflow commit cannot execute code changed through movable nested action tags
+- extended `tests/dependabot-auto-merge.sh` to reject every non-immutable nested action reference while retaining Dependabot's daily `github-actions` update configuration
+
+---
+
 ## 2026-07-12 - Reap Orphaned Polyscope Worktree Directories
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - pinned `lewagon/wait-on-check-action` and both `actions/github-script` invocations in `.github/workflows/reusable-dependabot-auto-merge.yml` to immutable commits, so callers pinned to a reviewed reusable-workflow commit cannot execute code changed through movable nested action tags
-- extended `tests/dependabot-auto-merge.sh` with semantic YAML fixtures that cover named and shorthand steps, quoted and flow-style references, lowercase and uppercase repository commit pins, canonical lowercase Docker digests, and rejection of caller-local actions while retaining Dependabot's daily `github-actions` update configuration
+- extended `tests/dependabot-auto-merge.sh` with semantic YAML fixtures that cover named and shorthand steps, quoted and flow-style references, lowercase and uppercase repository commit pins, canonical lowercase Docker digests, and rejection of caller-local actions; the parser uses the installed dependency when available and the repository's existing pinned-`npx` preflight model in clean checkouts while retaining Dependabot's daily `github-actions` update configuration
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - pinned `lewagon/wait-on-check-action` and both `actions/github-script` invocations in `.github/workflows/reusable-dependabot-auto-merge.yml` to immutable commits, so callers pinned to a reviewed reusable-workflow commit cannot execute code changed through movable nested action tags
-- extended `tests/dependabot-auto-merge.sh` with positive and negative fixtures that cover named and shorthand steps, quoted references, local actions, repository commit pins, and Docker digests while retaining Dependabot's daily `github-actions` update configuration
+- extended `tests/dependabot-auto-merge.sh` with semantic YAML fixtures that cover named and shorthand steps, quoted and flow-style references, lowercase and uppercase repository commit pins, canonical lowercase Docker digests, and rejection of caller-local actions while retaining Dependabot's daily `github-actions` update configuration
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - pinned `lewagon/wait-on-check-action` and both `actions/github-script` invocations in `.github/workflows/reusable-dependabot-auto-merge.yml` to immutable commits, so callers pinned to a reviewed reusable-workflow commit cannot execute code changed through movable nested action tags
-- extended `tests/dependabot-auto-merge.sh` to reject every non-immutable nested action reference while retaining Dependabot's daily `github-actions` update configuration
+- extended `tests/dependabot-auto-merge.sh` with positive and negative fixtures that cover named and shorthand steps, quoted references, local actions, repository commit pins, and Docker digests while retaining Dependabot's daily `github-actions` update configuration
 
 ---
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -177,68 +177,101 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
 }
 
 validate_immutable_action_references() {
-  awk '
-    function trim(value) {
-      sub(/^[[:space:]]+/, "", value)
-      sub(/[[:space:]]+$/, "", value)
-      return value
-    }
+  node -e '
+    const fs = require("node:fs");
+    const yaml = require("js-yaml");
 
-    {
-      line = $0
-      sub(/^[[:space:]]*/, "", line)
-      sub(/^-[[:space:]]*/, "", line)
-      if (line !~ /^uses:[[:space:]]+/) {
-        next
-      }
+    const inputPaths = process.argv.slice(1);
+    const inputs = inputPaths.length > 0
+      ? inputPaths.map((path) => ({ name: path, source: fs.readFileSync(path, "utf8") }))
+      : [{ name: "standard input", source: fs.readFileSync(0, "utf8") }];
+    let invalidReference = false;
 
-      sub(/^uses:[[:space:]]+/, "", line)
-      sub(/[[:space:]]+#.*$/, "", line)
-      reference = trim(line)
+    function validateReference(reference, location) {
+      const repositoryPin = /^[^@\s]+@[0-9a-f]{40}$/i;
+      const dockerPin = /^docker:\/\/[^@\s]+@sha256:[0-9a-f]{64}$/;
+      let immutable = false;
 
-      first_character = substr(reference, 1, 1)
-      last_character = substr(reference, length(reference), 1)
-      if ((first_character == "\"" && last_character == "\"") ||
-          (first_character == "\047" && last_character == "\047")) {
-        reference = substr(reference, 2, length(reference) - 2)
-      }
-
-      if (reference ~ /^\.\//) {
-        next
-      }
-
-      if (reference ~ /^docker:\/\//) {
-        immutable = reference ~ /^docker:\/\/[^@[:space:]]+@sha256:[0-9a-f]{64}$/
-      } else {
-        immutable = reference ~ /^[^@[:space:]]+@[0-9a-f]{40}$/
+      if (typeof reference === "string" && reference.startsWith("docker://")) {
+        immutable = dockerPin.test(reference);
+      } else if (typeof reference === "string" && !reference.startsWith("./")) {
+        immutable = repositoryPin.test(reference);
       }
 
       if (!immutable) {
-        printf "Movable nested action reference: %s\n", reference > "/dev/stderr"
-        invalid_reference = 1
+        process.stderr.write(`Movable nested action reference at ${location}: ${String(reference)}\n`);
+        invalidReference = true;
       }
     }
 
-    END { exit invalid_reference }
+    function validateWorkflow(workflow, sourceName) {
+      if (workflow === null || typeof workflow !== "object" || Array.isArray(workflow)) {
+        throw new Error(`${sourceName}: workflow document must be a mapping`);
+      }
+
+      const jobs = workflow.jobs;
+      if (jobs === null || typeof jobs !== "object" || Array.isArray(jobs)) {
+        return;
+      }
+
+      for (const [jobId, job] of Object.entries(jobs)) {
+        if (job === null || typeof job !== "object" || Array.isArray(job)) {
+          continue;
+        }
+        if (Object.prototype.hasOwnProperty.call(job, "uses")) {
+          validateReference(job.uses, `${sourceName}: jobs.${jobId}.uses`);
+        }
+        if (!Array.isArray(job.steps)) {
+          continue;
+        }
+        job.steps.forEach((step, index) => {
+          if (step !== null && typeof step === "object" &&
+              !Array.isArray(step) && Object.prototype.hasOwnProperty.call(step, "uses")) {
+            validateReference(step.uses, `${sourceName}: jobs.${jobId}.steps[${index}].uses`);
+          }
+        });
+      }
+    }
+
+    try {
+      for (const input of inputs) {
+        yaml.loadAll(input.source, (workflow) => validateWorkflow(workflow, input.name));
+      }
+    } catch (error) {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(1);
+    }
+
+    process.exit(invalidReference ? 1 : 0);
   ' "$@"
 }
 
-immutable_action_fixture='steps:
-  - uses: actions/example@0123456789abcdef0123456789abcdef01234567
-  - uses: "actions/example@0123456789abcdef0123456789abcdef01234567" # v1.2.3
-  - uses: ./.github/actions/local-check
-  - uses: docker://alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+immutable_action_fixture='jobs:
+  reusable-workflow:
+    uses: actions/example/.github/workflows/example.yml@0123456789abcdef0123456789abcdef01234567
+  action-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/example@0123456789abcdef0123456789abcdef01234567
+      - uses : actions/example@0123456789ABCDEF0123456789ABCDEF01234567
+      - { name: Example, uses: "actions/example@0123456789abcdef0123456789abcdef01234567" }
+      - uses: docker://alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
 
 if ! printf '%s\n' "$immutable_action_fixture" | validate_immutable_action_references; then
-  echo "Immutable action reference validation must accept Git commit pins, local actions, and Docker digests in every valid step form." >&2
+  echo "Immutable action reference validation must accept Git commit pins in either hex case and canonical Docker digests in every valid step form." >&2
   exit 1
 fi
 
 for movable_action_fixture in \
-  '      uses: actions/example@v1' \
-  '      - uses: actions/example@main' \
-  "      - uses: 'actions/example@v1.2.3' # release" \
-  '      uses: docker://alpine:latest'; do
+  'jobs: { fixture: { uses: actions/example/.github/workflows/example.yml@v1 } }' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@main' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses : actions/example@v1' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - { name: Example, uses: actions/example@v1 }' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/local-check' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/local-check@0123456789abcdef0123456789abcdef01234567' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: docker://alpine@0123456789abcdef0123456789abcdef01234567' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: docker://alpine@sha256:0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF' \
+  $'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: docker://alpine:latest'; do
   if printf '%s\n' "$movable_action_fixture" | validate_immutable_action_references 2>/dev/null; then
     echo "Immutable action reference validation accepted a movable reference: $movable_action_fixture" >&2
     exit 1
@@ -247,11 +280,11 @@ done
 
 # Cross-repository callers pin this reusable workflow to a commit, but that
 # pin is only meaningful when every action it invokes is also immutable.
-# Require a full commit SHA for repository actions and a SHA-256 digest for
-# Docker actions so a movable tag cannot silently change the code executed by
-# all callers. Local actions are part of the already-pinned workflow commit.
+# Require a full commit SHA for repository actions and a canonical SHA-256
+# digest for Docker actions so a movable or caller-local reference cannot
+# silently change the code executed by consumers.
 if ! validate_immutable_action_references "$REUSABLE_WORKFLOW"; then
-  echo "Reusable Dependabot workflow must pin every nested repository action to a full commit SHA and every Docker action to a SHA-256 digest." >&2
+  echo "Reusable Dependabot workflow must pin every nested repository action to a full commit SHA and every Docker action to a canonical SHA-256 digest; caller-local references are not allowed." >&2
   exit 1
 fi
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -177,14 +177,31 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
 }
 
 validate_immutable_action_references() {
+  local parser=()
+  local source_name yaml_json
+
+  if [[ $# -gt 1 ]]; then
+    echo "Immutable action reference validation accepts at most one workflow path." >&2
+    return 1
+  fi
+
+  if [[ -x "$REPO_ROOT/node_modules/.bin/js-yaml" ]]; then
+    parser=("$REPO_ROOT/node_modules/.bin/js-yaml")
+  elif command -v npx >/dev/null 2>&1; then
+    parser=(npx --yes js-yaml@4.2.0)
+  else
+    echo "Immutable action reference validation requires npm dependencies or npx." >&2
+    return 1
+  fi
+
+  source_name="${1:-standard input}"
+  yaml_json="$("${parser[@]}" "$@")" || return 1
+
+  printf '%s\n' "$yaml_json" |
   node -e '
     const fs = require("node:fs");
-    const yaml = require("js-yaml");
-
-    const inputPaths = process.argv.slice(1);
-    const inputs = inputPaths.length > 0
-      ? inputPaths.map((path) => ({ name: path, source: fs.readFileSync(path, "utf8") }))
-      : [{ name: "standard input", source: fs.readFileSync(0, "utf8") }];
+    const sourceName = process.argv[1];
+    const workflow = JSON.parse(fs.readFileSync(0, "utf8"));
     let invalidReference = false;
 
     function validateReference(reference, location) {
@@ -233,17 +250,9 @@ validate_immutable_action_references() {
       }
     }
 
-    try {
-      for (const input of inputs) {
-        yaml.loadAll(input.source, (workflow) => validateWorkflow(workflow, input.name));
-      }
-    } catch (error) {
-      process.stderr.write(`${error.message}\n`);
-      process.exit(1);
-    }
-
+    validateWorkflow(workflow, sourceName);
     process.exit(invalidReference ? 1 : 0);
-  ' "$@"
+  ' "$source_name"
 }
 
 immutable_action_fixture='jobs:

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -176,22 +176,82 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
   exit 1
 }
 
+validate_immutable_action_references() {
+  awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      sub(/^-[[:space:]]*/, "", line)
+      if (line !~ /^uses:[[:space:]]+/) {
+        next
+      }
+
+      sub(/^uses:[[:space:]]+/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      reference = trim(line)
+
+      first_character = substr(reference, 1, 1)
+      last_character = substr(reference, length(reference), 1)
+      if ((first_character == "\"" && last_character == "\"") ||
+          (first_character == "\047" && last_character == "\047")) {
+        reference = substr(reference, 2, length(reference) - 2)
+      }
+
+      if (reference ~ /^\.\//) {
+        next
+      }
+
+      if (reference ~ /^docker:\/\//) {
+        immutable = reference ~ /^docker:\/\/[^@[:space:]]+@sha256:[0-9a-f]{64}$/
+      } else {
+        immutable = reference ~ /^[^@[:space:]]+@[0-9a-f]{40}$/
+      }
+
+      if (!immutable) {
+        printf "Movable nested action reference: %s\n", reference > "/dev/stderr"
+        invalid_reference = 1
+      }
+    }
+
+    END { exit invalid_reference }
+  ' "$@"
+}
+
+immutable_action_fixture='steps:
+  - uses: actions/example@0123456789abcdef0123456789abcdef01234567
+  - uses: "actions/example@0123456789abcdef0123456789abcdef01234567" # v1.2.3
+  - uses: ./.github/actions/local-check
+  - uses: docker://alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+if ! printf '%s\n' "$immutable_action_fixture" | validate_immutable_action_references; then
+  echo "Immutable action reference validation must accept Git commit pins, local actions, and Docker digests in every valid step form." >&2
+  exit 1
+fi
+
+for movable_action_fixture in \
+  '      uses: actions/example@v1' \
+  '      - uses: actions/example@main' \
+  "      - uses: 'actions/example@v1.2.3' # release" \
+  '      uses: docker://alpine:latest'; do
+  if printf '%s\n' "$movable_action_fixture" | validate_immutable_action_references 2>/dev/null; then
+    echo "Immutable action reference validation accepted a movable reference: $movable_action_fixture" >&2
+    exit 1
+  fi
+done
+
 # Cross-repository callers pin this reusable workflow to a commit, but that
 # pin is only meaningful when every action it invokes is also immutable.
-# Require a full commit SHA for each action reference so a movable tag cannot
-# silently change the code executed by all callers.
-if ! awk '
-  /^[[:space:]]+uses: [^@[:space:]]+@/ {
-    reference = $2
-    sub(/^.*@/, "", reference)
-    if (reference !~ /^[0-9a-f]{40}$/) {
-      printf "Movable nested action reference: %s\n", $2 > "/dev/stderr"
-      invalid_reference = 1
-    }
-  }
-  END { exit invalid_reference }
-' "$REUSABLE_WORKFLOW"; then
-  echo "Reusable Dependabot workflow must pin every nested action to a full commit SHA." >&2
+# Require a full commit SHA for repository actions and a SHA-256 digest for
+# Docker actions so a movable tag cannot silently change the code executed by
+# all callers. Local actions are part of the already-pinned workflow commit.
+if ! validate_immutable_action_references "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must pin every nested repository action to a full commit SHA and every Docker action to a SHA-256 digest." >&2
   exit 1
 fi
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -17,6 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
+DEPENDABOT_CONFIG="$REPO_ROOT/.github/dependabot.yml"
 WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instructions.md"
 WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
 WORKFLOW_CATALOG_README="$REPO_ROOT/.github/workflows/README.md"
@@ -73,6 +74,16 @@ if [ ! -f "$ROLLOUT_GUIDE" ]; then
   echo "Expected rollout guide was not found: $ROLLOUT_GUIDE" >&2
   exit 1
 fi
+
+if [ ! -f "$DEPENDABOT_CONFIG" ]; then
+  echo "Expected Dependabot configuration was not found: $DEPENDABOT_CONFIG" >&2
+  exit 1
+fi
+
+grep -q '^  - package-ecosystem: "github-actions"$' "$DEPENDABOT_CONFIG" || {
+  echo "Dependabot must continue to update immutable GitHub Actions references." >&2
+  exit 1
+}
 
 if ! awk '
   /^---$/ { document_start_markers++ }
@@ -164,6 +175,25 @@ grep -q '^        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3f
   echo "Reusable Dependabot workflow must pin dependabot/fetch-metadata to the v3.1.0 commit with the null update-type fix." >&2
   exit 1
 }
+
+# Cross-repository callers pin this reusable workflow to a commit, but that
+# pin is only meaningful when every action it invokes is also immutable.
+# Require a full commit SHA for each action reference so a movable tag cannot
+# silently change the code executed by all callers.
+if ! awk '
+  /^[[:space:]]+uses: [^@[:space:]]+@/ {
+    reference = $2
+    sub(/^.*@/, "", reference)
+    if (reference !~ /^[0-9a-f]{40}$/) {
+      printf "Movable nested action reference: %s\n", $2 > "/dev/stderr"
+      invalid_reference = 1
+    }
+  }
+  END { exit invalid_reference }
+' "$REUSABLE_WORKFLOW"; then
+  echo "Reusable Dependabot workflow must pin every nested action to a full commit SHA." >&2
+  exit 1
+fi
 
 grep -q '^        continue-on-error: true$' "$REUSABLE_WORKFLOW" || {
   echo "Reusable Dependabot workflow must soft-fail fetch-metadata into the manual-review path." >&2


### PR DESCRIPTION
## Reproduced defect

The reusable Dependabot workflow invoked nested actions through movable release tags. Pinning a caller to a reusable-workflow commit therefore did not make the nested action code immutable. The focused regression check fails whenever a nested action reference is not a full commit SHA.

Fixes #562.

## Summary

- pin the wait-for-check and GitHub Script actions to immutable commits
- retain Dependabot's `github-actions` update configuration for action-reference updates
- add semantic YAML regression coverage for movable, caller-local, and malformed digest references
- preserve semantic validation in clean checkouts before `npm ci` through the pinned parser fallback
- record the fix in the changelog

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/dependabot-auto-merge.sh` failed when the reusable workflow used `lewagon/wait-on-check-action@v1.8.1` and `actions/github-script@v9` instead of immutable commit SHAs.
- Follow-up failing proof: `bash tests/dependabot-auto-merge.sh` reported that the line-based validator accepted valid YAML spelling variants and caller-local references before the semantic YAML validation was added.
- Clean-checkout failing proof: `bash tests/dependabot-auto-merge.sh` failed with `MODULE_NOT_FOUND` in a fresh clone without `node_modules` before the pinned parser fallback was added.
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`
- Validate-first exception reference: N/A

## Validation

- `bash tests/dependabot-auto-merge.sh`
- `yamllint .github/workflows/`
- `actionlint .github/workflows/reusable-dependabot-auto-merge.yml`
- `shellcheck tests/dependabot-auto-merge.sh`
- `reuse lint`
- `./scripts/preflight.sh`
- `./scripts/preflight.sh` in a fresh clone without `node_modules`
- `git diff --check`

## Follow-up

No linked workspaces or deferred findings. The final local self-review is complete; GitHub checks rerun for the latest commit.
