### PR TITLE
Fix instruction validation whitespace handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<!-- markdownlint-disable MD012 -->
+
 # SecPal/.github Copilot Instructions
 
 This file mirrors the authoritative root `AGENTS.md` for tooling

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
   "default": true,
-  "MD012": false,
   "MD013": false,
   "MD024": false,
   "MD033": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
   "default": true,
+  "MD012": false,
   "MD013": false,
   "MD024": false,
   "MD033": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<!-- markdownlint-disable MD012 -->
+
 # SecPal/.github Agent Instructions
 
 This file is the authoritative, provider-neutral runtime baseline for this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Fixed:**
 
 - scoped the extra-blank-line exception to the authoritative and mirrored instruction files, so formatting-only whitespace differences no longer block validated pushes without weakening repository-wide Markdown validation
-- added positive and negative regression coverage for the file-local exception and continued enforcement in ordinary Markdown files
+- added positive and negative regression coverage for the file-local exception and continued enforcement in ordinary Markdown files, requiring the directive in each instruction header and the lockfile-installed Markdownlint binary for self-contained validation
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-15 - Fix Instruction Validation During Push
+
+**Fixed:**
+
+- aligned the tracked markdownlint configuration with instruction mirror validation by allowing extra blank lines, so formatting-only whitespace before mirrored instruction sections no longer blocks validated pushes
+- added a regression assertion that the repository configuration preserves this instruction-validation contract
+
+---
+
 ## 2026-07-15 - Pin Nested Dependabot Workflow Actions
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 **Fixed:**
 
-- aligned the tracked markdownlint configuration with instruction mirror validation by allowing extra blank lines, so formatting-only whitespace before mirrored instruction sections no longer blocks validated pushes
-- added a regression assertion that the repository configuration preserves this instruction-validation contract
+- scoped the extra-blank-line exception to the authoritative and mirrored instruction files, so formatting-only whitespace differences no longer block validated pushes without weakening repository-wide Markdown validation
+- added positive and negative regression coverage for the file-local exception and continued enforcement in ordinary Markdown files
 
 ---
 

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -13,6 +13,11 @@ trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/bin"
 
+if ! grep -qE '"MD012"[[:space:]]*:[[:space:]]*false' "$REPO_ROOT/.markdownlint.json"; then
+    echo "repository markdownlint configuration must allow extra blank lines in mirrored instruction sections" >&2
+    exit 1
+fi
+
 cat >"$workspace/bin/npx" <<'STUB'
 #!/usr/bin/env bash
 exit 0

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -19,28 +19,23 @@ if grep -qE '"MD012"[[:space:]]*:[[:space:]]*false' "$REPO_ROOT/.markdownlint.js
 fi
 
 for instruction_file in AGENTS.md .github/copilot-instructions.md; do
-    if ! grep -q '^<!-- markdownlint-disable MD012 -->$' "$REPO_ROOT/$instruction_file"; then
-        echo "$instruction_file must scope the mirrored-instruction blank-line exception to itself" >&2
+    if ! sed -n '1,10p' "$REPO_ROOT/$instruction_file" \
+        | grep -q '^<!-- markdownlint-disable MD012 -->$'; then
+        echo "$instruction_file must scope the mirrored-instruction blank-line exception in its header" >&2
         exit 1
     fi
 done
 
+MARKDOWNLINT="$REPO_ROOT/node_modules/.bin/markdownlint"
+if [ ! -x "$MARKDOWNLINT" ]; then
+    echo "repository-pinned markdownlint is required; run npm ci" >&2
+    exit 1
+fi
+
 run_markdownlint_fixture() {
     local target="$1"
 
-    if [ -x "$REPO_ROOT/node_modules/.bin/markdownlint" ]; then
-        "$REPO_ROOT/node_modules/.bin/markdownlint" --config "$REPO_ROOT/.markdownlint.json" "$target"
-        return
-    fi
-
-    if command -v npx >/dev/null 2>&1; then
-        npx --yes --package markdownlint-cli@0.49.0 markdownlint \
-            --config "$REPO_ROOT/.markdownlint.json" "$target"
-        return
-    fi
-
-    echo "markdownlint is required; run npm ci" >&2
-    return 127
+    "$MARKDOWNLINT" --config "$REPO_ROOT/.markdownlint.json" "$target"
 }
 
 cat >"$workspace/ordinary-markdown.md" <<'EOF'

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -13,8 +13,57 @@ trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/bin"
 
-if ! grep -qE '"MD012"[[:space:]]*:[[:space:]]*false' "$REPO_ROOT/.markdownlint.json"; then
-    echo "repository markdownlint configuration must allow extra blank lines in mirrored instruction sections" >&2
+if grep -qE '"MD012"[[:space:]]*:[[:space:]]*false' "$REPO_ROOT/.markdownlint.json"; then
+    echo "repository markdownlint configuration must keep excessive blank-line validation enabled" >&2
+    exit 1
+fi
+
+for instruction_file in AGENTS.md .github/copilot-instructions.md; do
+    if ! grep -q '^<!-- markdownlint-disable MD012 -->$' "$REPO_ROOT/$instruction_file"; then
+        echo "$instruction_file must scope the mirrored-instruction blank-line exception to itself" >&2
+        exit 1
+    fi
+done
+
+run_markdownlint_fixture() {
+    local target="$1"
+
+    if [ -x "$REPO_ROOT/node_modules/.bin/markdownlint" ]; then
+        "$REPO_ROOT/node_modules/.bin/markdownlint" --config "$REPO_ROOT/.markdownlint.json" "$target"
+        return
+    fi
+
+    if command -v npx >/dev/null 2>&1; then
+        npx --yes --package markdownlint-cli@0.49.0 markdownlint \
+            --config "$REPO_ROOT/.markdownlint.json" "$target"
+        return
+    fi
+
+    echo "markdownlint is required; run npm ci" >&2
+    return 127
+}
+
+cat >"$workspace/ordinary-markdown.md" <<'EOF'
+# Ordinary Markdown
+
+
+Excessive blank lines must still fail repository-wide validation.
+EOF
+if run_markdownlint_fixture "$workspace/ordinary-markdown.md" >/dev/null 2>&1; then
+    echo "repository markdownlint configuration unexpectedly allows excessive blank lines" >&2
+    exit 1
+fi
+
+cat >"$workspace/mirrored-instruction.md" <<'EOF'
+<!-- markdownlint-disable MD012 -->
+
+# Mirrored Instruction
+
+
+Formatting-only blank-line differences are allowed in instruction mirrors.
+EOF
+if ! run_markdownlint_fixture "$workspace/mirrored-instruction.md" >/dev/null 2>&1; then
+    echo "file-local mirrored-instruction blank-line exception is ineffective" >&2
     exit 1
 fi
 
@@ -47,6 +96,8 @@ EOF
 SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
+
+<!-- markdownlint-disable MD012 -->
 
 # Test Agent Instructions
 
@@ -81,6 +132,8 @@ EOF
 SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: CC0-1.0
 -->
+
+<!-- markdownlint-disable MD012 -->
 
 # Test Copilot Instructions
 
@@ -177,7 +230,6 @@ touch "$normalized_mirror_repo/composer.json"
 write_common_instruction_file "$normalized_mirror_repo" "$valid_api_extra_ai_lines"
 cat >"$normalized_mirror_repo/.markdownlint.json" <<'EOF'
 {
-  "MD012": false,
   "MD013": false
 }
 EOF


### PR DESCRIPTION
## Failing validation

`git push -u origin replace-project-client-id` ran the instruction validator, which reported a markdownlint failure for `AGENTS.md`. Its regression fixture then failed when extra blank lines preceded a mirrored section.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/validate-ai-instructions.sh` exited with `repository markdownlint configuration must allow extra blank lines in mirrored instruction sections` before the instruction files declared a file-local MD012 exception.
- Passing proof after implementation: `bash tests/validate-ai-instructions.sh` passes with MD012 still enforced repository-wide and disabled only in the authoritative and mirrored instruction files.

## Changes

- Add file-local MD012 directives to `AGENTS.md` and `.github/copilot-instructions.md` while retaining repository-wide enforcement for ordinary Markdown.
- Add positive and negative fixtures for ordinary Markdown, mirrored instructions, directive placement in instruction headers, and use of the lockfile-installed Markdownlint binary.
- Record the fix in the changelog.

Closes #565.

## Validation

- `bash tests/validate-ai-instructions.sh`
- `npm run lint:markdown:ai`
- `bash scripts/validate-ai-instructions.sh`
- `./scripts/preflight.sh`

## Review status

- No linked workspaces, unresolved local checks, or open review threads.
- The final PR-view self-review and required checks are complete.
