### PR TITLE
Replace deprecated project token input

### DIFF
--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit
@@ -327,7 +327,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit
@@ -503,7 +503,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-15 - Replace Deprecated Project Token Input
+
+**Fixed:**
+
+- replaced the deprecated `app-id` input with `client-id` in every GitHub App token step of `.github/workflows/project-automation-core.yml` while retaining the existing `APP_ID` and `APP_PRIVATE_KEY` caller secret contract
+- added a focused project-automation workflow regression test to prevent reintroducing the deprecated input and verify all token steps retain that secret wiring
+
+---
+
 ## 2026-07-15 - Pin Nested Dependabot Workflow Actions
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-15 - Replace Deprecated Project Token Input
+
+**Fixed:**
+
+- replaced the deprecated `app-id` input with `client-id` in every GitHub App token step of `.github/workflows/project-automation-core.yml` while retaining the existing `APP_ID` and `APP_PRIVATE_KEY` caller secret contract
+- added a focused project-automation workflow regression test to prevent reintroducing the deprecated input and verify all token steps retain that secret wiring
+
+---
+
 ## 2026-07-15 - Pin Nested Dependabot Workflow Actions
 
 **Fixed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -131,6 +131,15 @@ if [ -f tests/reusable-workflow-policy.sh ]; then
   }
 fi
 
+if [ -f tests/project-automation-core.sh ]; then
+  bash tests/project-automation-core.sh || {
+    echo "" >&2
+    echo "❌ Project automation workflow token-input regression test failed!" >&2
+    echo "Use the supported client-id input while preserving the APP_ID and APP_PRIVATE_KEY secret contract." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/deploy-main-workflow.sh ]; then
   bash tests/deploy-main-workflow.sh || {
     echo "" >&2

--- a/tests/project-automation-core.sh
+++ b/tests/project-automation-core.sh
@@ -12,7 +12,7 @@ if [ ! -f "$WORKFLOW" ]; then
   exit 1
 fi
 
-if grep -q '^          app-id:' "$WORKFLOW"; then
+if grep -q '^[[:space:]]*app-id:[[:space:]]*' "$WORKFLOW"; then
   echo "Project automation must not use the deprecated GitHub App app-id input." >&2
   exit 1
 fi

--- a/tests/project-automation-core.sh
+++ b/tests/project-automation-core.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKFLOW="${WORKFLOW:-$SCRIPT_DIR/../.github/workflows/project-automation-core.yml}"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "Expected project automation workflow was not found: $WORKFLOW" >&2
+  exit 1
+fi
+
+if grep -q '^          app-id:' "$WORKFLOW"; then
+  echo "Project automation must not use the deprecated GitHub App app-id input." >&2
+  exit 1
+fi
+
+if ! awk '
+  function validate_token_step() {
+    if (!has_with || !has_client_id || !has_private_key) {
+      invalid_token_step = 1
+    }
+  }
+
+  /^        uses: actions\/create-github-app-token@v3$/ {
+    if (in_token_step) {
+      validate_token_step()
+    }
+    token_steps++
+    in_token_step = 1
+    has_with = has_client_id = has_private_key = 0
+    next
+  }
+
+  in_token_step && /^      - name:/ {
+    validate_token_step()
+    in_token_step = 0
+    next
+  }
+
+  in_token_step && /^        with:$/ { has_with = 1 }
+  in_token_step && /^          client-id: \${{ secrets.APP_ID }}$/ { has_client_id = 1 }
+  in_token_step && /^          private-key: \${{ secrets.APP_PRIVATE_KEY }}$/ { has_private_key = 1 }
+
+  END {
+    if (in_token_step) {
+      validate_token_step()
+    }
+    exit invalid_token_step || token_steps != 3
+  }
+' "$WORKFLOW"; then
+  echo "Each project automation token step must use client-id with the APP_ID and APP_PRIVATE_KEY secret contract." >&2
+  exit 1
+fi
+
+echo "✓ project automation GitHub App token inputs passed"


### PR DESCRIPTION
## Reproduced defect

Project Board Automation run `29364943062` emitted the warning `Input 'app-id' has been deprecated with message: Use 'client-id' instead` twice while processing SecPal/android PR #382. The shared workflow passed the deprecated input in all three GitHub App token steps.

Closes #561

## Summary

- replace `app-id` with `client-id` in each project-automation GitHub App token step while retaining the `APP_ID` and `APP_PRIVATE_KEY` secret contract
- add a focused regression test that verifies each token step contains its own supported input and private-key wiring
- run the regression test from preflight and document the fix in the changelog

## Validation

- `bash tests/project-automation-core.sh` failed before the workflow migration and passes after it
- a temporary negative workflow fixture with `client-id` outside its token step is rejected
- `yamllint .github/workflows`
- `actionlint` across all workflow files
- `./scripts/preflight.sh`
- commit hooks: REUSE, Prettier, markdownlint, yamllint, actionlint, shellcheck, YAML checks, and whitespace checks

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/project-automation-core.sh` failed against the original workflow because it contained the deprecated `app-id` input.
- Passing proof after implementation: `bash tests/project-automation-core.sh` passes; a temporary negative workflow fixture with `client-id` outside its token step is rejected.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Follow-up before ready for review

- #565 was fixed by #567.
- The remote PR branch must be updated with the rebased commit before final review and readiness checks.
- No linked workspaces.
