### PR TITLE
fix(polyscope): coordinate linked workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-17 - Coordinate Polyscope Plan And Autopilot Modes
+
+**Fixed:**
+
+- provisioned a scoped global Codex instruction that keeps Plan strictly analysis-only, records required GitHub and branch setup as the first dependency-ordered Autopilot stories, and requires execution to continue in the resulting writable context
+- prevented sandbox, approval, or network denials from being misreported as user cancellations or invalid GitHub credentials without corresponding evidence
+- partitioned cross-repository plans by linked workspace root and explicitly delegated each repository scope to its own subagent during Autopilot execution
+- added rollout regression coverage for installing the global instruction without overwriting unrelated user guidance and for keeping its source under the existing rollout watcher
+
+---
+
 ## 2026-07-15 - Fix Instruction Validation During Push
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - prevented sandbox, approval, or network denials from being misreported as user cancellations or invalid GitHub credentials without corresponding evidence
 - partitioned cross-repository plans by linked workspace root and explicitly delegated each repository scope to its own subagent during Autopilot execution
 - added rollout regression coverage for installing the global instruction without overwriting unrelated user guidance, keeping its source under the existing rollout watcher, and retaining idempotent installs on `readlink` implementations without GNU-style option delimiters
+- hardened global guidance rollout to refresh stale installer-owned links, reject active global `AGENTS.override.md` files that would suppress the managed guidance, and isolate installer tests from an inherited `CODEX_HOME`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - provisioned a scoped global Codex instruction that keeps Plan strictly analysis-only, records required GitHub and branch setup as the first dependency-ordered Autopilot stories, and requires execution to continue in the resulting writable context
 - prevented sandbox, approval, or network denials from being misreported as user cancellations or invalid GitHub credentials without corresponding evidence
 - partitioned cross-repository plans by linked workspace root and explicitly delegated each repository scope to its own subagent during Autopilot execution
-- added rollout regression coverage for installing the global instruction without overwriting unrelated user guidance and for keeping its source under the existing rollout watcher
+- added rollout regression coverage for installing the global instruction without overwriting unrelated user guidance, keeping its source under the existing rollout watcher, and retaining idempotent installs on `readlink` implementations without GNU-style option delimiters
 
 ---
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -72,6 +72,7 @@ REAPER_TARGET="$BIN_DIR/reap-polyscope-clones.py"
 EXPOSE_WRAPPER_TARGET="$BIN_DIR/polyscope-expose-wrapper.sh"
 GIT_WRAPPER_TARGET="$BIN_DIR/polyscope-git-wrapper.sh"
 CODEX_AGENTS_TARGET="$CODEX_HOME_DIR/AGENTS.md"
+CODEX_AGENTS_OVERRIDE="$CODEX_HOME_DIR/AGENTS.override.md"
 SERVER_UNIT="$UNIT_DIR/polyscope-server.service"
 SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
 PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
@@ -152,6 +153,14 @@ run_privileged() {
     "$SUDO_BIN" -n "$@"
 }
 
+is_managed_codex_agents_link() {
+    local link_target
+
+    [[ -L "$CODEX_AGENTS_TARGET" ]] || return 1
+    link_target="$(readlink "$CODEX_AGENTS_TARGET")" || return 1
+    [[ "$link_target" == "$CODEX_AGENTS_SOURCE" || "$link_target" == /*/templates/polyscope-codex-AGENTS.md ]]
+}
+
 if [[ -z "$POLYSCOPE_SERVER_BIN" ]]; then
     echo "Error: polyscope-server binary not found. Pass --polyscope-server-bin or ensure it is in PATH." >&2
     exit 1
@@ -218,11 +227,15 @@ if [[ ! -f "$CODEX_AGENTS_SOURCE" ]]; then
     exit 1
 fi
 
-if [[ -e "$CODEX_AGENTS_TARGET" || -L "$CODEX_AGENTS_TARGET" ]]; then
-    if [[ ! -L "$CODEX_AGENTS_TARGET" || "$(readlink "$CODEX_AGENTS_TARGET")" != "$CODEX_AGENTS_SOURCE" ]]; then
-        echo "Error: refusing to overwrite existing Codex instructions: $CODEX_AGENTS_TARGET" >&2
-        exit 1
-    fi
+if [[ -f "$CODEX_AGENTS_OVERRIDE" && -s "$CODEX_AGENTS_OVERRIDE" ]]; then
+    echo "Error: AGENTS.override.md takes precedence over the managed AGENTS.md: $CODEX_AGENTS_OVERRIDE" >&2
+    echo "Merge the Polyscope guidance into the override, or remove or empty the override before re-running the installer." >&2
+    exit 1
+fi
+
+if [[ ( -e "$CODEX_AGENTS_TARGET" || -L "$CODEX_AGENTS_TARGET" ) ]] && ! is_managed_codex_agents_link; then
+    echo "Error: refusing to overwrite existing Codex instructions: $CODEX_AGENTS_TARGET" >&2
+    exit 1
 fi
 
 mkdir -p "$BIN_DIR" "$UNIT_DIR" "$CODEX_HOME_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -9,8 +9,10 @@ SOURCE_SCRIPT="$SCRIPT_DIR/polyscope-rollout.py"
 REAPER_SOURCE="$SCRIPT_DIR/reap-polyscope-clones.py"
 WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-expose-wrapper.sh"
 GIT_WRAPPER_SOURCE="$SCRIPT_DIR/polyscope-git-wrapper.sh"
+CODEX_AGENTS_SOURCE="$(cd -- "$SCRIPT_DIR/../templates" && pwd)/polyscope-codex-AGENTS.md"
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$HOME/code/SecPal}"
 BIN_DIR="$HOME/.local/bin"
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
 UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 POLYSCOPE_SERVER_BIN="${POLYSCOPE_SERVER_BIN:-$(command -v polyscope-server || true)}"
@@ -69,6 +71,7 @@ INSTALL_TARGET="$BIN_DIR/polyscope-secpal-rollout.py"
 REAPER_TARGET="$BIN_DIR/reap-polyscope-clones.py"
 EXPOSE_WRAPPER_TARGET="$BIN_DIR/polyscope-expose-wrapper.sh"
 GIT_WRAPPER_TARGET="$BIN_DIR/polyscope-git-wrapper.sh"
+CODEX_AGENTS_TARGET="$CODEX_HOME_DIR/AGENTS.md"
 SERVER_UNIT="$UNIT_DIR/polyscope-server.service"
 SERVICE_UNIT="$UNIT_DIR/polyscope-rollout-sync.service"
 PATH_UNIT="$UNIT_DIR/polyscope-rollout-sync.path"
@@ -169,7 +172,7 @@ if [[ ! -x "$POLYSCOPE_REAL_GIT_BIN" ]]; then
     exit 1
 fi
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR SERVICE_PATH SUDO_BIN; do
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE CODEX_AGENTS_SOURCE CODEX_HOME_DIR POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR SERVICE_PATH SUDO_BIN; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -210,11 +213,24 @@ if ! can_run_privileged_commands; then
     exit 1
 fi
 
-mkdir -p "$BIN_DIR" "$UNIT_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"
+if [[ ! -f "$CODEX_AGENTS_SOURCE" ]]; then
+    echo "Error: Polyscope Codex instructions not found: $CODEX_AGENTS_SOURCE" >&2
+    exit 1
+fi
+
+if [[ -e "$CODEX_AGENTS_TARGET" || -L "$CODEX_AGENTS_TARGET" ]]; then
+    if [[ ! -L "$CODEX_AGENTS_TARGET" || "$(readlink -- "$CODEX_AGENTS_TARGET")" != "$CODEX_AGENTS_SOURCE" ]]; then
+        echo "Error: refusing to overwrite existing Codex instructions: $CODEX_AGENTS_TARGET" >&2
+        exit 1
+    fi
+fi
+
+mkdir -p "$BIN_DIR" "$UNIT_DIR" "$CODEX_HOME_DIR" "$POLYSCOPE_GIT_BIN_DIR" "$(dirname -- "$POLYSCOPE_EXPOSE_BIN")" "$(dirname -- "$POLYSCOPE_EXPOSE_REAL_BIN")"
 ln -sfn "$SOURCE_SCRIPT" "$INSTALL_TARGET"
 ln -sfn "$REAPER_SOURCE" "$REAPER_TARGET"
 ln -sfn "$WRAPPER_SOURCE" "$EXPOSE_WRAPPER_TARGET"
 ln -sfn "$GIT_WRAPPER_SOURCE" "$GIT_WRAPPER_TARGET"
+ln -sfn "$CODEX_AGENTS_SOURCE" "$CODEX_AGENTS_TARGET"
 
 if [[ -e "$POLYSCOPE_EXPOSE_BIN" && ! -L "$POLYSCOPE_EXPOSE_BIN" ]]; then
     if [[ -e "$POLYSCOPE_EXPOSE_REAL_BIN" ]]; then
@@ -333,6 +349,7 @@ PathChanged=$WORKSPACE_ROOT/changelog/.github/instructions
 PathChanged=$WORKSPACE_ROOT/.github/AGENTS.md
 PathChanged=$WORKSPACE_ROOT/.github/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/.github/.github/instructions
+PathChanged=$CODEX_AGENTS_SOURCE
 PathChanged=$SOURCE_SCRIPT
 
 [Install]
@@ -450,6 +467,7 @@ echo "Installed $EXPOSE_WRAPPER_TARGET"
 echo "Installed $GIT_WRAPPER_TARGET"
 echo "Installed expose wrapper at $POLYSCOPE_EXPOSE_BIN"
 echo "Installed git wrapper at $POLYSCOPE_GIT_WRAPPER_BIN"
+echo "Installed Codex instructions at $CODEX_AGENTS_TARGET"
 echo "Installed $installed_server_target"
 echo "Installed $SERVICE_UNIT"
 echo "Installed $PATH_UNIT"

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -219,7 +219,7 @@ if [[ ! -f "$CODEX_AGENTS_SOURCE" ]]; then
 fi
 
 if [[ -e "$CODEX_AGENTS_TARGET" || -L "$CODEX_AGENTS_TARGET" ]]; then
-    if [[ ! -L "$CODEX_AGENTS_TARGET" || "$(readlink -- "$CODEX_AGENTS_TARGET")" != "$CODEX_AGENTS_SOURCE" ]]; then
+    if [[ ! -L "$CODEX_AGENTS_TARGET" || "$(readlink "$CODEX_AGENTS_TARGET")" != "$CODEX_AGENTS_SOURCE" ]]; then
         echo "Error: refusing to overwrite existing Codex instructions: $CODEX_AGENTS_TARGET" >&2
         exit 1
     fi

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2854,6 +2854,8 @@ def render_copilot_compat_instructions(spec: dict[str, Any]) -> str:
             "SPDX-License" + "-Identifier: AGPL-3.0-or-later",
             "-->",
             "",
+            "<!-- markdownlint-disable MD012 -->",
+            "",
             f"# {spec['display_name']} Copilot Instructions",
             "",
             "This file mirrors the authoritative root `AGENTS.md` for tooling",

--- a/templates/polyscope-codex-AGENTS.md
+++ b/templates/polyscope-codex-AGENTS.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Polyscope linked-workspace coordination
+
+Apply these rules only when the session says it is running inside Polyscope.
+
+## Linked repositories
+
+- Treat every entry in `workspace_roots` as a separate repository and execution
+  root. A linked workspace makes those roots available; it does not by itself
+  move the main agent or start an agent in each repository.
+- When a request or approved plan spans multiple linked repositories,
+  explicitly delegate independent repository scopes to subagents. Assign one
+  owner per affected root and include that exact root as the subagent's working
+  directory. Keep dependency-ordered scopes sequential; run independent scopes
+  in parallel.
+- The main agent owns cross-repository sequencing, shared contract decisions,
+  integration checks, and the consolidated status. Do not implement a sibling
+  repository's scope from the primary repository merely because its files are
+  reachable by absolute path.
+- Partition a plan intended for Autopilot by repository. Every story must name
+  its workspace root, dependencies, acceptance criteria, and validation
+  commands. After plan approval, explicitly dispatch each story in its named
+  root.
+
+## Planning versus execution
+
+- Determine the active mode and sandbox before using tools. A Polyscope Plan
+  session is analysis-only and must not attempt any side effect: no branch
+  rename, file change, commit, push, GitHub issue creation, or side-effecting
+  connector call. Read-only inspection is allowed when it helps produce the
+  plan.
+- If the requested outcome requires an EPIC, sub-issues, branches, or other
+  setup, describe their exact repositories, contents, links, and ordering in
+  the plan. Make their creation the first dependency-ordered Autopilot stories,
+  before implementation stories.
+- A tool result such as cancelled, denied, or unauthenticated does not prove
+  that the user cancelled an action or that stored credentials are invalid.
+  Never attribute that denial to the user unless the user explicitly cancelled
+  it. Report the actual sandbox, approval, network, or authentication evidence.
+- After plan approval, use **Use plan for Autopilot** and continue only in the
+  resulting writable execution context. Verify that context before the first
+  side effect, then execute all approved stories instead of remaining in the
+  planning workspace.
+- In Autopilot, rename the branch separately in every affected repository before that
+  repository's first write, then verify it with
+  `git status --short --branch`.
+
+## GitHub diagnostics
+
+- Distinguish authentication failure from sandboxed networking. Failure to
+  reach `api.github.com` does not prove that the stored token is invalid.
+- Validate `gh auth status` only in a network-capable Autopilot or Work context
+  before treating a GitHub failure as an authentication problem.

--- a/templates/polyscope-codex-AGENTS.md
+++ b/templates/polyscope-codex-AGENTS.md
@@ -41,7 +41,7 @@ Apply these rules only when the session says it is running inside Polyscope.
   that the user cancelled an action or that stored credentials are invalid.
   Never attribute that denial to the user unless the user explicitly cancelled
   it. Report the actual sandbox, approval, network, or authentication evidence.
-- After plan approval, use **Use plan for Autopilot** and continue only in the
+- After plan approval, select **Use plan for Autopilot** and continue only in the
   resulting writable execution context. Verify that context before the first
   side effect, then execute all approved stories instead of remaining in the
   planning workspace.

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -764,6 +764,7 @@ if grep -qF '"command": "php artisan migrate:fresh --seed"' "$workspace_root/api
 fi
 grep -q 'frontend/AGENTS.md before taking action' "$workspace_root/frontend/polyscope.local.json"
 grep -q 'https://frontend-{{worktree}}.preview.secpal.dev' "$workspace_root/frontend/polyscope.local.json"
+grep -qFx '<!-- markdownlint-disable MD012 -->' "$workspace_root/.github/.github/copilot-instructions.md"
 grep -q '## Always-On Rules' "$workspace_root/frontend/.github/copilot-instructions.md"
 grep -q 'https://guardguide-{{worktree}}.preview.secpal.dev' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -q 'https://secpal-app-{{worktree}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
@@ -4721,6 +4722,13 @@ test -L "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -x "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -L "$fake_bin_dir/polyscope-git-wrapper.sh"
 test -x "$fake_bin_dir/polyscope-git-wrapper.sh"
+test -L "$home_dir/.codex/AGENTS.md"
+test "$(readlink "$home_dir/.codex/AGENTS.md")" = "$REPO_ROOT/templates/polyscope-codex-AGENTS.md"
+# shellcheck disable=SC2016 # Backticks are literal Markdown in the expected text.
+grep -qF 'Treat every entry in `workspace_roots` as a separate repository' "$home_dir/.codex/AGENTS.md"
+grep -qF 'Use plan for Autopilot' "$home_dir/.codex/AGENTS.md"
+grep -qF 'must not attempt any side effect' "$home_dir/.codex/AGENTS.md"
+grep -qF 'Never attribute that denial to the user' "$home_dir/.codex/AGENTS.md"
 test -L "$fake_polyscope_git_dir/git"
 test -x "$fake_polyscope_git_dir/git"
 test "$(readlink "$fake_polyscope_git_dir/git")" = "$fake_bin_dir/polyscope-git-wrapper.sh"
@@ -4728,6 +4736,27 @@ test -L "$fake_polyscope_bin_dir/expose-linux-x64"
 test -x "$fake_polyscope_bin_dir/expose-linux-x64"
 test -x "$fake_polyscope_bin_dir/expose-linux-x64.real"
 test "$(readlink "$fake_polyscope_bin_dir/expose-linux-x64")" = "$fake_bin_dir/polyscope-expose-wrapper.sh"
+
+# Existing user-managed global guidance must not be replaced by rollout.
+custom_codex_home="$workspace/custom-codex-home"
+mkdir -p "$custom_codex_home"
+printf '# User-managed Codex guidance\n' >"$custom_codex_home/AGENTS.md"
+custom_codex_install_exit=0
+env HOME="$home_dir" \
+    CODEX_HOME="$custom_codex_home" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null \
+    || custom_codex_install_exit=$?
+if [[ "$custom_codex_install_exit" -eq 0 ]]; then
+    echo "installer must refuse to overwrite user-managed Codex instructions" >&2
+    exit 1
+fi
+grep -qxF '# User-managed Codex guidance' "$custom_codex_home/AGENTS.md"
 
 # Re-running the installer after the expose binary has been wrapped must stay idempotent.
 env HOME="$home_dir" \
@@ -4882,6 +4911,7 @@ grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-
 grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
+grep -q '/templates/polyscope-codex-AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'StartLimitIntervalSec=300' "$fake_unit_dir/polyscope-worktree-provision.service"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4645,6 +4645,7 @@ fake_expose_real_log="$workspace/expose-real.log"
 fake_git_real_log="$workspace/git-real.log"
 fake_polyscope_bin_dir="$home_dir/.polyscope/bin"
 fake_polyscope_git_dir="$home_dir/.local/lib/polyscope/bin"
+fake_codex_home="$home_dir/.codex"
 real_readlink_bin="$(command -v readlink)"
 export REAL_READLINK_BIN="$real_readlink_bin"
 mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir" "$fake_sudo_dir" "$fake_polyscope_bin_dir" "$fake_polyscope_git_dir"
@@ -4717,6 +4718,7 @@ STUB
 chmod +x "$fake_sudo_dir/sudo"
 
 env HOME="$home_dir" \
+    CODEX_HOME="$fake_codex_home" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
@@ -4734,13 +4736,13 @@ test -L "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -x "$fake_bin_dir/polyscope-expose-wrapper.sh"
 test -L "$fake_bin_dir/polyscope-git-wrapper.sh"
 test -x "$fake_bin_dir/polyscope-git-wrapper.sh"
-test -L "$home_dir/.codex/AGENTS.md"
-test "$(readlink "$home_dir/.codex/AGENTS.md")" = "$REPO_ROOT/templates/polyscope-codex-AGENTS.md"
+test -L "$fake_codex_home/AGENTS.md"
+test "$(readlink "$fake_codex_home/AGENTS.md")" = "$REPO_ROOT/templates/polyscope-codex-AGENTS.md"
 # shellcheck disable=SC2016 # Backticks are literal Markdown in the expected text.
-grep -qF 'Treat every entry in `workspace_roots` as a separate repository' "$home_dir/.codex/AGENTS.md"
-grep -qF 'select **Use plan for Autopilot**' "$home_dir/.codex/AGENTS.md"
-grep -qF 'must not attempt any side effect' "$home_dir/.codex/AGENTS.md"
-grep -qF 'Never attribute that denial to the user' "$home_dir/.codex/AGENTS.md"
+grep -qF 'Treat every entry in `workspace_roots` as a separate repository' "$fake_codex_home/AGENTS.md"
+grep -qF 'select **Use plan for Autopilot**' "$fake_codex_home/AGENTS.md"
+grep -qF 'must not attempt any side effect' "$fake_codex_home/AGENTS.md"
+grep -qF 'Never attribute that denial to the user' "$fake_codex_home/AGENTS.md"
 test -L "$fake_polyscope_git_dir/git"
 test -x "$fake_polyscope_git_dir/git"
 test "$(readlink "$fake_polyscope_git_dir/git")" = "$fake_bin_dir/polyscope-git-wrapper.sh"
@@ -4770,8 +4772,75 @@ if [[ "$custom_codex_install_exit" -eq 0 ]]; then
 fi
 grep -qxF '# User-managed Codex guidance' "$custom_codex_home/AGENTS.md"
 
+# A dangling link created by an older checkout must be refreshed, while an
+# unrelated symlink remains protected as user-managed guidance.
+stale_codex_home="$workspace/stale-codex-home"
+stale_codex_target="$workspace/old-checkout/templates/polyscope-codex-AGENTS.md"
+mkdir -p "$stale_codex_home"
+touch "$stale_codex_home/AGENTS.override.md"
+ln -s "$stale_codex_target" "$stale_codex_home/AGENTS.md"
+env HOME="$home_dir" \
+    CODEX_HOME="$stale_codex_home" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
+    FAKE_EXPOSE_REAL_LOG="$fake_expose_real_log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin"
+test "$(readlink "$stale_codex_home/AGENTS.md")" = "$REPO_ROOT/templates/polyscope-codex-AGENTS.md"
+
+unrelated_codex_home="$workspace/unrelated-codex-home"
+unrelated_codex_source="$workspace/unrelated-guidance.md"
+mkdir -p "$unrelated_codex_home"
+printf '# Unrelated linked guidance\n' >"$unrelated_codex_source"
+ln -s "$unrelated_codex_source" "$unrelated_codex_home/AGENTS.md"
+unrelated_codex_install_exit=0
+env HOME="$home_dir" \
+    CODEX_HOME="$unrelated_codex_home" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>/dev/null \
+    || unrelated_codex_install_exit=$?
+if [[ "$unrelated_codex_install_exit" -eq 0 ]]; then
+    echo "installer must refuse to overwrite unrelated linked Codex instructions" >&2
+    exit 1
+fi
+test "$(readlink "$unrelated_codex_home/AGENTS.md")" = "$unrelated_codex_source"
+
+# Non-empty global overrides take precedence over AGENTS.md and must not let
+# the installer report that inactive Polyscope guidance was installed.
+override_codex_home="$workspace/override-codex-home"
+override_codex_error="$workspace/override-codex-error.log"
+mkdir -p "$override_codex_home"
+printf '# User override\n' >"$override_codex_home/AGENTS.override.md"
+override_codex_install_exit=0
+env HOME="$home_dir" \
+    CODEX_HOME="$override_codex_home" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$fake_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$workspace/user-sudo.log" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$fake_bin_dir" --unit-dir "$fake_unit_dir" --polyscope-server-bin "$fake_server_bin" 2>"$override_codex_error" \
+    || override_codex_install_exit=$?
+if [[ "$override_codex_install_exit" -eq 0 ]]; then
+    echo "installer must reject a non-empty global Codex override" >&2
+    exit 1
+fi
+grep -qF 'AGENTS.override.md takes precedence' "$override_codex_error"
+grep -qxF '# User override' "$override_codex_home/AGENTS.override.md"
+test ! -e "$override_codex_home/AGENTS.md"
+
 # Re-running the installer after the expose binary has been wrapped must stay idempotent.
 env HOME="$home_dir" \
+    CODEX_HOME="$fake_codex_home" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
@@ -4787,6 +4856,7 @@ rm -f "$fake_polyscope_bin_dir/expose-linux-x64"
 cp "$fake_polyscope_bin_dir/expose-linux-x64.real" "$fake_polyscope_bin_dir/expose-linux-x64"
 
 env HOME="$home_dir" \
+    CODEX_HOME="$fake_codex_home" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
@@ -4811,6 +4881,7 @@ printf '#!/usr/bin/env bash\nexit 7\n' >"$fake_guard_expose_real"
 chmod +x "$fake_guard_expose_real"
 install_real_guard_exit=0
 env HOME="$home_dir" \
+    CODEX_HOME="$fake_codex_home" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$fake_systemctl_log" \
@@ -4849,6 +4920,7 @@ STUB
 chmod +x "$system_polyscope_bin_dir/expose-linux-x64"
 
 env HOME="$system_home_dir" \
+    CODEX_HOME="$system_home_dir/.codex" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$system_systemctl_log" \
@@ -4892,6 +4964,7 @@ system_fallback_dropin_dir="$workspace/system-fallback-service-units/polyscope-s
 mkdir -p "$system_fallback_dropin_dir"
 
 env HOME="$system_home_dir" \
+    CODEX_HOME="$system_home_dir/.codex" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$system_systemctl_log" \
@@ -5007,6 +5080,7 @@ chmod +x "$no_sudo_sudo_dir/sudo"
 
 no_sudo_exit=0
 env HOME="$no_sudo_home_dir" \
+    CODEX_HOME="$no_sudo_home_dir/.codex" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$no_sudo_systemctl_log" \
@@ -5033,6 +5107,7 @@ exit 0
 STUB
 chmod +x "$no_sudo_user_home_dir/.polyscope/bin/expose-linux-x64"
 env HOME="$no_sudo_user_home_dir" \
+    CODEX_HOME="$no_sudo_user_home_dir/.codex" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$no_sudo_systemctl_log" \
@@ -5053,6 +5128,7 @@ test ! -e "$no_sudo_user_unit_dir/polyscope-rollout-sync.service"
 # installer must also refuse when --polyscope-server-scope system is forced but no unit exists
 no_unit_exit=0
 env HOME="$no_sudo_home_dir" \
+    CODEX_HOME="$no_sudo_home_dir/.codex" \
     WORKSPACE_ROOT="$workspace_root" \
     SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
     SYSTEMCTL_LOG="$no_sudo_systemctl_log" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4645,6 +4645,8 @@ fake_expose_real_log="$workspace/expose-real.log"
 fake_git_real_log="$workspace/git-real.log"
 fake_polyscope_bin_dir="$home_dir/.polyscope/bin"
 fake_polyscope_git_dir="$home_dir/.local/lib/polyscope/bin"
+real_readlink_bin="$(command -v readlink)"
+export REAL_READLINK_BIN="$real_readlink_bin"
 mkdir -p "$fake_bin_dir" "$fake_unit_dir" "$fake_systemctl_dir" "$fake_sudo_dir" "$fake_polyscope_bin_dir" "$fake_polyscope_git_dir"
 mkdir -p "$(dirname "$fake_server_bin")"
 
@@ -4684,6 +4686,16 @@ fi
 exit 0
 STUB
 chmod +x "$fake_systemctl_dir/systemctl"
+
+cat >"$fake_systemctl_dir/readlink" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--" ]]; then
+    echo "readlink: unsupported option: --" >&2
+    exit 64
+fi
+exec "$REAL_READLINK_BIN" "$@"
+STUB
+chmod +x "$fake_systemctl_dir/readlink"
 
 cat >"$fake_sudo_dir/sudo" <<'STUB'
 #!/usr/bin/env bash
@@ -4726,7 +4738,7 @@ test -L "$home_dir/.codex/AGENTS.md"
 test "$(readlink "$home_dir/.codex/AGENTS.md")" = "$REPO_ROOT/templates/polyscope-codex-AGENTS.md"
 # shellcheck disable=SC2016 # Backticks are literal Markdown in the expected text.
 grep -qF 'Treat every entry in `workspace_roots` as a separate repository' "$home_dir/.codex/AGENTS.md"
-grep -qF 'Use plan for Autopilot' "$home_dir/.codex/AGENTS.md"
+grep -qF 'select **Use plan for Autopilot**' "$home_dir/.codex/AGENTS.md"
 grep -qF 'must not attempt any side effect' "$home_dir/.codex/AGENTS.md"
 grep -qF 'Never attribute that denial to the user' "$home_dir/.codex/AGENTS.md"
 test -L "$fake_polyscope_git_dir/git"


### PR DESCRIPTION
## What changed

- install a Polyscope-scoped global Codex instruction through the existing rollout installer
- keep Plan sessions analysis-only and require repository-scoped Autopilot execution for linked workspaces
- preserve user-managed global Codex guidance instead of overwriting it
- keep the instruction source under the rollout watcher
- preserve the required local Markdownlint exception when Polyscope regenerates Copilot compatibility mirrors

## Why

Linked Polyscope workspaces expose multiple repository roots, but the runtime guidance did not reliably distinguish planning from writable execution or require repository-specific delegation. This could leave approved work in the planning context, blur repository ownership, and misclassify sandbox or network denials.

The active rollout renderer also omitted the file-local `MD012` exception when regenerating Copilot compatibility instructions, leaving a dirty, validation-failing mirror.

## Impact

Polyscope sessions receive scoped coordination rules without changing non-Polyscope behavior. Existing user-managed global Codex instructions are protected, and generated compatibility mirrors remain valid.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` exited 1 after adding the regression assertion for the missing `MD012` marker and before changing the renderer.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` exited 0 after the renderer fix; `./scripts/preflight.sh` subsequently completed with `Preflight OK`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/polyscope-rollout.sh`
- `./scripts/preflight.sh`
- commit hooks: REUSE, Prettier, Markdownlint, Shellcheck, large-file, conflict, EOF, whitespace, and line-ending checks
- GPG/SSH commit signature verified
- four-pass local review completed with no open findings
