### PR TITLE
fix(polyscope): complete workspace lifecycle closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
+
+**Fixed:**
+
+- wrapped canonical validation and every generated native setup command in one strict fail-closed shell entry, preventing multiline or `||`-bearing setup entries from running after an invalid workspace and stopping all later setup after any command failure
+- preserved physical registered workspace paths as the authoritative Polyscope deletion identity, tracked stable direct aliases separately, and removed only verified Package-1-owned broken aliases after official deletion
+- serialized worktree provisioning with an invocation lock, coalesced database event bursts before execution, bounded the service activation window so expected bursts cannot fail the path unit, and made installer convergence clear only historical provision-unit failure state
+
 ## 2026-07-18 - Close Polyscope Workspace Lifecycle Gaps
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -278,10 +278,15 @@ root-owned helper validates and renders the one fixed preview nginx target
 before testing and reloading nginx. Failed validation or reload restores the
 previous target.
 
-Every generated workspace setup starts with canonical instruction validation.
-The external provisioner considers only active worktrees registered in the
-Polyscope database, while unregistered clone directories remain solely under
-the conservative seven-day clone-reaper policy. See
+Every generated workspace setup is one fail-closed shell unit: canonical
+instruction validation must succeed before the complete native setup sequence,
+and any later setup failure stops all remaining commands. The external
+provisioner considers only active worktrees registered in the Polyscope
+database. It preserves their physical paths as the authoritative deletion
+identity and tracks stable aliases separately for bounded cleanup. Unregistered
+clone directories remain solely under the conservative seven-day clone-reaper
+policy. Provision events are serialized and briefly coalesced so SQLite bursts
+cannot permanently fail the path unit. See
 [`scripts/README.md`](scripts/README.md) for installation and verification
 details.
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -119,11 +119,14 @@ licensing, frontmatter, or size rules. All managed source roots are validated
 before any instruction-dependent local configuration or repository metadata is
 written. A missing validator or missing Markdown tooling blocks rollout.
 
-Generated Polyscope workspace setup sequences invoke the validation-only
-`--validate-instruction-worktree` mode as their first effective boundary.
-Polyscope may already have created and registered the candidate at that point,
-but canonical validation must succeed before npm, Composer, `.env`, database,
-migration, seed, or any other native setup command runs.
+Generated Polyscope workspace setup sequences contain exactly one strict shell
+entry. That entry invokes the validation-only
+`--validate-instruction-worktree` mode, then runs the complete original native
+setup as fail-fast command groups. Polyscope may already have created and
+registered the candidate at that point, but canonical validation must succeed
+before npm, Composer, `.env`, database, migration, seed, or any other native
+setup command runs. A multiline command cannot escape the guard, and failure of
+any native command stops every later setup operation.
 
 The external worktree provisioner derives its allowlist only from active
 `worktrees` registrations in the current Polyscope SQLite database. Registered
@@ -139,6 +142,16 @@ provisionable candidates before the first such candidate mutation, so one
 invalid candidate cannot leave another candidate partially provisioned.
 Validator failures remain errors and include the affected root and canonical
 validator output.
+
+The provisioner keeps the resolved physical hash directory as the authoritative
+`worktrees.path` deletion identity. It never replaces that database value with
+a stable alias. Direct sibling aliases are tracked separately in a strict
+per-repository registry. When official workspace deletion removes the physical
+path and active registration, the database event reconciliation removes only
+recorded aliases whose exact direct target is gone; symlink chains, traversal,
+changed targets, non-directory targets, and unrelated aliases fail closed or
+remain untouched. The seven-day clone reaper is reserved for genuinely
+unregistered historical clones, not successful workspace deletion.
 
 The direct `--prepare-api-worktree`, `--bootstrap-api-worktree`,
 `--refresh-api-worktree`, and `--run-api-worktree` commands share one
@@ -190,7 +203,16 @@ The rollout sync path watches the rollout, canonical validator, manifest
 library and helper sources, instruction roots and Codex template, committed
 `package-lock.json`, and installed `node_modules/.package-lock.json`. The
 provision path watches database and local-configuration state, while its timer
-provides a bounded fallback. No user unit invokes broad privileged commands.
+provides a bounded fallback. Both target one process-locked provision service.
+Each activation waits three seconds to coalesce SQLite event bursts; the
+five-start, ten-second limit therefore cannot be exhausted by expected
+activations. systemd collapses duplicate starts while the oneshot is active;
+the three-minute timer provides a bounded recovery run if a path event does not
+yield a follow-up activation. No-op provisioning avoids rewriting the database
+or watched local configuration. The installer clears only historical failed
+state for the provision path and service during deliberate convergence;
+subsequent service failures remain visible. No user unit invokes broad
+privileged commands.
 
 Rollout requires both independent files, always reads runtime policy from
 `AGENTS.md`, and never treats the Copilot review profile as runtime

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -391,16 +391,29 @@ managed repositories automatically when the canonical repo list changes. Both
 the provision path and the three-minute fallback timer are enabled. The
 provisioner reads only active `worktrees` registrations from `polyscope.db`,
 resolves them beneath the matching repository clone root, and never scans an
-unregistered clone as a setup candidate. The paired daily
+unregistered clone as a setup candidate. The physical hash directory remains
+the database's authoritative deletion path. Stable aliases are direct sibling
+symlinks recorded in a strict per-repository registry; after official deletion
+removes the physical path and registration, the next database-triggered
+reconciliation removes only those recorded broken aliases. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.
 
 Every generated repository setup sequence starts with the validation-only
-`--validate-instruction-worktree` command. It validates the actual candidate
-root synchronously before npm, Composer, `.env`, database, migration, seed, or
-repository setup commands can run. The external provisioner applies the same
-canonical contract before its local configuration, hook, alias, setup, and
-marker writes.
+`--validate-instruction-worktree` command inside one strict shell entry. That
+entry groups the complete native setup with fail-fast semantics, so validation
+or any later command failure prevents every remaining npm, Composer, `.env`,
+database, migration, seed, build, or repository setup command. The external
+provisioner applies the same canonical contract before its local configuration,
+hook, alias, setup, and marker writes.
+
+The worktree provision service waits three seconds before each activation to
+coalesce SQLite event bursts and takes a process-shared lock before provisioning.
+The path and fallback timer both target that serialized service. Five starts per
+ten seconds cannot be exhausted by the three-second activations, while genuine
+service failures remain visible. A deliberate user-installer convergence clears
+only historical failed state for the provision path and service before enabling
+the new unit contract; it does not hide later failures.
 
 ### `install-polyscope-system-components.sh`
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -22,6 +22,7 @@ POLYSCOPE_REAL_GIT_BIN="${POLYSCOPE_REAL_GIT_BIN:-$(command -v git || true)}"
 POLYSCOPE_API_BASE="${POLYSCOPE_API_BASE:-http://127.0.0.1:4321/api}"
 POLYSCOPE_CLONE_ROOT="${POLYSCOPE_CLONE_ROOT:-$HOME/.polyscope/clones}"
 POLYSCOPE_HOME="${POLYSCOPE_HOME:-$HOME/.polyscope}"
+POLYSCOPE_PROVISION_LOCK="${POLYSCOPE_PROVISION_LOCK:-$HOME/.local/state/polyscope/worktree-provision.lock}"
 POLYSCOPE_EXPOSE_BIN="${POLYSCOPE_EXPOSE_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64}"
 POLYSCOPE_EXPOSE_REAL_BIN="${POLYSCOPE_EXPOSE_REAL_BIN:-$POLYSCOPE_HOME/bin/expose-linux-x64.real}"
 POLYSCOPE_GIT_BIN_DIR="${POLYSCOPE_GIT_BIN_DIR:-$HOME/.local/lib/polyscope/bin}"
@@ -175,7 +176,7 @@ if [[ ! -x "$POLYSCOPE_REAL_GIT_BIN" ]]; then
     exit 1
 fi
 
-for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE NGINX_LIBRARY_SOURCE NGINX_HELPER_SOURCE CODEX_AGENTS_SOURCE CODEX_HOME_DIR POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR SERVICE_PATH SUDO_BIN POLYSCOPE_NGINX_HELPER POLYSCOPE_NGINX_HELPER_CHECK POLYSCOPE_NGINX_MANIFEST; do
+for _var_name in WORKSPACE_ROOT SOURCE_SCRIPT WRAPPER_SOURCE GIT_WRAPPER_SOURCE NGINX_LIBRARY_SOURCE NGINX_HELPER_SOURCE CODEX_AGENTS_SOURCE CODEX_HOME_DIR POLYSCOPE_SERVER_BIN POLYSCOPE_REAL_GIT_BIN POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_HOME POLYSCOPE_PROVISION_LOCK POLYSCOPE_EXPOSE_BIN POLYSCOPE_EXPOSE_REAL_BIN POLYSCOPE_GIT_BIN_DIR POLYSCOPE_GIT_WRAPPER_BIN POLYSCOPE_SERVER_SCOPE POLYSCOPE_SYSTEM_SERVER_UNIT POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR SERVICE_PATH SUDO_BIN POLYSCOPE_NGINX_HELPER POLYSCOPE_NGINX_HELPER_CHECK POLYSCOPE_NGINX_MANIFEST; do
     _val="${!_var_name}"
     if [[ "$_val" == *$'\n'* ]]; then
         echo "Error: $_var_name must not contain newlines" >&2
@@ -237,7 +238,7 @@ if [[ ! -f "$VALIDATOR_PACKAGE_LOCK" \
 fi
 
 # Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.
-for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE INSTALL_TARGET; do
+for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE POLYSCOPE_PROVISION_LOCK INSTALL_TARGET; do
     _val="${!_var_name}"
     if [[ "$_val" =~ [^a-zA-Z0-9/_.:-] ]]; then
         echo "Error: $_var_name contains characters that are unsafe in shell command strings; only letters, digits, /, _, ., :, - are permitted" >&2
@@ -476,12 +477,10 @@ cat >"$PROVISION_SERVICE_UNIT" <<EOF
 [Unit]
 Description=Provision SecPal Polyscope worktrees automatically
 After=polyscope-rollout-sync.service
-# Bound the self-trigger feedback loop: DB sync writes to polyscope.db which is
-# watched by the paired path unit; without a burst cap this can re-trigger the
-# service until systemd rate-limits the unit. Five starts per five minutes
-# leaves room for the three-minute fallback timer plus real workspace events
-# without letting the provisioning loop run away indefinitely.
-StartLimitIntervalSec=300
+# Each activation spends three seconds coalescing SQLite event bursts before
+# the serialized provisioner runs. With five starts per ten seconds, even
+# immediate failures remain visible without making the path unit hit its limit.
+StartLimitIntervalSec=10
 StartLimitBurst=5
 
 [Service]
@@ -490,7 +489,8 @@ WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --skip-local-configs --skip-db-sync --provision-worktrees
+ExecStartPre=/usr/bin/sleep 3
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --clone-root $POLYSCOPE_CLONE_ROOT --provision-lock-path $POLYSCOPE_PROVISION_LOCK --skip-local-configs --skip-db-sync --provision-worktrees
 EOF
 
 cat >"$PROVISION_PATH_UNIT" <<EOF
@@ -500,6 +500,7 @@ cat >"$PROVISION_PATH_UNIT" <<EOF
 Description=Watch SecPal Polyscope worktree metadata and generated local config for automatic provisioning
 
 [Path]
+Unit=polyscope-worktree-provision.service
 PathChanged=$HOME/.polyscope/polyscope.db
 PathModified=$HOME/.polyscope/polyscope.db-wal
 PathChanged=$WORKSPACE_ROOT/api/polyscope.local.json
@@ -522,6 +523,7 @@ cat >"$PROVISION_TIMER_UNIT" <<EOF
 Description=Poll SecPal Polyscope worktrees for provisioning fallback
 
 [Timer]
+Unit=polyscope-worktree-provision.service
 OnStartupSec=30s
 OnUnitActiveSec=3min
 Persistent=true
@@ -569,6 +571,10 @@ fi
 
 "$SYSTEMCTL_BIN" --user enable --now polyscope-rollout-sync.path
 "$SYSTEMCTL_BIN" --user start polyscope-rollout-sync.service
+# A prior unit-start-limit-hit survives unit replacement. Clear only the two
+# provision units during this deliberate convergence before enabling the new
+# coalesced path contract; later service failures remain observable.
+"$SYSTEMCTL_BIN" --user reset-failed polyscope-worktree-provision.path polyscope-worktree-provision.service
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.path
 "$SYSTEMCTL_BIN" --user enable --now polyscope-worktree-provision.timer
 "$SYSTEMCTL_BIN" --user enable --now polyscope-clone-reaper.timer

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -17,8 +17,10 @@ import secrets
 import shlex
 import shutil
 import sqlite3
+import stat
 import subprocess
 import sys
+import tempfile
 import textwrap
 import urllib.parse
 import urllib.request
@@ -209,7 +211,10 @@ def find_current_worktree_record(
     current_path = resolve_path_for_matching(worktree_path)
     columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(worktrees)")}
     order_by = "created_at desc, id desc" if "created_at" in columns else "id desc"
-    rows = connection.execute(f"select id, path from worktrees order by {order_by}").fetchall()
+    where_clause = " where status = 'active'" if "status" in columns else ""
+    rows = connection.execute(
+        f"select id, path from worktrees{where_clause} order by {order_by}"
+    ).fetchall()
 
     for worktree_id, registered_path in rows:
         if not isinstance(registered_path, str) or not registered_path.strip():
@@ -3498,50 +3503,194 @@ def sync_worktree_local_config(worktree_path: pathlib.Path, config_text: str) ->
     ensure_exclude(worktree_path, {POLYSCOPE_LOCAL_CONFIG_NAME, PROVISION_MARKER_FILENAME})
 
 
-def normalize_registered_workspace_path(
+def workspace_alias_registry_path(repo_clone_root: pathlib.Path) -> pathlib.Path:
+    return repo_clone_root / WORKSPACE_ALIAS_REGISTRY_FILENAME
+
+
+def validate_workspace_alias_component(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value in {".", ".."}:
+        raise RuntimeError(f"workspace alias registry has an invalid {field}")
+    if pathlib.PurePath(value).name != value or "/" in value or "\\" in value or "\0" in value:
+        raise RuntimeError(f"workspace alias registry {field} must be one path component")
+    return value
+
+
+def load_workspace_alias_registry(repo_clone_root: pathlib.Path) -> dict[str, str]:
+    registry_path = workspace_alias_registry_path(repo_clone_root)
+    if not registry_path.exists() and not registry_path.is_symlink():
+        return {}
+    if registry_path.is_symlink() or not registry_path.is_file():
+        raise RuntimeError(f"workspace alias registry is not a regular file: {registry_path}")
+
+    try:
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"unable to read workspace alias registry {registry_path}: {error}") from error
+    if not isinstance(payload, dict) or set(payload) != {"version", "aliases"}:
+        raise RuntimeError(f"workspace alias registry has an invalid schema: {registry_path}")
+    if payload["version"] != 1 or not isinstance(payload["aliases"], dict):
+        raise RuntimeError(f"workspace alias registry has an unsupported schema: {registry_path}")
+
+    aliases: dict[str, str] = {}
+    for raw_alias, raw_target in payload["aliases"].items():
+        alias = validate_workspace_alias_component(raw_alias, "alias")
+        target = validate_workspace_alias_component(raw_target, "target")
+        if alias == target:
+            raise RuntimeError(f"workspace alias registry maps {alias} to itself: {registry_path}")
+        aliases[alias] = target
+    return aliases
+
+
+def write_workspace_alias_registry(repo_clone_root: pathlib.Path, aliases: dict[str, str]) -> None:
+    registry_path = workspace_alias_registry_path(repo_clone_root)
+    if registry_path.is_symlink() or (registry_path.exists() and not registry_path.is_file()):
+        raise RuntimeError(f"workspace alias registry is not a regular file: {registry_path}")
+    if not aliases:
+        registry_path.unlink(missing_ok=True)
+        return
+
+    payload = json.dumps({"version": 1, "aliases": dict(sorted(aliases.items()))}, indent=2) + "\n"
+    repo_clone_root.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{WORKSPACE_ALIAS_REGISTRY_FILENAME}.",
+        dir=repo_clone_root,
+    )
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, registry_path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
+def record_workspace_alias(alias_path: pathlib.Path, worktree_path: pathlib.Path) -> None:
+    repo_clone_root = worktree_path.parent
+    if alias_path.parent != repo_clone_root or alias_path == worktree_path:
+        raise RuntimeError(f"workspace alias must be a distinct direct child of {repo_clone_root}: {alias_path}")
+    if worktree_path.is_symlink() or not worktree_path.is_dir():
+        raise RuntimeError(f"workspace alias target must be a physical directory: {worktree_path}")
+    if not alias_path.is_symlink() or os.readlink(alias_path) != worktree_path.name:
+        raise RuntimeError(f"workspace alias must point directly to {worktree_path.name}: {alias_path}")
+
+    alias_name = validate_workspace_alias_component(alias_path.name, "alias")
+    target_name = validate_workspace_alias_component(worktree_path.name, "target")
+    aliases = load_workspace_alias_registry(repo_clone_root)
+    if aliases.get(alias_name) == target_name:
+        return
+    if alias_name in aliases:
+        raise RuntimeError(f"workspace alias registry already owns {alias_path} for another target")
+    aliases[alias_name] = target_name
+    write_workspace_alias_registry(repo_clone_root, aliases)
+
+
+def preserve_registered_workspace_physical_path(
     worktree_path: pathlib.Path,
     *,
     db_path: pathlib.Path | None = None,
 ) -> None:
+    """Keep the server-owned deletion identity on the physical directory."""
+    if worktree_path.is_symlink() or not worktree_path.is_dir():
+        raise RuntimeError(f"registered workspace is not a physical directory: {worktree_path}")
+    physical_path = worktree_path.resolve(strict=True)
     resolved_db_path = db_path or default_polyscope_db_path()
-    if not resolved_db_path.exists():
-        return
-
-    normalized_path = worktree_path.parent / resolve_current_workspace_name(worktree_path, db_path=resolved_db_path)
-    if normalized_path == worktree_path:
-        return
-
-    if normalized_path.exists() and not normalized_path.is_symlink():
-        return
-
-    if normalized_path.is_symlink():
-        try:
-            if normalized_path.resolve() != worktree_path.resolve():
-                return
-        except OSError:
-            return
+    if not resolved_db_path.is_file():
+        raise RuntimeError(f"Polyscope DB not found while preserving workspace path: {resolved_db_path}")
 
     try:
         with sqlite3.connect(resolved_db_path) as connection:
-            current_worktree = find_current_worktree_record(connection, worktree_path)
+            current_worktree = find_current_worktree_record(connection, physical_path)
             if current_worktree is None:
+                raise RuntimeError(f"no current Polyscope registration matches {physical_path}")
+            worktree_id, registered_value = current_worktree
+            if not isinstance(worktree_id, str) or not isinstance(registered_value, str):
+                raise RuntimeError(f"Polyscope registration for {physical_path} is incomplete")
+
+            registered_path = pathlib.Path(registered_value)
+            if registered_path == physical_path:
                 return
+            if not registered_path.is_absolute() or registered_path.parent.resolve() != physical_path.parent:
+                raise RuntimeError(
+                    f"registered workspace alias is outside the physical clone root: {registered_path}"
+                )
+            if not registered_path.is_symlink():
+                raise RuntimeError(
+                    f"registered workspace path differs from its physical directory without a direct alias: {registered_path}"
+                )
+            link_target = pathlib.Path(os.readlink(registered_path))
+            if link_target.is_absolute() or len(link_target.parts) != 1 or link_target.name != physical_path.name:
+                raise RuntimeError(
+                    f"registered workspace path is not a direct alias to {physical_path.name}: {registered_path}"
+                )
+            if registered_path.resolve(strict=True) != physical_path:
+                raise RuntimeError(f"registered workspace alias target mismatch: {registered_path}")
 
-            worktree_id = current_worktree[0]
-            connection.execute(
-                """
-                update worktrees
-                set path = ?
-                where id = ?
-                """,
-                (str(normalized_path), worktree_id),
+            record_workspace_alias(registered_path, physical_path)
+            cursor = connection.execute(
+                "update worktrees set path = ? where id = ? and path = ?",
+                (str(physical_path), worktree_id, registered_value),
             )
+            if cursor.rowcount != 1:
+                raise RuntimeError(f"Polyscope registration changed while preserving {physical_path}")
             connection.commit()
-    except sqlite3.Error:
-        return
+    except sqlite3.Error as error:
+        raise RuntimeError(
+            f"unable to preserve physical Polyscope workspace path {physical_path}: {error}"
+        ) from error
 
-    if not normalized_path.exists():
-        normalized_path.symlink_to(worktree_path.name)
+
+def cleanup_removed_workspace_aliases(
+    repo_state: dict[str, dict[str, Any]],
+    clone_root: pathlib.Path,
+    registered_worktrees: dict[str, list[pathlib.Path]],
+) -> list[str]:
+    """Remove only recorded aliases whose physical registered target is gone."""
+    resolved_clone_root = clone_root.resolve()
+    removed: list[str] = []
+
+    for repo_name, repo_entry in repo_state.items():
+        repo_clone_root = resolved_clone_root / str(repo_entry["id"])
+        if repo_clone_root.is_symlink():
+            raise RuntimeError(f"repository clone root must not be a symlink: {repo_clone_root}")
+        aliases = load_workspace_alias_registry(repo_clone_root)
+        if not aliases:
+            continue
+
+        registered_targets = {
+            path.resolve()
+            for path in registered_worktrees.get(repo_name, [])
+        }
+        retained: dict[str, str] = {}
+        for alias_name, target_name in aliases.items():
+            alias_path = repo_clone_root / alias_name
+            target_path = repo_clone_root / target_name
+            if alias_path.is_symlink():
+                if os.readlink(alias_path) != target_name:
+                    raise RuntimeError(f"recorded workspace alias changed target: {alias_path}")
+            elif alias_path.exists():
+                raise RuntimeError(f"recorded workspace alias became a non-symlink: {alias_path}")
+
+            if target_path.is_symlink() or (target_path.exists() and not target_path.is_dir()):
+                raise RuntimeError(f"recorded workspace alias target is not a physical directory: {target_path}")
+            if target_path.exists() or target_path.resolve() in registered_targets:
+                retained[alias_name] = target_name
+                continue
+
+            if alias_path.is_symlink():
+                alias_path.unlink()
+                removed.append(str(alias_path))
+                continue
+
+        if retained != aliases:
+            write_workspace_alias_registry(repo_clone_root, retained)
+
+    return sorted(removed)
 
 
 def ensure_workspace_alias(worktree_path: pathlib.Path, *, db_path: pathlib.Path | None = None) -> None:
@@ -3556,6 +3705,7 @@ def ensure_workspace_alias(worktree_path: pathlib.Path, *, db_path: pathlib.Path
     if alias_path.is_symlink():
         try:
             if alias_path.resolve() == worktree_path.resolve():
+                record_workspace_alias(alias_path, worktree_path)
                 return
         except OSError:
             # Broken or inaccessible symlinks are recreated below.
@@ -3568,6 +3718,7 @@ def ensure_workspace_alias(worktree_path: pathlib.Path, *, db_path: pathlib.Path
         )
 
     alias_path.symlink_to(worktree_path.name)
+    record_workspace_alias(alias_path, worktree_path)
 
 
 def sync_worktree_auxiliary_files(repo_name: str, worktree_path: pathlib.Path) -> None:
@@ -3740,6 +3891,14 @@ def provision_worktrees(
     if canonical_validation_failed:
         return [], [], failed_provision_worktrees
 
+    removed_workspace_aliases = cleanup_removed_workspace_aliases(
+        repo_state,
+        clone_root,
+        registered_worktrees,
+    )
+    for removed_alias in removed_workspace_aliases:
+        print(f"Removed stale managed workspace alias {removed_alias}")
+
     cleaned_preview_storage_targets = cleanup_removed_api_preview_databases(
         repo_state,
         repo_specs,
@@ -3752,7 +3911,7 @@ def provision_worktrees(
 
     for repo_name, spec, worktree_path, _validation_commands, setup_commands in provisionable_worktrees:
         try:
-            normalize_registered_workspace_path(worktree_path, db_path=db_path)
+            preserve_registered_workspace_physical_path(worktree_path, db_path=db_path)
             config_text = render_worktree_local_config(spec, worktree_path, db_path=db_path)
             sync_worktree_local_config(worktree_path, config_text)
             ensure_workspace_alias(worktree_path, db_path=db_path)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import argparse
 import base64
+import contextlib
 import copy
+import fcntl
 import hashlib
 import json
 import os
@@ -100,6 +102,34 @@ class CanonicalInstructionValidationError(RuntimeError):
 
 def default_polyscope_db_path() -> pathlib.Path:
     return pathlib.Path(os.environ.get("POLYSCOPE_DB_PATH", pathlib.Path.home() / ".polyscope" / "polyscope.db"))
+
+
+def default_provision_lock_path() -> pathlib.Path:
+    return pathlib.Path.home() / ".local" / "state" / "polyscope" / "worktree-provision.lock"
+
+
+@contextlib.contextmanager
+def provision_worktree_lock(lock_path: pathlib.Path):
+    """Serialize provisioners without making the lock itself a watched input."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if lock_path.is_symlink():
+        raise RuntimeError(f"provision lock must not be a symlink: {lock_path}")
+
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        lock_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(lock_stat.st_mode):
+            raise RuntimeError(f"provision lock must be a regular file: {lock_path}")
+        if lock_stat.st_uid != os.geteuid() or lock_stat.st_nlink != 1:
+            raise RuntimeError(f"provision lock must be owned by the caller and have one link: {lock_path}")
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(descriptor)
 
 
 def resolve_path_for_matching(path: pathlib.Path) -> str:
@@ -4681,6 +4711,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
     parser.add_argument("--db-path", type=pathlib.Path, default=default_polyscope_db_path())
     parser.add_argument("--clone-root", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "clones")
+    parser.add_argument("--provision-lock-path", type=pathlib.Path, default=default_provision_lock_path())
     parser.add_argument("--polyscope-api-base", default="http://127.0.0.1:4321/api")
     parser.add_argument("--repo-state-file", type=pathlib.Path)
     parser.add_argument(
@@ -4770,13 +4801,14 @@ def main() -> int:
     cleaned_preview_storage_targets: list[str] = []
     failed_provision_worktrees: list[dict[str, str]] = []
     if args.provision_worktrees:
-        provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
-            repo_state,
-            repo_specs,
-            args.clone_root,
-            db_path=args.db_path,
-            validated_instruction_roots=validated_instruction_roots,
-        )
+        with provision_worktree_lock(args.provision_lock_path):
+            provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
+                repo_state,
+                repo_specs,
+                args.clone_root,
+                db_path=args.db_path,
+                validated_instruction_roots=validated_instruction_roots,
+            )
 
     summary = build_summary(
         repo_state,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -35,6 +35,8 @@ DEFAULT_NGINX_MANIFEST_PATH = pathlib.Path("/home/secpal/.local/state/polyscope/
 DEFAULT_NGINX_HELPER_PATH = pathlib.Path("/usr/local/libexec/secpal-polyscope-nginx-apply")
 NGINX_MANIFEST_USER = "secpal"
 CANONICAL_VALIDATION_SPEC_KEY = "_canonical_ai_instruction_root"
+NATIVE_SETUP_COMMANDS_KEY = "_native_setup_commands"
+WORKSPACE_ALIAS_REGISTRY_FILENAME = ".polyscope-secpal-workspace-aliases.json"
 DEFAULT_ANDROID_SDK_ROOT = pathlib.Path.home() / "Android" / "Sdk"
 PREVIEW_DATABASE_BASE_ENV_KEY = "POLYSCOPE_BASE_DB_DATABASE"
 PREVIEW_DB_PASSWORD_SOURCE_ENV_KEY = "POLYSCOPE_DB_PASSWORD_SOURCE"
@@ -519,6 +521,23 @@ def build_workspace_instruction_validation_command() -> str:
     """Return the synchronous guard used by Polyscope's native setup runner."""
     rollout_script = shlex.quote(str(ROLLOUT_SCRIPT_PATH))
     return f"python3 {rollout_script} --validate-instruction-worktree \"$PWD\""
+
+
+def build_fail_closed_setup_command(commands: list[str]) -> str:
+    """Render the complete Polyscope-native setup as one strict shell unit."""
+    if not commands:
+        raise ValueError("native setup requires at least one command")
+
+    grouped_commands = []
+    for command in commands:
+        if not isinstance(command, str) or not command.strip():
+            raise ValueError("native setup commands must be non-empty strings")
+        # Preserve command bytes exactly. Several commands contain quoted
+        # multiline Python whose indentation is semantically significant.
+        grouped_commands.append("(\n" + command + "\n)")
+
+    setup_script = "set -euo pipefail\n" + "\n".join(grouped_commands)
+    return f"bash -c {shlex.quote(setup_script)}"
 
 
 def build_api_preview_env_setup_command(source_repo_path: pathlib.Path) -> str:
@@ -1309,7 +1328,7 @@ def cleanup_removed_api_preview_databases(
         return []
 
     api_spec = repo_specs["api"]
-    api_validation_commands = render_local_config(api_spec).get("scripts", {}).get("setup", [])
+    api_validation_commands = list(api_spec[NATIVE_SETUP_COMMANDS_KEY])
     active_targets: set[str] = set()
     for worktree_path in registered_api_worktrees:
         active_targets.add(
@@ -2832,10 +2851,13 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
                     continue
                 if run_action.get("command") in API_RUNTIME_PREVIEW_COMMANDS:
                     run_action["command"] = build_api_preview_runtime_shell_command(run_action["command"], repo_path)
-        spec["local_config"]["scripts"]["setup"].insert(
-            0,
-            build_workspace_instruction_validation_command(),
-        )
+        native_setup_commands = list(spec["local_config"]["scripts"]["setup"])
+        spec[NATIVE_SETUP_COMMANDS_KEY] = native_setup_commands
+        spec["local_config"]["scripts"]["setup"] = [
+            build_fail_closed_setup_command(
+                [build_workspace_instruction_validation_command(), *native_setup_commands]
+            )
+        ]
         repo_specs[repo_name] = spec
     return repo_specs
 
@@ -3216,7 +3238,10 @@ def validate_repo_local_configs(repo_specs: dict[str, dict[str, Any]]) -> None:
         package_scripts = load_package_scripts(repo_path)
         composer_scripts = load_composer_scripts(repo_path)
 
-        for command in config.get("scripts", {}).get("setup", []):
+        for command in spec.get(
+            NATIVE_SETUP_COMMANDS_KEY,
+            config.get("scripts", {}).get("setup", []),
+        ):
             validate_local_config_command(repo_name, repo_path, package_scripts, composer_scripts, command)
 
         for item in config.get("scripts", {}).get("run", []):
@@ -3652,14 +3677,13 @@ def provision_worktrees(
     canonical_validation_failed = False
 
     for repo_name, spec in repo_specs.items():
-        local_config = render_local_config(spec)
-        validation_commands = local_config.get("scripts", {}).get("setup", [])
+        validation_commands = list(spec[NATIVE_SETUP_COMMANDS_KEY])
         setup_commands = validation_commands
         if repo_name == "api":
             # The external provisioner already validated the candidate and the
             # API bootstrap command performs its own readiness preparation.
-            # Skip the native-runner validation and prepare entries here.
-            setup_commands = setup_commands[2:]
+            # Skip the native runner's prepare entry here.
+            setup_commands = setup_commands[1:]
 
         for worktree_path in registered_worktrees[repo_name]:
             if not worktree_path.is_dir() or worktree_path.is_symlink():

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -15,9 +15,11 @@ import json
 import os
 import pathlib
 import shlex
+import shutil
 import sqlite3
 import subprocess
 import sys
+import time
 
 repo_root = pathlib.Path(sys.argv[1])
 workspace = pathlib.Path(sys.argv[2])
@@ -294,7 +296,7 @@ github_source.joinpath("package-lock.json").write_text(
 repo_specs = module.build_repo_specs(source_workspace)
 clone_root = workspace / "clone root with spaces"
 github_clone_root = clone_root / repo_state[".github"]["id"]
-valid_candidate = github_clone_root / "registered-valid"
+valid_candidate = github_clone_root / "registered-valid-1a2b3c4d"
 invalid_candidate = github_clone_root / "registered-invalid"
 unregistered_candidate = github_clone_root / "silent-seal-unregistered"
 outside_candidate = workspace / "outside-clone-root"
@@ -383,6 +385,211 @@ assert not unregistered_candidate.joinpath(module.PROVISION_MARKER_FILENAME).exi
 assert unregistered_sentinel.read_bytes() == b"unchanged"
 assert str(unregistered_candidate) not in setup_log.read_text()
 assert unregistered_candidate.is_dir()
+
+# Provisioning must preserve the physical hash directory as the authoritative
+# server deletion path. Stable aliases are separately owned and tracked by the
+# rollout so they can be removed after the official deletion removes the
+# physical target and database registration.
+deletion_candidate = github_clone_root / "registered-delete-5e6f7a8b"
+deletion_git_source = workspace / "official deletion git source"
+deletion_git_source.mkdir()
+subprocess.run(["git", "init", "-b", "main", str(deletion_git_source)], check=True, capture_output=True)
+write_valid_instructions(deletion_git_source)
+deletion_git_source.joinpath("package.json").write_text(
+    json.dumps({"name": "registered-delete", "private": True}) + "\n"
+)
+deletion_git_source.joinpath("package-lock.json").write_text(
+    json.dumps(
+        {
+            "name": "registered-delete",
+            "lockfileVersion": 3,
+            "requires": True,
+            "packages": {},
+        }
+    )
+    + "\n"
+)
+subprocess.run(["git", "-C", str(deletion_git_source), "add", "."], check=True)
+subprocess.run(
+    [
+        "git",
+        "-C",
+        str(deletion_git_source),
+        "-c",
+        "user.name=Package 1 fixture",
+        "-c",
+        "user.email=package-1-fixture@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-m",
+        "test: seed deletion fixture",
+    ],
+    check=True,
+    capture_output=True,
+)
+subprocess.run(
+    [
+        "git",
+        "-C",
+        str(deletion_git_source),
+        "worktree",
+        "add",
+        "-b",
+        "package-1-deletion-fixture",
+        str(deletion_candidate),
+    ],
+    check=True,
+    capture_output=True,
+)
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        "insert into worktrees (id, repo_id, branch, path, status) values (?, ?, ?, ?, 'active')",
+        ("delete", repo_state[".github"]["id"], "delete", str(deletion_candidate)),
+    )
+provisioned, cleaned, failures = module.provision_worktrees(
+    repo_state,
+    repo_specs,
+    clone_root,
+    db_path=db_path,
+)
+assert provisioned == [".github:registered-delete"], provisioned
+assert cleaned == []
+assert failures == []
+
+with sqlite3.connect(db_path) as connection:
+    registered_path = connection.execute(
+        "select path from worktrees where id = 'delete'"
+    ).fetchone()[0]
+assert pathlib.Path(registered_path) == deletion_candidate
+primary_alias = github_clone_root / "registered-delete"
+assert primary_alias.is_symlink()
+assert os.readlink(primary_alias) == deletion_candidate.name
+assert deletion_candidate.joinpath(module.PROVISION_MARKER_FILENAME).is_file()
+deletion_candidate.joinpath("node_modules").mkdir()
+deletion_candidate.joinpath("node_modules", "dependency-sentinel").write_text("installed")
+
+source_config_snapshots: dict[pathlib.Path, tuple[bytes, int]] = {}
+for source_root_entry in source_workspace.iterdir():
+    source_config = source_root_entry / module.POLYSCOPE_LOCAL_CONFIG_NAME
+    source_config.write_text('{"sentinel":true}\n')
+    source_config_snapshots[source_config] = (
+        source_config.read_bytes(),
+        source_config.stat().st_mtime_ns,
+    )
+db_snapshot = (db_path.read_bytes(), db_path.stat().st_mtime_ns)
+provisioned, cleaned, failures = module.provision_worktrees(
+    repo_state,
+    repo_specs,
+    clone_root,
+    db_path=db_path,
+)
+assert provisioned == []
+assert cleaned == []
+assert failures == []
+assert (db_path.read_bytes(), db_path.stat().st_mtime_ns) == db_snapshot
+for source_config, snapshot in source_config_snapshots.items():
+    assert (source_config.read_bytes(), source_config.stat().st_mtime_ns) == snapshot
+
+secondary_alias = github_clone_root / "registered-delete-secondary"
+secondary_alias.symlink_to(deletion_candidate.name)
+module.record_workspace_alias(secondary_alias, deletion_candidate)
+unrelated_alias = github_clone_root / "user-owned-alias"
+unrelated_alias.symlink_to(deletion_candidate.name)
+assert unrelated_alias.is_symlink()
+
+# Model the official server contract: delete precisely the registered path and
+# row, then let the registration-triggered provision reconciliation clean only
+# Package-1-owned aliases. This is deliberately not a clone-reaper fixture.
+deletion_result = subprocess.run(
+    # Polyscope owns the generated local config and provision marker, so its
+    # official delete is allowed to remove those untracked lifecycle files.
+    ["git", "-C", str(deletion_git_source), "worktree", "remove", "--force", str(registered_path)],
+    capture_output=True,
+    text=True,
+)
+assert deletion_result.returncode == 0, (
+    deletion_result.stdout,
+    deletion_result.stderr,
+    subprocess.run(
+        ["git", "-C", str(deletion_candidate), "status", "--short", "--ignored"],
+        capture_output=True,
+        text=True,
+    ).stdout,
+)
+with sqlite3.connect(db_path) as connection:
+    connection.execute("delete from worktrees where id = 'delete'")
+    assert connection.execute("select count(*) from worktrees where id = 'delete'").fetchone()[0] == 0
+removed_aliases = module.cleanup_removed_workspace_aliases(
+    repo_state,
+    clone_root,
+    {repo_name: [] for repo_name in repo_state},
+)
+assert removed_aliases == sorted([str(primary_alias), str(secondary_alias)])
+assert not deletion_candidate.exists()
+assert not deletion_candidate.joinpath("node_modules", "dependency-sentinel").exists()
+assert not deletion_candidate.joinpath(module.PROVISION_MARKER_FILENAME).exists()
+assert str(deletion_candidate) not in subprocess.run(
+    ["git", "-C", str(deletion_git_source), "worktree", "list", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout
+assert not primary_alias.exists() and not primary_alias.is_symlink()
+assert not secondary_alias.exists() and not secondary_alias.is_symlink()
+assert unrelated_alias.is_symlink(), (
+    os.path.lexists(unrelated_alias),
+    module.load_workspace_alias_registry(github_clone_root),
+    removed_aliases,
+)
+assert module.load_workspace_alias_registry(github_clone_root) == {
+    "registered-valid": valid_candidate.name,
+}
+
+# Registration aliases may be migrated back to their verified physical target,
+# but symlink chains and paths outside the expected repository clone root are
+# never accepted as authoritative deletion identities.
+chain_target = github_clone_root / "chain-target-2b3c4d5e"
+chain_target.mkdir()
+chain_middle = github_clone_root / "chain-middle"
+chain_middle.symlink_to(chain_target.name)
+chain_alias = github_clone_root / "chain-alias"
+chain_alias.symlink_to(chain_middle.name)
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        "insert into worktrees (id, repo_id, branch, path, status) values (?, ?, ?, ?, 'active')",
+        ("chain", repo_state[".github"]["id"], "chain", str(chain_alias)),
+    )
+try:
+    module.preserve_registered_workspace_physical_path(chain_target, db_path=db_path)
+except RuntimeError as error:
+    assert "direct alias" in str(error).lower() or "symlink" in str(error).lower(), error
+else:
+    raise AssertionError("symlink-chain registration must fail closed")
+with sqlite3.connect(db_path) as connection:
+    assert connection.execute("select path from worktrees where id = 'chain'").fetchone()[0] == str(chain_alias)
+    connection.execute("delete from worktrees where id = 'chain'")
+
+# Registry records cannot escape the repository clone root or turn another
+# user-owned path into an alias-cleanup target.
+unsafe_registry_root = clone_root / repo_state["GuardGuide"]["id"]
+unsafe_registry_root.mkdir(parents=True)
+outside_sentinel = workspace / "outside-alias-sentinel"
+outside_sentinel.write_text("unchanged")
+module.workspace_alias_registry_path(unsafe_registry_root).write_text(
+    json.dumps({"version": 1, "aliases": {"managed": "../outside-alias-sentinel"}}) + "\n"
+)
+try:
+    module.cleanup_removed_workspace_aliases(
+        repo_state,
+        clone_root,
+        {repo_name: [] for repo_name in repo_state},
+    )
+except RuntimeError as error:
+    assert "one path component" in str(error), error
+else:
+    raise AssertionError("workspace alias registry traversal must fail closed")
+assert outside_sentinel.read_text() == "unchanged"
 
 # SQLite URI mode must quote legal filename characters instead of treating
 # them as URI query, fragment, or percent-escape syntax and selecting or

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -697,5 +697,67 @@ except (RuntimeError, SystemExit, ValueError) as error:
 else:
     raise AssertionError("registered path outside clone root must fail closed")
 
+# A process-shared provision lock serializes path, timer, and manual callers.
+# The second real process must remain blocked until the first releases the
+# production lock helper, then complete exactly once.
+lock_path = workspace / "state with spaces" / "worktree-provision.lock"
+holder_ready = workspace / "holder-ready"
+lock_probe = """
+import importlib.util
+import pathlib
+import sys
+import time
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", pathlib.Path(sys.argv[1]))
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+with module.provision_worktree_lock(pathlib.Path(sys.argv[2])):
+    pathlib.Path(sys.argv[3]).write_text("acquired")
+    time.sleep(float(sys.argv[4]))
+"""
+holder = subprocess.Popen(
+    [sys.executable, "-B", "-c", lock_probe, str(script_path), str(lock_path), str(holder_ready), "0.5"]
+)
+for _ in range(100):
+    if holder_ready.exists():
+        break
+    time.sleep(0.01)
+else:
+    holder.terminate()
+    holder.wait()
+    raise AssertionError("first provision-lock process did not acquire the lock")
+
+contender_ready = workspace / "contender-ready"
+contender = subprocess.Popen(
+    [sys.executable, "-B", "-c", lock_probe, str(script_path), str(lock_path), str(contender_ready), "0"]
+)
+time.sleep(0.1)
+assert contender.poll() is None, "provision lock did not serialize concurrent caller"
+assert not contender_ready.exists()
+assert holder.wait(timeout=3) == 0
+assert contender.wait(timeout=3) == 0
+assert contender_ready.read_text() == "acquired"
+
+lock_sentinel = workspace / "lock-sentinel"
+lock_sentinel.write_text("unchanged")
+symlink_lock = workspace / "symlink-provision.lock"
+symlink_lock.symlink_to(lock_sentinel.name)
+try:
+    with module.provision_worktree_lock(symlink_lock):
+        raise AssertionError("symlink provision lock must not be acquired")
+except RuntimeError as error:
+    assert "symlink" in str(error).lower(), error
+assert lock_sentinel.read_text() == "unchanged"
+
+hardlink_lock = workspace / "hardlink-provision.lock"
+os.link(lock_sentinel, hardlink_lock)
+try:
+    with module.provision_worktree_lock(hardlink_lock):
+        raise AssertionError("multiply linked provision lock must not be acquired")
+except RuntimeError as error:
+    assert "one link" in str(error).lower(), error
+assert lock_sentinel.read_text() == "unchanged"
+
 print("Package-1 setup-order and registered-worktree tests passed.")
 PY

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -51,14 +51,20 @@ def write_valid_instructions(root: pathlib.Path) -> None:
     )
 
 
-def run_setup_sequence(root: pathlib.Path, commands: list[str], env: dict[str, str]) -> None:
-    for command in commands:
-        subprocess.run(
-            ["bash", "-c", "set -euo pipefail; " + command],
-            cwd=root,
-            env=env,
-            check=True,
-        )
+def run_polyscope_setup(
+    root: pathlib.Path,
+    commands: list[str],
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Execute setup exactly as Polyscope joins the generated entries."""
+    return subprocess.run(
+        ["bash", "-c", " && ".join(commands)],
+        cwd=root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 # Every generated native setup must enter the real canonical validator before
@@ -66,53 +72,188 @@ def run_setup_sequence(root: pathlib.Path, commands: list[str], env: dict[str, s
 # inspecting source ordering.
 native_source_workspace = workspace / "native source roots"
 for repo_name in module.REPO_SETTINGS:
-    write_valid_instructions(native_source_workspace / repo_name)
+    source_root = native_source_workspace / repo_name
+    write_valid_instructions(source_root)
+    source_root.joinpath("package.json").write_text(
+        json.dumps({"name": f"source-{repo_name}", "private": True}) + "\n"
+    )
+    source_root.joinpath("package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": f"source-{repo_name}",
+                "lockfileVersion": 3,
+                "requires": True,
+                "packages": {},
+            }
+        )
+        + "\n"
+    )
+    source_root.joinpath(".env.example").write_text(
+        "APP_KEY=base64:test-key\nDB_CONNECTION=sqlite\nDB_DATABASE=database/database.sqlite\n"
+    )
 generated_specs = module.build_repo_specs(native_source_workspace)
-side_effect_script = (
-    "from pathlib import Path; "
-    "Path('.env').write_text('mutated\\n'); "
-    "Path('node_modules').mkdir(); "
-    "Path('vendor').mkdir(); "
-    "Path('database.sqlite').write_text('mutated'); "
-    "Path('.setup-side-effect').write_text('ran'); "
-    "Path('.polyscope-secpal-provisioned.json').write_text('{}')"
-)
-side_effect_command = f"python3 -c {shlex.quote(side_effect_script)}"
+native_fake_bin = workspace / "native fake bin"
+native_fake_bin.mkdir()
+native_setup_log = workspace / "native-setup.log"
+for executable in ("composer", "npm", "php"):
+    fake_executable = native_fake_bin / executable
+    fake_executable.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"printf '{executable}:%s\\n' \"$*\" >>\"$NATIVE_SETUP_LOG\"\n"
+        f"touch .native-{executable}-invoked\n"
+        + (
+            "mkdir -p node_modules\n"
+            "printf '{}\\n' >node_modules/.package-lock.json\n"
+            "if [[ \"${1:-}\" == run && \"${2:-}\" == build && -n \"${VITE_POLYSCOPE_OUTPUT_DIR:-}\" ]]; then\n"
+            "    mkdir -p \"$VITE_POLYSCOPE_OUTPUT_DIR\"\n"
+            "    printf '<html></html>\\n' >\"$VITE_POLYSCOPE_OUTPUT_DIR/index.html\"\n"
+            "fi\n"
+            "previous=''\n"
+            "for argument in \"$@\"; do\n"
+            "    if [[ \"$previous\" == --outDir ]]; then\n"
+            "        mkdir -p \"$argument\"\n"
+            "        printf '<html></html>\\n' >\"$argument/index.html\"\n"
+            "    fi\n"
+            "    previous=\"$argument\"\n"
+            "done\n"
+            if executable == "npm"
+            else "mkdir -p vendor; touch vendor/autoload.php\n"
+            if executable == "composer"
+            else ""
+        )
+        + "exit 0\n"
+    )
+    fake_executable.chmod(0o755)
+
+native_env = os.environ.copy()
+native_env["PATH"] = f"{native_fake_bin}:{native_env['PATH']}"
+native_env["NATIVE_SETUP_LOG"] = str(native_setup_log)
+native_env["POLYSCOPE_DB_PATH"] = str(workspace / "native-polyscope.db")
 
 for repo_name, generated_spec in generated_specs.items():
     setup_commands = module.render_local_config(generated_spec).get("scripts", {}).get("setup", [])
     assert setup_commands, repo_name
-    validation_command = setup_commands[0]
-    assert "--validate-instruction-worktree" in validation_command, (repo_name, validation_command)
+    assert "--validate-instruction-worktree" in setup_commands[0], (repo_name, setup_commands)
 
     invalid_root = workspace / "native setup ; invalid roots" / repo_name
     write_valid_instructions(invalid_root)
     invalid_root.joinpath("AGENTS.md").write_text("# Missing SPDX metadata\n")
+    invalid_root.joinpath("package.json").write_text(
+        json.dumps({"name": f"invalid-{repo_name}", "private": True}) + "\n"
+    )
+    invalid_root.joinpath("package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": f"invalid-{repo_name}",
+                "lockfileVersion": 3,
+                "requires": True,
+                "packages": {},
+            }
+        )
+        + "\n"
+    )
     unrelated = invalid_root / "unrelated-sentinel"
     unrelated.write_bytes(b"unchanged")
-    try:
-        run_setup_sequence(invalid_root, [validation_command, side_effect_command], os.environ.copy())
-    except subprocess.CalledProcessError:
-        pass
-    else:
-        raise AssertionError(f"invalid {repo_name} instructions reached native setup")
+    result = run_polyscope_setup(invalid_root, setup_commands, native_env)
+    assert result.returncode != 0, (repo_name, result.stdout, result.stderr)
+    assert "canonical AI-instruction validation failed" in result.stderr, (
+        repo_name,
+        result.stdout,
+        result.stderr,
+    )
+    assert "Canonical AI-instruction validation passed" not in result.stdout, result.stdout
 
     for forbidden in (
         ".env",
         "node_modules",
         "vendor",
         "database.sqlite",
-        ".setup-side-effect",
+        ".native-composer-invoked",
+        ".native-npm-invoked",
+        ".native-php-invoked",
         ".polyscope-secpal-provisioned.json",
     ):
-        assert not invalid_root.joinpath(forbidden).exists(), (repo_name, forbidden)
+        assert not invalid_root.joinpath(forbidden).exists(), (
+            repo_name,
+            forbidden,
+            setup_commands,
+            result.stdout,
+            result.stderr,
+            native_setup_log.read_text() if native_setup_log.exists() else "",
+        )
     assert unrelated.read_bytes() == b"unchanged"
 
-valid_root = workspace / "native setup valid root with spaces"
-write_valid_instructions(valid_root)
-valid_validation_command = module.render_local_config(generated_specs[".github"])["scripts"]["setup"][0]
-run_setup_sequence(valid_root, [valid_validation_command, side_effect_command], os.environ.copy())
-assert valid_root.joinpath(".setup-side-effect").read_text() == "ran"
+# The generated setup contract must be a single native-runner entry. Within
+# that entry, multiline commands remain ordered and any failure stops every
+# later command.
+for repo_name, generated_spec in generated_specs.items():
+    setup_commands = module.render_local_config(generated_spec)["scripts"]["setup"]
+    assert len(setup_commands) == 1, (repo_name, setup_commands)
+
+ordered_root = workspace / "ordered setup root with spaces ; and shell chars"
+ordered_root.mkdir(parents=True)
+ordered_log = ordered_root / "order.log"
+ordered_commands = [
+    "printf 'first\\n' >>order.log",
+    "for item in second; do printf '%s\\n' \"$item\" >>order.log; done",
+    "printf 'third\\n' >>order.log",
+]
+ordered_setup = module.build_fail_closed_setup_command(ordered_commands)
+ordered_result = run_polyscope_setup(ordered_root, [ordered_setup], os.environ.copy())
+assert ordered_result.returncode == 0, ordered_result.stderr
+assert ordered_log.read_text().splitlines() == ["first", "second", "third"]
+
+failing_commands = [
+    "printf 'first\\n' >failure-order.log",
+    "printf 'failed\\n' >>failure-order.log\nfalse",
+    "printf 'must-not-run\\n' >>failure-order.log",
+]
+failing_setup = module.build_fail_closed_setup_command(failing_commands)
+failing_result = run_polyscope_setup(ordered_root, [failing_setup], os.environ.copy())
+assert failing_result.returncode != 0
+assert ordered_root.joinpath("failure-order.log").read_text().splitlines() == ["first", "failed"]
+
+# Fully valid candidates retain the generated setup behavior for every managed
+# repository after entering the single fail-closed boundary.
+for repo_name, generated_spec in generated_specs.items():
+    valid_root = workspace / "native setup valid roots with spaces" / repo_name
+    write_valid_instructions(valid_root)
+    valid_root.joinpath("package.json").write_text(
+        json.dumps({"name": f"valid-{repo_name}", "private": True}) + "\n"
+    )
+    valid_root.joinpath("package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": f"valid-{repo_name}",
+                "lockfileVersion": 3,
+                "requires": True,
+                "packages": {},
+            }
+        )
+        + "\n"
+    )
+    valid_root.joinpath("composer.json").write_text(
+        json.dumps({"name": f"secpal/{repo_name.lower().replace('.', '-')}", "scripts": {}}) + "\n"
+    )
+    valid_root.joinpath("composer.lock").write_text("{}\n")
+    valid_root.joinpath(".env.example").write_text(
+        "APP_KEY=base64:test-key\nDB_CONNECTION=sqlite\nDB_DATABASE=database/database.sqlite\n"
+    )
+    valid_root.joinpath("database").mkdir()
+
+    setup_commands = module.render_local_config(generated_spec)["scripts"]["setup"]
+    result = run_polyscope_setup(valid_root, setup_commands, native_env)
+    assert result.returncode == 0, (repo_name, result.stdout, result.stderr)
+
+    native_commands = generated_spec[module.NATIVE_SETUP_COMMANDS_KEY]
+    command_text = "\n".join(native_commands)
+    if "npm " in command_text:
+        assert valid_root.joinpath(".native-npm-invoked").is_file(), repo_name
+    if "composer " in command_text:
+        assert valid_root.joinpath(".native-composer-invoked").is_file(), repo_name
+    if "php " in command_text or "--bootstrap-api-worktree" in command_text:
+        assert valid_root.joinpath(".native-php-invoked").is_file(), repo_name
 
 
 # Provisioning must use current active database registrations as its allowlist.

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1903,8 +1903,8 @@ assert "PLAYWRIGHT_BASE_URL=https://frontend-azure-cheetah.preview.secpal.dev" i
 assert "PLAYWRIGHT_API_BASE_URL=https://api-azure-cheetah.preview.secpal.dev" in playwright_probe_result.stdout, playwright_probe_result.stdout
 PY
 
-# normalize_registered_workspace_path must update the matched worktree row even when
-# Polyscope stored a different path string that resolves to the same directory.
+# The physical workspace must replace a safely verified legacy alias as the
+# authoritative deletion path, while stable aliases remain separately tracked.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
@@ -1970,7 +1970,8 @@ with sqlite3.connect(db_path) as connection:
         ("api-worktree", "frontend-worktree"),
     )
 
-module.normalize_registered_workspace_path(worktree_path, db_path=db_path)
+module.preserve_registered_workspace_physical_path(worktree_path, db_path=db_path)
+module.ensure_workspace_alias(worktree_path, db_path=db_path)
 
 with sqlite3.connect(db_path) as connection:
     stored_path = connection.execute(
@@ -1978,10 +1979,14 @@ with sqlite3.connect(db_path) as connection:
         ("api-worktree",),
     ).fetchone()[0]
 
-assert stored_path == str(worktree_path.parent / "azure-cheetah"), stored_path
+assert stored_path == str(worktree_path), stored_path
 normalized_path = worktree_path.parent / "azure-cheetah"
 assert normalized_path.is_symlink(), normalized_path
 assert normalized_path.resolve() == worktree_path.resolve(), normalized_path.resolve()
+assert module.load_workspace_alias_registry(worktree_path.parent) == {
+    "azure-cheetah": worktree_path.name,
+    "registered-worktree": worktree_path.name,
+}
 PY
 
 # Git branch metadata must not be used as the preview workspace name; hostnames

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6230,6 +6230,7 @@ grep -q '^--user disable --now polyscope-server.service$' "$system_systemctl_log
 grep -q '^--user daemon-reload$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-rollout-sync.path$' "$system_systemctl_log"
 grep -q '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log"
+grep -q '^--user reset-failed polyscope-worktree-provision.path polyscope-worktree-provision.service$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-worktree-provision.path$' "$system_systemctl_log"
 grep -q '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log"
 if [[ "$(grep -n '^--user start polyscope-rollout-sync.service$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" -ge "$(grep -n '^--user enable --now polyscope-worktree-provision.timer$' "$system_systemctl_log" | tail -n1 | cut -d: -f1)" ]]; then
@@ -6272,9 +6273,17 @@ if grep -qF '/../' "$fake_unit_dir/polyscope-rollout-sync.path"; then
     exit 1
 fi
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
-grep -q 'StartLimitIntervalSec=300' "$fake_unit_dir/polyscope-worktree-provision.service"
-grep -q 'StartLimitBurst=5' "$fake_unit_dir/polyscope-worktree-provision.service"
-grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^Type=oneshot$' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^StartLimitIntervalSec=10$' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^StartLimitBurst=5$' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^ExecStartPre=/usr/bin/sleep 3$' "$fake_unit_dir/polyscope-worktree-provision.service"
+if grep -qE '^(Restart=|SuccessExitStatus=|ExecStart=-)' "$fake_unit_dir/polyscope-worktree-provision.service"; then
+  echo "provision service must expose failures without suppressing them" >&2
+  exit 1
+fi
+grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --provision-lock-path .*worktree-provision.lock --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.path"
+grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnStartupSec=30s$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnUnitActiveSec=3min$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^Persistent=true$' "$fake_unit_dir/polyscope-worktree-provision.timer"
@@ -6301,6 +6310,20 @@ if grep -qE '^PathModified=.*/\.polyscope/clones$' "$fake_unit_dir/polyscope-wor
 fi
 grep -qE '^PathChanged=.*/api/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
 grep -qE '^PathChanged=.*/frontend/polyscope\.local\.json$' "$fake_unit_dir/polyscope-worktree-provision.path"
+if grep -qE 'worktree-provision\.lock|\.polyscope/clones' "$fake_unit_dir/polyscope-worktree-provision.path"; then
+  echo "provision path must not watch state written by the provisioner" >&2
+  exit 1
+fi
+if command -v systemd-analyze >/dev/null 2>&1; then
+  systemd_verify_log="$workspace/systemd-analyze-verify.log"
+  if ! SYSTEMD_UNIT_PATH="$fake_unit_dir:" systemd-analyze verify \
+    "$fake_unit_dir"/*.service \
+    "$fake_unit_dir"/*.path \
+    "$fake_unit_dir"/*.timer >"$systemd_verify_log" 2>&1; then
+    cat "$systemd_verify_log" >&2
+    exit 1
+  fi
+fi
 grep -qF 'fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '.polyscope-preview-stage' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'build.lock' "$workspace_root/frontend/polyscope.local.json"
@@ -6309,6 +6332,7 @@ grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-rollout-sync.path' "$fake_systemctl_log"
 grep -q 'start polyscope-rollout-sync.service' "$fake_systemctl_log"
+grep -q 'reset-failed polyscope-worktree-provision.path polyscope-worktree-provision.service' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.path' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-worktree-provision.timer' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-clone-reaper.timer' "$fake_systemctl_log"


### PR DESCRIPTION
## Description

Close the three defects reproduced during the real post-merge lifecycle
acceptance of PR #570:

- native setup could continue after canonical validation failed when a later
  setup entry contained multiline or `||` shell control flow;
- replacing the registered physical workspace path with an alias caused the
  official deletion path to remove only the symlink;
- SQLite event bursts could leave the worktree provision path in
  `unit-start-limit-hit`.

The generated setup is now one strict fail-closed shell entry. Physical
workspace paths remain authoritative in Polyscope, while stable aliases are
tracked separately and cleaned only after official deletion. Provision runs
are serialized, briefly coalesced, and use a bounded activation window with the
existing timer as recovery fallback.

## Related Issues

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [ ] Manual testing performed

Focused fixtures execute the exact generated Polyscope setup representation for
all nine managed repository profiles, use a real temporary Git worktree for the
deletion contract, exercise process-level provision locking, and validate the
generated systemd units with `systemd-analyze verify`.

Real invalid and valid `.github` workspace lifecycle acceptance will be
repeated only after this correction is merged and installed.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-package-1-closure.sh` showed the API fixture running fake Composer and creating `vendor` after canonical validation failed; the deletion fixture observed the database path rewritten to a symlink; `bash tests/polyscope-rollout.sh` rejected the old 300-second provision-service start limit and missing coalescing/lock contract.
- Passing proof after implementation: all focused Polyscope, canonical instruction, clone-reaper, nginx-helper, system-installer, reusable-workflow, ShellCheck, Bash syntax, Python AST, Markdownlint, Prettier, REUSE, generated-systemd, changed-file pre-commit, and `git diff --check` validations pass.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Key Outcomes

- Canonical validation guards the complete native setup as one fail-closed unit.
- Every later setup failure prevents all subsequent setup commands.
- Physical hash worktree paths remain the authoritative deletion identity.
- Only direct, registry-owned aliases are eligible for bounded cleanup.
- Provisioning is serialized and database-event bursts are coalesced.
- Historical provision-unit failed state is cleared only during deliberate installer convergence.
- The established constrained nginx helper and sudo boundary are unchanged.

## Scope

This PR does not install components, alter live units or Polyscope state, run a
real workspace lifecycle, change the nginx privilege architecture, modify
sibling repositories, or begin governance package 2.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above or explicitly not applicable

## Screenshots (if applicable)

Not applicable.
