### PR TITLE
feat(review): add deterministic PR evidence layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-19 - Add Deterministic PR Evidence State Layer
+
+**Added:**
+
+- added a standard-library Python helper that captures canonical, digest-bound
+  PR evidence with complete bounded review, thread, reply, reaction, commit,
+  and check pagination while blocking on partial state or head movement
+- added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
+  rule, branch-protection, and required-check verification without polling,
+  GitHub mutations, Git writes, review requests, or merge authority
+- added versioned snapshot and repository-configuration schemas, safely escaped
+  derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
+  regression coverage for the Package 2.1 data contract
+
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract
+- bound required-check evidence to GitHub's effective test-merge or head commit,
+  proved same-named check/status evaluation, rejected contradictory snapshot
+  check and repository-identity metadata, and removed unenforced arbitrary
+  local-validation commands from the read-only Package 2.1 configuration
+  contract
 
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   PR evidence with complete bounded review, thread, reply, reaction, commit,
   and check pagination while blocking on partial state or anchor movement
 - added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
-  rule, branch-protection, and required-check verification without polling,
-  GitHub mutations, Git writes, review requests, or merge authority
+  rule, branch-protection, required-check, and strict up-to-date-base
+  verification without polling, GitHub mutations, Git writes, review requests,
+  or merge authority
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - added a standard-library Python helper that captures canonical, digest-bound
   PR evidence with complete bounded review, thread, reply, reaction, commit,
-  and check pagination while blocking on partial state or head movement
+  and check pagination while blocking on partial state or anchor movement
 - added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
   rule, branch-protection, and required-check verification without polling,
   GitHub mutations, Git writes, review requests, or merge authority

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   command search paths, closed standard input, bounded each invocation, captured
   direct PR and review-summary reactions, and rejected unknown required-check
   reasons or duplicate stable review-state identities
+- preserved structured gate reports when a newly required rule source is absent,
+  enforced every current capture cap against stored usage, and rejected non-object
+  JSON configuration roots without an unhandled exception
 
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   and check pagination while blocking on partial state or anchor movement
 - added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
   rule, branch-protection, required-check, and strict up-to-date-base
-  verification with GitHub.com host pinning and update/count race sentinels,
-  without polling, GitHub mutations, Git writes, review requests, or merge
-  authority
+  verification with GitHub.com host pinning, sanitized non-locking Git reads,
+  replacement-ref suppression, explicit merge-state gating, head-in-commit-set
+  validation, and update/count race sentinels, without polling, GitHub
+  mutations, Git writes, review requests, or merge authority
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   verification with GitHub.com host pinning, sanitized non-locking Git reads,
   fsmonitor and configured-verifier suppression, replacement-ref suppression,
   explicit merge-state gating, head-in-commit-set validation, three PR anchors,
-  and bounded revalidation of all paginated PR collections, commit signatures,
-  checks, and required rules, without polling, GitHub mutations, Git writes,
-  review requests, or merge authority
+  retained connection-count validation, signature state/verification
+  consistency, and bounded revalidation of all paginated PR collections,
+  commit signatures, checks, and required rules, without polling, GitHub
+  mutations, Git writes, review requests, or merge authority
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 - preserved structured gate reports when a newly required rule source is absent,
   enforced every current capture cap against stored usage, and rejected non-object
   JSON configuration roots without an unhandled exception
+- rejected ambiguous reviewer aliases across every supported identity namespace
+  and failed closed when required-workflow rules cannot be mapped completely to
+  captured check evidence
 
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
   rule, branch-protection, required-check, and strict up-to-date-base
   verification with GitHub.com host pinning, sanitized non-locking Git reads,
-  replacement-ref suppression, explicit merge-state gating, head-in-commit-set
-  validation, and update/count race sentinels, without polling, GitHub
-  mutations, Git writes, review requests, or merge authority
+  fsmonitor and configured-verifier suppression, replacement-ref suppression,
+  explicit merge-state gating, head-in-commit-set validation, three PR anchors,
+  and bounded revalidation of all paginated PR collections, commit signatures,
+  checks, and required rules, without polling, GitHub mutations, Git writes,
+  review requests, or merge authority
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 - rejected ambiguous reviewer aliases across every supported identity namespace
   and failed closed when required-workflow rules cannot be mapped completely to
   captured check evidence
+- rejected pagination evidence whose items cannot fit in its recorded pages,
+  preserved generic ruleset checks when app-bound branch protection also
+  applies, and included direct and nested reactions in raw review classification
 
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   and check pagination while blocking on partial state or anchor movement
 - added read-only local-head, exact commit-set, SSH/OpenPGP signature, applicable
   rule, branch-protection, required-check, and strict up-to-date-base
-  verification without polling, GitHub mutations, Git writes, review requests,
-  or merge authority
+  verification with GitHub.com host pinning and update/count race sentinels,
+  without polling, GitHub mutations, Git writes, review requests, or merge
+  authority
 - added versioned snapshot and repository-configuration schemas, safely escaped
   derived Markdown, atomic private outputs, and offline fake-GitHub/fake-Git
   regression coverage for the Package 2.1 data contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   check and repository-identity metadata, and removed unenforced arbitrary
   local-validation commands from the read-only Package 2.1 configuration
   contract
+- resolved `git` and `gh` only from fixed host-tool prefixes, replaced inherited
+  command search paths, closed standard input, bounded each invocation, captured
+  direct PR and review-summary reactions, and rejected unknown required-check
+  reasons or duplicate stable review-state identities
 
 ## 2026-07-19 - Complete Polyscope Workspace Lifecycle Closure
 

--- a/docs/schemas/secpal-pr-review-repositories.schema.json
+++ b/docs/schemas/secpal-pr-review-repositories.schema.json
@@ -11,7 +11,6 @@
     "default_branch",
     "allowed_base_repositories",
     "reviewer_identities",
-    "required_local_validation",
     "signature_policy",
     "check_policy",
     "maximum_api_calls",
@@ -66,22 +65,6 @@
             "type": "array",
             "uniqueItems": true,
             "items": { "type": "integer", "minimum": 1 }
-          }
-        }
-      }
-    },
-    "required_local_validation": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["name", "command"],
-        "properties": {
-          "name": { "type": "string", "minLength": 1 },
-          "command": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "type": "string", "minLength": 1 }
           }
         }
       }

--- a/docs/schemas/secpal-pr-review-repositories.schema.json
+++ b/docs/schemas/secpal-pr-review-repositories.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SecPal/.github/blob/main/docs/schemas/secpal-pr-review-repositories.schema.json",
+  "$comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors; SPDX-License-Identifier: CC0-1.0",
+  "title": "SecPal deterministic pull request evidence repository configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository",
+    "default_branch",
+    "allowed_base_repositories",
+    "reviewer_identities",
+    "required_local_validation",
+    "signature_policy",
+    "check_policy",
+    "maximum_api_calls",
+    "maximum_items",
+    "maximum_threads",
+    "maximum_comments",
+    "maximum_reactions"
+  ],
+  "properties": {
+    "$comment": { "type": "string" },
+    "schema_version": { "const": "1.0" },
+    "repository": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
+    "default_branch": { "type": "string", "minLength": 1 },
+    "allowed_base_repositories": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[^/]+/[^/]+$" }
+    },
+    "reviewer_identities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "canonical_identity",
+          "kind",
+          "graphql_aliases",
+          "rest_event_aliases",
+          "node_ids",
+          "database_ids"
+        ],
+        "properties": {
+          "canonical_identity": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["human", "bot", "app"] },
+          "graphql_aliases": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "rest_event_aliases": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "node_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "database_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "required_local_validation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "command"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "signature_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["require_github_verified", "require_local_verified", "accepted_formats"],
+      "properties": {
+        "require_github_verified": { "type": "boolean" },
+        "require_local_verified": { "type": "boolean" },
+        "accepted_formats": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["ssh", "openpgp"] }
+        }
+      }
+    },
+    "check_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "require_ruleset_evidence",
+        "require_branch_protection_evidence",
+        "expected_skipped"
+      ],
+      "properties": {
+        "require_ruleset_evidence": { "type": "boolean" },
+        "require_branch_protection_evidence": { "type": "boolean" },
+        "expected_skipped": { "enum": ["block", "allow"] }
+      }
+    },
+    "maximum_api_calls": { "type": "integer", "minimum": 1 },
+    "maximum_items": { "type": "integer", "minimum": 1 },
+    "maximum_threads": { "type": "integer", "minimum": 1 },
+    "maximum_comments": { "type": "integer", "minimum": 1 },
+    "maximum_reactions": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/docs/schemas/secpal-pr-review-repositories.schema.json.license
+++ b/docs/schemas/secpal-pr-review-repositories.schema.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -392,7 +392,11 @@
         "determination": { "enum": ["complete", "incomplete"] },
         "required": { "type": "array", "items": { "type": "string" } },
         "missing": { "type": "array", "items": { "type": "string" } },
-        "sources": { "type": "array", "items": { "type": "string" } },
+        "sources": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "enum": ["rulesets", "branch_protection"] }
+        },
         "unknown_reasons": { "type": "array", "items": { "type": "string" } }
       }
     },
@@ -440,9 +444,10 @@
         },
         "fully_paginated_connections": {
           "type": "array",
+          "minItems": 8,
           "items": { "$ref": "#/$defs/connection_evidence" }
         },
-        "warnings": { "type": "array", "items": { "type": "string" } },
+        "warnings": { "type": "array", "maxItems": 0, "items": { "type": "string" } },
         "blocked_reason": { "type": "null" }
       }
     }

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -104,6 +104,7 @@
         "is_draft",
         "is_merged",
         "mergeable",
+        "merge_state_status",
         "review_decision",
         "author",
         "base_repository",
@@ -127,6 +128,9 @@
         "is_draft": { "type": "boolean" },
         "is_merged": { "type": "boolean" },
         "mergeable": { "enum": ["MERGEABLE", "CONFLICTING", "UNKNOWN", null] },
+        "merge_state_status": {
+          "enum": ["DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"]
+        },
         "review_decision": { "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", null] },
         "author": { "$ref": "#/$defs/author" },
         "base_repository": { "$ref": "#/$defs/repository_ref" },

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -100,6 +100,7 @@
         "number",
         "url",
         "title",
+        "body",
         "state",
         "is_draft",
         "is_merged",
@@ -120,7 +121,8 @@
         "captured_connection_counts",
         "labels",
         "requested_reviewers",
-        "requested_teams"
+        "requested_teams",
+        "reactions"
       ],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
@@ -128,6 +130,7 @@
         "number": { "type": "integer", "minimum": 1 },
         "url": { "type": "string", "minLength": 1 },
         "title": { "type": "string" },
+        "body": { "type": "string" },
         "state": { "enum": ["OPEN", "CLOSED", "MERGED"] },
         "is_draft": { "type": "boolean" },
         "is_merged": { "type": "boolean" },
@@ -166,6 +169,7 @@
             "labels",
             "review_requests",
             "reviews",
+            "pull_request_reactions",
             "conversation_comments",
             "review_threads",
             "commits"
@@ -174,6 +178,7 @@
             "labels": { "type": "integer", "minimum": 0 },
             "review_requests": { "type": "integer", "minimum": 0 },
             "reviews": { "type": "integer", "minimum": 0 },
+            "pull_request_reactions": { "type": "integer", "minimum": 0 },
             "conversation_comments": { "type": "integer", "minimum": 0 },
             "review_threads": { "type": "integer", "minimum": 0 },
             "commits": { "type": "integer", "minimum": 1 }
@@ -200,6 +205,10 @@
               "url": { "$ref": "#/$defs/nullable_string" }
             }
           }
+        },
+        "reactions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reaction" }
         }
       }
     },
@@ -208,7 +217,7 @@
       "additionalProperties": false,
       "required": ["id", "content", "created_at", "user"],
       "properties": {
-        "id": { "$ref": "#/$defs/nullable_string" },
+        "id": { "type": "string", "minLength": 1 },
         "content": { "type": "string", "minLength": 1 },
         "created_at": { "$ref": "#/$defs/nullable_string" },
         "user": { "$ref": "#/$defs/author" }
@@ -225,7 +234,8 @@
         "body",
         "url",
         "submitted_at",
-        "commit_oid"
+        "commit_oid",
+        "reactions"
       ],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
@@ -235,7 +245,11 @@
         "body": { "type": "string" },
         "url": { "type": "string" },
         "submitted_at": { "$ref": "#/$defs/nullable_string" },
-        "commit_oid": { "$ref": "#/$defs/nullable_string" }
+        "commit_oid": { "$ref": "#/$defs/nullable_string" },
+        "reactions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reaction" }
+        }
       }
     },
     "conversation_comment": {
@@ -432,7 +446,7 @@
       "additionalProperties": false,
       "required": ["determination", "required", "missing", "sources", "unknown_reasons"],
       "properties": {
-        "determination": { "enum": ["complete", "incomplete"] },
+        "determination": { "const": "complete" },
         "required": { "type": "array", "items": { "type": "string" } },
         "missing": { "type": "array", "items": { "type": "string" } },
         "sources": {
@@ -440,7 +454,7 @@
           "uniqueItems": true,
           "items": { "enum": ["rulesets", "branch_protection"] }
         },
-        "unknown_reasons": { "type": "array", "items": { "type": "string" } }
+        "unknown_reasons": { "type": "array", "maxItems": 0, "items": { "type": "string" } }
       }
     },
     "connection_evidence": {

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -114,6 +114,7 @@
         "head_ref",
         "head_oid_before",
         "head_oid_after",
+        "captured_connection_counts",
         "labels",
         "requested_reviewers",
         "requested_teams"
@@ -149,6 +150,26 @@
         "head_ref": { "$ref": "#/$defs/nullable_string" },
         "head_oid_before": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
         "head_oid_after": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "captured_connection_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "labels",
+            "review_requests",
+            "reviews",
+            "conversation_comments",
+            "review_threads",
+            "commits"
+          ],
+          "properties": {
+            "labels": { "type": "integer", "minimum": 0 },
+            "review_requests": { "type": "integer", "minimum": 0 },
+            "reviews": { "type": "integer", "minimum": 0 },
+            "conversation_comments": { "type": "integer", "minimum": 0 },
+            "review_threads": { "type": "integer", "minimum": 0 },
+            "commits": { "type": "integer", "minimum": 1 }
+          }
+        },
         "labels": {
           "type": "array",
           "items": { "type": "string" }

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -114,6 +114,9 @@
         "head_ref",
         "head_oid_before",
         "head_oid_after",
+        "potential_merge_commit_oid",
+        "check_commit_oid",
+        "check_commit_source",
         "captured_connection_counts",
         "labels",
         "requested_reviewers",
@@ -150,6 +153,12 @@
         "head_ref": { "$ref": "#/$defs/nullable_string" },
         "head_oid_before": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
         "head_oid_after": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "potential_merge_commit_oid": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-fA-F]{40,64}$"
+        },
+        "check_commit_oid": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "check_commit_source": { "enum": ["head", "test_merge"] },
         "captured_connection_counts": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SecPal/.github/blob/main/docs/schemas/secpal-pr-review-snapshot.schema.json",
+  "$comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors; SPDX-License-Identifier: CC0-1.0",
+  "title": "SecPal deterministic pull request evidence snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "snapshot_digest_algorithm",
+    "snapshot_digest",
+    "repository",
+    "pull_request",
+    "reviews",
+    "conversation_comments",
+    "review_threads",
+    "commits",
+    "checks",
+    "applicable_rules",
+    "required_check_evidence",
+    "completeness"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "snapshot_digest_algorithm": { "const": "sha256" },
+    "snapshot_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "repository": { "$ref": "#/$defs/repository" },
+    "pull_request": { "$ref": "#/$defs/pull_request" },
+    "reviews": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/review" }
+    },
+    "conversation_comments": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/conversation_comment" }
+    },
+    "review_threads": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/review_thread" }
+    },
+    "commits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/commit" }
+    },
+    "checks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "applicable_rules": { "$ref": "#/$defs/applicable_rules" },
+    "required_check_evidence": { "$ref": "#/$defs/required_check_evidence" },
+    "completeness": { "$ref": "#/$defs/completeness" }
+  },
+  "$defs": {
+    "nullable_string": { "type": ["string", "null"] },
+    "nullable_integer": { "type": ["integer", "null"] },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "login", "database_id", "node_id", "url"],
+      "properties": {
+        "kind": {
+          "enum": ["user", "bot", "organization", "mannequin", "deleted_or_unavailable"]
+        },
+        "login": { "$ref": "#/$defs/nullable_string" },
+        "database_id": { "$ref": "#/$defs/nullable_integer" },
+        "node_id": { "$ref": "#/$defs/nullable_string" },
+        "url": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "repository_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name_with_owner", "url"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nullable_string" },
+        "name_with_owner": { "$ref": "#/$defs/nullable_string" },
+        "url": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "owner", "name", "name_with_owner", "url", "default_branch"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "name_with_owner": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
+        "url": { "type": "string", "minLength": 1 },
+        "default_branch": { "type": "string", "minLength": 1 }
+      }
+    },
+    "pull_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "database_id",
+        "number",
+        "url",
+        "title",
+        "state",
+        "is_draft",
+        "is_merged",
+        "mergeable",
+        "review_decision",
+        "author",
+        "base_repository",
+        "base_ref",
+        "base_oid",
+        "head_repository",
+        "head_ref",
+        "head_oid_before",
+        "head_oid_after",
+        "labels",
+        "requested_reviewers",
+        "requested_teams"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "database_id": { "$ref": "#/$defs/nullable_integer" },
+        "number": { "type": "integer", "minimum": 1 },
+        "url": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "state": { "enum": ["OPEN", "CLOSED", "MERGED"] },
+        "is_draft": { "type": "boolean" },
+        "is_merged": { "type": "boolean" },
+        "mergeable": { "enum": ["MERGEABLE", "CONFLICTING", "UNKNOWN", null] },
+        "review_decision": { "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", null] },
+        "author": { "$ref": "#/$defs/author" },
+        "base_repository": { "$ref": "#/$defs/repository_ref" },
+        "base_ref": { "type": "string", "minLength": 1 },
+        "base_oid": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "head_repository": { "$ref": "#/$defs/repository_ref" },
+        "head_ref": { "$ref": "#/$defs/nullable_string" },
+        "head_oid_before": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "head_oid_after": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "requested_reviewers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/author" }
+        },
+        "requested_teams": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "slug", "name", "url"],
+            "properties": {
+              "id": { "$ref": "#/$defs/nullable_string" },
+              "slug": { "$ref": "#/$defs/nullable_string" },
+              "name": { "$ref": "#/$defs/nullable_string" },
+              "url": { "$ref": "#/$defs/nullable_string" }
+            }
+          }
+        }
+      }
+    },
+    "reaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "content", "created_at", "user"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nullable_string" },
+        "content": { "type": "string", "minLength": 1 },
+        "created_at": { "$ref": "#/$defs/nullable_string" },
+        "user": { "$ref": "#/$defs/author" }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "database_id",
+        "author",
+        "state",
+        "body",
+        "url",
+        "submitted_at",
+        "commit_oid"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "database_id": { "$ref": "#/$defs/nullable_integer" },
+        "author": { "$ref": "#/$defs/author" },
+        "state": { "enum": ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING"] },
+        "body": { "type": "string" },
+        "url": { "type": "string" },
+        "submitted_at": { "$ref": "#/$defs/nullable_string" },
+        "commit_oid": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "conversation_comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "database_id",
+        "author",
+        "body",
+        "url",
+        "created_at",
+        "updated_at",
+        "reactions"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "database_id": { "$ref": "#/$defs/nullable_integer" },
+        "author": { "$ref": "#/$defs/author" },
+        "body": { "type": "string" },
+        "url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "reactions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reaction" }
+        }
+      }
+    },
+    "review_comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "database_id",
+        "author",
+        "body",
+        "url",
+        "created_at",
+        "updated_at",
+        "reply_to_id",
+        "review_id",
+        "reactions"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "database_id": { "$ref": "#/$defs/nullable_integer" },
+        "author": { "$ref": "#/$defs/author" },
+        "body": { "type": "string" },
+        "url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "reply_to_id": { "$ref": "#/$defs/nullable_string" },
+        "review_id": { "$ref": "#/$defs/nullable_string" },
+        "reactions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reaction" }
+        }
+      }
+    },
+    "review_thread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "is_resolved",
+        "is_outdated",
+        "path",
+        "line",
+        "original_line",
+        "side",
+        "start_line",
+        "start_side",
+        "comments"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "is_resolved": { "type": "boolean" },
+        "is_outdated": { "type": "boolean" },
+        "path": { "$ref": "#/$defs/nullable_string" },
+        "line": { "$ref": "#/$defs/nullable_integer" },
+        "original_line": { "$ref": "#/$defs/nullable_integer" },
+        "side": { "$ref": "#/$defs/nullable_string" },
+        "start_line": { "$ref": "#/$defs/nullable_integer" },
+        "start_side": { "$ref": "#/$defs/nullable_string" },
+        "comments": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/review_comment" }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "verified", "format", "reason", "signer"],
+      "properties": {
+        "state": {
+          "enum": [
+            "valid",
+            "invalid",
+            "unsigned",
+            "unknown_key",
+            "object_unavailable",
+            "verification_pending"
+          ]
+        },
+        "verified": { "type": "boolean" },
+        "format": { "enum": ["ssh", "openpgp", "smime", "unknown", null] },
+        "reason": { "$ref": "#/$defs/nullable_string" },
+        "signer": { "$ref": "#/$defs/author" }
+      }
+    },
+    "commit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "oid",
+        "parents",
+        "authored_at",
+        "committed_at",
+        "github_signature",
+        "local_signature"
+      ],
+      "properties": {
+        "oid": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" },
+        "parents": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[0-9a-fA-F]{40,64}$" }
+        },
+        "authored_at": { "type": "string" },
+        "committed_at": { "type": "string" },
+        "github_signature": { "$ref": "#/$defs/signature" },
+        "local_signature": { "$ref": "#/$defs/signature" }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stable_id",
+        "name",
+        "application",
+        "status",
+        "conclusion",
+        "requiredness",
+        "evidence_state",
+        "details_url"
+      ],
+      "properties": {
+        "stable_id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "application": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database_id", "name", "slug"],
+          "properties": {
+            "id": { "$ref": "#/$defs/nullable_string" },
+            "database_id": { "$ref": "#/$defs/nullable_integer" },
+            "name": { "$ref": "#/$defs/nullable_string" },
+            "slug": { "$ref": "#/$defs/nullable_string" }
+          }
+        },
+        "status": { "$ref": "#/$defs/nullable_string" },
+        "conclusion": { "$ref": "#/$defs/nullable_string" },
+        "requiredness": { "enum": ["required", "non_required", "unknown"] },
+        "evidence_state": {
+          "enum": [
+            "required_successful",
+            "required_pending",
+            "required_failed",
+            "required_missing",
+            "non_required_successful",
+            "non_required_pending",
+            "non_required_failed",
+            "requiredness_unknown"
+          ]
+        },
+        "details_url": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "applicable_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rulesets", "branch_protection", "evidence_complete"],
+      "properties": {
+        "rulesets": { "type": "array", "items": { "type": "object" } },
+        "branch_protection": { "type": "object" },
+        "evidence_complete": { "type": "boolean" }
+      }
+    },
+    "required_check_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["determination", "required", "missing", "sources", "unknown_reasons"],
+      "properties": {
+        "determination": { "enum": ["complete", "incomplete"] },
+        "required": { "type": "array", "items": { "type": "string" } },
+        "missing": { "type": "array", "items": { "type": "string" } },
+        "sources": { "type": "array", "items": { "type": "string" } },
+        "unknown_reasons": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "connection_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["connection", "pages", "items"],
+      "properties": {
+        "connection": { "type": "string", "minLength": 1 },
+        "pages": { "type": "integer", "minimum": 1 },
+        "items": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "completeness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "api_calls",
+        "items",
+        "configured_caps",
+        "fully_paginated_connections",
+        "warnings",
+        "blocked_reason"
+      ],
+      "properties": {
+        "api_calls": { "type": "integer", "minimum": 1 },
+        "items": { "type": "integer", "minimum": 0 },
+        "configured_caps": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "maximum_api_calls",
+            "maximum_items",
+            "maximum_threads",
+            "maximum_comments",
+            "maximum_reactions"
+          ],
+          "properties": {
+            "maximum_api_calls": { "type": "integer", "minimum": 1 },
+            "maximum_items": { "type": "integer", "minimum": 1 },
+            "maximum_threads": { "type": "integer", "minimum": 1 },
+            "maximum_comments": { "type": "integer", "minimum": 1 },
+            "maximum_reactions": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "fully_paginated_connections": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/connection_evidence" }
+        },
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "blocked_reason": { "type": "null" }
+      }
+    }
+  }
+}

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -129,7 +129,16 @@
         "is_merged": { "type": "boolean" },
         "mergeable": { "enum": ["MERGEABLE", "CONFLICTING", "UNKNOWN", null] },
         "merge_state_status": {
-          "enum": ["DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"]
+          "enum": [
+            "DIRTY",
+            "UNKNOWN",
+            "BLOCKED",
+            "BEHIND",
+            "DRAFT",
+            "UNSTABLE",
+            "HAS_HOOKS",
+            "CLEAN"
+          ]
         },
         "review_decision": { "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", null] },
         "author": { "$ref": "#/$defs/author" },

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json.license
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -27,9 +27,11 @@ is a derived, non-authoritative view.
 
 The helper validates both structures against these checked-in schemas and then
 applies semantic validation such as unique reviewer aliases and evidence digest
-verification. Commit evidence must use unique object IDs and contain the
-captured PR head commit. Stored anchor counts must exactly match all supplied
-top-level PR collections, including the complete commit set. Configuration
+verification. Repository owner, name, URL, PR URL, base repository, head
+repository, and merged-state components must be internally consistent. Commit
+evidence must use unique object IDs and contain the captured PR head commit.
+Stored anchor counts must exactly match all supplied top-level PR collections,
+including the complete commit set. Configuration
 supports a stable canonical identity with GraphQL, REST/event, numeric, and
 node-ID aliases; no suffix-sensitive login is the sole identity contract.
 
@@ -101,6 +103,11 @@ upstream, local head, remote-tracking head, PR head, expected head, base
 repository and branch, exact base-to-head commit set, commit-object
 availability, and every local commit signature.
 
+Repository configuration deliberately contains no arbitrary local-validation
+command list. Executing repository-selected programs would cross this layer's
+strict read-only process boundary; Package 2.2 owns orchestration of the
+repository's documented test and validation commands.
+
 It never fetches automatically. The helper also sets `GIT_NO_LAZY_FETCH=1` so
 a partial clone cannot silently fetch a missing object. It disables replacement
 refs and optional locks, and removes inherited Git variables that could select
@@ -165,16 +172,16 @@ whenever a snapshot is loaded. It fully paginates:
 - top-level conversation comments and each reaction connection;
 - review threads, every nested reply, and each nested reaction connection;
 - PR commits and their bounded parent evidence;
-- head-commit check runs and status contexts;
+- check runs and status contexts from GitHub's effective check commit;
 - applicable branch rules.
 
 After the first anchor comparison, the helper performs a second complete,
 bounded observation of every fully paginated PR collection and of volatile
 evidence that can change without moving the PR head or its top-level counts.
 This includes labels, review requests, reviews, comments and reactions, inline
-threads and replies, remote commit and GitHub-signature evidence, head checks,
-rulesets, and branch protection. The two normalized observations must be
-identical. Their connections, API calls, and items are recorded with a
+threads and replies, remote commit and GitHub-signature evidence, effective
+commit checks, rulesets, and branch protection. The two normalized observations
+must be identical. Their connections, API calls, and items are recorded with a
 `.revalidation` suffix and count against the same configured caps. Any
 difference terminates with `BLOCKED_INCOMPLETE_REVIEW_STATE` before output is
 prepared.
@@ -226,13 +233,28 @@ trusting capture-time outcome labels. It also retains each configured source's
 strict up-to-date policy and blocks a `BEHIND` merge state whenever either
 enabled source requires checks against the current base.
 
+The anchor records GitHub's potential test-merge commit. When that commit has
+any check or status context, its fully paginated rollup is authoritative;
+otherwise the helper captures the head-commit rollup. The selected source and
+OID are stored, semantically validated, and independently selected again during
+revalidation. An open PR whose test merge is still being generated blocks as
+incomplete instead of assuming the head rollup is authoritative. A generic
+required name matches every check-run and legacy
+status-context entry when both kinds are present, so one successful kind cannot
+hide a failed same-named counterpart. It does not invent an absent context
+kind; application-specific requirements remain bound to a check run from that
+application.
+
 Evidence distinguishes required success, pending, failure, and absence;
 non-required success, pending, and failure; and unknown requiredness. Required
-skipped checks follow the explicit `check_policy.expected_skipped` value. A
+skipped checks follow the explicit `check_policy.expected_skipped` value.
+GitHub's seven-day recency rule governs whether a check or expected application
+can be selected when required-check policy is configured; it does not expire a
+successful result on the current effective commit. A
 missing or inaccessible configured rules source, unsupported check type,
 malformed rule, or otherwise unknown requiredness terminates with
 `BLOCKED_INCOMPLETE_REVIEW_STATE`. Pending checks are reported once and are not
-polled. Head-check state, applicable rules, and the derived required-check
+polled. Effective-check state, applicable rules, and the derived required-check
 evidence must also match their bounded revalidation observations.
 
 ## Output and untrusted content
@@ -295,7 +317,8 @@ serialization, outer and nested pagination with unequal page counts, reactions,
 caps, partial failures, signature-envelope classification, update-time and
 connection-count anchor races, strict stale-base state, required checks, hostile
 rendering, atomic outputs, host pinning, merge-state policy coverage, commit-set
-invariants, volatile-evidence revalidation, sanitized Git environments,
-fsmonitor and verifier-program suppression, and executable-call spies that
-reject GitHub and Git writes. Live acceptance is a separately identified
-read-only phase and never requests an AI review.
+invariants, test-merge selection, duplicate-name check/status evaluation,
+volatile-evidence revalidation, sanitized Git
+environments, fsmonitor and verifier-program suppression, and executable-call
+spies that reject GitHub and Git writes. Live acceptance is a separately
+identified read-only phase and never requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -101,7 +101,9 @@ refs and optional locks, and removes inherited Git variables that could select
 another repository, worktree, index, object database, shallow boundary,
 namespace, injected configuration, subcommand path, or trace-output target.
 Normal system, global, and repository configuration still loads from its
-standard locations. The `fetched` result is always `false`.
+standard locations, but `core.fsmonitor` is disabled and the OpenPGP, SSH, and
+X.509 verifier programs are pinned to their standard command names so config
+cannot select an arbitrary executable. The `fetched` result is always `false`.
 
 ### Verify the mechanical gate
 
@@ -141,12 +143,12 @@ Every rendering states:
 ## Complete bounded pagination
 
 The snapshot anchors the repository and PR before reading any collection,
-advances each connection independently, and reads the complete anchor once more
-after all evidence is captured. The anchor includes the PR `updatedAt` value and
-the total counts for labels, review requests, reviews, conversation comments,
-review threads, and commits. Any lifecycle, identity, update-time, or count
-change blocks the capture, and every count must match its fully paginated
-collection. It fully paginates:
+advances each connection independently, reads the complete anchor after the
+initial capture, and reads it a third time after revalidation. The anchor
+includes the PR `updatedAt` value and the total counts for labels, review
+requests, reviews, conversation comments, review threads, and commits. Any
+lifecycle, identity, update-time, or count change blocks the capture, and every
+count must match its fully paginated collection. It fully paginates:
 
 - labels and requested reviewers or teams;
 - review submissions, including informational, approved, dismissed, and
@@ -156,6 +158,17 @@ collection. It fully paginates:
 - PR commits and their bounded parent evidence;
 - head-commit check runs and status contexts;
 - applicable branch rules.
+
+After the first anchor comparison, the helper performs a second complete,
+bounded observation of every fully paginated PR collection and of volatile
+evidence that can change without moving the PR head or its top-level counts.
+This includes labels, review requests, reviews, comments and reactions, inline
+threads and replies, remote commit and GitHub-signature evidence, head checks,
+rulesets, and branch protection. The two normalized observations must be
+identical. Their connections, API calls, and items are recorded with a
+`.revalidation` suffix and count against the same configured caps. Any
+difference terminates with `BLOCKED_INCOMPLETE_REVIEW_STATE` before output is
+prepared.
 
 Independent cursors prevent unequal page counts from causing duplicate or
 omitted reads. `completeness.fully_paginated_connections` records pages and
@@ -186,7 +199,9 @@ The evidence distinguishes `valid`, `invalid`, `unsigned`, `unknown_key`,
 `object_unavailable`, and `verification_pending`. An unknown key is never
 reported as cryptographically verified. Required invalid, unsigned, unknown,
 pending, or unavailable verification blocks the gate. The helper does not
-import keys or change signing configuration.
+import keys or persist signing configuration. Verification still uses the
+configured trust material, while command-scoped overrides prevent configuration
+from substituting the verifier executables themselves.
 
 ## Required checks
 
@@ -206,7 +221,8 @@ skipped checks follow the explicit `check_policy.expected_skipped` value. A
 missing or inaccessible configured rules source, unsupported check type,
 malformed rule, or otherwise unknown requiredness terminates with
 `BLOCKED_INCOMPLETE_REVIEW_STATE`. Pending checks are reported once and are not
-polled.
+polled. Head-check state, applicable rules, and the derived required-check
+evidence must also match their bounded revalidation observations.
 
 ## Output and untrusted content
 
@@ -231,14 +247,16 @@ credential-helper output.
 
 External processes use argument arrays and exact command-shape validation.
 There is no `shell=True`, shell interpolation, dynamic query construction,
-retry loop, or configuration execution. GitHub CLI calls pin `GH_HOST` to
-`github.com` and pass `--hostname github.com` explicitly; caller-provided host
-overrides and repository-context inference cannot redirect evidence reads.
-GraphQL operations are static query documents with variables. Git commands run
-with pagers pinned, optional locking disabled, replacement refs ignored, lazy
-fetches disabled, and repository- or object-selection environment overrides
-removed before process creation. Trace-file and executable-path overrides are
-removed as part of the same boundary.
+retry loop, or execution of caller-selected helper programs. GitHub CLI calls
+pin `GH_HOST` to `github.com` and pass `--hostname github.com` explicitly;
+caller-provided host overrides and repository-context inference cannot redirect
+evidence reads. GraphQL operations are static query documents with variables.
+Git commands run with pagers pinned, optional locking disabled, replacement refs
+ignored, lazy fetches disabled, and repository- or object-selection environment
+overrides removed before process creation. Trace-file and executable-path
+overrides are removed as part of the same boundary. Command-scoped Git
+configuration disables filesystem-monitor hooks and pins every supported
+signature-verifier program.
 
 The helper exposes no operation for:
 
@@ -266,6 +284,7 @@ serialization, outer and nested pagination with unequal page counts, reactions,
 caps, partial failures, signature-envelope classification, update-time and
 connection-count anchor races, strict stale-base state, required checks, hostile
 rendering, atomic outputs, host pinning, merge-state policy coverage, commit-set
-invariants, sanitized Git environments, and executable-call spies that reject
-GitHub and Git writes. Live acceptance is a separately identified read-only
-phase and never requests an AI review.
+invariants, volatile-evidence revalidation, sanitized Git environments,
+fsmonitor and verifier-program suppression, and executable-call spies that
+reject GitHub and Git writes. Live acceptance is a separately identified
+read-only phase and never requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -108,10 +108,10 @@ python3 scripts/secpal-pr-review.py verify-gate \
 
 The gate verifies schema version, digest, complete pagination, an unchanged
 repository and pull-request anchor, safe repository and PR identity, the
-current signature and check policies, required-check evidence, check outcomes,
-required or requested reviews, and raw unresolved thread state. It reports
-separately whether raw unresolved items exist and whether Package 2.2 technical
-classification remains necessary.
+current signature and check policies, required-check evidence, strict
+up-to-date-base requirements, check outcomes, required or requested reviews,
+and raw unresolved thread state. It reports separately whether raw unresolved
+items exist and whether Package 2.2 technical classification remains necessary.
 
 A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
 not merge readiness or merge authorization. Draft, closed, merged, conflicting,
@@ -182,7 +182,9 @@ from a hard-coded workflow name or from visible green checks alone. Check runs
 and status contexts retain stable GitHub identities and are matched to required
 contexts plus application IDs when those IDs are governed. Gate verification
 rebuilds requiredness and outcomes from the supplied current policy rather than
-trusting capture-time outcome labels.
+trusting capture-time outcome labels. It also retains each configured source's
+strict up-to-date policy and blocks a `BEHIND` merge state whenever either
+enabled source requires checks against the current base.
 
 Evidence distinguishes required success, pending, failure, and absence;
 non-required success, pending, and failure; and unknown requiredness. Required
@@ -241,7 +243,7 @@ handling are explicit non-goals.
 
 Offline tests use fake `gh` and fake Git executables. They cover deterministic
 serialization, outer and nested pagination with unequal page counts, reactions,
-caps, partial failures, signatures, full-anchor races, required checks, hostile
-rendering, atomic outputs, and executable-call spies that reject GitHub and Git
-writes. Live acceptance is a separately identified read-only phase and never
-requests an AI review.
+caps, partial failures, signatures, full-anchor races, strict stale-base state,
+required checks, hostile rendering, atomic outputs, and executable-call spies
+that reject GitHub and Git writes. Live acceptance is a separately identified
+read-only phase and never requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -36,7 +36,9 @@ evidence cannot carry an unknown reason.
 Stored anchor counts must exactly match all supplied top-level PR collections,
 including the complete commit set. Configuration
 supports a stable canonical identity with GraphQL, REST/event, numeric, and
-node-ID aliases; no suffix-sensitive login is the sole identity contract.
+node-ID aliases. An alias may appear in multiple namespaces for the same
+canonical identity, but it cannot identify different reviewers; no
+suffix-sensitive login is the sole identity contract.
 Configuration and snapshot files must have JSON objects at their roots; every
 other valid JSON root produces the same structured invalid-input response as a
 schema violation.
@@ -271,7 +273,8 @@ GitHub's seven-day recency rule governs whether a check or expected application
 can be selected when required-check policy is configured; it does not expire a
 successful result on the current effective commit. A
 missing or inaccessible configured rules source, unsupported check type,
-malformed rule, or otherwise unknown requiredness terminates with
+malformed rule, required-workflow rule that cannot be mapped unambiguously to
+the captured check rollup, or otherwise unknown requiredness terminates with
 `BLOCKED_INCOMPLETE_REVIEW_STATE`. Pending checks are reported once and are not
 polled. Effective-check state, applicable rules, and the derived required-check
 evidence must also match their bounded revalidation observations.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -141,9 +141,11 @@ The gate verifies schema version, digest, complete pagination, stored anchor
 counts, an unchanged repository and pull-request anchor, safe repository and PR
 identity, the current signature and check policies, required-check evidence,
 strict up-to-date-base requirements, check outcomes, required or requested
-reviews, and raw unresolved thread state. It reports separately whether raw
-unresolved items exist and whether Package 2.2 technical classification remains
-necessary.
+reviews, reactions on every supported PR subject, and raw unresolved thread
+state. It reports separately whether raw unresolved items exist and whether
+Package 2.2 technical classification remains necessary. Direct PR reactions
+therefore cannot disappear merely because no review or comment accompanies
+them.
 
 The current repository configuration is authoritative at gate time. Recorded
 API calls, aggregate items, threads, comments, and reactions must fit its current
@@ -210,7 +212,10 @@ prepared.
 Independent cursors prevent unequal page counts from causing duplicate or
 omitted reads. `completeness.fully_paginated_connections` records pages and
 items for every completed connection. `completeness.api_calls` and
-`completeness.items` record actual bounded work.
+`completeness.items` record actual bounded work. Every paginated request uses a
+page size of 100, and loaded evidence is rejected when its item count could not
+fit within the recorded number of pages. This keeps recomputed digests from
+legitimizing impossible, under-reported API-call evidence.
 
 The configured defaults are 200 API calls, 10,000 aggregate items, 500 threads,
 10,000 comments, and 10,000 reactions. Reaching a cap while `hasNextPage` is
@@ -250,9 +255,13 @@ from a hard-coded workflow name or from visible green checks alone. Check runs
 and status contexts retain stable GitHub identities and are matched to required
 contexts plus application IDs when those IDs are governed. Gate verification
 rebuilds requiredness and outcomes from the supplied current policy rather than
-trusting capture-time outcome labels. It also retains each configured source's
-strict up-to-date policy and blocks a `BEHIND` merge state whenever either
-enabled source requires checks against the current base.
+trusting capture-time outcome labels. Enabled rulesets and branch protection
+layer together: an application-specific branch-protection requirement cannot
+erase a generic same-named ruleset requirement. Within branch-protection
+evidence itself, the application-bound form still refines its legacy generic
+context. The gate also retains each configured source's strict up-to-date
+policy and blocks a `BEHIND` merge state whenever either enabled source requires
+checks against the current base.
 
 The anchor records GitHub's potential test-merge commit. When that commit has
 any check or status context, its fully paginated rollup is authoritative;

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -37,6 +37,9 @@ Stored anchor counts must exactly match all supplied top-level PR collections,
 including the complete commit set. Configuration
 supports a stable canonical identity with GraphQL, REST/event, numeric, and
 node-ID aliases; no suffix-sensitive login is the sole identity contract.
+Configuration and snapshot files must have JSON objects at their roots; every
+other valid JSON root produces the same structured invalid-input response as a
+schema violation.
 
 Package 2.1 does not add a production multi-repository registry. Package 2.2
 will supply the authoritative runtime registry and must validate each selected
@@ -139,6 +142,13 @@ strict up-to-date-base requirements, check outcomes, required or requested
 reviews, and raw unresolved thread state. It reports separately whether raw
 unresolved items exist and whether Package 2.2 technical classification remains
 necessary.
+
+The current repository configuration is authoritative at gate time. Recorded
+API calls, aggregate items, threads, comments, and reactions must fit its current
+caps even when the snapshot was captured under looser limits. If a rule source
+required by the current configuration was not captured, the gate retains the
+snapshot digest and all accumulated blockers in its structured report and does
+not attempt to infer missing required checks from placeholder evidence.
 
 A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
 not merge readiness or merge authorization. Draft, closed, merged, conflicting,

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -133,8 +133,11 @@ Every rendering states:
 
 The snapshot anchors the repository and PR before reading any collection,
 advances each connection independently, and reads the complete anchor once more
-after all evidence is captured. Any anchor change blocks the capture. It fully
-paginates:
+after all evidence is captured. The anchor includes the PR `updatedAt` value and
+the total counts for labels, review requests, reviews, conversation comments,
+review threads, and commits. Any lifecycle, identity, update-time, or count
+change blocks the capture, and every count must match its fully paginated
+collection. It fully paginates:
 
 - labels and requested reviewers or teams;
 - review submissions, including informational, approved, dismissed, and
@@ -165,7 +168,9 @@ API call is one terminal blocker.
 Each PR commit records two independent observations:
 
 1. GitHub's signature type, state, signer, and verification result;
-2. local `git verify-commit --raw` evidence when the commit object exists.
+2. local `git verify-commit --raw` evidence when the commit object exists,
+   with the signature format derived from the commit's standard ASCII-armor
+   header rather than potentially ambiguous verifier status text.
 
 Valid SSH and OpenPGP signatures are accepted when configuration permits them.
 The evidence distinguishes `valid`, `invalid`, `unsigned`, `unknown_key`,
@@ -217,8 +222,10 @@ credential-helper output.
 
 External processes use argument arrays and exact command-shape validation.
 There is no `shell=True`, shell interpolation, dynamic query construction,
-retry loop, or configuration execution. GraphQL operations are static query
-documents with variables.
+retry loop, or configuration execution. GitHub CLI calls pin `GH_HOST` to
+`github.com` and pass `--hostname github.com` explicitly; caller-provided host
+overrides and repository-context inference cannot redirect evidence reads.
+GraphQL operations are static query documents with variables.
 
 The helper exposes no operation for:
 
@@ -243,7 +250,8 @@ handling are explicit non-goals.
 
 Offline tests use fake `gh` and fake Git executables. They cover deterministic
 serialization, outer and nested pagination with unequal page counts, reactions,
-caps, partial failures, signatures, full-anchor races, strict stale-base state,
-required checks, hostile rendering, atomic outputs, and executable-call spies
-that reject GitHub and Git writes. Live acceptance is a separately identified
-read-only phase and never requests an AI review.
+caps, partial failures, signature-envelope classification, update-time and
+connection-count anchor races, strict stale-base state, required checks, hostile
+rendering, atomic outputs, host pinning, and executable-call spies that reject
+GitHub and Git writes. Live acceptance is a separately identified read-only
+phase and never requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -30,6 +30,9 @@ applies semantic validation such as unique reviewer aliases and evidence digest
 verification. Repository owner, name, URL, PR URL, base repository, head
 repository, and merged-state components must be internally consistent. Commit
 evidence must use unique object IDs and contain the captured PR head commit.
+Reviews, conversation comments, review threads, inline comments, and reactions
+must also have unique stable GitHub identities. Complete required-check
+evidence cannot carry an unknown reason.
 Stored anchor counts must exactly match all supplied top-level PR collections,
 including the complete commit set. Configuration
 supports a stable canonical identity with GraphQL, REST/event, numeric, and
@@ -113,10 +116,13 @@ a partial clone cannot silently fetch a missing object. It disables replacement
 refs and optional locks, and removes inherited Git variables that could select
 another repository, worktree, index, object database, shallow boundary,
 namespace, injected configuration, subcommand path, or trace-output target.
-Normal system, global, and repository configuration still loads from its
-standard locations, but `core.fsmonitor` is disabled and the OpenPGP, SSH, and
-X.509 verifier programs are pinned to their standard command names so config
-cannot select an arbitrary executable. The `fetched` result is always `false`.
+Every `git` and `gh` invocation uses a resolved absolute executable from fixed
+host-tool prefixes; the inherited `PATH` is replaced for the command and any
+configured verifier child process. Standard Git configuration still loads, but
+`core.fsmonitor` is disabled and the OpenPGP, SSH, and X.509 verifier programs
+are pinned to their standard names within that trusted command path. Standard
+input is closed and each external command has a 30-second timeout. The
+`fetched` result is always `false`.
 
 ### Verify the mechanical gate
 
@@ -160,7 +166,8 @@ The snapshot anchors the repository and PR before reading any collection,
 advances each connection independently, reads the complete anchor after the
 initial capture, and reads it a third time after revalidation. The anchor
 includes the PR `updatedAt` value and the total counts for labels, review
-requests, reviews, conversation comments, review threads, and commits. Any
+requests, reviews, direct PR reactions, conversation comments, review threads,
+and commits. Any
 lifecycle, identity, update-time, or count change blocks the capture, and every
 count must match its fully paginated collection. The normalized counts are
 retained as `pull_request.captured_connection_counts` and validated again
@@ -168,7 +175,8 @@ whenever a snapshot is loaded. It fully paginates:
 
 - labels and requested reviewers or teams;
 - review submissions, including informational, approved, dismissed, and
-  requested-changes reviews;
+  requested-changes reviews, plus each review-summary reaction connection;
+- the pull-request body and its direct reaction connection;
 - top-level conversation comments and each reaction connection;
 - review threads, every nested reply, and each nested reaction connection;
 - PR commits and their bounded parent evidence;
@@ -178,11 +186,12 @@ whenever a snapshot is loaded. It fully paginates:
 After the first anchor comparison, the helper performs a second complete,
 bounded observation of every fully paginated PR collection and of volatile
 evidence that can change without moving the PR head or its top-level counts.
-This includes labels, review requests, reviews, comments and reactions, inline
-threads and replies, remote commit and GitHub-signature evidence, effective
-commit checks, rulesets, and branch protection. The two normalized observations
-must be identical. Their connections, API calls, and items are recorded with a
-`.revalidation` suffix and count against the same configured caps. Any
+This includes labels, review requests, reviews and their reactions, the pull
+request and its reactions, comments and reactions, inline threads and replies,
+remote commit and GitHub-signature evidence, effective commit checks, rulesets,
+and branch protection. The two normalized observations must be identical. Their
+connections, API calls, and items are recorded with a `.revalidation` suffix
+and count against the same configured caps. Any
 difference terminates with `BLOCKED_INCOMPLETE_REVIEW_STATE` before output is
 prepared.
 
@@ -198,8 +207,8 @@ true is never completeness. The helper terminates with
 cursor. A nested-page failure prevents any authoritative snapshot or requested
 output from being emitted.
 
-There are no retries, sleeps, polls, or wait-until-complete loops. One failed
-API call is one terminal blocker.
+There are no retries, sleeps, polls, or wait-until-complete loops. One failed or
+timed-out API call is one terminal blocker.
 
 ## Signatures
 

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -106,9 +106,10 @@ python3 scripts/secpal-pr-review.py verify-gate \
   --config path/to/repository-config.json
 ```
 
-The gate verifies schema version, digest, complete pagination, unchanged head,
-safe repository and PR identity, signature policy, required-check evidence,
-check outcomes, requested changes, and raw unresolved thread state. It reports
+The gate verifies schema version, digest, complete pagination, an unchanged
+repository and pull-request anchor, safe repository and PR identity, the
+current signature and check policies, required-check evidence, check outcomes,
+required or requested reviews, and raw unresolved thread state. It reports
 separately whether raw unresolved items exist and whether Package 2.2 technical
 classification remains necessary.
 
@@ -130,9 +131,10 @@ Every rendering states:
 
 ## Complete bounded pagination
 
-The snapshot anchors the PR head before reading any collection, advances each
-connection independently, and reads the head once more after all evidence is
-captured. It fully paginates:
+The snapshot anchors the repository and PR before reading any collection,
+advances each connection independently, and reads the complete anchor once more
+after all evidence is captured. Any anchor change blocks the capture. It fully
+paginates:
 
 - labels and requested reviewers or teams;
 - review submissions, including informational, approved, dismissed, and
@@ -174,17 +176,19 @@ import keys or change signing configuration.
 
 ## Required checks
 
-Requiredness is derived from current applicable repository rules for the base
-branch and branch-protection required-status-check evidence. It is not derived
+Requiredness is derived from the repository-rule and branch-protection sources
+enabled by configuration. Disabled sources are not called. It is not derived
 from a hard-coded workflow name or from visible green checks alone. Check runs
 and status contexts retain stable GitHub identities and are matched to required
-contexts plus application IDs when those IDs are governed.
+contexts plus application IDs when those IDs are governed. Gate verification
+rebuilds requiredness and outcomes from the supplied current policy rather than
+trusting capture-time outcome labels.
 
 Evidence distinguishes required success, pending, failure, and absence;
 non-required success, pending, and failure; and unknown requiredness. Required
 skipped checks follow the explicit `check_policy.expected_skipped` value. A
-missing or inaccessible rules source, unsupported check type, malformed rule,
-or otherwise unknown requiredness terminates with
+missing or inaccessible configured rules source, unsupported check type,
+malformed rule, or otherwise unknown requiredness terminates with
 `BLOCKED_INCOMPLETE_REVIEW_STATE`. Pending checks are reported once and are not
 polled.
 
@@ -237,7 +241,7 @@ handling are explicit non-goals.
 
 Offline tests use fake `gh` and fake Git executables. They cover deterministic
 serialization, outer and nested pagination with unequal page counts, reactions,
-caps, partial failures, signatures, local-head races, required checks, hostile
+caps, partial failures, signatures, full-anchor races, required checks, hostile
 rendering, atomic outputs, and executable-call spies that reject GitHub and Git
 writes. Live acceptance is a separately identified read-only phase and never
 requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -1,0 +1,243 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Deterministic PR State and Evidence Layer
+
+Governance Package 2.1 provides a deterministic, read-only Git and GitHub data
+layer for a later finite pull-request review procedure. It captures canonical
+evidence, verifies local Git state, evaluates mechanical merge-gate evidence,
+and produces a safely escaped display rendering.
+
+Package 2.1 does not classify technical findings, remediate code, resolve
+threads, authorize a merge, or make the finite workflow operational. The
+`secpal-pr-review` Codex skill, its finite orchestration, and its installation
+belong to Package 2.2 and post-merge acceptance.
+
+## Authority and schemas
+
+The canonical authority is the JSON snapshot and its SHA-256 digest. Markdown
+is a derived, non-authoritative view.
+
+- [`secpal-pr-review-snapshot.schema.json`](schemas/secpal-pr-review-snapshot.schema.json)
+  defines snapshot version `1.0`.
+- [`secpal-pr-review-repositories.schema.json`](schemas/secpal-pr-review-repositories.schema.json)
+  defines repository configuration version `1.0`.
+
+The helper validates both structures against these checked-in schemas and then
+applies semantic validation such as unique reviewer aliases and evidence digest
+verification. Configuration supports a stable canonical identity with GraphQL,
+REST/event, numeric, and node-ID aliases; no suffix-sensitive login is the sole
+identity contract.
+
+Package 2.1 does not add a production multi-repository registry. Package 2.2
+will supply the authoritative runtime registry and must validate each selected
+repository configuration against the Package 2.1 configuration schema. The
+registry scope must be governed explicitly; it must not be inferred from the
+four repositories currently scanned by review-memory automation.
+
+## Canonical digest
+
+The digest is calculated over the complete normalized snapshot after removing
+only `snapshot_digest` from its own input. Serialization uses UTF-8, sorted
+object keys, deterministic array ordering, no insignificant whitespace, and no
+wall-clock capture timestamp or output path. GitHub-provided timestamps remain
+evidence. The serialized snapshot itself ends with one newline; that newline is
+not part of the digest input.
+
+Identical source and local-checkout evidence therefore produces byte-identical
+canonical JSON and the same digest. A local commit becoming available or a
+GitHub state change is evidence and can correctly change the digest.
+
+## Commands
+
+Run all commands from the relevant local repository checkout. The helper uses
+only the Python standard library.
+
+### Capture a snapshot
+
+```bash
+python3 scripts/secpal-pr-review.py snapshot \
+  --repo SecPal/.github \
+  --pr 123 \
+  --config path/to/repository-config.json
+```
+
+Canonical JSON is written to standard output by default. A persistent file is
+created only when an output option is explicit:
+
+```bash
+python3 scripts/secpal-pr-review.py snapshot \
+  --repo SecPal/.github \
+  --pr 123 \
+  --output snapshot.json \
+  --markdown-output snapshot.md
+```
+
+`--max-api-calls` and `--max-items` may lower or raise the corresponding
+configuration limits for one capture. Thread, comment, and reaction caps come
+from repository configuration.
+
+### Verify local state
+
+```bash
+python3 scripts/secpal-pr-review.py verify-local \
+  --repo SecPal/.github \
+  --pr 123 \
+  --expected-head 0123456789abcdef0123456789abcdef01234567
+```
+
+This captures live read-only evidence and then verifies the repository root,
+origin identity, clean tracked and untracked state, current branch, configured
+upstream, local head, remote-tracking head, PR head, expected head, base
+repository and branch, exact base-to-head commit set, commit-object
+availability, and every local commit signature.
+
+It never fetches automatically. The helper also sets `GIT_NO_LAZY_FETCH=1` so
+a partial clone cannot silently fetch a missing object. The `fetched` result is
+always `false`.
+
+### Verify the mechanical gate
+
+```bash
+python3 scripts/secpal-pr-review.py verify-gate \
+  --snapshot snapshot.json \
+  --config path/to/repository-config.json
+```
+
+The gate verifies schema version, digest, complete pagination, unchanged head,
+safe repository and PR identity, signature policy, required-check evidence,
+check outcomes, requested changes, and raw unresolved thread state. It reports
+separately whether raw unresolved items exist and whether Package 2.2 technical
+classification remains necessary.
+
+A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
+not merge readiness or merge authorization. Draft, closed, merged, conflicting,
+or not-yet-computed mergeability states block the mechanical gate.
+
+### Render Markdown
+
+```bash
+python3 scripts/secpal-pr-review.py render \
+  --snapshot snapshot.json \
+  --format markdown
+```
+
+Every rendering states:
+
+> Canonical authority: JSON snapshot and SHA-256 digest
+
+## Complete bounded pagination
+
+The snapshot anchors the PR head before reading any collection, advances each
+connection independently, and reads the head once more after all evidence is
+captured. It fully paginates:
+
+- labels and requested reviewers or teams;
+- review submissions, including informational, approved, dismissed, and
+  requested-changes reviews;
+- top-level conversation comments and each reaction connection;
+- review threads, every nested reply, and each nested reaction connection;
+- PR commits and their bounded parent evidence;
+- head-commit check runs and status contexts;
+- applicable branch rules.
+
+Independent cursors prevent unequal page counts from causing duplicate or
+omitted reads. `completeness.fully_paginated_connections` records pages and
+items for every completed connection. `completeness.api_calls` and
+`completeness.items` record actual bounded work.
+
+The configured defaults are 200 API calls, 10,000 aggregate items, 500 threads,
+10,000 comments, and 10,000 reactions. Reaching a cap while `hasNextPage` is
+true is never completeness. The helper terminates with
+`BLOCKED_INCOMPLETE_REVIEW_STATE` and identifies the exact connection and
+cursor. A nested-page failure prevents any authoritative snapshot or requested
+output from being emitted.
+
+There are no retries, sleeps, polls, or wait-until-complete loops. One failed
+API call is one terminal blocker.
+
+## Signatures
+
+Each PR commit records two independent observations:
+
+1. GitHub's signature type, state, signer, and verification result;
+2. local `git verify-commit --raw` evidence when the commit object exists.
+
+Valid SSH and OpenPGP signatures are accepted when configuration permits them.
+The evidence distinguishes `valid`, `invalid`, `unsigned`, `unknown_key`,
+`object_unavailable`, and `verification_pending`. An unknown key is never
+reported as cryptographically verified. Required invalid, unsigned, unknown,
+pending, or unavailable verification blocks the gate. The helper does not
+import keys or change signing configuration.
+
+## Required checks
+
+Requiredness is derived from current applicable repository rules for the base
+branch and branch-protection required-status-check evidence. It is not derived
+from a hard-coded workflow name or from visible green checks alone. Check runs
+and status contexts retain stable GitHub identities and are matched to required
+contexts plus application IDs when those IDs are governed.
+
+Evidence distinguishes required success, pending, failure, and absence;
+non-required success, pending, and failure; and unknown requiredness. Required
+skipped checks follow the explicit `check_policy.expected_skipped` value. A
+missing or inaccessible rules source, unsupported check type, malformed rule,
+or otherwise unknown requiredness terminates with
+`BLOCKED_INCOMPLETE_REVIEW_STATE`. Pending checks are reported once and are not
+polled.
+
+## Output and untrusted content
+
+Canonical JSON retains review text as evidence. Derived Markdown escapes
+Markdown punctuation, HTML delimiters, code fences, brackets, parentheses,
+angle brackets, control characters, and carriage returns. It does not embed
+hidden JSON in HTML comments. Only validated `https://github.com` URLs without
+unsafe delimiters or credentials are rendered as links; other URLs remain
+escaped text.
+
+Explicit outputs use same-directory temporary files, `fsync`, and atomic
+replacement. Final mode is `0600`. Existing non-regular targets, output
+symlinks, and symlinked parent chains are rejected. Canonical JSON and Markdown
+cannot target the same path. Staged temporary files are removed after failure,
+and capture failures occur before output preparation.
+
+Diagnostics are structured, bounded, and redact token-, authorization-, key-,
+and secret-shaped content. The helper never prints an environment dump or
+credential-helper output.
+
+## Strict read-only boundary
+
+External processes use argument arrays and exact command-shape validation.
+There is no `shell=True`, shell interpolation, dynamic query construction,
+retry loop, or configuration execution. GraphQL operations are static query
+documents with variables.
+
+The helper exposes no operation for:
+
+- GraphQL mutations or non-GET REST writes;
+- reactions, replies, thread resolution, reviews, or reviewer requests;
+- labels, issues, Draft/Ready transitions, or review dispatch;
+- commits, pushes, checkouts, branch switches, resets, cleaning, or stashing;
+- merges, auto-merge, history rewriting, or force-pushes.
+
+Package 2.1 is also separate from review memory. It neither updates tracking
+issues nor promotes historical lessons. Review-memory changes, finding
+classification, remediation cycles, GitHub writes, and user-authorized merge
+handling are explicit non-goals.
+
+## Exit behavior and testing
+
+- `0` means the requested capture, render, or verification completed without a
+  mechanical blocker.
+- `2` means invalid or unsafe local input or output handling.
+- `3` means a deterministic state, API, completeness, signature, check, or
+  review-state blocker.
+
+Offline tests use fake `gh` and fake Git executables. They cover deterministic
+serialization, outer and nested pagination with unequal page counts, reactions,
+caps, partial failures, signatures, local-head races, required checks, hostile
+rendering, atomic outputs, and executable-call spies that reject GitHub and Git
+writes. Live acceptance is a separately identified read-only phase and never
+requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -27,9 +27,10 @@ is a derived, non-authoritative view.
 
 The helper validates both structures against these checked-in schemas and then
 applies semantic validation such as unique reviewer aliases and evidence digest
-verification. Configuration supports a stable canonical identity with GraphQL,
-REST/event, numeric, and node-ID aliases; no suffix-sensitive login is the sole
-identity contract.
+verification. Commit evidence must use unique object IDs and contain the
+captured PR head commit. Configuration supports a stable canonical identity
+with GraphQL, REST/event, numeric, and node-ID aliases; no suffix-sensitive
+login is the sole identity contract.
 
 Package 2.1 does not add a production multi-repository registry. Package 2.2
 will supply the authoritative runtime registry and must validate each selected
@@ -95,8 +96,12 @@ repository and branch, exact base-to-head commit set, commit-object
 availability, and every local commit signature.
 
 It never fetches automatically. The helper also sets `GIT_NO_LAZY_FETCH=1` so
-a partial clone cannot silently fetch a missing object. The `fetched` result is
-always `false`.
+a partial clone cannot silently fetch a missing object. It disables replacement
+refs and optional locks, and removes inherited Git variables that could select
+another repository, worktree, index, object database, shallow boundary,
+namespace, injected configuration, subcommand path, or trace-output target.
+Normal system, global, and repository configuration still loads from its
+standard locations. The `fetched` result is always `false`.
 
 ### Verify the mechanical gate
 
@@ -115,7 +120,11 @@ items exist and whether Package 2.2 technical classification remains necessary.
 
 A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
 not merge readiness or merge authorization. Draft, closed, merged, conflicting,
-or not-yet-computed mergeability states block the mechanical gate.
+or not-yet-computed mergeability states block the mechanical gate. GitHub merge
+states `DIRTY`, `UNKNOWN`, `BLOCKED`, and `DRAFT` fail closed. `UNSTABLE`
+continues through the granular required-check policy so an optional failure is
+not promoted into a required failure; `CLEAN` and `HAS_HOOKS` add no merge-state
+blocker, while `BEHIND` follows the configured strict up-to-date-base policy.
 
 ### Render Markdown
 
@@ -225,7 +234,11 @@ There is no `shell=True`, shell interpolation, dynamic query construction,
 retry loop, or configuration execution. GitHub CLI calls pin `GH_HOST` to
 `github.com` and pass `--hostname github.com` explicitly; caller-provided host
 overrides and repository-context inference cannot redirect evidence reads.
-GraphQL operations are static query documents with variables.
+GraphQL operations are static query documents with variables. Git commands run
+with pagers pinned, optional locking disabled, replacement refs ignored, lazy
+fetches disabled, and repository- or object-selection environment overrides
+removed before process creation. Trace-file and executable-path overrides are
+removed as part of the same boundary.
 
 The helper exposes no operation for:
 
@@ -252,6 +265,7 @@ Offline tests use fake `gh` and fake Git executables. They cover deterministic
 serialization, outer and nested pagination with unequal page counts, reactions,
 caps, partial failures, signature-envelope classification, update-time and
 connection-count anchor races, strict stale-base state, required checks, hostile
-rendering, atomic outputs, host pinning, and executable-call spies that reject
+rendering, atomic outputs, host pinning, merge-state policy coverage, commit-set
+invariants, sanitized Git environments, and executable-call spies that reject
 GitHub and Git writes. Live acceptance is a separately identified read-only
 phase and never requests an AI review.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -28,9 +28,10 @@ is a derived, non-authoritative view.
 The helper validates both structures against these checked-in schemas and then
 applies semantic validation such as unique reviewer aliases and evidence digest
 verification. Commit evidence must use unique object IDs and contain the
-captured PR head commit. Configuration supports a stable canonical identity
-with GraphQL, REST/event, numeric, and node-ID aliases; no suffix-sensitive
-login is the sole identity contract.
+captured PR head commit. Stored anchor counts must exactly match all supplied
+top-level PR collections, including the complete commit set. Configuration
+supports a stable canonical identity with GraphQL, REST/event, numeric, and
+node-ID aliases; no suffix-sensitive login is the sole identity contract.
 
 Package 2.1 does not add a production multi-repository registry. Package 2.2
 will supply the authoritative runtime registry and must validate each selected
@@ -50,6 +51,11 @@ not part of the digest input.
 Identical source and local-checkout evidence therefore produces byte-identical
 canonical JSON and the same digest. A local commit becoming available or a
 GitHub state change is evidence and can correctly change the digest.
+
+SHA-256 provides deterministic integrity and equality evidence; it is not a
+signature or message-authentication code and does not authenticate who produced
+a snapshot. Callers must obtain gate input from the trusted capture execution
+or a separately authenticated artifact channel.
 
 ## Commands
 
@@ -113,12 +119,13 @@ python3 scripts/secpal-pr-review.py verify-gate \
   --config path/to/repository-config.json
 ```
 
-The gate verifies schema version, digest, complete pagination, an unchanged
-repository and pull-request anchor, safe repository and PR identity, the
-current signature and check policies, required-check evidence, strict
-up-to-date-base requirements, check outcomes, required or requested reviews,
-and raw unresolved thread state. It reports separately whether raw unresolved
-items exist and whether Package 2.2 technical classification remains necessary.
+The gate verifies schema version, digest, complete pagination, stored anchor
+counts, an unchanged repository and pull-request anchor, safe repository and PR
+identity, the current signature and check policies, required-check evidence,
+strict up-to-date-base requirements, check outcomes, required or requested
+reviews, and raw unresolved thread state. It reports separately whether raw
+unresolved items exist and whether Package 2.2 technical classification remains
+necessary.
 
 A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
 not merge readiness or merge authorization. Draft, closed, merged, conflicting,
@@ -148,7 +155,9 @@ initial capture, and reads it a third time after revalidation. The anchor
 includes the PR `updatedAt` value and the total counts for labels, review
 requests, reviews, conversation comments, review threads, and commits. Any
 lifecycle, identity, update-time, or count change blocks the capture, and every
-count must match its fully paginated collection. It fully paginates:
+count must match its fully paginated collection. The normalized counts are
+retained as `pull_request.captured_connection_counts` and validated again
+whenever a snapshot is loaded. It fully paginates:
 
 - labels and requested reviewers or teams;
 - review submissions, including informational, approved, dismissed, and
@@ -197,11 +206,13 @@ Each PR commit records two independent observations:
 Valid SSH and OpenPGP signatures are accepted when configuration permits them.
 The evidence distinguishes `valid`, `invalid`, `unsigned`, `unknown_key`,
 `object_unavailable`, and `verification_pending`. An unknown key is never
-reported as cryptographically verified. Required invalid, unsigned, unknown,
-pending, or unavailable verification blocks the gate. The helper does not
-import keys or persist signing configuration. Verification still uses the
-configured trust material, while command-scoped overrides prevent configuration
-from substituting the verifier executables themselves.
+reported as cryptographically verified. A `valid` state requires
+`verified: true`; every other state requires `verified: false`. Required
+invalid, unsigned, unknown, pending, unavailable, or internally inconsistent
+verification blocks the gate. The helper does not import keys or persist
+signing configuration. Verification still uses the configured trust material,
+while command-scoped overrides prevent configuration from substituting the
+verifier executables themselves.
 
 ## Required checks
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,19 @@ SPDX-License-Identifier: CC0-1.0
 
 This directory contains utility scripts for SecPal development.
 
+## Pull Request Evidence
+
+### `secpal-pr-review.py`
+
+Captures deterministic, thread-aware GitHub pull-request evidence and verifies
+local Git state through a strict read-only command boundary. Canonical JSON is
+the authority; Markdown is an escaped derived view. The helper performs no
+review request, reaction, reply, thread resolution, push, or merge operation.
+
+See [Deterministic PR State and Evidence Layer](../docs/secpal-pr-review-state-layer.md)
+for schemas, bounded pagination, signature and required-check semantics, safe
+outputs, commands, and Package 2.1 non-goals.
+
 ## Validation Scripts
 
 ### `check-domains.sh`

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -603,7 +603,6 @@ def validate_config(configuration: dict[str, Any]) -> None:
         "default_branch",
         "allowed_base_repositories",
         "reviewer_identities",
-        "required_local_validation",
         "signature_policy",
         "check_policy",
         "maximum_api_calls",
@@ -665,17 +664,6 @@ def validate_config(configuration: dict[str, Any]) -> None:
             isinstance(value, bool) or not isinstance(value, int) or value < 1 for value in database_ids
         ):
             raise ContractError("database_ids must contain positive integers")
-    validations = configuration["required_local_validation"]
-    if not isinstance(validations, list):
-        raise ContractError("required_local_validation must be a list")
-    for validation in validations:
-        if not isinstance(validation, dict) or set(validation) != {"name", "command"}:
-            raise ContractError("Each local validation requires name and command")
-        command = validation["command"]
-        if not validation["name"] or not isinstance(command, list) or not command:
-            raise ContractError("Local validation name and command cannot be empty")
-        if any(not isinstance(argument, str) or not argument for argument in command):
-            raise ContractError("Local validation command must be an argument array")
     signature_policy = configuration["signature_policy"]
     if not isinstance(signature_policy, dict) or set(signature_policy) != {
         "require_github_verified",
@@ -720,7 +708,6 @@ def default_config(repository: str) -> dict[str, Any]:
         "default_branch": "main",
         "allowed_base_repositories": [repository],
         "reviewer_identities": [],
-        "required_local_validation": [],
         "signature_policy": {
             "require_github_verified": True,
             "require_local_verified": True,
@@ -1009,8 +996,17 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
         "conversation_comments": captured_counts["conversation_comments"],
         "review_threads": captured_counts["review_threads"],
         "commits": captured_counts["commits"],
-        "checks": sum(item["status"] != "MISSING" for item in snapshot["checks"]),
     }
+    check_items = sum(item["status"] != "MISSING" for item in snapshot["checks"])
+    check_source = pr["check_commit_source"]
+    if check_source == "test_merge":
+        expected["test_merge_checks"] = check_items
+    elif check_source == "head":
+        if pr["potential_merge_commit_oid"] is not None:
+            expected["test_merge_checks"] = 0
+        expected["head_checks"] = check_items
+    else:
+        raise ContractError("Unsupported check commit source")
     sources = snapshot["required_check_evidence"]["sources"]
     if len(sources) != len(set(sources)) or not set(sources) <= {"rulesets", "branch_protection"}:
         raise ContractError("Required-check sources must be unique and supported")
@@ -1032,7 +1028,9 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
     expected[f"conversation_comments{REVALIDATION_SUFFIX}"] = len(snapshot["conversation_comments"])
     expected[f"review_threads{REVALIDATION_SUFFIX}"] = len(snapshot["review_threads"])
     expected[f"commits{REVALIDATION_SUFFIX}"] = len(snapshot["commits"])
-    expected[f"checks{REVALIDATION_SUFFIX}"] = expected["checks"]
+    for connection in ("test_merge_checks", "head_checks"):
+        if connection in expected:
+            expected[f"{connection}{REVALIDATION_SUFFIX}"] = expected[connection]
     if "rulesets" in sources:
         expected[f"rulesets{REVALIDATION_SUFFIX}"] = len(snapshot["applicable_rules"]["rulesets"])
     if "branch_protection" in sources:
@@ -1062,7 +1060,8 @@ def expected_api_calls(connections: list[dict[str, Any]]) -> int:
         "conversation_comments",
         "review_threads",
         "commits",
-        "checks",
+        "test_merge_checks",
+        "head_checks",
         "rulesets",
         "branch_protection",
     }
@@ -1251,6 +1250,9 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             "head_ref",
             "head_oid_before",
             "head_oid_after",
+            "potential_merge_commit_oid",
+            "check_commit_oid",
+            "check_commit_source",
             "captured_connection_counts",
             "labels",
             "requested_reviewers",
@@ -1258,13 +1260,66 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         },
         "pull_request",
     )
+    repository_name = f"{repository['owner']}/{repository['name']}"
+    repository_url = f"https://github.com/{repository_name}"
+    if (
+        repository["name_with_owner"] != repository_name
+        or repository["url"] != repository_url
+    ):
+        raise ContractError("Snapshot repository identity components disagree")
+    if pr["base_repository"] != {
+        "id": repository["id"],
+        "name_with_owner": repository_name,
+        "url": repository_url,
+    }:
+        raise ContractError("Pull request base repository does not match the queried repository")
+    if pr["url"] != f"{repository_url}/pull/{pr['number']}":
+        raise ContractError("Pull request URL does not match its repository and number")
+    if pr["is_merged"] is not (pr["state"] == "MERGED"):
+        raise ContractError("Pull request merged state is internally inconsistent")
+    head_repository = pr["head_repository"]
+    head_values = (
+        head_repository["id"],
+        head_repository["name_with_owner"],
+        head_repository["url"],
+    )
+    if any(value is None for value in head_values) and not all(value is None for value in head_values):
+        raise ContractError("Pull request head repository identity is incomplete")
+    if all(value is not None for value in head_values):
+        validate_repository_name(head_repository["name_with_owner"])
+        if head_repository["url"] != f"https://github.com/{head_repository['name_with_owner']}":
+            raise ContractError("Pull request head repository URL is inconsistent")
+        if head_repository["id"] == repository["id"] and head_repository != pr["base_repository"]:
+            raise ContractError("Pull request head repository identity disagrees with its repository ID")
     if not isinstance(pr["number"], int) or pr["number"] < 1:
         raise ContractError("Pull request number must be positive")
-    for key in ("base_oid", "head_oid_before", "head_oid_after"):
+    for key in ("base_oid", "head_oid_before", "head_oid_after", "check_commit_oid"):
         if not isinstance(pr[key], str) or not OID_PATTERN.fullmatch(pr[key]):
             raise ContractError(f"Invalid pull request {key}")
+    potential_merge_commit_oid = pr["potential_merge_commit_oid"]
+    if potential_merge_commit_oid is not None and (
+        not isinstance(potential_merge_commit_oid, str)
+        or not OID_PATTERN.fullmatch(potential_merge_commit_oid)
+    ):
+        raise ContractError("Invalid pull request potential_merge_commit_oid")
+    if (
+        pr["state"] == "OPEN"
+        and pr["mergeable"] in {"MERGEABLE", "UNKNOWN"}
+        and potential_merge_commit_oid is None
+    ):
+        raise ContractError("Potential merge commit is unavailable for an open mergeable pull request")
     if pr["head_oid_before"] != pr["head_oid_after"]:
         raise ContractError("Snapshot head changed during capture")
+    if pr["check_commit_source"] == "head":
+        if pr["check_commit_oid"] != pr["head_oid_after"]:
+            raise ContractError("Head check evidence is bound to the wrong commit")
+    elif pr["check_commit_source"] == "test_merge":
+        if potential_merge_commit_oid is None or pr["check_commit_oid"] != potential_merge_commit_oid:
+            raise ContractError("Test-merge check evidence is bound to the wrong commit")
+        if not any(item.get("status") != "MISSING" for item in snapshot["checks"]):
+            raise ContractError("Test-merge check evidence cannot be empty")
+    else:
+        raise ContractError("Unsupported check commit source")
     for collection in ("reviews", "conversation_comments", "review_threads", "commits", "checks"):
         if not isinstance(snapshot[collection], list):
             raise ContractError(f"{collection} must be an array")
@@ -1289,6 +1344,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         raise ContractError("Applicable-rule evidence is incomplete")
     if snapshot["required_check_evidence"].get("determination") != "complete":
         raise ContractError("Required-check evidence is incomplete")
+    validate_required_check_metadata(snapshot)
     validate_completeness(snapshot)
 
 
@@ -1535,10 +1591,52 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
     pull_request = repository.get("pullRequest")
     if pull_request is None:
         raise BlockedError(BLOCKED_INCOMPLETE, "Pull request is unavailable", "pull_request.anchor", None)
-    if not pull_request.get("headRefOid") or not pull_request.get("baseRefOid"):
+    if any(
+        not isinstance(pull_request.get(key), str)
+        or not OID_PATTERN.fullmatch(pull_request[key])
+        for key in ("headRefOid", "baseRefOid")
+    ):
         raise BlockedError(
             BLOCKED_INCOMPLETE,
             "Pull request head or base OID is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    if "potentialMergeCommit" not in pull_request:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Potential merge commit evidence is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    potential_merge_commit = pull_request["potentialMergeCommit"]
+    if potential_merge_commit is not None and (
+        not isinstance(potential_merge_commit, dict)
+        or not isinstance(potential_merge_commit.get("oid"), str)
+        or not OID_PATTERN.fullmatch(potential_merge_commit["oid"])
+    ):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Potential merge commit identity is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    mergeable = pull_request.get("mergeable")
+    if mergeable not in {"MERGEABLE", "CONFLICTING", "UNKNOWN"}:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request mergeability is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    if (
+        pull_request.get("state") == "OPEN"
+        and mergeable in {"MERGEABLE", "UNKNOWN"}
+        and potential_merge_commit is None
+    ):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Potential merge commit is still being generated",
             "pull_request.anchor",
             None,
         )
@@ -1829,7 +1927,10 @@ def evaluate_checks(
             outcome = _check_outcome(item.get("status"), item.get("conclusion"), policy["expected_skipped"])
             item["evidence_state"] = f"non_required_{outcome}"
     missing: list[str] = []
-    for key in sorted(set(required_by_key) - matched, key=lambda value: (value[0], value[1] or 0)):
+    for key in sorted(
+        set(required_by_key) - matched,
+        key=lambda value: (value[0], value[1] or 0),
+    ):
         stable_id = _required_stable_id(key[0], key[1])
         missing.append(stable_id)
         checks.append(
@@ -1971,6 +2072,71 @@ def required_specs_from_snapshot(
         branch_protection if policy["require_branch_protection_evidence"] else None,
         policy,
     )
+
+
+def validate_required_check_metadata(snapshot: dict[str, Any]) -> None:
+    """Reject internally contradictory required-check snapshot evidence."""
+
+    stored_checks = snapshot["checks"]
+    stable_ids = [item["stable_id"] for item in stored_checks]
+    if len(stable_ids) != len(set(stable_ids)):
+        raise ContractError("Snapshot contains a duplicate check identity")
+    sources = snapshot["required_check_evidence"]["sources"]
+    source_set = set(sources)
+    policy = {
+        "require_ruleset_evidence": "rulesets" in source_set,
+        "require_branch_protection_evidence": "branch_protection" in source_set,
+        "expected_skipped": "block",
+    }
+    try:
+        required_specs = required_specs_from_snapshot(snapshot, policy)
+    except BlockedError as exc:
+        raise ContractError(f"Invalid required-check rule evidence: {exc.message}") from exc
+    raw_fields = (
+        "stable_id",
+        "name",
+        "application",
+        "status",
+        "conclusion",
+        "details_url",
+    )
+    raw_checks = [
+        {key: copy.deepcopy(item[key]) for key in raw_fields}
+        for item in stored_checks
+        if item["status"] != "MISSING"
+    ]
+    evaluated, expected_evidence = evaluate_checks(
+        raw_checks,
+        required_specs,
+        policy,
+        sources,
+    )
+    stored_evidence = snapshot["required_check_evidence"]
+    if (
+        stored_evidence["required"] != expected_evidence["required"]
+        or stored_evidence["missing"] != expected_evidence["missing"]
+    ):
+        raise ContractError("Required-check metadata disagrees with applicable rules and checks")
+    stored_by_id = {item["stable_id"]: item for item in stored_checks}
+    expected_by_id = {item["stable_id"]: item for item in evaluated}
+    if stored_by_id.keys() != expected_by_id.keys():
+        raise ContractError("Required-check metadata omits or invents check evidence")
+    for stable_id, expected in expected_by_id.items():
+        stored = stored_by_id[stable_id]
+        for key in (*raw_fields[1:], "requiredness"):
+            if stored[key] != expected[key]:
+                raise ContractError(f"Check requiredness or identity is inconsistent for {stable_id}")
+        if stored["status"] == "MISSING":
+            allowed_states = {"required_missing"}
+        else:
+            prefix = stored["requiredness"]
+            outcomes = {
+                _check_outcome(stored["status"], stored["conclusion"], skipped_policy)
+                for skipped_policy in ("allow", "block")
+            }
+            allowed_states = {f"{prefix}_{outcome}" for outcome in outcomes}
+        if stored["evidence_state"] not in allowed_states:
+            raise ContractError(f"Check outcome evidence is inconsistent for {stable_id}")
 
 
 def strict_checks_require_current_base(snapshot: dict[str, Any], policy: dict[str, Any]) -> bool:
@@ -2120,9 +2286,9 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
         }:
             blockers.append(
                 {
-                    "code": "BLOCKED_FAILED_OR_PENDING_CI"
-                    if item["evidence_state"] != "requiredness_unknown"
-                    else BLOCKED_INCOMPLETE,
+                    "code": BLOCKED_INCOMPLETE
+                    if item["evidence_state"] == "requiredness_unknown"
+                    else "BLOCKED_FAILED_OR_PENDING_CI",
                     "reason": f"{item['name']}: {item['evidence_state']}",
                 }
             )
@@ -2315,6 +2481,7 @@ query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
       headRepository { id nameWithOwner url }
       headRefName
       headRefOid
+      potentialMergeCommit { oid }
     }
   }
 }
@@ -3135,27 +3302,65 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
 
 def _capture_checks(
     client: GitHubClient,
-    head_oid: str,
-    connection_suffix: str = "",
+    commit_oid: str,
+    connection: str,
 ) -> list[dict[str, Any]]:
-    connection = f"checks{connection_suffix}"
 
     def fetch(cursor: str | None) -> Page:
         payload = client.graphql(
             COMMIT_CHECKS_QUERY,
             connection,
             cursor,
-            {"oid": head_oid},
+            {"oid": commit_oid},
         )
         commit_object = _path(payload, ("data", "repository", "object"), connection)
         if commit_object is None:
-            raise BlockedError(BLOCKED_INCOMPLETE, "Head commit object is inaccessible", connection, cursor)
+            raise BlockedError(BLOCKED_INCOMPLETE, "Check commit object is inaccessible", connection, cursor)
         rollup = commit_object.get("statusCheckRollup")
         if rollup is None:
             return Page([], False, None)
         return _connection_page(rollup.get("contexts"), connection)
 
     return [_normalize_check(item) for item in collect_pages(connection, fetch, client.budget)]
+
+
+def select_effective_check_target(
+    head_oid: str,
+    potential_merge_commit_oid: str | None,
+    test_merge_checks: list[dict[str, Any]],
+) -> tuple[str, str]:
+    """Apply GitHub's test-merge-first required-check selection rule."""
+
+    if potential_merge_commit_oid is not None and test_merge_checks:
+        return potential_merge_commit_oid, "test_merge"
+    return head_oid, "head"
+
+
+def _capture_effective_checks(
+    client: GitHubClient,
+    head_oid: str,
+    potential_merge_commit_oid: str | None,
+    connection_suffix: str = "",
+) -> tuple[list[dict[str, Any]], str, str]:
+    test_merge_checks: list[dict[str, Any]] = []
+    if potential_merge_commit_oid is not None:
+        test_merge_checks = _capture_checks(
+            client,
+            potential_merge_commit_oid,
+            f"test_merge_checks{connection_suffix}",
+        )
+    check_commit_oid, check_commit_source = select_effective_check_target(
+        head_oid,
+        potential_merge_commit_oid,
+        test_merge_checks,
+    )
+    if check_commit_source == "test_merge":
+        return test_merge_checks, check_commit_oid, check_commit_source
+    return (
+        _capture_checks(client, head_oid, f"head_checks{connection_suffix}"),
+        check_commit_oid,
+        check_commit_source,
+    )
 
 
 def _normalize_applicable_rules(rulesets: list[Any], branch_protection: dict[str, Any]) -> dict[str, Any]:
@@ -3265,6 +3470,7 @@ def _capture_rules(
 def _capture_remote_evidence(
     client: GitHubClient,
     head_oid: str,
+    potential_merge_commit_oid: str | None,
     base_ref: str,
     configuration: dict[str, Any],
     connection_suffix: str = "",
@@ -3277,7 +3483,12 @@ def _capture_remote_evidence(
     conversation_comments = _capture_conversation_comments(client, connection_suffix)
     review_threads = _capture_review_threads(client, connection_suffix)
     commits = _capture_commits(client, connection_suffix)
-    raw_checks = _capture_checks(client, head_oid, connection_suffix)
+    raw_checks, check_commit_oid, check_commit_source = _capture_effective_checks(
+        client,
+        head_oid,
+        potential_merge_commit_oid,
+        connection_suffix,
+    )
     applicable_rules, required_specs, rule_sources = _capture_rules(
         client,
         base_ref,
@@ -3299,6 +3510,8 @@ def _capture_remote_evidence(
         "review_threads": review_threads,
         "commits": commits,
         "checks": checks,
+        "check_commit_oid": check_commit_oid,
+        "check_commit_source": check_commit_source,
         "applicable_rules": applicable_rules,
         "required_check_evidence": required_check_evidence,
     }
@@ -3329,10 +3542,15 @@ def capture_snapshot(
             None,
         )
     head_before = before_pr["headRefOid"]
+    potential_merge_commit = before_pr.get("potentialMergeCommit")
+    potential_merge_commit_oid = (
+        potential_merge_commit.get("oid") if isinstance(potential_merge_commit, dict) else None
+    )
 
     evidence = _capture_remote_evidence(
         client,
         head_before,
+        potential_merge_commit_oid,
         before_pr["baseRefName"],
         configuration,
     )
@@ -3366,6 +3584,7 @@ def capture_snapshot(
     revalidated_evidence = _capture_remote_evidence(
         client,
         head_before,
+        potential_merge_commit_oid,
         before_pr["baseRefName"],
         configuration,
         REVALIDATION_SUFFIX,
@@ -3424,6 +3643,9 @@ def capture_snapshot(
             "head_ref": before_pr.get("headRefName"),
             "head_oid_before": head_before,
             "head_oid_after": head_after,
+            "potential_merge_commit_oid": potential_merge_commit_oid,
+            "check_commit_oid": evidence["check_commit_oid"],
+            "check_commit_source": evidence["check_commit_source"],
             "captured_connection_counts": {
                 name: before_pr[connection]["totalCount"]
                 for name, connection in CAPTURED_CONNECTIONS.items()

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -31,6 +31,7 @@ DEFAULT_MAXIMUM_THREADS = 500
 DEFAULT_MAXIMUM_COMMENTS = 10_000
 DEFAULT_MAXIMUM_REACTIONS = 10_000
 DEFAULT_EXTERNAL_COMMAND_TIMEOUT_SECONDS = 30
+CAPTURE_PAGE_SIZE = 100
 BLOCKED_INCOMPLETE = "BLOCKED_INCOMPLETE_REVIEW_STATE"
 ZERO_AUTHOR = {
     "kind": "deleted_or_unavailable",
@@ -284,7 +285,7 @@ def validate_external_command(arguments: list[str]) -> None:
     encoded_ref = r"[A-Za-z0-9._~%-]+"
     endpoint = arguments[6]
     allowed_endpoint = re.fullmatch(
-        rf"repos/{repository}/rules/branches/{encoded_ref}\?per_page=100&page=[1-9][0-9]*",
+        rf"repos/{repository}/rules/branches/{encoded_ref}\?per_page={CAPTURE_PAGE_SIZE}&page=[1-9][0-9]*",
         endpoint,
     ) or re.fullmatch(
         rf"repos/{repository}/branches/{encoded_ref}/protection/required_status_checks",
@@ -1215,6 +1216,8 @@ def validate_completeness(snapshot: dict[str, Any]) -> None:
         connection = item["connection"]
         if connection in evidence:
             raise ContractError(f"Duplicate pagination evidence for {connection}")
+        if item["items"] > item["pages"] * CAPTURE_PAGE_SIZE:
+            raise ContractError(f"Pagination evidence exceeds page capacity for {connection}")
         evidence[connection] = item["items"]
     missing = sorted(expected.keys() - evidence.keys())
     extra = sorted(evidence.keys() - expected.keys())
@@ -1311,13 +1314,24 @@ def validate_stable_evidence_identities(snapshot: dict[str, Any]) -> None:
         for comment in thread["comments"]
     ]
     _require_unique_identities("review comment", (item.get("id") for item in review_comments))
-    reactions = [
+    reactions = snapshot_reactions(snapshot)
+    _require_unique_identities("reaction", (item.get("id") for item in reactions))
+
+
+def snapshot_reactions(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return every reaction captured on a supported pull-request subject."""
+
+    review_comments = [
+        comment
+        for thread in snapshot["review_threads"]
+        for comment in thread["comments"]
+    ]
+    return [
         *snapshot["pull_request"]["reactions"],
         *(reaction for item in snapshot["reviews"] for reaction in item["reactions"]),
         *(reaction for item in snapshot["conversation_comments"] for reaction in item["reactions"]),
         *(reaction for item in review_comments for reaction in item["reactions"]),
     ]
-    _require_unique_identities("reaction", (item.get("id") for item in reactions))
 
 
 def validate_snapshot(snapshot: dict[str, Any]) -> None:
@@ -2108,6 +2122,7 @@ def require_rule_evidence(
             None,
         )
     specifications: dict[tuple[str, int | None], dict[str, Any]] = {}
+    generic_ruleset_contexts: set[str] = set()
     for rule in rulesets or []:
         if not isinstance(rule, dict):
             raise BlockedError(BLOCKED_INCOMPLETE, "Malformed applicable rule", "rulesets", None)
@@ -2149,6 +2164,8 @@ def require_rule_evidence(
                 "context": context,
                 "integration_id": integration_id,
             }
+            if integration_id is None:
+                generic_ruleset_contexts.add(context)
     if isinstance(branch_protection, dict):
         if policy["require_branch_protection_evidence"] and not isinstance(branch_protection.get("strict"), bool):
             raise BlockedError(
@@ -2183,7 +2200,7 @@ def require_rule_evidence(
             ):
                 raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "branch_protection", None)
             specifications[(context, app_id)] = {"context": context, "integration_id": app_id}
-            if app_id is not None:
+            if app_id is not None and context not in generic_ruleset_contexts:
                 specifications.pop((context, None), None)
     return [specifications[key] for key in sorted(specifications, key=lambda value: (value[0], value[1] or 0))]
 
@@ -2451,6 +2468,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
     requested_changes = pr["review_decision"] == "CHANGES_REQUESTED"
     review_required = pr["review_decision"] == "REVIEW_REQUIRED"
     review_requested = bool(pr["requested_reviewers"] or pr["requested_teams"])
+    reaction_count = len(snapshot_reactions(snapshot))
     if unresolved or requested_changes or review_required or review_requested:
         blockers.append(
             {
@@ -2467,6 +2485,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
             "reviews": len(snapshot["reviews"]),
             "conversation_comments": len(snapshot["conversation_comments"]),
             "review_threads": len(snapshot["review_threads"]),
+            "reactions": reaction_count,
             "resolved_threads": len(snapshot["review_threads"]) - len(unresolved),
             "unresolved_threads": len(unresolved),
             "requested_changes": requested_changes,
@@ -2474,7 +2493,10 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
             "review_requested": review_requested,
         },
         "technical_classification_required": bool(
-            snapshot["reviews"] or snapshot["conversation_comments"] or snapshot["review_threads"]
+            snapshot["reviews"]
+            or snapshot["conversation_comments"]
+            or snapshot["review_threads"]
+            or reaction_count
         ),
         "merge_authorized": False,
     }
@@ -3701,7 +3723,7 @@ def _capture_rules(
         base_endpoint = f"repos/{client.owner}/{client.name}/rules/branches/{encoded_ref}"
         page_number = 1
         while True:
-            endpoint = f"{base_endpoint}?per_page=100&page={page_number}"
+            endpoint = f"{base_endpoint}?per_page={CAPTURE_PAGE_SIZE}&page={page_number}"
             page = client.rest(endpoint, connection, str(page_number))
             if not isinstance(page, list):
                 raise BlockedError(
@@ -3712,7 +3734,7 @@ def _capture_rules(
                 )
             client.budget.add_items(len(page), connection, str(page_number))
             rulesets.extend(page)
-            if len(page) < 100:
+            if len(page) < CAPTURE_PAGE_SIZE:
                 client.budget.record_connection(connection, page_number, len(rulesets))
                 break
             page_number += 1

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -180,7 +180,7 @@ def validate_external_command(arguments: list[str]) -> None:
         return
     if executable != "gh":
         raise CommandPolicyError(f"Executable is not allowlisted: {executable}")
-    if len(arguments) < 2:
+    if len(arguments) < 3:
         raise CommandPolicyError("GitHub CLI subcommand is required")
     if arguments[1] == "pr":
         subcommand = arguments[2] if len(arguments) > 2 else ""
@@ -188,18 +188,51 @@ def validate_external_command(arguments: list[str]) -> None:
             raise CommandPolicyError(f"GitHub PR operation is not allowlisted: {subcommand}")
     if arguments[1] != "api":
         raise CommandPolicyError(f"GitHub CLI operation is not allowlisted: {arguments[1]}")
-    method = "GET"
-    if "--method" in arguments:
-        index = arguments.index("--method")
-        if index + 1 >= len(arguments):
-            raise CommandPolicyError("Missing GitHub API method")
-        method = arguments[index + 1].upper()
-    if method != "GET":
-        raise CommandPolicyError(f"GitHub API method is not read-only: {method}")
-    if len(arguments) > 2 and arguments[2] == "graphql":
-        query = next((value.split("=", 1)[1] for value in arguments if value.startswith("query=")), "")
+    if arguments[2] == "graphql":
+        fields = arguments[3:]
+        if len(fields) % 2:
+            raise CommandPolicyError("GraphQL arguments must be exact flag/value pairs")
+        query = ""
+        seen_variables: set[str] = set()
+        string_variables = {"owner", "name", "after", "nodeId", "oid"}
+        for index in range(0, len(fields), 2):
+            flag, field = fields[index : index + 2]
+            if flag not in {"-f", "-F"} or "=" not in field:
+                raise CommandPolicyError("GraphQL arguments are not exactly allowlisted")
+            key, value = field.split("=", 1)
+            if key == "query":
+                if flag != "-f" or query:
+                    raise CommandPolicyError("GraphQL query must be supplied once as a raw field")
+                query = value
+                continue
+            if key in seen_variables:
+                raise CommandPolicyError(f"GraphQL variable is duplicated: {key}")
+            seen_variables.add(key)
+            if key == "number":
+                if flag != "-F" or not re.fullmatch(r"[1-9][0-9]*", value):
+                    raise CommandPolicyError("GraphQL number must be a positive typed integer")
+            elif key in string_variables:
+                if flag != "-f" or not value or re.search(r"[\x00-\x1f\x7f]", value):
+                    raise CommandPolicyError(f"GraphQL string variable is invalid: {key}")
+            else:
+                raise CommandPolicyError(f"GraphQL variable is not allowlisted: {key}")
         if not re.match(r"^\s*query\b", query) or re.search(r"\bmutation\b", query, re.IGNORECASE):
             raise CommandPolicyError("Only static GraphQL query operations are allowed")
+        return
+    if len(arguments) != 5 or arguments[2:4] != ["--method", "GET"]:
+        raise CommandPolicyError("REST requests must use the exact explicit GET command shape")
+    repository = r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
+    encoded_ref = r"[A-Za-z0-9._~%-]+"
+    endpoint = arguments[4]
+    allowed_endpoint = re.fullmatch(
+        rf"repos/{repository}/rules/branches/{encoded_ref}\?per_page=100&page=[1-9][0-9]*",
+        endpoint,
+    ) or re.fullmatch(
+        rf"repos/{repository}/branches/{encoded_ref}/protection/required_status_checks",
+        endpoint,
+    )
+    if not allowed_endpoint:
+        raise CommandPolicyError("REST endpoint is not exactly read-only allowlisted")
 
 
 class CommandRunner:
@@ -459,6 +492,9 @@ def _validate_schema_value(
         minimum_items = schema.get("minItems")
         if isinstance(minimum_items, int) and len(value) < minimum_items:
             raise ContractError(f"Schema array is too short at {location}")
+        maximum_items = schema.get("maxItems")
+        if isinstance(maximum_items, int) and len(value) > maximum_items:
+            raise ContractError(f"Schema array is too long at {location}")
         if schema.get("uniqueItems") is True:
             serialized = [json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value]
             if len(serialized) != len(set(serialized)):
@@ -893,6 +929,103 @@ def _require_keys(value: dict[str, Any], required: set[str], location: str) -> N
         raise ContractError(f"Missing {location} fields: {missing}")
 
 
+def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
+    pr = snapshot["pull_request"]
+    expected = {
+        "labels": len(pr["labels"]),
+        "review_requests": len(pr["requested_reviewers"]) + len(pr["requested_teams"]),
+        "reviews": len(snapshot["reviews"]),
+        "conversation_comments": len(snapshot["conversation_comments"]),
+        "review_threads": len(snapshot["review_threads"]),
+        "commits": len(snapshot["commits"]),
+        "checks": sum(item["status"] != "MISSING" for item in snapshot["checks"]),
+    }
+    sources = snapshot["required_check_evidence"]["sources"]
+    if len(sources) != len(set(sources)) or not set(sources) <= {"rulesets", "branch_protection"}:
+        raise ContractError("Required-check sources must be unique and supported")
+    if "rulesets" in sources:
+        expected["rulesets"] = len(snapshot["applicable_rules"]["rulesets"])
+    if "branch_protection" in sources:
+        expected["branch_protection"] = 1
+    for comment in snapshot["conversation_comments"]:
+        expected[f"conversation_comment.{comment['id']}.reactions"] = len(comment["reactions"])
+    for thread in snapshot["review_threads"]:
+        expected[f"review_thread.{thread['id']}.comments"] = len(thread["comments"])
+        for comment in thread["comments"]:
+            expected[f"review_comment.{comment['id']}.reactions"] = len(comment["reactions"])
+    for commit in snapshot["commits"]:
+        expected[f"commit.{commit['oid']}.parents"] = len(commit["parents"])
+    return expected
+
+
+def expected_api_calls(connections: list[dict[str, Any]]) -> int:
+    direct_connections = {
+        "labels",
+        "review_requests",
+        "reviews",
+        "conversation_comments",
+        "review_threads",
+        "commits",
+        "checks",
+        "rulesets",
+        "branch_protection",
+    }
+    calls = 2
+    for item in connections:
+        connection = item["connection"]
+        pages = item["pages"]
+        if connection in direct_connections or (
+            connection.startswith("review_thread.") and connection.endswith(".comments")
+        ):
+            calls += pages
+        elif connection.endswith(".reactions"):
+            calls += max(0, pages - 1)
+    return calls
+
+
+def validate_completeness(snapshot: dict[str, Any]) -> None:
+    completeness = snapshot["completeness"]
+    if completeness["warnings"]:
+        raise ContractError("An authoritative snapshot cannot contain capture warnings")
+    expected = expected_connection_items(snapshot)
+    evidence: dict[str, int] = {}
+    for item in completeness["fully_paginated_connections"]:
+        connection = item["connection"]
+        if connection in evidence:
+            raise ContractError(f"Duplicate pagination evidence for {connection}")
+        evidence[connection] = item["items"]
+    missing = sorted(expected.keys() - evidence.keys())
+    extra = sorted(evidence.keys() - expected.keys())
+    mismatched = sorted(
+        connection for connection in expected.keys() & evidence.keys() if expected[connection] != evidence[connection]
+    )
+    if missing or extra or mismatched:
+        raise ContractError(
+            "Invalid pagination evidence: "
+            f"missing={missing}, extra={extra}, mismatched={mismatched}"
+        )
+    if completeness["items"] != sum(expected.values()):
+        raise ContractError("Completeness item total does not match connection evidence")
+    if completeness["api_calls"] != expected_api_calls(completeness["fully_paginated_connections"]):
+        raise ContractError("Completeness API-call total does not match pagination evidence")
+    caps = completeness["configured_caps"]
+    if completeness["api_calls"] > caps["maximum_api_calls"] or completeness["items"] > caps["maximum_items"]:
+        raise ContractError("Completeness totals exceed configured aggregate caps")
+    thread_items = expected["review_threads"]
+    comment_items = expected["conversation_comments"] + sum(
+        count for connection, count in expected.items() if connection.startswith("review_thread.")
+    )
+    reaction_items = sum(
+        count for connection, count in expected.items() if connection.endswith(".reactions")
+    )
+    if (
+        thread_items > caps["maximum_threads"]
+        or comment_items > caps["maximum_comments"]
+        or reaction_items > caps["maximum_reactions"]
+    ):
+        raise ContractError("Completeness totals exceed configured item-kind caps")
+
+
 def validate_snapshot(snapshot: dict[str, Any]) -> None:
     if not isinstance(snapshot, dict):
         raise ContractError("Snapshot must be a JSON object")
@@ -997,6 +1130,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         raise ContractError("Applicable-rule evidence is incomplete")
     if snapshot["required_check_evidence"].get("determination") != "complete":
         raise ContractError("Required-check evidence is incomplete")
+    validate_completeness(snapshot)
 
 
 def trusted_github_url(value: str | None) -> bool:
@@ -1210,17 +1344,17 @@ def graphql_arguments(
         "graphql",
         "-f",
         f"query={query_document}",
-        "-F",
+        "-f",
         f"owner={owner}",
-        "-F",
+        "-f",
         f"name={name}",
         "-F",
         f"number={number}",
     ]
     if cursor is not None:
-        arguments.extend(["-F", f"after={cursor}"])
+        arguments.extend(["-f", f"after={cursor}"])
     for key, value in sorted((extra_variables or {}).items()):
-        arguments.extend(["-F", f"{key}={value}"])
+        arguments.extend(["-f", f"{key}={value}"])
     return arguments
 
 
@@ -1299,14 +1433,35 @@ def ensure_unchanged_head(before: str, after: str) -> None:
         )
 
 
+def ensure_unchanged_anchor(before: dict[str, Any], after: dict[str, Any]) -> None:
+    if before != after:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request or repository anchor changed during capture",
+            "pull_request.anchor",
+            None,
+        )
+
+
 def _empty_signer() -> dict[str, Any]:
     return copy.deepcopy(ZERO_AUTHOR)
 
 
+def _local_signature_format(output: str) -> str:
+    lowered = output.lower()
+    if 'good "git" signature' in lowered or "ssh" in lowered:
+        return "ssh"
+    if "gpgsm" in lowered or "x.509" in lowered or "x509" in lowered or "s/mime" in lowered:
+        return "smime"
+    if "gpg" in lowered or "goodsig" in lowered:
+        return "openpgp"
+    return "unknown"
+
+
 def interpret_local_signature(returncode: int, output: str) -> dict[str, Any]:
     lowered = output.lower()
+    signature_format = _local_signature_format(lowered)
     if returncode == 0:
-        signature_format = "ssh" if "good \"git\" signature" in lowered or " ssh " in lowered else "openpgp"
         return {
             "state": "valid",
             "verified": True,
@@ -1325,7 +1480,7 @@ def interpret_local_signature(returncode: int, output: str) -> dict[str, Any]:
     return {
         "state": state,
         "verified": False,
-        "format": "ssh" if "ssh" in lowered else ("openpgp" if "gpg" in lowered else "unknown"),
+        "format": signature_format,
         "reason": state,
         "signer": _empty_signer(),
     }
@@ -1405,6 +1560,7 @@ def evaluate_checks(
     raw_checks: list[dict[str, Any]],
     required_specs: list[dict[str, Any]] | None,
     policy: dict[str, Any],
+    sources: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     checks = [copy.deepcopy(item) for item in raw_checks]
     if required_specs is None:
@@ -1468,7 +1624,7 @@ def evaluate_checks(
         "determination": "complete",
         "required": required_ids,
         "missing": missing,
-        "sources": ["branch_protection", "rulesets"],
+        "sources": sorted(sources if sources is not None else ["branch_protection", "rulesets"]),
         "unknown_reasons": [],
     }
 
@@ -1545,6 +1701,28 @@ def require_rule_evidence(
     return [specifications[key] for key in sorted(specifications, key=lambda value: (value[0], value[1] or 0))]
 
 
+def required_specs_from_snapshot(
+    snapshot: dict[str, Any],
+    policy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    normalized_rules = snapshot["applicable_rules"]["rulesets"]
+    rulesets = []
+    for rule in normalized_rules:
+        if rule.get("type") == "required_status_checks":
+            rulesets.append(
+                {
+                    "type": "required_status_checks",
+                    "parameters": {"required_status_checks": rule.get("required_checks")},
+                }
+            )
+    branch_protection = snapshot["applicable_rules"]["branch_protection"]
+    return require_rule_evidence(
+        rulesets if policy["require_ruleset_evidence"] else None,
+        branch_protection if policy["require_branch_protection_evidence"] else None,
+        policy,
+    )
+
+
 def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
     validate_config(configuration)
     validate_snapshot(snapshot)
@@ -1605,7 +1783,46 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                     "reason": f"Local signature invalid for {commit['oid']}",
                 }
             )
-    for item in snapshot["checks"]:
+    check_policy = configuration["check_policy"]
+    required_sources = {
+        source
+        for source, required in (
+            ("rulesets", check_policy["require_ruleset_evidence"]),
+            ("branch_protection", check_policy["require_branch_protection_evidence"]),
+        )
+        if required
+    }
+    captured_sources = set(snapshot["required_check_evidence"]["sources"])
+    for source in sorted(required_sources - captured_sources):
+        blockers.append(
+            {
+                "code": BLOCKED_INCOMPLETE,
+                "reason": f"Required check-policy source is absent: {source}",
+            }
+        )
+    raw_checks = [
+        {
+            key: copy.deepcopy(item[key])
+            for key in (
+                "stable_id",
+                "name",
+                "application",
+                "status",
+                "conclusion",
+                "details_url",
+            )
+        }
+        for item in snapshot["checks"]
+        if item["status"] != "MISSING"
+    ]
+    required_specs = required_specs_from_snapshot(snapshot, check_policy)
+    evaluated_checks, _ = evaluate_checks(
+        raw_checks,
+        required_specs,
+        check_policy,
+        sorted(required_sources),
+    )
+    for item in evaluated_checks:
         if item["evidence_state"] in {
             "required_pending",
             "required_failed",
@@ -1624,11 +1841,13 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
     requested_changes = pr["review_decision"] == "CHANGES_REQUESTED" or any(
         item["state"] == "CHANGES_REQUESTED" for item in snapshot["reviews"]
     )
-    if unresolved or requested_changes:
+    review_required = pr["review_decision"] == "REVIEW_REQUIRED"
+    review_requested = bool(pr["requested_reviewers"] or pr["requested_teams"])
+    if unresolved or requested_changes or review_required or review_requested:
         blockers.append(
             {
                 "code": "NOT_READY_FOR_MERGE",
-                "reason": "Raw unresolved review state requires Package 2.2 classification",
+                "reason": "Required or unresolved review state prevents the mechanical gate",
             }
         )
     return {
@@ -1643,6 +1862,8 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
             "resolved_threads": len(snapshot["review_threads"]) - len(unresolved),
             "unresolved_threads": len(unresolved),
             "requested_changes": requested_changes,
+            "review_required": review_required,
+            "review_requested": review_requested,
         },
         "technical_classification_required": bool(
             snapshot["reviews"] or snapshot["conversation_comments"] or snapshot["review_threads"]
@@ -1734,10 +1955,14 @@ def verify_local_against_snapshot(
         block("BLOCKED_UNSAFE_GITHUB_STATE", "PR is closed or merged")
 
     signatures = []
+    signature_policy = configuration["signature_policy"]
+    accepted_formats = set(signature_policy["accepted_formats"])
     for commit in snapshot["commits"]:
         value = local_signature_for_commit(runner, commit["oid"])
         signatures.append({"oid": commit["oid"], **value})
-        if value["state"] != "valid":
+        if signature_policy["require_local_verified"] and (
+            value["state"] != "valid" or value["format"] not in accepted_formats
+        ):
             block("BLOCKED_INVALID_SIGNATURE", f"Local signature is not valid for {commit['oid']}")
 
     return {
@@ -2468,38 +2693,53 @@ def _capture_rules(
     client: GitHubClient,
     base_ref: str,
     policy: dict[str, Any],
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
     encoded_ref = quote(base_ref, safe="")
-    base_endpoint = f"repos/{client.owner}/{client.name}/rules/branches/{encoded_ref}"
     rulesets: list[Any] = []
-    page_number = 1
-    while True:
-        endpoint = f"{base_endpoint}?per_page=100&page={page_number}"
-        page = client.rest(endpoint, "rulesets", str(page_number))
-        if not isinstance(page, list):
+    branch_protection: dict[str, Any] = {}
+    sources: list[str] = []
+    if policy["require_ruleset_evidence"]:
+        base_endpoint = f"repos/{client.owner}/{client.name}/rules/branches/{encoded_ref}"
+        page_number = 1
+        while True:
+            endpoint = f"{base_endpoint}?per_page=100&page={page_number}"
+            page = client.rest(endpoint, "rulesets", str(page_number))
+            if not isinstance(page, list):
+                raise BlockedError(
+                    BLOCKED_INCOMPLETE,
+                    "Applicable rules response is not an array",
+                    "rulesets",
+                    str(page_number),
+                )
+            client.budget.add_items(len(page), "rulesets", str(page_number))
+            rulesets.extend(page)
+            if len(page) < 100:
+                client.budget.record_connection("rulesets", page_number, len(rulesets))
+                break
+            page_number += 1
+            client.budget.require_capacity_for_next_page("rulesets", str(page_number), "items")
+        sources.append("rulesets")
+    if policy["require_branch_protection_evidence"]:
+        protection_endpoint = (
+            f"repos/{client.owner}/{client.name}/branches/{encoded_ref}/protection/required_status_checks"
+        )
+        branch_protection = client.rest(protection_endpoint, "branch_protection")
+        if not isinstance(branch_protection, dict):
             raise BlockedError(
                 BLOCKED_INCOMPLETE,
-                "Applicable rules response is not an array",
-                "rulesets",
-                str(page_number),
+                "Branch-protection response is not an object",
+                "branch_protection",
+                None,
             )
-        client.budget.add_items(len(page), "rulesets", str(page_number))
-        rulesets.extend(page)
-        if len(page) < 100:
-            client.budget.record_connection("rulesets", page_number, len(rulesets))
-            break
-        page_number += 1
-        client.budget.require_capacity_for_next_page("rulesets", str(page_number), "items")
-    protection_endpoint = (
-        f"repos/{client.owner}/{client.name}/branches/{encoded_ref}/protection/required_status_checks"
+        client.budget.add_items(1, "branch_protection", None)
+        client.budget.record_connection("branch_protection", 1, 1)
+        sources.append("branch_protection")
+    required = require_rule_evidence(
+        rulesets if policy["require_ruleset_evidence"] else None,
+        branch_protection if policy["require_branch_protection_evidence"] else None,
+        policy,
     )
-    branch_protection = client.rest(protection_endpoint, "branch_protection")
-    if not isinstance(branch_protection, dict):
-        raise BlockedError(BLOCKED_INCOMPLETE, "Branch-protection response is not an object", "branch_protection", None)
-    client.budget.add_items(1, "branch_protection", None)
-    client.budget.record_connection("branch_protection", 1, 1)
-    required = require_rule_evidence(rulesets, branch_protection, policy)
-    return _normalize_applicable_rules(rulesets, branch_protection), required
+    return _normalize_applicable_rules(rulesets, branch_protection), required, sorted(sources)
 
 
 def capture_snapshot(
@@ -2627,8 +2867,17 @@ def capture_snapshot(
         return _connection_page(rollup.get("contexts"), "checks")
 
     raw_checks = [_normalize_check(item) for item in collect_pages("checks", fetch_checks, budget)]
-    applicable_rules, required_specs = _capture_rules(client, before_pr["baseRefName"], configuration["check_policy"])
-    checks, required_check_evidence = evaluate_checks(raw_checks, required_specs, configuration["check_policy"])
+    applicable_rules, required_specs, rule_sources = _capture_rules(
+        client,
+        before_pr["baseRefName"],
+        configuration["check_policy"],
+    )
+    checks, required_check_evidence = evaluate_checks(
+        raw_checks,
+        required_specs,
+        configuration["check_policy"],
+        rule_sources,
+    )
 
     after_payload = client.graphql(PULL_REQUEST_ANCHOR_QUERY, "pull_request.anchor.after")
     after = extract_anchor(after_payload)
@@ -2641,6 +2890,7 @@ def capture_snapshot(
             "pull_request.anchor",
             None,
         )
+    ensure_unchanged_anchor(before, after)
 
     repository_data = before["repository"]
     base_repository = before_pr.get("baseRepository") or {}

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -1269,7 +1269,7 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
             "pull_request.anchor",
             None,
         )
-    if pull_request.get("state") not in {"OPEN", "CLOSED"}:
+    if pull_request.get("state") not in {"OPEN", "CLOSED", "MERGED"}:
         raise BlockedError(BLOCKED_INCOMPLETE, "Pull request state is unsupported", "pull_request.anchor", None)
     if not isinstance(pull_request.get("number"), int) or isinstance(pull_request.get("number"), bool):
         raise BlockedError(BLOCKED_INCOMPLETE, "Pull request number is unavailable", "pull_request.anchor", None)

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -1,0 +1,2903 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Capture deterministic, read-only Git and GitHub pull-request evidence."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Any, Callable, Iterable
+from urllib.parse import quote, urlparse
+
+
+SCHEMA_VERSION = "1.0"
+DIGEST_ALGORITHM = "sha256"
+DEFAULT_MAXIMUM_API_CALLS = 200
+DEFAULT_MAXIMUM_ITEMS = 10_000
+DEFAULT_MAXIMUM_THREADS = 500
+DEFAULT_MAXIMUM_COMMENTS = 10_000
+DEFAULT_MAXIMUM_REACTIONS = 10_000
+BLOCKED_INCOMPLETE = "BLOCKED_INCOMPLETE_REVIEW_STATE"
+ZERO_AUTHOR = {
+    "kind": "deleted_or_unavailable",
+    "login": None,
+    "database_id": None,
+    "node_id": None,
+    "url": None,
+}
+ALLOWED_GIT_SUBCOMMANDS = {
+    "branch",
+    "cat-file",
+    "remote",
+    "rev-list",
+    "rev-parse",
+    "status",
+    "verify-commit",
+}
+PROHIBITED_GIT_SUBCOMMANDS = {
+    "checkout",
+    "clean",
+    "commit",
+    "fetch",
+    "push",
+    "reset",
+    "stash",
+    "switch",
+}
+PROHIBITED_GH_PR_SUBCOMMANDS = {"edit", "merge", "ready", "review"}
+SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL"}
+PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+OID_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT_SCHEMA_PATH = REPOSITORY_ROOT / "docs/schemas/secpal-pr-review-snapshot.schema.json"
+CONFIG_SCHEMA_PATH = REPOSITORY_ROOT / "docs/schemas/secpal-pr-review-repositories.schema.json"
+
+
+class ContractError(ValueError):
+    """Raised when canonical evidence or repository configuration is invalid."""
+
+
+class CommandPolicyError(ValueError):
+    """Raised when an external command is outside the read-only allowlist."""
+
+
+class OutputSafetyError(ValueError):
+    """Raised when an output path is not safe for atomic replacement."""
+
+
+class BlockedError(RuntimeError):
+    """A deterministic terminal blocker."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        connection: str | None = None,
+        cursor: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = redact_diagnostic(message)
+        self.connection = connection
+        self.cursor = cursor
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.code,
+            "blocked_reason": {
+                "message": self.message,
+                "connection": self.connection,
+                "cursor": self.cursor,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandFailure(RuntimeError):
+    def __init__(self, arguments: list[str], result: CommandResult) -> None:
+        self.arguments = list(arguments)
+        self.result = result
+        executable = Path(arguments[0]).name if arguments else "command"
+        detail = redact_diagnostic(result.stderr or result.stdout or "command failed")
+        super().__init__(f"{executable} exited {result.returncode}: {detail}")
+
+
+@dataclass(frozen=True)
+class Page:
+    nodes: list[Any]
+    has_next_page: bool
+    end_cursor: str | None
+
+
+def redact_diagnostic(value: str) -> str:
+    cleaned = CONTROL_CHARACTERS.sub("�", value).strip()
+    cleaned = re.sub(r"(?i)(authorization\s*:\s*)(\S+)", r"\1[REDACTED]", cleaned)
+    cleaned = re.sub(r"(?i)(token|private[_ -]?key|secret)(\s*[=:]\s*)(\S+)", r"\1\2[REDACTED]", cleaned)
+    cleaned = re.sub(r"\b(?:gh[opsu]_|github_pat_)[A-Za-z0-9_]+\b", "[REDACTED]", cleaned)
+    return cleaned[:1000]
+
+
+def validate_external_command(arguments: list[str]) -> None:
+    if not arguments:
+        raise CommandPolicyError("Empty external command")
+    executable = Path(arguments[0]).name
+    if executable == "git":
+        if len(arguments) < 2:
+            raise CommandPolicyError("Git subcommand is required")
+        subcommand = arguments[1]
+        if subcommand in PROHIBITED_GIT_SUBCOMMANDS or subcommand not in ALLOWED_GIT_SUBCOMMANDS:
+            raise CommandPolicyError(f"Git subcommand is not read-only allowlisted: {subcommand}")
+        static_commands = {
+            ("git", "rev-parse", "--show-toplevel"),
+            ("git", "remote", "get-url", "origin"),
+            ("git", "status", "--porcelain=v2", "--untracked-files=all"),
+            ("git", "branch", "--show-current"),
+            ("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"),
+            ("git", "rev-parse", "HEAD"),
+            ("git", "rev-parse", "@{upstream}"),
+        }
+        command = tuple(arguments)
+        oid = r"[0-9a-fA-F]{40,64}"
+        dynamic_command = (
+            len(arguments) == 4
+            and (
+                (
+                    subcommand == "cat-file"
+                    and arguments[2] == "-e"
+                    and re.fullmatch(rf"{oid}\^\{{commit\}}", arguments[3])
+                )
+                or (subcommand == "verify-commit" and arguments[2] == "--raw" and re.fullmatch(oid, arguments[3]))
+                or (
+                    subcommand == "rev-list"
+                    and arguments[2] == "--reverse"
+                    and re.fullmatch(rf"{oid}\.\.{oid}", arguments[3])
+                )
+            )
+        )
+        if command not in static_commands and not dynamic_command:
+            raise CommandPolicyError("Git command arguments are not exactly read-only allowlisted")
+        return
+    if executable != "gh":
+        raise CommandPolicyError(f"Executable is not allowlisted: {executable}")
+    if len(arguments) < 2:
+        raise CommandPolicyError("GitHub CLI subcommand is required")
+    if arguments[1] == "pr":
+        subcommand = arguments[2] if len(arguments) > 2 else ""
+        if subcommand in PROHIBITED_GH_PR_SUBCOMMANDS or subcommand:
+            raise CommandPolicyError(f"GitHub PR operation is not allowlisted: {subcommand}")
+    if arguments[1] != "api":
+        raise CommandPolicyError(f"GitHub CLI operation is not allowlisted: {arguments[1]}")
+    method = "GET"
+    if "--method" in arguments:
+        index = arguments.index("--method")
+        if index + 1 >= len(arguments):
+            raise CommandPolicyError("Missing GitHub API method")
+        method = arguments[index + 1].upper()
+    if method != "GET":
+        raise CommandPolicyError(f"GitHub API method is not read-only: {method}")
+    if len(arguments) > 2 and arguments[2] == "graphql":
+        query = next((value.split("=", 1)[1] for value in arguments if value.startswith("query=")), "")
+        if not re.match(r"^\s*query\b", query) or re.search(r"\bmutation\b", query, re.IGNORECASE):
+            raise CommandPolicyError("Only static GraphQL query operations are allowed")
+
+
+class CommandRunner:
+    """Execute only validated, read-only external commands through argument arrays."""
+
+    def run(self, arguments: list[str], *, allow_failure: bool = False) -> CommandResult:
+        validate_external_command(arguments)
+        environment = os.environ.copy()
+        environment["PAGER"] = "cat"
+        environment["GH_PAGER"] = "cat"
+        environment["GIT_NO_LAZY_FETCH"] = "1"
+        completed = subprocess.run(
+            arguments,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=environment,
+        )
+        result = CommandResult(completed.returncode, completed.stdout, completed.stderr)
+        if result.returncode != 0 and not allow_failure:
+            raise CommandFailure(arguments, result)
+        return result
+
+
+class Budget:
+    """Track finite API, aggregate-item, and item-kind limits."""
+
+    def __init__(self, configuration: dict[str, Any]) -> None:
+        self.maximum_api_calls = configuration["maximum_api_calls"]
+        self.maximum_items = configuration["maximum_items"]
+        self.kind_caps = {
+            "threads": configuration["maximum_threads"],
+            "comments": configuration["maximum_comments"],
+            "reactions": configuration["maximum_reactions"],
+        }
+        self.api_calls = 0
+        self.items = 0
+        self.kind_items = {key: 0 for key in self.kind_caps}
+        self.connections: list[dict[str, Any]] = []
+
+    def note_api_call(self, connection: str, cursor: str | None) -> None:
+        if self.api_calls >= self.maximum_api_calls:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"API call cap reached before completing {connection}",
+                connection,
+                cursor,
+            )
+        self.api_calls += 1
+
+    def add_items(
+        self,
+        count: int,
+        connection: str,
+        cursor: str | None,
+        kind: str = "items",
+    ) -> None:
+        if count < 0:
+            raise ContractError("Item count cannot be negative")
+        if self.items + count > self.maximum_items:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"Aggregate item cap reached while reading {connection}",
+                connection,
+                cursor,
+            )
+        if kind in self.kind_caps and self.kind_items[kind] + count > self.kind_caps[kind]:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"{kind} cap reached while reading {connection}",
+                connection,
+                cursor,
+            )
+        self.items += count
+        if kind in self.kind_caps:
+            self.kind_items[kind] += count
+
+    def require_capacity_for_next_page(self, connection: str, cursor: str | None, kind: str) -> None:
+        exhausted = self.items >= self.maximum_items or self.api_calls >= self.maximum_api_calls
+        if kind in self.kind_caps:
+            exhausted = exhausted or self.kind_items[kind] >= self.kind_caps[kind]
+        if exhausted:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"Configured cap reached before completing {connection}",
+                connection,
+                cursor,
+            )
+
+    def record_connection(self, connection: str, pages: int, items: int) -> None:
+        self.connections.append({"connection": connection, "pages": pages, "items": items})
+
+
+def collect_pages(
+    connection: str,
+    fetch_page: Callable[[str | None], Page],
+    budget: Budget,
+    *,
+    kind: str = "items",
+) -> list[Any]:
+    cursor: str | None = None
+    result: list[Any] = []
+    pages = 0
+    while True:
+        page = fetch_page(cursor)
+        if not isinstance(page, Page):
+            raise ContractError(f"Page fetcher for {connection} returned an invalid page")
+        pages += 1
+        budget.add_items(len(page.nodes), connection, cursor, kind)
+        result.extend(page.nodes)
+        if not page.has_next_page:
+            budget.record_connection(connection, pages, len(result))
+            return result
+        if not page.end_cursor:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"{connection} reported another page without an end cursor",
+                connection,
+                cursor,
+            )
+        cursor = page.end_cursor
+        budget.require_capacity_for_next_page(connection, cursor, kind)
+
+
+def parse_api_json(raw: str, connection: str) -> Any:
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Malformed JSON returned for "
+            f"{connection}: {exc.msg if isinstance(exc, json.JSONDecodeError) else 'invalid value'}",
+            connection,
+            None,
+        ) from exc
+
+
+def parse_graphql_payload(raw: str, connection: str) -> dict[str, Any]:
+    payload = parse_api_json(raw, connection)
+    if not isinstance(payload, dict):
+        raise BlockedError(BLOCKED_INCOMPLETE, f"Invalid GraphQL response for {connection}", connection, None)
+    errors = payload.get("errors")
+    if errors:
+        messages = sorted(
+            redact_diagnostic(str(item.get("message", "GraphQL error")))
+            for item in errors
+            if isinstance(item, dict)
+        )
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            f"GraphQL returned errors for {connection}: {'; '.join(messages) or 'unknown error'}",
+            connection,
+            None,
+        )
+    if not isinstance(payload.get("data"), dict):
+        raise BlockedError(BLOCKED_INCOMPLETE, f"GraphQL data is missing for {connection}", connection, None)
+    return payload
+
+
+def classify_api_failure(message: str) -> BlockedError:
+    diagnostic = redact_diagnostic(message)
+    lowered = diagnostic.lower()
+    if "secondary rate limit" in lowered:
+        diagnostic = "GitHub secondary rate limit prevented a complete read"
+    elif "rate limit" in lowered:
+        diagnostic = "GitHub API rate limit prevented a complete read"
+    return BlockedError(BLOCKED_INCOMPLETE, diagnostic)
+
+
+def validate_repository_name(repository: str) -> tuple[str, str]:
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise ContractError("Repository must be exactly OWNER/REPO")
+    owner, name = repository.split("/", 1)
+    return owner, name
+
+
+def _require_positive_integer(configuration: dict[str, Any], key: str) -> None:
+    value = configuration.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ContractError(f"{key} must be a positive integer")
+
+
+@cache
+def _load_authoritative_schema(path: str) -> dict[str, Any]:
+    try:
+        schema = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractError(f"Cannot load authoritative schema: {redact_diagnostic(str(exc))}") from exc
+    if not isinstance(schema, dict):
+        raise ContractError("Authoritative schema must be a JSON object")
+    return schema
+
+
+def _json_type_matches(value: Any, expected: str) -> bool:
+    return {
+        "null": value is None,
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+    }.get(expected, False)
+
+
+def _validate_schema_value(
+    value: Any,
+    schema: dict[str, Any],
+    root: dict[str, Any],
+    location: str,
+) -> None:
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+            raise ContractError(f"Unsupported schema reference at {location}")
+        name = reference.removeprefix("#/$defs/")
+        target = root.get("$defs", {}).get(name)
+        if not isinstance(target, dict):
+            raise ContractError(f"Unknown schema reference at {location}: {reference}")
+        _validate_schema_value(value, target, root, location)
+        return
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        expected_types = [expected_type] if isinstance(expected_type, str) else expected_type
+        if not isinstance(expected_types, list) or not any(
+            isinstance(item, str) and _json_type_matches(value, item) for item in expected_types
+        ):
+            raise ContractError(f"Schema type mismatch at {location}")
+
+    if "const" in schema and value != schema["const"]:
+        raise ContractError(f"Schema constant mismatch at {location}")
+    if "enum" in schema and value not in schema["enum"]:
+        raise ContractError(f"Schema enum mismatch at {location}")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        if not isinstance(required, list) or any(not isinstance(item, str) for item in required):
+            raise ContractError(f"Invalid authoritative object schema at {location}")
+        missing = sorted(set(required) - value.keys())
+        if missing:
+            raise ContractError(f"Missing schema fields at {location}: {missing}")
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            raise ContractError(f"Invalid authoritative properties at {location}")
+        if schema.get("additionalProperties") is False:
+            extra = sorted(value.keys() - properties.keys())
+            if extra:
+                raise ContractError(f"Unknown schema fields at {location}: {extra}")
+        for key, item in value.items():
+            child = properties.get(key)
+            if isinstance(child, dict):
+                _validate_schema_value(item, child, root, f"{location}.{key}")
+
+    if isinstance(value, list):
+        minimum_items = schema.get("minItems")
+        if isinstance(minimum_items, int) and len(value) < minimum_items:
+            raise ContractError(f"Schema array is too short at {location}")
+        if schema.get("uniqueItems") is True:
+            serialized = [json.dumps(item, ensure_ascii=False, sort_keys=True) for item in value]
+            if len(serialized) != len(set(serialized)):
+                raise ContractError(f"Schema array contains duplicates at {location}")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                _validate_schema_value(item, item_schema, root, f"{location}[{index}]")
+
+    if isinstance(value, str):
+        minimum_length = schema.get("minLength")
+        if isinstance(minimum_length, int) and len(value) < minimum_length:
+            raise ContractError(f"Schema string is too short at {location}")
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            raise ContractError(f"Schema pattern mismatch at {location}")
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, int) and value < minimum:
+            raise ContractError(f"Schema integer is too small at {location}")
+
+
+def validate_against_authoritative_schema(value: Any, path: Path, location: str) -> None:
+    schema = _load_authoritative_schema(str(path))
+    _validate_schema_value(value, schema, schema, location)
+
+
+def validate_config(configuration: dict[str, Any]) -> None:
+    if not isinstance(configuration, dict):
+        raise ContractError("Repository configuration must be a JSON object")
+    validate_against_authoritative_schema(configuration, CONFIG_SCHEMA_PATH, "configuration")
+    required = {
+        "schema_version",
+        "repository",
+        "default_branch",
+        "allowed_base_repositories",
+        "reviewer_identities",
+        "required_local_validation",
+        "signature_policy",
+        "check_policy",
+        "maximum_api_calls",
+        "maximum_items",
+        "maximum_threads",
+        "maximum_comments",
+        "maximum_reactions",
+    }
+    allowed = required | {"$comment"}
+    missing = sorted(required - configuration.keys())
+    extra = sorted(configuration.keys() - allowed)
+    if missing or extra:
+        raise ContractError(f"Invalid repository configuration keys: missing={missing}, extra={extra}")
+    if configuration["schema_version"] != SCHEMA_VERSION:
+        raise ContractError(f"Unsupported repository configuration schema: {configuration['schema_version']}")
+    validate_repository_name(configuration["repository"])
+    if not isinstance(configuration["default_branch"], str) or not configuration["default_branch"]:
+        raise ContractError("default_branch must be a non-empty string")
+    bases = configuration["allowed_base_repositories"]
+    if not isinstance(bases, list) or not bases or len(set(bases)) != len(bases):
+        raise ContractError("allowed_base_repositories must be a non-empty unique list")
+    for repository in bases:
+        validate_repository_name(repository)
+    identities = configuration["reviewer_identities"]
+    if not isinstance(identities, list):
+        raise ContractError("reviewer_identities must be a list")
+    canonical: set[str] = set()
+    aliases: set[str] = set()
+    for identity in identities:
+        expected = {
+            "canonical_identity",
+            "kind",
+            "graphql_aliases",
+            "rest_event_aliases",
+            "node_ids",
+            "database_ids",
+        }
+        if not isinstance(identity, dict) or set(identity) != expected:
+            raise ContractError("Each reviewer identity must use the canonical identity fields")
+        name = identity["canonical_identity"]
+        if not isinstance(name, str) or not name or name in canonical:
+            raise ContractError("canonical_identity must be non-empty and unique")
+        canonical.add(name)
+        if identity["kind"] not in {"human", "bot", "app"}:
+            raise ContractError(f"Invalid reviewer identity kind for {name}")
+        for key in ("graphql_aliases", "rest_event_aliases", "node_ids"):
+            values = identity[key]
+            if not isinstance(values, list) or any(not isinstance(value, str) or not value for value in values):
+                raise ContractError(f"{key} must contain non-empty strings")
+            if len(values) != len(set(values)):
+                raise ContractError(f"{key} contains duplicates")
+            for value in values:
+                token = f"{key}:{value}"
+                if token in aliases:
+                    raise ContractError(f"Reviewer identity alias is duplicated: {value}")
+                aliases.add(token)
+        database_ids = identity["database_ids"]
+        if not isinstance(database_ids, list) or any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 1 for value in database_ids
+        ):
+            raise ContractError("database_ids must contain positive integers")
+    validations = configuration["required_local_validation"]
+    if not isinstance(validations, list):
+        raise ContractError("required_local_validation must be a list")
+    for validation in validations:
+        if not isinstance(validation, dict) or set(validation) != {"name", "command"}:
+            raise ContractError("Each local validation requires name and command")
+        command = validation["command"]
+        if not validation["name"] or not isinstance(command, list) or not command:
+            raise ContractError("Local validation name and command cannot be empty")
+        if any(not isinstance(argument, str) or not argument for argument in command):
+            raise ContractError("Local validation command must be an argument array")
+    signature_policy = configuration["signature_policy"]
+    if not isinstance(signature_policy, dict) or set(signature_policy) != {
+        "require_github_verified",
+        "require_local_verified",
+        "accepted_formats",
+    }:
+        raise ContractError("Invalid signature_policy")
+    if not all(
+        isinstance(signature_policy[key], bool)
+        for key in ("require_github_verified", "require_local_verified")
+    ):
+        raise ContractError("Signature requirements must be booleans")
+    formats = signature_policy["accepted_formats"]
+    if not isinstance(formats, list) or not formats or not set(formats) <= {"ssh", "openpgp"}:
+        raise ContractError("accepted_formats must contain ssh and/or openpgp")
+    check_policy = configuration["check_policy"]
+    if not isinstance(check_policy, dict) or set(check_policy) != {
+        "require_ruleset_evidence",
+        "require_branch_protection_evidence",
+        "expected_skipped",
+    }:
+        raise ContractError("Invalid check_policy")
+    if not all(
+        isinstance(check_policy[key], bool)
+        for key in ("require_ruleset_evidence", "require_branch_protection_evidence")
+    ) or check_policy["expected_skipped"] not in {"block", "allow"}:
+        raise ContractError("Invalid required-check policy values")
+    for key in (
+        "maximum_api_calls",
+        "maximum_items",
+        "maximum_threads",
+        "maximum_comments",
+        "maximum_reactions",
+    ):
+        _require_positive_integer(configuration, key)
+
+
+def default_config(repository: str) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repository": repository,
+        "default_branch": "main",
+        "allowed_base_repositories": [repository],
+        "reviewer_identities": [],
+        "required_local_validation": [],
+        "signature_policy": {
+            "require_github_verified": True,
+            "require_local_verified": True,
+            "accepted_formats": ["ssh", "openpgp"],
+        },
+        "check_policy": {
+            "require_ruleset_evidence": True,
+            "require_branch_protection_evidence": True,
+            "expected_skipped": "block",
+        },
+        "maximum_api_calls": DEFAULT_MAXIMUM_API_CALLS,
+        "maximum_items": DEFAULT_MAXIMUM_ITEMS,
+        "maximum_threads": DEFAULT_MAXIMUM_THREADS,
+        "maximum_comments": DEFAULT_MAXIMUM_COMMENTS,
+        "maximum_reactions": DEFAULT_MAXIMUM_REACTIONS,
+    }
+
+
+def load_config(
+    path: str | None,
+    repository: str,
+    maximum_api_calls: int | None = None,
+    maximum_items: int | None = None,
+) -> dict[str, Any]:
+    configuration = default_config(repository)
+    if path:
+        try:
+            loaded = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ContractError(f"Cannot load repository configuration: {redact_diagnostic(str(exc))}") from exc
+        configuration = loaded
+    configuration = copy.deepcopy(configuration)
+    if configuration.get("repository") != repository:
+        raise ContractError(
+            f"Configuration repository {configuration.get('repository')!r} does not match {repository!r}"
+        )
+    if maximum_api_calls is not None:
+        configuration["maximum_api_calls"] = maximum_api_calls
+    if maximum_items is not None:
+        configuration["maximum_items"] = maximum_items
+    validate_config(configuration)
+    return configuration
+
+
+def index_reviewer_identities(configuration: dict[str, Any]) -> dict[Any, str]:
+    result: dict[Any, str] = {}
+    for identity in configuration["reviewer_identities"]:
+        canonical = identity["canonical_identity"]
+        for key in ("graphql_aliases", "rest_event_aliases", "node_ids", "database_ids"):
+            for value in identity[key]:
+                result[value] = canonical
+    return result
+
+
+def normalize_actor(value: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return copy.deepcopy(ZERO_AUTHOR)
+    if set(value) == {"kind", "login", "database_id", "node_id", "url"}:
+        return copy.deepcopy(value)
+    typename = str(value.get("__typename") or "").lower()
+    kind = {
+        "user": "user",
+        "enterpriseuseraccount": "user",
+        "bot": "bot",
+        "organization": "organization",
+        "mannequin": "mannequin",
+    }.get(typename, "deleted_or_unavailable")
+    login = value.get("login")
+    if not isinstance(login, str) or not login:
+        return copy.deepcopy(ZERO_AUTHOR)
+    database_id = value.get("databaseId", value.get("database_id"))
+    if isinstance(database_id, bool) or not isinstance(database_id, int):
+        database_id = None
+    node_id = value.get("id", value.get("node_id"))
+    url = value.get("url")
+    return {
+        "kind": kind,
+        "login": login,
+        "database_id": database_id,
+        "node_id": node_id if isinstance(node_id, str) else None,
+        "url": url if isinstance(url, str) else None,
+    }
+
+
+def _author_sort_key(value: dict[str, Any]) -> tuple[str, int, str]:
+    return (
+        str(value.get("login") or ""),
+        int(value.get("database_id") or 0),
+        str(value.get("node_id") or ""),
+    )
+
+
+def normalize_reaction(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value.get("id"), str) or not value.get("id"):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Reaction identity is unavailable", "reactions", None)
+    if not isinstance(value.get("content"), str) or not value.get("content"):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Reaction content is unavailable", "reactions", None)
+    return {
+        "id": value["id"],
+        "content": value["content"],
+        "created_at": value.get("createdAt", value.get("created_at")),
+        "user": normalize_actor(value.get("user")),
+    }
+
+
+def normalize_reactions(values: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    result = [normalize_reaction(value) for value in values]
+    return sorted(
+        result,
+        key=lambda item: (
+            str(item["created_at"] or ""),
+            item["content"],
+            _author_sort_key(item["user"]),
+            str(item["id"] or ""),
+        ),
+    )
+
+
+def normalize_review_comment(value: dict[str, Any]) -> dict[str, Any]:
+    comment_id = value.get("id")
+    created_at = value.get("createdAt", value.get("created_at"))
+    updated_at = value.get("updatedAt", value.get("updated_at"))
+    if not isinstance(comment_id, str) or not comment_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review comment identity is unavailable", "review_comments", None)
+    if any(not isinstance(value.get(key), str) for key in ("body", "url")):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review comment content is unavailable", "review_comments", None)
+    if not isinstance(created_at, str) or not isinstance(updated_at, str):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review comment timestamps are unavailable", "review_comments", None)
+    return {
+        "id": comment_id,
+        "database_id": value.get("databaseId", value.get("database_id")),
+        "author": normalize_actor(value.get("author")) if "author" in value else copy.deepcopy(value["author"]),
+        "body": value["body"],
+        "url": value["url"],
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "reply_to_id": (
+            value.get("replyTo", {}).get("id")
+            if isinstance(value.get("replyTo"), dict)
+            else value.get("reply_to_id")
+        ),
+        "review_id": (
+            value.get("pullRequestReview", {}).get("id")
+            if isinstance(value.get("pullRequestReview"), dict)
+            else value.get("review_id")
+        ),
+        "reactions": normalize_reactions(value.get("reactions", {}).get("nodes", []))
+        if isinstance(value.get("reactions"), dict)
+        else normalize_reactions(value.get("reactions", [])),
+    }
+
+
+def normalize_review_thread(value: dict[str, Any]) -> dict[str, Any]:
+    thread_id = value.get("id")
+    if not isinstance(thread_id, str) or not thread_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review thread identity is unavailable", "review_threads", None)
+    raw_comments = value.get("comments", [])
+    if isinstance(raw_comments, dict):
+        raw_comments = raw_comments.get("nodes", [])
+    comments = sorted(
+        [normalize_review_comment(comment) for comment in raw_comments],
+        key=lambda item: (item["created_at"], item["database_id"] or 0, item["id"]),
+    )
+    if not comments:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Review thread contains no accessible comments",
+            f"review_thread.{thread_id}.comments",
+            None,
+        )
+    return {
+        "id": thread_id,
+        "is_resolved": bool(value.get("isResolved", value.get("is_resolved", False))),
+        "is_outdated": bool(value.get("isOutdated", value.get("is_outdated", False))),
+        "path": value.get("path"),
+        "line": value.get("line"),
+        "original_line": value.get("originalLine", value.get("original_line")),
+        "side": value.get("diffSide", value.get("side")),
+        "start_line": value.get("startLine", value.get("start_line")),
+        "start_side": value.get("startDiffSide", value.get("start_side")),
+        "comments": comments,
+    }
+
+
+def _normalize_existing_author(value: dict[str, Any]) -> dict[str, Any]:
+    if set(value) == {"kind", "login", "database_id", "node_id", "url"}:
+        return copy.deepcopy(value)
+    return normalize_actor(value)
+
+
+def normalize_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(snapshot)
+    pr = result.get("pull_request", {})
+    if isinstance(pr.get("author"), dict):
+        pr["author"] = _normalize_existing_author(pr["author"])
+    pr["labels"] = sorted(set(pr.get("labels", [])))
+    pr["requested_reviewers"] = sorted(
+        [_normalize_existing_author(item) for item in pr.get("requested_reviewers", [])],
+        key=_author_sort_key,
+    )
+    pr["requested_teams"] = sorted(
+        pr.get("requested_teams", []), key=lambda item: (str(item.get("slug") or ""), str(item.get("id") or ""))
+    )
+    result["reviews"] = sorted(
+        result.get("reviews", []),
+        key=lambda item: (
+            str(item.get("submitted_at") or ""),
+            int(item.get("database_id") or 0),
+            str(item.get("id") or ""),
+        ),
+    )
+    for item in result["reviews"]:
+        item["author"] = _normalize_existing_author(item["author"])
+    result["conversation_comments"] = sorted(
+        result.get("conversation_comments", []),
+        key=lambda item: (
+            str(item.get("created_at") or ""),
+            int(item.get("database_id") or 0),
+            str(item.get("id") or ""),
+        ),
+    )
+    for item in result["conversation_comments"]:
+        item["author"] = _normalize_existing_author(item["author"])
+        item["reactions"] = normalize_reactions(item.get("reactions", []))
+    result["review_threads"] = sorted(
+        [normalize_review_thread(item) for item in result.get("review_threads", [])],
+        key=lambda item: item["id"],
+    )
+    result["commits"] = sorted(
+        result.get("commits", []),
+        key=lambda item: (str(item.get("committed_at") or ""), str(item.get("oid") or "")),
+    )
+    result["checks"] = sorted(result.get("checks", []), key=lambda item: item["stable_id"])
+    completeness = result.get("completeness", {})
+    completeness["fully_paginated_connections"] = sorted(
+        completeness.get("fully_paginated_connections", []), key=lambda item: item["connection"]
+    )
+    completeness["warnings"] = sorted(set(completeness.get("warnings", [])))
+    evidence = result.get("required_check_evidence", {})
+    for key in ("required", "missing", "sources", "unknown_reasons"):
+        evidence[key] = sorted(set(evidence.get(key, [])))
+    return result
+
+
+def _canonical_without_digest(snapshot: dict[str, Any]) -> bytes:
+    normalized = normalize_snapshot(snapshot)
+    normalized.pop("snapshot_digest", None)
+    return json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_digest(snapshot: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_without_digest(snapshot)).hexdigest()
+
+
+def attach_digest(snapshot: dict[str, Any]) -> dict[str, Any]:
+    normalized = normalize_snapshot(snapshot)
+    normalized["snapshot_digest"] = compute_digest(normalized)
+    return normalized
+
+
+def verify_digest(snapshot: dict[str, Any]) -> bool:
+    value = snapshot.get("snapshot_digest")
+    return isinstance(value, str) and value == compute_digest(snapshot)
+
+
+def canonical_json_bytes(value: dict[str, Any]) -> bytes:
+    normalized = normalize_snapshot(value) if "snapshot_digest" in value else copy.deepcopy(value)
+    return (
+        json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
+def _require_keys(value: dict[str, Any], required: set[str], location: str) -> None:
+    missing = sorted(required - value.keys())
+    if missing:
+        raise ContractError(f"Missing {location} fields: {missing}")
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    if not isinstance(snapshot, dict):
+        raise ContractError("Snapshot must be a JSON object")
+    validate_against_authoritative_schema(snapshot, SNAPSHOT_SCHEMA_PATH, "snapshot")
+    required = {
+        "schema_version",
+        "snapshot_digest_algorithm",
+        "snapshot_digest",
+        "repository",
+        "pull_request",
+        "reviews",
+        "conversation_comments",
+        "review_threads",
+        "commits",
+        "checks",
+        "applicable_rules",
+        "required_check_evidence",
+        "completeness",
+    }
+    _require_keys(snapshot, required, "snapshot")
+    if set(snapshot) != required:
+        raise ContractError(f"Unknown snapshot fields: {sorted(set(snapshot) - required)}")
+    if snapshot["schema_version"] != SCHEMA_VERSION or snapshot["snapshot_digest_algorithm"] != DIGEST_ALGORITHM:
+        raise ContractError("Unsupported snapshot schema or digest algorithm")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(snapshot["snapshot_digest"])):
+        raise ContractError("snapshot_digest must be a lowercase SHA-256 digest")
+    if not verify_digest(snapshot):
+        raise ContractError("Snapshot digest does not match canonical evidence")
+    repository = snapshot["repository"]
+    _require_keys(repository, {"id", "owner", "name", "name_with_owner", "url", "default_branch"}, "repository")
+    validate_repository_name(repository["name_with_owner"])
+    pr = snapshot["pull_request"]
+    _require_keys(
+        pr,
+        {
+            "id",
+            "database_id",
+            "number",
+            "url",
+            "title",
+            "state",
+            "is_draft",
+            "is_merged",
+            "mergeable",
+            "review_decision",
+            "author",
+            "base_repository",
+            "base_ref",
+            "base_oid",
+            "head_repository",
+            "head_ref",
+            "head_oid_before",
+            "head_oid_after",
+            "labels",
+            "requested_reviewers",
+            "requested_teams",
+        },
+        "pull_request",
+    )
+    if not isinstance(pr["number"], int) or pr["number"] < 1:
+        raise ContractError("Pull request number must be positive")
+    for key in ("base_oid", "head_oid_before", "head_oid_after"):
+        if not isinstance(pr[key], str) or not OID_PATTERN.fullmatch(pr[key]):
+            raise ContractError(f"Invalid pull request {key}")
+    if pr["head_oid_before"] != pr["head_oid_after"]:
+        raise ContractError("Snapshot head changed during capture")
+    for collection in ("reviews", "conversation_comments", "review_threads", "commits", "checks"):
+        if not isinstance(snapshot[collection], list):
+            raise ContractError(f"{collection} must be an array")
+    if not snapshot["commits"]:
+        raise ContractError("Snapshot must include at least one PR commit")
+    for commit in snapshot["commits"]:
+        if not OID_PATTERN.fullmatch(str(commit.get("oid", ""))):
+            raise ContractError("Snapshot contains an invalid commit OID")
+        for signature_name in ("github_signature", "local_signature"):
+            signature = commit.get(signature_name)
+            if not isinstance(signature, dict) or signature.get("state") not in {
+                "valid",
+                "invalid",
+                "unsigned",
+                "unknown_key",
+                "object_unavailable",
+                "verification_pending",
+            }:
+                raise ContractError(f"Invalid {signature_name} evidence")
+    completeness = snapshot["completeness"]
+    _require_keys(
+        completeness,
+        {
+            "api_calls",
+            "items",
+            "configured_caps",
+            "fully_paginated_connections",
+            "warnings",
+            "blocked_reason",
+        },
+        "completeness",
+    )
+    if completeness["blocked_reason"] is not None:
+        raise ContractError("An authoritative snapshot cannot contain a blocker")
+    if not snapshot["applicable_rules"].get("evidence_complete"):
+        raise ContractError("Applicable-rule evidence is incomplete")
+    if snapshot["required_check_evidence"].get("determination") != "complete":
+        raise ContractError("Required-check evidence is incomplete")
+
+
+def trusted_github_url(value: str | None) -> bool:
+    if not isinstance(value, str):
+        return False
+    if len(value) > 2048 or re.search(r'[\x00-\x20\x7f<>\\\[\]()"\']', value):
+        return False
+    try:
+        parsed = urlparse(value)
+        return (
+            parsed.scheme == "https"
+            and parsed.hostname == "github.com"
+            and parsed.port in {None, 443}
+            and not parsed.username
+            and not parsed.password
+        )
+    except ValueError:
+        return False
+
+
+def escape_markdown(value: Any) -> str:
+    text = CONTROL_CHARACTERS.sub("�", str(value if value is not None else ""))
+    text = text.replace("\r\n", "\n").replace("\r", "\n").replace("\t", "    ")
+    text = text.replace("<!--", "&lt;!--").replace("-->", "--&gt;")
+    text = text.replace("<", "&lt;").replace(">", "&gt;")
+    for character in "\\`*_{}[]()#+-.!|":
+        text = text.replace(character, f"\\{character}")
+    return text
+
+
+def _markdown_link(label: str, url: str | None) -> str:
+    safe_label = escape_markdown(label)
+    if trusted_github_url(url):
+        return f"[{safe_label}]({url})"
+    return f"{safe_label} — {escape_markdown(url or 'URL unavailable')}"
+
+
+def _markdown_body(body: str) -> str:
+    escaped = escape_markdown(body)
+    lines = escaped.splitlines() or [""]
+    return "\n".join(f"    {line}" for line in lines)
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    validate_snapshot(snapshot)
+    repository = snapshot["repository"]["name_with_owner"]
+    pr = snapshot["pull_request"]
+    lines = [
+        "# Pull Request Evidence Snapshot",
+        "",
+        "**Canonical authority: JSON snapshot and SHA-256 digest**",
+        "",
+        f"- Repository: {escape_markdown(repository)}",
+        f"- Pull request: {escape_markdown(pr['number'])}",
+        f"- Title: {escape_markdown(pr['title'])}",
+        f"- State: {escape_markdown(pr['state'])}",
+        f"- Draft: {'yes' if pr['is_draft'] else 'no'}",
+        f"- Head: `{pr['head_oid_after']}`",
+        f"- Digest: `{snapshot['snapshot_digest']}`",
+        f"- API calls: {snapshot['completeness']['api_calls']}",
+        f"- Captured items: {snapshot['completeness']['items']}",
+        "",
+        "## Reviews",
+    ]
+    if not snapshot["reviews"]:
+        lines.extend(["", "No review submissions were captured."])
+    for item in snapshot["reviews"]:
+        login = item["author"]["login"] or "deleted or unavailable"
+        lines.extend(
+            [
+                "",
+                f"### {escape_markdown(item['state'])} by {escape_markdown(login)}",
+                "",
+                f"- Source: {_markdown_link('review', item['url'])}",
+                f"- Commit: `{escape_markdown(item['commit_oid'] or 'unavailable')}`",
+                "",
+                _markdown_body(item["body"]),
+            ]
+        )
+    lines.extend(["", "## Conversation comments"])
+    if not snapshot["conversation_comments"]:
+        lines.extend(["", "No top-level conversation comments were captured."])
+    for item in snapshot["conversation_comments"]:
+        login = item["author"]["login"] or "deleted or unavailable"
+        lines.extend(
+            [
+                "",
+                f"### {escape_markdown(login)}",
+                "",
+                f"- Source: {_markdown_link('comment', item['url'])}",
+                "",
+                _markdown_body(item["body"]),
+            ]
+        )
+    lines.extend(["", "## Review threads"])
+    if not snapshot["review_threads"]:
+        lines.extend(["", "No inline review threads were captured."])
+    for item in snapshot["review_threads"]:
+        location = (
+            f"{escape_markdown(item['path'] or 'path unavailable')}:"
+            f"{escape_markdown(item['line'] if item['line'] is not None else 'line unavailable')}"
+        )
+        lines.extend(
+            [
+                "",
+                f"### {location}",
+                "",
+                f"- Thread: `{escape_markdown(item['id'])}`",
+                f"- Resolved: {'yes' if item['is_resolved'] else 'no'}",
+                f"- Outdated: {'yes' if item['is_outdated'] else 'no'}",
+            ]
+        )
+        for comment in item["comments"]:
+            login = comment["author"]["login"] or "deleted or unavailable"
+            lines.extend(
+                [
+                    "",
+                    f"#### {escape_markdown(login)}",
+                    "",
+                    f"- Source: {_markdown_link('inline comment', comment['url'])}",
+                    "",
+                    _markdown_body(comment["body"]),
+                ]
+            )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _validate_output_path(path: Path) -> None:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:-1]:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError as exc:
+            raise OutputSafetyError(f"Output parent does not exist: {current}") from exc
+        if stat.S_ISLNK(mode):
+            raise OutputSafetyError(f"Output path has a symlink parent: {current}")
+        if not stat.S_ISDIR(mode):
+            raise OutputSafetyError(f"Output parent is not a directory: {current}")
+    try:
+        mode = absolute.lstat().st_mode
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(mode):
+        raise OutputSafetyError(f"Output target is a symlink: {absolute}")
+    if not stat.S_ISREG(mode):
+        raise OutputSafetyError(f"Output target is not a regular file: {absolute}")
+
+
+def _stage_atomic_file(path: Path, content: bytes) -> Path:
+    _validate_output_path(path)
+    parent = path.absolute().parent
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+    temporary_path = Path(temporary)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return temporary_path
+
+
+def atomic_write_many(outputs: dict[Path, bytes]) -> None:
+    staged: list[tuple[Path, Path]] = []
+    try:
+        for target, content in outputs.items():
+            staged.append((target, _stage_atomic_file(target, content)))
+        for target, temporary in staged:
+            os.replace(temporary, target)
+            os.chmod(target, 0o600)
+    finally:
+        for _, temporary in staged:
+            temporary.unlink(missing_ok=True)
+
+
+def prepare_outputs(
+    snapshot: dict[str, Any],
+    output: str | None,
+    markdown_output: str | None,
+) -> dict[Path, bytes]:
+    outputs: dict[Path, bytes] = {}
+    if output and markdown_output and Path(output).absolute() == Path(markdown_output).absolute():
+        raise OutputSafetyError("Canonical JSON and derived Markdown require different output paths")
+    if output:
+        outputs[Path(output)] = canonical_json_bytes(snapshot)
+    if markdown_output:
+        outputs[Path(markdown_output)] = render_markdown(snapshot).encode("utf-8")
+    return outputs
+
+
+def graphql_arguments(
+    owner: str,
+    name: str,
+    number: int,
+    cursor: str | None,
+    query_document: str,
+    extra_variables: dict[str, Any] | None = None,
+) -> list[str]:
+    arguments = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={query_document}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+        "-F",
+        f"number={number}",
+    ]
+    if cursor is not None:
+        arguments.extend(["-F", f"after={cursor}"])
+    for key, value in sorted((extra_variables or {}).items()):
+        arguments.extend(["-F", f"{key}={value}"])
+    return arguments
+
+
+def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        repository = payload["data"]["repository"]
+    except (KeyError, TypeError) as exc:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Repository data is missing", "pull_request.anchor", None) from exc
+    if repository is None:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Repository is unavailable", "pull_request.anchor", None)
+    pull_request = repository.get("pullRequest")
+    if pull_request is None:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request is unavailable", "pull_request.anchor", None)
+    if not pull_request.get("headRefOid") or not pull_request.get("baseRefOid"):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request head or base OID is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    repository_strings = {
+        "id": repository.get("id"),
+        "name": repository.get("name"),
+        "nameWithOwner": repository.get("nameWithOwner"),
+        "url": repository.get("url"),
+        "defaultBranchRef.name": (repository.get("defaultBranchRef") or {}).get("name"),
+    }
+    pull_request_strings = {
+        "id": pull_request.get("id"),
+        "url": pull_request.get("url"),
+        "title": pull_request.get("title"),
+        "state": pull_request.get("state"),
+        "baseRefName": pull_request.get("baseRefName"),
+    }
+    if any(not isinstance(value, str) or not value for value in repository_strings.values()):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Required repository anchor field is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    if any(not isinstance(value, str) for value in pull_request_strings.values()):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Required pull request anchor field is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    if pull_request.get("state") not in {"OPEN", "CLOSED"}:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request state is unsupported", "pull_request.anchor", None)
+    if not isinstance(pull_request.get("number"), int) or isinstance(pull_request.get("number"), bool):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request number is unavailable", "pull_request.anchor", None)
+    if not isinstance(pull_request.get("isDraft"), bool) or not isinstance(pull_request.get("merged"), bool):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request lifecycle state is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    base_repository = pull_request.get("baseRepository")
+    if not isinstance(base_repository, dict) or any(
+        not isinstance(base_repository.get(key), str) or not base_repository.get(key)
+        for key in ("id", "nameWithOwner", "url")
+    ):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Base repository identity is unavailable", "pull_request.anchor", None)
+    return {"repository": repository, "pull_request": pull_request}
+
+
+def ensure_unchanged_head(before: str, after: str) -> None:
+    if before != after:
+        raise BlockedError(
+            "BLOCKED_HEAD_MOVED",
+            f"Pull request head moved during capture: {before} -> {after}",
+            "pull_request.anchor",
+            None,
+        )
+
+
+def _empty_signer() -> dict[str, Any]:
+    return copy.deepcopy(ZERO_AUTHOR)
+
+
+def interpret_local_signature(returncode: int, output: str) -> dict[str, Any]:
+    lowered = output.lower()
+    if returncode == 0:
+        signature_format = "ssh" if "good \"git\" signature" in lowered or " ssh " in lowered else "openpgp"
+        return {
+            "state": "valid",
+            "verified": True,
+            "format": signature_format,
+            "reason": "valid",
+            "signer": _empty_signer(),
+        }
+    if "no public key" in lowered or "unknown key" in lowered or "can't check signature" in lowered:
+        state = "unknown_key"
+    elif "does not have a signature" in lowered or "no signature" in lowered or "unsigned" in lowered:
+        state = "unsigned"
+    elif "pending" in lowered or "temporarily unavailable" in lowered:
+        state = "verification_pending"
+    else:
+        state = "invalid"
+    return {
+        "state": state,
+        "verified": False,
+        "format": "ssh" if "ssh" in lowered else ("openpgp" if "gpg" in lowered else "unknown"),
+        "reason": state,
+        "signer": _empty_signer(),
+    }
+
+
+def normalize_github_signature(value: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {
+            "state": "unsigned",
+            "verified": False,
+            "format": None,
+            "reason": "unsigned",
+            "signer": _empty_signer(),
+        }
+    typename = str(value.get("__typename") or "")
+    signature_format = {
+        "SshSignature": "ssh",
+        "GpgSignature": "openpgp",
+        "SmimeSignature": "smime",
+    }.get(typename, "unknown")
+    raw_state = str(value.get("state") or "").upper()
+    is_valid = value.get("isValid") is True
+    if is_valid and raw_state in {"VALID", ""}:
+        state = "valid"
+    elif raw_state in {"PENDING", "UNKNOWN", "UNVERIFIED"}:
+        state = "verification_pending"
+    elif raw_state in {"UNKNOWN_KEY", "NO_USER"}:
+        state = "unknown_key"
+    elif raw_state in {"UNSIGNED", "NO_SIGNATURE"}:
+        state = "unsigned"
+    else:
+        state = "invalid"
+    return {
+        "state": state,
+        "verified": state == "valid",
+        "format": signature_format,
+        "reason": raw_state.lower() or state,
+        "signer": normalize_actor(value.get("signer")),
+    }
+
+
+def local_signature_for_commit(runner: Any, oid: str) -> dict[str, Any]:
+    available = runner.run(["git", "cat-file", "-e", f"{oid}^{{commit}}"], allow_failure=True)
+    if available.returncode != 0:
+        return {
+            "state": "object_unavailable",
+            "verified": False,
+            "format": None,
+            "reason": "object_unavailable",
+            "signer": _empty_signer(),
+        }
+    verified = runner.run(["git", "verify-commit", "--raw", oid], allow_failure=True)
+    return interpret_local_signature(verified.returncode, f"{verified.stdout}\n{verified.stderr}")
+
+
+def _check_application() -> dict[str, Any]:
+    return {"id": None, "database_id": None, "name": None, "slug": None}
+
+
+def _required_stable_id(context: str, integration_id: int | None) -> str:
+    return f"check:{integration_id or 0}:{context}"
+
+
+def _check_outcome(status: str | None, conclusion: str | None, expected_skipped: str) -> str:
+    normalized_status = str(status or "").upper()
+    normalized_conclusion = str(conclusion or "").upper()
+    if normalized_status in PENDING_CHECK_STATUSES or not normalized_conclusion:
+        return "pending"
+    if normalized_conclusion in SUCCESSFUL_CHECK_CONCLUSIONS:
+        return "successful"
+    if normalized_conclusion == "SKIPPED" and expected_skipped == "allow":
+        return "successful"
+    return "failed"
+
+
+def evaluate_checks(
+    raw_checks: list[dict[str, Any]],
+    required_specs: list[dict[str, Any]] | None,
+    policy: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    checks = [copy.deepcopy(item) for item in raw_checks]
+    if required_specs is None:
+        for item in checks:
+            item["requiredness"] = "unknown"
+            item["evidence_state"] = "requiredness_unknown"
+        return sorted(checks, key=lambda item: item["stable_id"]), {
+            "determination": "incomplete",
+            "required": [],
+            "missing": [],
+            "sources": [],
+            "unknown_reasons": ["required check evidence unavailable"],
+        }
+    required_by_key = {
+        (str(spec["context"]), spec.get("integration_id")): spec for spec in required_specs
+    }
+    matched: set[tuple[str, int | None]] = set()
+    for item in checks:
+        name = item["name"]
+        app_id = item.get("application", {}).get("database_id")
+        matching = [
+            key
+            for key in required_by_key
+            if key[0] == name and (key[1] is None or key[1] == app_id)
+        ]
+        if matching:
+            key = sorted(matching, key=lambda value: (value[0], value[1] or 0))[0]
+            matched.add(key)
+            item["requiredness"] = "required"
+            outcome = _check_outcome(item.get("status"), item.get("conclusion"), policy["expected_skipped"])
+            item["evidence_state"] = f"required_{outcome}"
+        else:
+            item["requiredness"] = "non_required"
+            outcome = _check_outcome(item.get("status"), item.get("conclusion"), policy["expected_skipped"])
+            item["evidence_state"] = f"non_required_{outcome}"
+    missing: list[str] = []
+    for key in sorted(set(required_by_key) - matched, key=lambda value: (value[0], value[1] or 0)):
+        stable_id = _required_stable_id(key[0], key[1])
+        missing.append(stable_id)
+        checks.append(
+            {
+                "stable_id": stable_id,
+                "name": key[0],
+                "application": {
+                    "id": None,
+                    "database_id": key[1],
+                    "name": None,
+                    "slug": None,
+                },
+                "status": "MISSING",
+                "conclusion": None,
+                "requiredness": "required",
+                "evidence_state": "required_missing",
+                "details_url": None,
+            }
+        )
+    required_ids = sorted(
+        _required_stable_id(context, integration_id) for context, integration_id in required_by_key
+    )
+    return sorted(checks, key=lambda item: item["stable_id"]), {
+        "determination": "complete",
+        "required": required_ids,
+        "missing": missing,
+        "sources": ["branch_protection", "rulesets"],
+        "unknown_reasons": [],
+    }
+
+
+def require_rule_evidence(
+    rulesets: Any,
+    branch_protection: Any,
+    policy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if policy["require_ruleset_evidence"] and not isinstance(rulesets, list):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Applicable ruleset evidence is inaccessible", "rulesets", None)
+    if policy["require_branch_protection_evidence"] and not isinstance(branch_protection, dict):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Branch-protection required-check evidence is inaccessible",
+            "branch_protection",
+            None,
+        )
+    specifications: dict[tuple[str, int | None], dict[str, Any]] = {}
+    for rule in rulesets or []:
+        if not isinstance(rule, dict):
+            raise BlockedError(BLOCKED_INCOMPLETE, "Malformed applicable rule", "rulesets", None)
+        if rule.get("type") != "required_status_checks":
+            continue
+        parameters = rule.get("parameters")
+        checks = parameters.get("required_status_checks") if isinstance(parameters, dict) else None
+        if not isinstance(checks, list):
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                "Required-status-check rule has malformed parameters",
+                "rulesets",
+                None,
+            )
+        for item in checks:
+            if not isinstance(item, dict):
+                raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check rule", "rulesets", None)
+            context = item.get("context")
+            integration_id = item.get("integration_id")
+            if not isinstance(context, str) or not context or (
+                integration_id is not None
+                and (isinstance(integration_id, bool) or not isinstance(integration_id, int))
+            ):
+                raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "rulesets", None)
+            specifications[(context, integration_id)] = {
+                "context": context,
+                "integration_id": integration_id,
+            }
+    if isinstance(branch_protection, dict):
+        contexts = branch_protection.get("contexts")
+        checks = branch_protection.get("checks")
+        if not isinstance(contexts, list) or not isinstance(checks, list):
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                "Branch-protection required checks are malformed",
+                "branch_protection",
+                None,
+            )
+        for context in contexts:
+            if not isinstance(context, str) or not context:
+                raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required status context", "branch_protection", None)
+            specifications.setdefault((context, None), {"context": context, "integration_id": None})
+        for item in checks:
+            if not isinstance(item, dict):
+                raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check", "branch_protection", None)
+            context = item.get("context")
+            app_id = item.get("app_id")
+            if not isinstance(context, str) or not context or (
+                app_id is not None and (isinstance(app_id, bool) or not isinstance(app_id, int))
+            ):
+                raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "branch_protection", None)
+            specifications[(context, app_id)] = {"context": context, "integration_id": app_id}
+            specifications.pop((context, None), None)
+    return [specifications[key] for key in sorted(specifications, key=lambda value: (value[0], value[1] or 0))]
+
+
+def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
+    validate_config(configuration)
+    validate_snapshot(snapshot)
+    blockers: list[dict[str, str]] = []
+    pr = snapshot["pull_request"]
+    if snapshot["repository"]["name_with_owner"] != configuration["repository"]:
+        blockers.append(
+            {
+                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                "reason": "Snapshot repository does not match configuration",
+            }
+        )
+    if pr["base_repository"]["name_with_owner"] not in configuration["allowed_base_repositories"]:
+        blockers.append({"code": "BLOCKED_UNSAFE_GITHUB_STATE", "reason": "PR base repository is not allowed"})
+    if pr["base_ref"] != configuration["default_branch"]:
+        blockers.append(
+            {
+                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                "reason": "PR base branch does not match configuration",
+            }
+        )
+    if pr["head_repository"]["name_with_owner"] is None or pr["head_ref"] is None:
+        blockers.append(
+            {
+                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                "reason": "PR head repository or branch is unavailable",
+            }
+        )
+    if pr["state"] != "OPEN" or pr["is_merged"] or pr["is_draft"]:
+        blockers.append(
+            {
+                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                "reason": "PR is not an open non-draft merge candidate",
+            }
+        )
+    if pr["mergeable"] != "MERGEABLE":
+        blockers.append({"code": "BLOCKED_UNSAFE_GITHUB_STATE", "reason": "PR mergeability is conflicting or unknown"})
+    signature_policy = configuration["signature_policy"]
+    accepted_formats = set(signature_policy["accepted_formats"])
+    for commit in snapshot["commits"]:
+        if signature_policy["require_github_verified"] and (
+            commit["github_signature"]["state"] != "valid"
+            or commit["github_signature"]["format"] not in accepted_formats
+        ):
+            blockers.append(
+                {
+                    "code": "BLOCKED_INVALID_SIGNATURE",
+                    "reason": f"GitHub signature invalid for {commit['oid']}",
+                }
+            )
+        if signature_policy["require_local_verified"] and (
+            commit["local_signature"]["state"] != "valid"
+            or commit["local_signature"]["format"] not in accepted_formats
+        ):
+            blockers.append(
+                {
+                    "code": "BLOCKED_INVALID_SIGNATURE",
+                    "reason": f"Local signature invalid for {commit['oid']}",
+                }
+            )
+    for item in snapshot["checks"]:
+        if item["evidence_state"] in {
+            "required_pending",
+            "required_failed",
+            "required_missing",
+            "requiredness_unknown",
+        }:
+            blockers.append(
+                {
+                    "code": "BLOCKED_FAILED_OR_PENDING_CI"
+                    if item["evidence_state"] != "requiredness_unknown"
+                    else BLOCKED_INCOMPLETE,
+                    "reason": f"{item['name']}: {item['evidence_state']}",
+                }
+            )
+    unresolved = [item for item in snapshot["review_threads"] if not item["is_resolved"]]
+    requested_changes = pr["review_decision"] == "CHANGES_REQUESTED" or any(
+        item["state"] == "CHANGES_REQUESTED" for item in snapshot["reviews"]
+    )
+    if unresolved or requested_changes:
+        blockers.append(
+            {
+                "code": "NOT_READY_FOR_MERGE",
+                "reason": "Raw unresolved review state requires Package 2.2 classification",
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "snapshot_digest": snapshot["snapshot_digest"],
+        "status": "BLOCKED" if blockers else "PACKAGE_2_2_CLASSIFICATION_REQUIRED",
+        "blockers": blockers,
+        "raw_review_state": {
+            "reviews": len(snapshot["reviews"]),
+            "conversation_comments": len(snapshot["conversation_comments"]),
+            "review_threads": len(snapshot["review_threads"]),
+            "resolved_threads": len(snapshot["review_threads"]) - len(unresolved),
+            "unresolved_threads": len(unresolved),
+            "requested_changes": requested_changes,
+        },
+        "technical_classification_required": bool(
+            snapshot["reviews"] or snapshot["conversation_comments"] or snapshot["review_threads"]
+        ),
+        "merge_authorized": False,
+    }
+
+
+def _safe_git(runner: Any, arguments: list[str]) -> CommandResult:
+    try:
+        return runner.run(arguments, allow_failure=True)
+    except CommandFailure as exc:
+        return exc.result
+
+
+def _remote_repository(remote_url: str) -> str | None:
+    value = remote_url.strip()
+    patterns = (
+        r"^git@github\.com:([^/]+/[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+        r"^https://github\.com/([^/]+/[^/]+?)(?:\.git)?/?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, value)
+        if match:
+            return match.group(1)
+    return None
+
+
+def verify_local_against_snapshot(
+    snapshot: dict[str, Any],
+    configuration: dict[str, Any],
+    runner: Any,
+    expected_head: str | None,
+) -> dict[str, Any]:
+    validate_config(configuration)
+    validate_snapshot(snapshot)
+    blockers: list[dict[str, str]] = []
+
+    def block(code: str, reason: str) -> None:
+        blockers.append({"code": code, "reason": reason})
+
+    root = _safe_git(runner, ["git", "rev-parse", "--show-toplevel"])
+    remote = _safe_git(runner, ["git", "remote", "get-url", "origin"])
+    status = _safe_git(runner, ["git", "status", "--porcelain=v2", "--untracked-files=all"])
+    branch = _safe_git(runner, ["git", "branch", "--show-current"])
+    upstream = _safe_git(
+        runner,
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    )
+    local_head = _safe_git(runner, ["git", "rev-parse", "HEAD"])
+    remote_head = _safe_git(runner, ["git", "rev-parse", "@{upstream}"])
+    repository_root = root.stdout.strip() if root.returncode == 0 else None
+    remote_identity = _remote_repository(remote.stdout) if remote.returncode == 0 else None
+    current_branch = branch.stdout.strip() if branch.returncode == 0 else None
+    local_oid = local_head.stdout.strip() if local_head.returncode == 0 else None
+    remote_oid = remote_head.stdout.strip() if remote_head.returncode == 0 else None
+    pr = snapshot["pull_request"]
+    pr_head = pr["head_oid_after"]
+    commit_range = f"{pr['base_oid']}..{pr_head}"
+    local_commits = _safe_git(runner, ["git", "rev-list", "--reverse", commit_range])
+    local_commit_oids = local_commits.stdout.splitlines() if local_commits.returncode == 0 else []
+    snapshot_commit_oids = [item["oid"] for item in snapshot["commits"]]
+
+    if root.returncode != 0 or not repository_root:
+        block("BLOCKED_UNSAFE_GITHUB_STATE", "Local repository root is unavailable")
+    if remote_identity != configuration["repository"]:
+        block("BLOCKED_UNSAFE_GITHUB_STATE", "Origin repository identity does not match configuration")
+    if status.returncode != 0 or status.stdout:
+        block("BLOCKED_UNCLEAN_WORKTREE", "Local worktree contains tracked or untracked changes")
+    if not current_branch or current_branch != pr["head_ref"]:
+        block("BLOCKED_HEAD_MOVED", "Current branch does not match the PR head branch")
+    if upstream.returncode != 0 or not upstream.stdout.strip():
+        block("BLOCKED_HEAD_MOVED", "Current branch has no configured upstream")
+    if local_oid != pr_head or remote_oid != pr_head:
+        block("BLOCKED_HEAD_MOVED", "Local, remote-tracking, and PR head OIDs do not match")
+    if expected_head is not None and expected_head != pr_head:
+        block("BLOCKED_HEAD_MOVED", "Expected head does not match the PR head")
+    if local_commits.returncode != 0 or sorted(local_commit_oids) != sorted(snapshot_commit_oids):
+        block(
+            "BLOCKED_UNEXPLAINED_COMMIT",
+            "Local base-to-head commit set does not match the PR commit set",
+        )
+    if pr["base_repository"]["name_with_owner"] not in configuration["allowed_base_repositories"]:
+        block("BLOCKED_UNSAFE_GITHUB_STATE", "PR base repository is not allowed")
+    if pr["base_ref"] != configuration["default_branch"]:
+        block("BLOCKED_UNSAFE_GITHUB_STATE", "PR base branch does not match configuration")
+    if pr["state"] != "OPEN" or pr["is_merged"]:
+        block("BLOCKED_UNSAFE_GITHUB_STATE", "PR is closed or merged")
+
+    signatures = []
+    for commit in snapshot["commits"]:
+        value = local_signature_for_commit(runner, commit["oid"])
+        signatures.append({"oid": commit["oid"], **value})
+        if value["state"] != "valid":
+            block("BLOCKED_INVALID_SIGNATURE", f"Local signature is not valid for {commit['oid']}")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "VERIFIED" if not blockers else "BLOCKED",
+        "repository": configuration["repository"],
+        "repository_root": repository_root,
+        "origin_repository": remote_identity,
+        "current_branch": current_branch,
+        "upstream": upstream.stdout.strip() if upstream.returncode == 0 else None,
+        "local_head": local_oid,
+        "remote_tracking_head": remote_oid,
+        "pr_head": pr_head,
+        "pr_state": pr["state"],
+        "is_draft": pr["is_draft"],
+        "commit_oids": snapshot_commit_oids,
+        "local_commit_oids": local_commit_oids,
+        "commit_signatures": signatures,
+        "blockers": blockers,
+        "fetched": False,
+    }
+
+
+PULL_REQUEST_ANCHOR_QUERY = r"""
+query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    id
+    name
+    nameWithOwner
+    url
+    defaultBranchRef { name }
+    pullRequest(number:$number) {
+      id
+      databaseId
+      number
+      url
+      title
+      state
+      isDraft
+      merged
+      mergeable
+      reviewDecision
+      author {
+        __typename
+        login
+        url
+        ... on User { id databaseId }
+        ... on Bot { id databaseId }
+        ... on Organization { id databaseId }
+        ... on Mannequin { id databaseId }
+      }
+      baseRepository { id nameWithOwner url }
+      baseRefName
+      baseRefOid
+      headRepository { id nameWithOwner url }
+      headRefName
+      headRefOid
+    }
+  }
+}
+"""
+
+PULL_REQUEST_LABELS_QUERY = r"""
+query PullRequestLabels($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      labels(first:100, after:$after) {
+        nodes { name }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_REVIEW_REQUESTS_QUERY = r"""
+query PullRequestReviewRequests($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviewRequests(first:100, after:$after) {
+        nodes {
+          requestedReviewer {
+            __typename
+            ... on User { id databaseId login url }
+            ... on Mannequin { id databaseId login url }
+            ... on Team { id slug name url }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_REVIEWS_QUERY = r"""
+query PullRequestReviews($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviews(first:100, after:$after) {
+        nodes {
+          id
+          databaseId
+          author {
+            __typename
+            login
+            url
+            ... on User { id databaseId }
+            ... on Bot { id databaseId }
+            ... on Organization { id databaseId }
+            ... on Mannequin { id databaseId }
+          }
+          state
+          body
+          url
+          submittedAt
+          commit { oid }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+CONVERSATION_COMMENTS_QUERY = r"""
+query ConversationComments($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      comments(first:100, after:$after) {
+        nodes {
+          id
+          databaseId
+          author {
+            __typename
+            login
+            url
+            ... on User { id databaseId }
+            ... on Bot { id databaseId }
+            ... on Organization { id databaseId }
+            ... on Mannequin { id databaseId }
+          }
+          body
+          url
+          createdAt
+          updatedAt
+          reactions(first:100) {
+            nodes {
+              id
+              content
+              createdAt
+              user {
+                __typename
+                id
+                databaseId
+                login
+                url
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+ISSUE_COMMENT_REACTIONS_QUERY = r"""
+query IssueCommentReactions($owner:String!, $name:String!, $number:Int!, $nodeId:ID!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) { id }
+  }
+  node(id:$nodeId) {
+    ... on IssueComment {
+      reactions(first:100, after:$after) {
+        nodes {
+          id
+          content
+          createdAt
+          user {
+            __typename
+            id
+            databaseId
+            login
+            url
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+REVIEW_THREADS_QUERY = r"""
+query ReviewThreads($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100, after:$after) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          diffSide
+          startLine
+          startDiffSide
+          comments(first:100) {
+            nodes {
+              id
+              databaseId
+              author {
+                __typename
+                login
+                url
+                ... on User { id databaseId }
+                ... on Bot { id databaseId }
+                ... on Organization { id databaseId }
+                ... on Mannequin { id databaseId }
+              }
+              body
+              url
+              createdAt
+              updatedAt
+              replyTo { id }
+              pullRequestReview { id }
+              reactions(first:100) {
+                nodes {
+                  id
+                  content
+                  createdAt
+                  user {
+                    __typename
+                    id
+                    databaseId
+                    login
+                    url
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+REVIEW_THREAD_COMMENTS_QUERY = r"""
+query ReviewThreadComments($owner:String!, $name:String!, $number:Int!, $nodeId:ID!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) { id }
+  }
+  node(id:$nodeId) {
+    ... on PullRequestReviewThread {
+      comments(first:100, after:$after) {
+        nodes {
+          id
+          databaseId
+          author {
+            __typename
+            login
+            url
+            ... on User { id databaseId }
+            ... on Bot { id databaseId }
+            ... on Organization { id databaseId }
+            ... on Mannequin { id databaseId }
+          }
+          body
+          url
+          createdAt
+          updatedAt
+          replyTo { id }
+          pullRequestReview { id }
+          reactions(first:100) {
+            nodes {
+              id
+              content
+              createdAt
+              user {
+                __typename
+                id
+                databaseId
+                login
+                url
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+REVIEW_COMMENT_REACTIONS_QUERY = r"""
+query ReviewCommentReactions($owner:String!, $name:String!, $number:Int!, $nodeId:ID!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) { id }
+  }
+  node(id:$nodeId) {
+    ... on PullRequestReviewComment {
+      reactions(first:100, after:$after) {
+        nodes {
+          id
+          content
+          createdAt
+          user {
+            __typename
+            id
+            databaseId
+            login
+            url
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_COMMITS_QUERY = r"""
+query PullRequestCommits($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      commits(first:100, after:$after) {
+        nodes {
+          commit {
+            oid
+            authoredDate
+            committedDate
+            parents(first:100) {
+              nodes { oid }
+              pageInfo { hasNextPage endCursor }
+            }
+            signature {
+              __typename
+              isValid
+              state
+              wasSignedByGitHub
+              signer {
+                __typename
+                id
+                databaseId
+                login
+                url
+              }
+            }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+COMMIT_CHECKS_QUERY = r"""
+query CommitChecks($owner:String!, $name:String!, $number:Int!, $oid:GitObjectID!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) { id }
+    object(oid:$oid) {
+      ... on Commit {
+        statusCheckRollup {
+          contexts(first:100, after:$after) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                id
+                name
+                status
+                conclusion
+                detailsUrl
+                checkSuite {
+                  app { id databaseId name slug }
+                }
+              }
+              ... on StatusContext {
+                id
+                context
+                state
+                targetUrl
+                creator {
+                  __typename
+                  login
+                  url
+                  ... on User { id databaseId }
+                  ... on Bot { id databaseId }
+                  ... on Organization { id databaseId }
+                  ... on Mannequin { id databaseId }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _connection_page(value: Any, connection: str) -> Page:
+    if not isinstance(value, dict):
+        raise BlockedError(BLOCKED_INCOMPLETE, f"Missing connection data for {connection}", connection, None)
+    nodes = value.get("nodes")
+    page_info = value.get("pageInfo")
+    if not isinstance(nodes, list) or not isinstance(page_info, dict) or not isinstance(
+        page_info.get("hasNextPage"), bool
+    ):
+        raise BlockedError(BLOCKED_INCOMPLETE, f"Malformed connection data for {connection}", connection, None)
+    if any(not isinstance(node, dict) for node in nodes):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            f"Connection contains an unavailable item for {connection}",
+            connection,
+            None,
+        )
+    end_cursor = page_info.get("endCursor")
+    if end_cursor is not None and not isinstance(end_cursor, str):
+        raise BlockedError(BLOCKED_INCOMPLETE, f"Invalid cursor for {connection}", connection, None)
+    return Page(nodes, page_info["hasNextPage"], end_cursor)
+
+
+def _path(payload: dict[str, Any], keys: tuple[str, ...], connection: str) -> Any:
+    value: Any = payload
+    try:
+        for key in keys:
+            value = value[key]
+    except (KeyError, TypeError) as exc:
+        raise BlockedError(BLOCKED_INCOMPLETE, f"Missing response field for {connection}", connection, None) from exc
+    return value
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        runner: Any,
+        budget: Budget,
+        owner: str,
+        name: str,
+        number: int,
+    ) -> None:
+        self.runner = runner
+        self.budget = budget
+        self.owner = owner
+        self.name = name
+        self.number = number
+
+    def graphql(
+        self,
+        query_document: str,
+        connection: str,
+        cursor: str | None = None,
+        extra_variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.budget.note_api_call(connection, cursor)
+        arguments = graphql_arguments(
+            self.owner,
+            self.name,
+            self.number,
+            cursor,
+            query_document,
+            extra_variables,
+        )
+        try:
+            result = self.runner.run(arguments)
+        except CommandFailure as exc:
+            failure = classify_api_failure(str(exc))
+            failure.connection = connection
+            failure.cursor = cursor
+            raise failure from exc
+        return parse_graphql_payload(result.stdout, connection)
+
+    def rest(self, endpoint: str, connection: str, cursor: str | None = None) -> Any:
+        self.budget.note_api_call(connection, cursor)
+        arguments = ["gh", "api", "--method", "GET", endpoint]
+        try:
+            result = self.runner.run(arguments)
+        except CommandFailure as exc:
+            failure = classify_api_failure(str(exc))
+            failure.connection = connection
+            failure.cursor = cursor
+            raise failure from exc
+        return parse_api_json(result.stdout, connection)
+
+
+def _pull_request_connection_fetcher(
+    client: GitHubClient,
+    query_document: str,
+    field: str,
+    connection: str,
+) -> Callable[[str | None], Page]:
+    def fetch(cursor: str | None) -> Page:
+        payload = client.graphql(query_document, connection, cursor)
+        value = _path(payload, ("data", "repository", "pullRequest", field), connection)
+        return _connection_page(value, connection)
+
+    return fetch
+
+
+def _embedded_connection(
+    initial: Any,
+    fetch_next: Callable[[str], Page],
+    connection: str,
+    budget: Budget,
+    kind: str,
+) -> list[Any]:
+    first = True
+
+    def fetch(cursor: str | None) -> Page:
+        nonlocal first
+        if first:
+            first = False
+            return _connection_page(initial, connection)
+        if cursor is None:
+            raise ContractError(f"Missing cursor for nested connection {connection}")
+        return fetch_next(cursor)
+
+    return collect_pages(connection, fetch, budget, kind=kind)
+
+
+def _normalize_review(value: dict[str, Any]) -> dict[str, Any]:
+    review_id = value.get("id")
+    state = value.get("state")
+    if not isinstance(review_id, str) or not review_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review identity is unavailable", "reviews", None)
+    if state not in {"APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING"}:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review state is unavailable or unsupported", "reviews", None)
+    if not isinstance(value.get("body"), str) or not isinstance(value.get("url"), str):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review content fields are unavailable", "reviews", None)
+    commit = value.get("commit")
+    return {
+        "id": review_id,
+        "database_id": value.get("databaseId"),
+        "author": normalize_actor(value.get("author")),
+        "state": state,
+        "body": value["body"],
+        "url": value["url"],
+        "submitted_at": value.get("submittedAt"),
+        "commit_oid": commit.get("oid") if isinstance(commit, dict) else None,
+    }
+
+
+def _normalize_conversation_comment(value: dict[str, Any]) -> dict[str, Any]:
+    required = ("id", "body", "url", "createdAt", "updatedAt")
+    if any(not isinstance(value.get(key), str) for key in required) or not value.get("id"):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Conversation comment required fields are unavailable",
+            "conversation_comments",
+            None,
+        )
+    return {
+        "id": value["id"],
+        "database_id": value.get("databaseId"),
+        "author": normalize_actor(value.get("author")),
+        "body": value["body"],
+        "url": value["url"],
+        "created_at": value["createdAt"],
+        "updated_at": value["updatedAt"],
+        "reactions": normalize_reactions(value.get("reactions", [])),
+    }
+
+
+def _capture_comment_reactions(
+    client: GitHubClient,
+    comment: dict[str, Any],
+    *,
+    review_comment: bool,
+) -> list[dict[str, Any]]:
+    comment_id = comment.get("id")
+    if not isinstance(comment_id, str) or not comment_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Comment node ID is unavailable", "comment.reactions", None)
+    connection = (
+        f"review_comment.{comment_id}.reactions"
+        if review_comment
+        else f"conversation_comment.{comment_id}.reactions"
+    )
+    query = REVIEW_COMMENT_REACTIONS_QUERY if review_comment else ISSUE_COMMENT_REACTIONS_QUERY
+
+    def next_page(cursor: str) -> Page:
+        payload = client.graphql(query, connection, cursor, {"nodeId": comment_id})
+        value = _path(payload, ("data", "node", "reactions"), connection)
+        return _connection_page(value, connection)
+
+    return _embedded_connection(
+        comment.get("reactions"),
+        next_page,
+        connection,
+        client.budget,
+        "reactions",
+    )
+
+
+def _capture_thread_comments(client: GitHubClient, value: dict[str, Any]) -> list[dict[str, Any]]:
+    thread_id = value.get("id")
+    if not isinstance(thread_id, str) or not thread_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review thread ID is unavailable", "review_threads", None)
+    connection = f"review_thread.{thread_id}.comments"
+
+    def next_page(cursor: str) -> Page:
+        payload = client.graphql(
+            REVIEW_THREAD_COMMENTS_QUERY,
+            connection,
+            cursor,
+            {"nodeId": thread_id},
+        )
+        nested = _path(payload, ("data", "node", "comments"), connection)
+        return _connection_page(nested, connection)
+
+    raw_comments = _embedded_connection(
+        value.get("comments"),
+        next_page,
+        connection,
+        client.budget,
+        "comments",
+    )
+    result = []
+    for raw_comment in raw_comments:
+        reactions = _capture_comment_reactions(client, raw_comment, review_comment=True)
+        expanded = copy.deepcopy(raw_comment)
+        expanded["reactions"] = reactions
+        result.append(normalize_review_comment(expanded))
+    return result
+
+
+def _normalize_commit(value: dict[str, Any], runner: Any, budget: Budget) -> dict[str, Any]:
+    commit = value.get("commit")
+    if not isinstance(commit, dict):
+        raise BlockedError(BLOCKED_INCOMPLETE, "PR commit object is unavailable", "commits", None)
+    oid = commit.get("oid")
+    if not isinstance(oid, str) or not OID_PATTERN.fullmatch(oid):
+        raise BlockedError(BLOCKED_INCOMPLETE, "PR commit OID is unavailable", "commits", None)
+    parents = commit.get("parents")
+    page = _connection_page(parents, f"commit.{oid}.parents")
+    if page.has_next_page:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Commit parent connection exceeded the supported bounded page",
+            f"commit.{oid}.parents",
+            page.end_cursor,
+        )
+    budget.add_items(len(page.nodes), f"commit.{oid}.parents", None)
+    budget.record_connection(f"commit.{oid}.parents", 1, len(page.nodes))
+    parent_oids = []
+    for parent in page.nodes:
+        parent_oid = parent.get("oid") if isinstance(parent, dict) else None
+        if not isinstance(parent_oid, str) or not OID_PATTERN.fullmatch(parent_oid):
+            raise BlockedError(BLOCKED_INCOMPLETE, "Commit parent OID is unavailable", f"commit.{oid}.parents", None)
+        parent_oids.append(parent_oid)
+    return {
+        "oid": oid,
+        "parents": sorted(parent_oids),
+        "authored_at": str(commit.get("authoredDate") or ""),
+        "committed_at": str(commit.get("committedDate") or ""),
+        "github_signature": normalize_github_signature(commit.get("signature")),
+        "local_signature": local_signature_for_commit(runner, oid),
+    }
+
+
+def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
+    typename = value.get("__typename")
+    if typename == "CheckRun":
+        node_id = value.get("id")
+        if not isinstance(node_id, str) or not node_id:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Check run identity is unavailable", "checks", None)
+        app = value.get("checkSuite", {}).get("app") if isinstance(value.get("checkSuite"), dict) else None
+        application = {
+            "id": app.get("id") if isinstance(app, dict) else None,
+            "database_id": app.get("databaseId") if isinstance(app, dict) else None,
+            "name": app.get("name") if isinstance(app, dict) else None,
+            "slug": app.get("slug") if isinstance(app, dict) else None,
+        }
+        name = str(value.get("name") or "")
+        if not name:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Check run name is unavailable", "checks", None)
+        app_id = application["database_id"]
+        return {
+            "stable_id": f"check_run:{node_id}",
+            "name": name,
+            "application": application,
+            "status": value.get("status"),
+            "conclusion": value.get("conclusion"),
+            "details_url": value.get("detailsUrl"),
+        }
+    if typename == "StatusContext":
+        node_id = value.get("id")
+        if not isinstance(node_id, str) or not node_id:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Status context identity is unavailable", "checks", None)
+        name = str(value.get("context") or "")
+        if not name:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Status context name is unavailable", "checks", None)
+        creator = normalize_actor(value.get("creator"))
+        state = value.get("state")
+        return {
+            "stable_id": f"status_context:{node_id}",
+            "name": name,
+            "application": {
+                "id": creator["node_id"],
+                "database_id": creator["database_id"],
+                "name": creator["login"],
+                "slug": creator["login"],
+            },
+            "status": state,
+            "conclusion": state if str(state).upper() != "PENDING" else None,
+            "details_url": value.get("targetUrl"),
+        }
+    raise BlockedError(BLOCKED_INCOMPLETE, f"Unsupported check type: {typename!r}", "checks", None)
+
+
+def _normalize_applicable_rules(rulesets: list[Any], branch_protection: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules = []
+    for rule in rulesets:
+        if not isinstance(rule, dict):
+            raise BlockedError(BLOCKED_INCOMPLETE, "Malformed applicable rule", "rulesets", None)
+        if rule.get("type") == "required_status_checks":
+            checks = rule.get("parameters", {}).get("required_status_checks", [])
+            normalized_rules.append(
+                {
+                    "type": "required_status_checks",
+                    "required_checks": sorted(
+                        [
+                            {
+                                "context": item.get("context"),
+                                "integration_id": item.get("integration_id"),
+                            }
+                            for item in checks
+                            if isinstance(item, dict) and isinstance(item.get("context"), str)
+                        ],
+                        key=lambda item: (item["context"], item["integration_id"] or 0),
+                    ),
+                }
+            )
+        else:
+            normalized_rules.append({"type": str(rule.get("type") or "unknown")})
+    normalized_branch = {
+        "strict": branch_protection.get("strict"),
+        "contexts": sorted(
+            value for value in branch_protection.get("contexts", []) if isinstance(value, str)
+        ),
+        "checks": sorted(
+            [
+                {"context": item.get("context"), "app_id": item.get("app_id")}
+                for item in branch_protection.get("checks", [])
+                if isinstance(item, dict) and isinstance(item.get("context"), str)
+            ],
+            key=lambda item: (item["context"], item["app_id"] or 0),
+        ),
+    }
+    return {
+        "rulesets": sorted(normalized_rules, key=lambda item: json.dumps(item, sort_keys=True)),
+        "branch_protection": normalized_branch,
+        "evidence_complete": True,
+    }
+
+
+def _capture_rules(
+    client: GitHubClient,
+    base_ref: str,
+    policy: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    encoded_ref = quote(base_ref, safe="")
+    base_endpoint = f"repos/{client.owner}/{client.name}/rules/branches/{encoded_ref}"
+    rulesets: list[Any] = []
+    page_number = 1
+    while True:
+        endpoint = f"{base_endpoint}?per_page=100&page={page_number}"
+        page = client.rest(endpoint, "rulesets", str(page_number))
+        if not isinstance(page, list):
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                "Applicable rules response is not an array",
+                "rulesets",
+                str(page_number),
+            )
+        client.budget.add_items(len(page), "rulesets", str(page_number))
+        rulesets.extend(page)
+        if len(page) < 100:
+            client.budget.record_connection("rulesets", page_number, len(rulesets))
+            break
+        page_number += 1
+        client.budget.require_capacity_for_next_page("rulesets", str(page_number), "items")
+    protection_endpoint = (
+        f"repos/{client.owner}/{client.name}/branches/{encoded_ref}/protection/required_status_checks"
+    )
+    branch_protection = client.rest(protection_endpoint, "branch_protection")
+    if not isinstance(branch_protection, dict):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Branch-protection response is not an object", "branch_protection", None)
+    client.budget.add_items(1, "branch_protection", None)
+    client.budget.record_connection("branch_protection", 1, 1)
+    required = require_rule_evidence(rulesets, branch_protection, policy)
+    return _normalize_applicable_rules(rulesets, branch_protection), required
+
+
+def capture_snapshot(
+    repository: str,
+    number: int,
+    configuration: dict[str, Any],
+    runner: Any | None = None,
+) -> dict[str, Any]:
+    validate_config(configuration)
+    owner, name = validate_repository_name(repository)
+    if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+        raise ContractError("Pull request number must be a positive integer")
+    command_runner = runner or CommandRunner()
+    budget = Budget(configuration)
+    client = GitHubClient(command_runner, budget, owner, name, number)
+
+    before_payload = client.graphql(PULL_REQUEST_ANCHOR_QUERY, "pull_request.anchor.before")
+    before = extract_anchor(before_payload)
+    before_pr = before["pull_request"]
+    if before["repository"]["nameWithOwner"] != repository:
+        raise BlockedError(
+            "BLOCKED_UNSAFE_GITHUB_STATE",
+            "GitHub repository identity does not match the requested repository",
+            "pull_request.anchor",
+            None,
+        )
+    head_before = before_pr["headRefOid"]
+
+    labels_raw = collect_pages(
+        "labels",
+        _pull_request_connection_fetcher(client, PULL_REQUEST_LABELS_QUERY, "labels", "labels"),
+        budget,
+    )
+    if any(not isinstance(item.get("name"), str) or not item.get("name") for item in labels_raw):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Label identity is unavailable", "labels", None)
+    labels = sorted(item["name"] for item in labels_raw)
+
+    requests_raw = collect_pages(
+        "review_requests",
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_REVIEW_REQUESTS_QUERY,
+            "reviewRequests",
+            "review_requests",
+        ),
+        budget,
+    )
+    requested_reviewers = []
+    requested_teams = []
+    for request in requests_raw:
+        target = request.get("requestedReviewer") if isinstance(request, dict) else None
+        if not isinstance(target, dict):
+            raise BlockedError(BLOCKED_INCOMPLETE, "Requested reviewer is unavailable", "review_requests", None)
+        if target.get("__typename") == "Team":
+            requested_teams.append(
+                {
+                    "id": target.get("id"),
+                    "slug": target.get("slug"),
+                    "name": target.get("name"),
+                    "url": target.get("url"),
+                }
+            )
+        else:
+            requested_reviewers.append(normalize_actor(target))
+
+    reviews_raw = collect_pages(
+        "reviews",
+        _pull_request_connection_fetcher(client, PULL_REQUEST_REVIEWS_QUERY, "reviews", "reviews"),
+        budget,
+    )
+    reviews = [_normalize_review(item) for item in reviews_raw]
+
+    conversation_raw = collect_pages(
+        "conversation_comments",
+        _pull_request_connection_fetcher(
+            client,
+            CONVERSATION_COMMENTS_QUERY,
+            "comments",
+            "conversation_comments",
+        ),
+        budget,
+        kind="comments",
+    )
+    conversation_comments = []
+    for raw_comment in conversation_raw:
+        reactions = _capture_comment_reactions(client, raw_comment, review_comment=False)
+        expanded = copy.deepcopy(raw_comment)
+        expanded["reactions"] = reactions
+        conversation_comments.append(_normalize_conversation_comment(expanded))
+
+    threads_raw = collect_pages(
+        "review_threads",
+        _pull_request_connection_fetcher(client, REVIEW_THREADS_QUERY, "reviewThreads", "review_threads"),
+        budget,
+        kind="threads",
+    )
+    review_threads = []
+    for raw_thread in threads_raw:
+        expanded = copy.deepcopy(raw_thread)
+        expanded["comments"] = _capture_thread_comments(client, raw_thread)
+        review_threads.append(normalize_review_thread(expanded))
+
+    commits_raw = collect_pages(
+        "commits",
+        _pull_request_connection_fetcher(client, PULL_REQUEST_COMMITS_QUERY, "commits", "commits"),
+        budget,
+    )
+    commits = [_normalize_commit(item, command_runner, budget) for item in commits_raw]
+    if not commits:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request has no accessible commits", "commits", None)
+
+    def fetch_checks(cursor: str | None) -> Page:
+        payload = client.graphql(
+            COMMIT_CHECKS_QUERY,
+            "checks",
+            cursor,
+            {"oid": head_before},
+        )
+        commit_object = _path(payload, ("data", "repository", "object"), "checks")
+        if commit_object is None:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Head commit object is inaccessible", "checks", cursor)
+        rollup = commit_object.get("statusCheckRollup")
+        if rollup is None:
+            return Page([], False, None)
+        return _connection_page(rollup.get("contexts"), "checks")
+
+    raw_checks = [_normalize_check(item) for item in collect_pages("checks", fetch_checks, budget)]
+    applicable_rules, required_specs = _capture_rules(client, before_pr["baseRefName"], configuration["check_policy"])
+    checks, required_check_evidence = evaluate_checks(raw_checks, required_specs, configuration["check_policy"])
+
+    after_payload = client.graphql(PULL_REQUEST_ANCHOR_QUERY, "pull_request.anchor.after")
+    after = extract_anchor(after_payload)
+    head_after = after["pull_request"]["headRefOid"]
+    ensure_unchanged_head(head_before, head_after)
+    if after["pull_request"]["id"] != before_pr["id"]:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request identity changed during capture",
+            "pull_request.anchor",
+            None,
+        )
+
+    repository_data = before["repository"]
+    base_repository = before_pr.get("baseRepository") or {}
+    head_repository = before_pr.get("headRepository") or {}
+    state = "MERGED" if before_pr.get("merged") else str(before_pr.get("state") or "CLOSED")
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "snapshot_digest_algorithm": DIGEST_ALGORITHM,
+        "snapshot_digest": "0" * 64,
+        "repository": {
+            "id": str(repository_data.get("id") or ""),
+            "owner": owner,
+            "name": name,
+            "name_with_owner": str(repository_data.get("nameWithOwner") or ""),
+            "url": str(repository_data.get("url") or ""),
+            "default_branch": str((repository_data.get("defaultBranchRef") or {}).get("name") or ""),
+        },
+        "pull_request": {
+            "id": str(before_pr.get("id") or ""),
+            "database_id": before_pr.get("databaseId"),
+            "number": int(before_pr.get("number")),
+            "url": str(before_pr.get("url") or ""),
+            "title": str(before_pr.get("title") or ""),
+            "state": state,
+            "is_draft": bool(before_pr.get("isDraft")),
+            "is_merged": bool(before_pr.get("merged")),
+            "mergeable": before_pr.get("mergeable"),
+            "review_decision": before_pr.get("reviewDecision"),
+            "author": normalize_actor(before_pr.get("author")),
+            "base_repository": {
+                "id": base_repository.get("id"),
+                "name_with_owner": base_repository.get("nameWithOwner"),
+                "url": base_repository.get("url"),
+            },
+            "base_ref": str(before_pr.get("baseRefName") or ""),
+            "base_oid": str(before_pr.get("baseRefOid") or ""),
+            "head_repository": {
+                "id": head_repository.get("id"),
+                "name_with_owner": head_repository.get("nameWithOwner"),
+                "url": head_repository.get("url"),
+            },
+            "head_ref": before_pr.get("headRefName"),
+            "head_oid_before": head_before,
+            "head_oid_after": head_after,
+            "labels": labels,
+            "requested_reviewers": requested_reviewers,
+            "requested_teams": requested_teams,
+        },
+        "reviews": reviews,
+        "conversation_comments": conversation_comments,
+        "review_threads": review_threads,
+        "commits": commits,
+        "checks": checks,
+        "applicable_rules": applicable_rules,
+        "required_check_evidence": required_check_evidence,
+        "completeness": {
+            "api_calls": budget.api_calls,
+            "items": budget.items,
+            "configured_caps": {
+                "maximum_api_calls": configuration["maximum_api_calls"],
+                "maximum_items": configuration["maximum_items"],
+                "maximum_threads": configuration["maximum_threads"],
+                "maximum_comments": configuration["maximum_comments"],
+                "maximum_reactions": configuration["maximum_reactions"],
+            },
+            "fully_paginated_connections": budget.connections,
+            "warnings": [],
+            "blocked_reason": None,
+        },
+    }
+    result = attach_digest(result)
+    validate_snapshot(result)
+    return result
+
+
+def _load_snapshot_file(path: str) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractError(f"Cannot load snapshot: {redact_diagnostic(str(exc))}") from exc
+    validate_snapshot(value)
+    return value
+
+
+def _json_report(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture deterministic, read-only Git and GitHub pull-request evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot_parser = subparsers.add_parser("snapshot", help="Capture one complete bounded snapshot.")
+    snapshot_parser.add_argument("--repo", required=True, help="Repository in OWNER/REPO form.")
+    snapshot_parser.add_argument("--pr", required=True, type=_positive_integer, help="Pull request number.")
+    snapshot_parser.add_argument("--config", help="Repository configuration JSON.")
+    snapshot_parser.add_argument("--output", help="Atomic canonical JSON output path.")
+    snapshot_parser.add_argument("--markdown-output", help="Atomic derived Markdown output path.")
+    snapshot_parser.add_argument("--max-api-calls", type=_positive_integer)
+    snapshot_parser.add_argument("--max-items", type=_positive_integer)
+
+    local_parser = subparsers.add_parser("verify-local", help="Verify local Git state against live PR evidence.")
+    local_parser.add_argument("--repo", required=True, help="Repository in OWNER/REPO form.")
+    local_parser.add_argument("--pr", required=True, type=_positive_integer, help="Pull request number.")
+    local_parser.add_argument("--config", help="Repository configuration JSON.")
+    local_parser.add_argument("--expected-head", help="Expected pull-request head OID.")
+
+    gate_parser = subparsers.add_parser("verify-gate", help="Verify deterministic mechanical gate evidence.")
+    gate_parser.add_argument("--snapshot", required=True, help="Canonical snapshot JSON.")
+    gate_parser.add_argument("--config", help="Repository configuration JSON.")
+
+    render_parser = subparsers.add_parser("render", help="Render derived non-authoritative evidence.")
+    render_parser.add_argument("--snapshot", required=True, help="Canonical snapshot JSON.")
+    render_parser.add_argument("--format", required=True, choices=("markdown",))
+    return parser
+
+
+def _command_snapshot(arguments: argparse.Namespace) -> int:
+    configuration = load_config(
+        arguments.config,
+        arguments.repo,
+        arguments.max_api_calls,
+        arguments.max_items,
+    )
+    value = capture_snapshot(arguments.repo, arguments.pr, configuration)
+    outputs = prepare_outputs(value, arguments.output, arguments.markdown_output)
+    if outputs:
+        atomic_write_many(outputs)
+        print(
+            _json_report(
+                {
+                    "status": "SNAPSHOT_WRITTEN",
+                    "snapshot_digest": value["snapshot_digest"],
+                    "output": str(Path(arguments.output).absolute()) if arguments.output else None,
+                    "markdown_output": str(Path(arguments.markdown_output).absolute())
+                    if arguments.markdown_output
+                    else None,
+                }
+            ),
+            end="",
+        )
+    else:
+        sys.stdout.buffer.write(canonical_json_bytes(value))
+    return 0
+
+
+def _command_verify_local(arguments: argparse.Namespace) -> int:
+    if arguments.expected_head and not OID_PATTERN.fullmatch(arguments.expected_head):
+        raise ContractError("--expected-head must be a 40-64 character hexadecimal OID")
+    configuration = load_config(arguments.config, arguments.repo)
+    runner = CommandRunner()
+    value = capture_snapshot(arguments.repo, arguments.pr, configuration, runner)
+    result = verify_local_against_snapshot(
+        value,
+        configuration,
+        runner,
+        arguments.expected_head,
+    )
+    print(_json_report(result), end="")
+    return 0 if not result["blockers"] else 3
+
+
+def _command_verify_gate(arguments: argparse.Namespace) -> int:
+    value = _load_snapshot_file(arguments.snapshot)
+    repository = value["repository"]["name_with_owner"]
+    configuration = load_config(arguments.config, repository)
+    result = verify_snapshot_gate(value, configuration)
+    print(_json_report(result), end="")
+    return 0 if not result["blockers"] else 3
+
+
+def _command_render(arguments: argparse.Namespace) -> int:
+    value = _load_snapshot_file(arguments.snapshot)
+    if arguments.format != "markdown":
+        raise ContractError("Only Markdown rendering is supported")
+    print(render_markdown(value), end="")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        if arguments.command == "snapshot":
+            return _command_snapshot(arguments)
+        if arguments.command == "verify-local":
+            return _command_verify_local(arguments)
+        if arguments.command == "verify-gate":
+            return _command_verify_gate(arguments)
+        if arguments.command == "render":
+            return _command_render(arguments)
+        raise ContractError(f"Unknown command: {arguments.command}")
+    except BlockedError as exc:
+        print(_json_report(exc.as_dict()), file=sys.stderr, end="")
+        return 3
+    except (CommandFailure, CommandPolicyError, ContractError, OutputSafetyError, OSError) as exc:
+        error = {
+            "status": "INVALID_OR_UNSAFE_INPUT",
+            "error": redact_diagnostic(str(exc)),
+        }
+        print(_json_report(error), file=sys.stderr, end="")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -59,18 +59,44 @@ PROHIBITED_GIT_SUBCOMMANDS = {
 }
 SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL"}
 PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
-MERGE_STATE_STATUSES = {
-    "DIRTY",
-    "UNKNOWN",
-    "BLOCKED",
-    "BEHIND",
-    "DRAFT",
-    "UNSTABLE",
-    "HAS_HOOKS",
-    "CLEAN",
+MERGE_STATE_POLICY = {
+    "DIRTY": "block",
+    "UNKNOWN": "block",
+    "BLOCKED": "block",
+    "BEHIND": "strict_base",
+    "DRAFT": "block",
+    "UNSTABLE": "required_checks",
+    "HAS_HOOKS": "allow",
+    "CLEAN": "allow",
+}
+MERGE_STATE_STATUSES = set(MERGE_STATE_POLICY)
+GIT_ENVIRONMENT_OVERRIDES = {
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_DIR",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_EXEC_PATH",
+    "GIT_GRAFT_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE",
 }
 ANCHOR_CONNECTIONS = ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits")
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+GIT_CONFIG_PAIR = re.compile(r"^GIT_CONFIG_(?:KEY|VALUE)_[0-9]+$")
+GIT_TRACE_VARIABLE = re.compile(r"^GIT_TRACE(?:2)?(?:$|_)")
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 OID_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -246,11 +272,7 @@ class CommandRunner:
 
     def run(self, arguments: list[str], *, allow_failure: bool = False) -> CommandResult:
         validate_external_command(arguments)
-        environment = os.environ.copy()
-        environment["PAGER"] = "cat"
-        environment["GH_PAGER"] = "cat"
-        environment["GH_HOST"] = "github.com"
-        environment["GIT_NO_LAZY_FETCH"] = "1"
+        environment = command_environment(Path(arguments[0]).name)
         completed = subprocess.run(
             arguments,
             check=False,
@@ -264,6 +286,27 @@ class CommandRunner:
         if result.returncode != 0 and not allow_failure:
             raise CommandFailure(arguments, result)
         return result
+
+
+def command_environment(executable: str) -> dict[str, str]:
+    """Build a deterministic environment for an allowlisted external command."""
+
+    environment = os.environ.copy()
+    environment["PAGER"] = "cat"
+    if executable == "gh":
+        environment["GH_PAGER"] = "cat"
+        environment["GH_HOST"] = "github.com"
+    elif executable == "git":
+        for key in GIT_ENVIRONMENT_OVERRIDES:
+            environment.pop(key, None)
+        for key in tuple(environment):
+            if GIT_CONFIG_PAIR.fullmatch(key) or GIT_TRACE_VARIABLE.match(key):
+                environment.pop(key)
+        environment["GIT_PAGER"] = "cat"
+        environment["GIT_NO_LAZY_FETCH"] = "1"
+        environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return environment
 
 
 class Budget:
@@ -1033,6 +1076,35 @@ def validate_completeness(snapshot: dict[str, Any]) -> None:
         raise ContractError("Completeness totals exceed configured item-kind caps")
 
 
+def validate_commit_evidence(pull_request: dict[str, Any], commits: list[dict[str, Any]]) -> None:
+    """Require a unique, well-formed commit set that contains the captured head."""
+
+    if not commits:
+        raise ContractError("Snapshot must include at least one PR commit")
+    commit_oids: set[str] = set()
+    for commit in commits:
+        oid = str(commit.get("oid", ""))
+        if not OID_PATTERN.fullmatch(oid):
+            raise ContractError("Snapshot contains an invalid commit OID")
+        normalized_oid = oid.lower()
+        if normalized_oid in commit_oids:
+            raise ContractError(f"Snapshot contains a duplicate commit OID: {oid}")
+        commit_oids.add(normalized_oid)
+        for signature_name in ("github_signature", "local_signature"):
+            signature = commit.get(signature_name)
+            if not isinstance(signature, dict) or signature.get("state") not in {
+                "valid",
+                "invalid",
+                "unsigned",
+                "unknown_key",
+                "object_unavailable",
+                "verification_pending",
+            }:
+                raise ContractError(f"Invalid {signature_name} evidence")
+    if pull_request["head_oid_after"].lower() not in commit_oids:
+        raise ContractError("Snapshot commit evidence does not include the pull request head commit")
+
+
 def validate_snapshot(snapshot: dict[str, Any]) -> None:
     if not isinstance(snapshot, dict):
         raise ContractError("Snapshot must be a JSON object")
@@ -1103,22 +1175,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
     for collection in ("reviews", "conversation_comments", "review_threads", "commits", "checks"):
         if not isinstance(snapshot[collection], list):
             raise ContractError(f"{collection} must be an array")
-    if not snapshot["commits"]:
-        raise ContractError("Snapshot must include at least one PR commit")
-    for commit in snapshot["commits"]:
-        if not OID_PATTERN.fullmatch(str(commit.get("oid", ""))):
-            raise ContractError("Snapshot contains an invalid commit OID")
-        for signature_name in ("github_signature", "local_signature"):
-            signature = commit.get(signature_name)
-            if not isinstance(signature, dict) or signature.get("state") not in {
-                "valid",
-                "invalid",
-                "unsigned",
-                "unknown_key",
-                "object_unavailable",
-                "verification_pending",
-            }:
-                raise ContractError(f"Invalid {signature_name} evidence")
+    validate_commit_evidence(pr, snapshot["commits"])
     completeness = snapshot["completeness"]
     _require_keys(
         completeness,
@@ -1839,6 +1896,24 @@ def strict_checks_require_current_base(snapshot: dict[str, Any], policy: dict[st
     return ruleset_strict or branch_protection_strict
 
 
+def merge_state_blocker(snapshot: dict[str, Any], policy: dict[str, Any]) -> dict[str, str] | None:
+    """Apply the complete fail-closed policy for GitHub merge-state evidence."""
+
+    merge_state = snapshot["pull_request"]["merge_state_status"]
+    disposition = MERGE_STATE_POLICY[merge_state]
+    if disposition == "block":
+        return {
+            "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+            "reason": f"GitHub reports a non-ready merge state: {merge_state}",
+        }
+    if disposition == "strict_base" and strict_checks_require_current_base(snapshot, policy):
+        return {
+            "code": "BLOCKED_HEAD_BEHIND_BASE",
+            "reason": "Strict required checks require the pull request head to include the current base",
+        }
+    return None
+
+
 def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
     validate_config(configuration)
     validate_snapshot(snapshot)
@@ -1876,6 +1951,9 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
         )
     if pr["mergeable"] != "MERGEABLE":
         blockers.append({"code": "BLOCKED_UNSAFE_GITHUB_STATE", "reason": "PR mergeability is conflicting or unknown"})
+    check_policy = configuration["check_policy"]
+    if blocker := merge_state_blocker(snapshot, check_policy):
+        blockers.append(blocker)
     signature_policy = configuration["signature_policy"]
     accepted_formats = set(signature_policy["accepted_formats"])
     for commit in snapshot["commits"]:
@@ -1899,14 +1977,6 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                     "reason": f"Local signature invalid for {commit['oid']}",
                 }
             )
-    check_policy = configuration["check_policy"]
-    if pr["merge_state_status"] == "BEHIND" and strict_checks_require_current_base(snapshot, check_policy):
-        blockers.append(
-            {
-                "code": "BLOCKED_HEAD_BEHIND_BASE",
-                "reason": "Strict required checks require the pull request head to include the current base",
-            }
-        )
     required_sources = {
         source
         for source, required in (

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -59,7 +59,17 @@ PROHIBITED_GIT_SUBCOMMANDS = {
 }
 SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL"}
 PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
-MERGE_STATE_STATUSES = {"DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"}
+MERGE_STATE_STATUSES = {
+    "DIRTY",
+    "UNKNOWN",
+    "BLOCKED",
+    "BEHIND",
+    "DRAFT",
+    "UNSTABLE",
+    "HAS_HOOKS",
+    "CLEAN",
+}
+ANCHOR_CONNECTIONS = ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits")
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 OID_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -162,11 +172,7 @@ def validate_external_command(arguments: list[str]) -> None:
         dynamic_command = (
             len(arguments) == 4
             and (
-                (
-                    subcommand == "cat-file"
-                    and arguments[2] == "-e"
-                    and re.fullmatch(rf"{oid}\^\{{commit\}}", arguments[3])
-                )
+                (subcommand == "cat-file" and arguments[2] == "commit" and re.fullmatch(oid, arguments[3]))
                 or (subcommand == "verify-commit" and arguments[2] == "--raw" and re.fullmatch(oid, arguments[3]))
                 or (
                     subcommand == "rev-list"
@@ -186,8 +192,10 @@ def validate_external_command(arguments: list[str]) -> None:
         raise CommandPolicyError(f"GitHub PR operation is not allowlisted: {arguments[2]}")
     if arguments[1] != "api":
         raise CommandPolicyError(f"GitHub CLI operation is not allowlisted: {arguments[1]}")
-    if arguments[2] == "graphql":
-        fields = arguments[3:]
+    if len(arguments) < 5 or arguments[2:4] != ["--hostname", "github.com"]:
+        raise CommandPolicyError("GitHub API host must be explicitly pinned to github.com")
+    if arguments[4] == "graphql":
+        fields = arguments[5:]
         if len(fields) % 2:
             raise CommandPolicyError("GraphQL arguments must be exact flag/value pairs")
         query = ""
@@ -217,11 +225,11 @@ def validate_external_command(arguments: list[str]) -> None:
         if not re.match(r"^\s*query\b", query) or re.search(r"\bmutation\b", query, re.IGNORECASE):
             raise CommandPolicyError("Only static GraphQL query operations are allowed")
         return
-    if len(arguments) != 5 or arguments[2:4] != ["--method", "GET"]:
+    if len(arguments) != 7 or arguments[4:6] != ["--method", "GET"]:
         raise CommandPolicyError("REST requests must use the exact explicit GET command shape")
     repository = r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
     encoded_ref = r"[A-Za-z0-9._~%-]+"
-    endpoint = arguments[4]
+    endpoint = arguments[6]
     allowed_endpoint = re.fullmatch(
         rf"repos/{repository}/rules/branches/{encoded_ref}\?per_page=100&page=[1-9][0-9]*",
         endpoint,
@@ -241,6 +249,7 @@ class CommandRunner:
         environment = os.environ.copy()
         environment["PAGER"] = "cat"
         environment["GH_PAGER"] = "cat"
+        environment["GH_HOST"] = "github.com"
         environment["GIT_NO_LAZY_FETCH"] = "1"
         completed = subprocess.run(
             arguments,
@@ -1346,6 +1355,8 @@ def graphql_arguments(
     arguments = [
         "gh",
         "api",
+        "--hostname",
+        "github.com",
         "graphql",
         "-f",
         f"query={query_document}",
@@ -1421,6 +1432,23 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
             "pull_request.anchor",
             None,
         )
+    if not isinstance(pull_request.get("updatedAt"), str) or not pull_request.get("updatedAt"):
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            "Pull request update sentinel is unavailable",
+            "pull_request.anchor",
+            None,
+        )
+    for connection in ANCHOR_CONNECTIONS:
+        value = pull_request.get(connection)
+        total_count = value.get("totalCount") if isinstance(value, dict) else None
+        if not isinstance(total_count, int) or isinstance(total_count, bool) or total_count < 0:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"Pull request {connection} count sentinel is unavailable",
+                "pull_request.anchor",
+                None,
+            )
     base_repository = pull_request.get("baseRepository")
     if not isinstance(base_repository, dict) or any(
         not isinstance(base_repository.get(key), str) or not base_repository.get(key)
@@ -1450,6 +1478,18 @@ def ensure_unchanged_anchor(before: dict[str, Any], after: dict[str, Any]) -> No
         )
 
 
+def ensure_anchor_counts_match(pull_request: dict[str, Any], captured: dict[str, int]) -> None:
+    for connection in ANCHOR_CONNECTIONS:
+        expected = pull_request[connection]["totalCount"]
+        if captured.get(connection) != expected:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"Captured {connection} count does not match pull request anchor",
+                connection,
+                None,
+            )
+
+
 def _empty_signer() -> dict[str, Any]:
     return copy.deepcopy(ZERO_AUTHOR)
 
@@ -1468,9 +1508,37 @@ def _local_signature_format(output: str) -> str:
     return "unknown"
 
 
-def interpret_local_signature(returncode: int, output: str) -> dict[str, Any]:
+def _commit_signature_format(commit_object: str) -> str:
+    header = commit_object.partition("\n\n")[0]
+    formats = {
+        {
+            "PGP SIGNATURE": "openpgp",
+            "PGP MESSAGE": "openpgp",
+            "SSH SIGNATURE": "ssh",
+            "SIGNED MESSAGE": "smime",
+        }[match]
+        for match in re.findall(
+            r"(?m)^gpgsig(?:-sha256)? -----BEGIN (PGP SIGNATURE|PGP MESSAGE|SSH SIGNATURE|SIGNED MESSAGE)-----$",
+            header,
+        )
+    }
+    return next(iter(formats)) if len(formats) == 1 else "unknown"
+
+
+def interpret_local_signature(
+    returncode: int,
+    output: str,
+    *,
+    signature_format_hint: str = "unknown",
+) -> dict[str, Any]:
     lowered = output.lower()
-    signature_format = _local_signature_format(lowered)
+    reported_format = _local_signature_format(lowered)
+    if reported_format == "unknown":
+        signature_format = signature_format_hint
+    elif signature_format_hint in {"unknown", reported_format}:
+        signature_format = reported_format
+    else:
+        signature_format = "unknown"
     if returncode == 0:
         return {
             "state": "valid",
@@ -1533,8 +1601,8 @@ def normalize_github_signature(value: dict[str, Any] | None) -> dict[str, Any]:
 
 
 def local_signature_for_commit(runner: Any, oid: str) -> dict[str, Any]:
-    available = runner.run(["git", "cat-file", "-e", f"{oid}^{{commit}}"], allow_failure=True)
-    if available.returncode != 0:
+    commit_object = runner.run(["git", "cat-file", "commit", oid], allow_failure=True)
+    if commit_object.returncode != 0:
         return {
             "state": "object_unavailable",
             "verified": False,
@@ -1543,7 +1611,11 @@ def local_signature_for_commit(runner: Any, oid: str) -> dict[str, Any]:
             "signer": _empty_signer(),
         }
     verified = runner.run(["git", "verify-commit", "--raw", oid], allow_failure=True)
-    return interpret_local_signature(verified.returncode, f"{verified.stdout}\n{verified.stderr}")
+    return interpret_local_signature(
+        verified.returncode,
+        f"{verified.stdout}\n{verified.stderr}",
+        signature_format_hint=_commit_signature_format(commit_object.stdout),
+    )
 
 
 def _check_application() -> dict[str, Any]:
@@ -2055,6 +2127,13 @@ query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
       mergeable
       mergeStateStatus
       reviewDecision
+      updatedAt
+      labels { totalCount }
+      reviewRequests { totalCount }
+      reviews { totalCount }
+      comments { totalCount }
+      reviewThreads { totalCount }
+      commits { totalCount }
       author {
         __typename
         login
@@ -2464,7 +2543,7 @@ class GitHubClient:
 
     def rest(self, endpoint: str, connection: str, cursor: str | None = None) -> Any:
         self.budget.note_api_call(connection, cursor)
-        arguments = ["gh", "api", "--method", "GET", endpoint]
+        arguments = ["gh", "api", "--hostname", "github.com", "--method", "GET", endpoint]
         try:
             result = self.runner.run(arguments)
         except CommandFailure as exc:
@@ -2659,7 +2738,6 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
         name = str(value.get("name") or "")
         if not name:
             raise BlockedError(BLOCKED_INCOMPLETE, "Check run name is unavailable", "checks", None)
-        app_id = application["database_id"]
         return {
             "stable_id": f"check_run:{node_id}",
             "name": name,
@@ -2929,6 +3007,18 @@ def capture_snapshot(
         required_specs,
         configuration["check_policy"],
         rule_sources,
+    )
+
+    ensure_anchor_counts_match(
+        before_pr,
+        {
+            "labels": len(labels_raw),
+            "reviewRequests": len(requests_raw),
+            "reviews": len(reviews_raw),
+            "comments": len(conversation_raw),
+            "reviewThreads": len(threads_raw),
+            "commits": len(commits_raw),
+        },
     )
 
     after_payload = client.graphql(PULL_REQUEST_ANCHOR_QUERY, "pull_request.anchor.after")

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -804,6 +804,8 @@ def load_config(
             raise ContractError(f"Cannot load repository configuration: {redact_diagnostic(str(exc))}") from exc
         configuration = loaded
     configuration = copy.deepcopy(configuration)
+    if not isinstance(configuration, dict):
+        raise ContractError("Repository configuration must be a JSON object")
     if configuration.get("repository") != repository:
         raise ContractError(
             f"Configuration repository {configuration.get('repository')!r} does not match {repository!r}"
@@ -1153,6 +1155,39 @@ def expected_api_calls(connections: list[dict[str, Any]]) -> int:
     return calls
 
 
+def capture_resource_usage(
+    snapshot: dict[str, Any],
+    expected: dict[str, int] | None = None,
+) -> dict[str, int]:
+    """Return aggregate and item-kind work represented by a complete snapshot."""
+
+    connection_items = expected if expected is not None else expected_connection_items(snapshot)
+    logical_connections = {
+        connection: connection.removesuffix(REVALIDATION_SUFFIX)
+        for connection in connection_items
+    }
+    return {
+        "maximum_api_calls": snapshot["completeness"]["api_calls"],
+        "maximum_items": snapshot["completeness"]["items"],
+        "maximum_threads": sum(
+            connection_items[connection]
+            for connection, logical in logical_connections.items()
+            if logical == "review_threads"
+        ),
+        "maximum_comments": sum(
+            connection_items[connection]
+            for connection, logical in logical_connections.items()
+            if logical == "conversation_comments"
+            or (logical.startswith("review_thread.") and logical.endswith(".comments"))
+        ),
+        "maximum_reactions": sum(
+            connection_items[connection]
+            for connection, logical in logical_connections.items()
+            if logical.endswith(".reactions")
+        ),
+    }
+
+
 def ensure_revalidated_evidence(label: str, before: Any, after: Any) -> None:
     """Reject volatile evidence that changed between bounded observations."""
 
@@ -1191,33 +1226,9 @@ def validate_completeness(snapshot: dict[str, Any]) -> None:
     if completeness["api_calls"] != expected_api_calls(completeness["fully_paginated_connections"]):
         raise ContractError("Completeness API-call total does not match pagination evidence")
     caps = completeness["configured_caps"]
-    if completeness["api_calls"] > caps["maximum_api_calls"] or completeness["items"] > caps["maximum_items"]:
-        raise ContractError("Completeness totals exceed configured aggregate caps")
-    logical_connections = {
-        connection: connection.removesuffix(REVALIDATION_SUFFIX) for connection in expected
-    }
-    thread_items = sum(
-        expected[connection]
-        for connection, logical in logical_connections.items()
-        if logical == "review_threads"
-    )
-    comment_items = sum(
-        expected[connection]
-        for connection, logical in logical_connections.items()
-        if logical == "conversation_comments"
-        or (logical.startswith("review_thread.") and logical.endswith(".comments"))
-    )
-    reaction_items = sum(
-        expected[connection]
-        for connection, logical in logical_connections.items()
-        if logical.endswith(".reactions")
-    )
-    if (
-        thread_items > caps["maximum_threads"]
-        or comment_items > caps["maximum_comments"]
-        or reaction_items > caps["maximum_reactions"]
-    ):
-        raise ContractError("Completeness totals exceed configured item-kind caps")
+    usage = capture_resource_usage(snapshot, expected)
+    if any(usage[key] > caps[key] for key in usage):
+        raise ContractError("Completeness totals exceed configured capture caps")
 
 
 def validate_commit_evidence(pull_request: dict[str, Any], commits: list[dict[str, Any]]) -> None:
@@ -2294,6 +2305,18 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
     validate_snapshot(snapshot)
     blockers: list[dict[str, str]] = []
     pr = snapshot["pull_request"]
+    current_usage = capture_resource_usage(snapshot)
+    for cap, used in current_usage.items():
+        if used > configuration[cap]:
+            blockers.append(
+                {
+                    "code": BLOCKED_INCOMPLETE,
+                    "reason": (
+                        f"Snapshot {cap} usage {used} exceeds current limit "
+                        f"{configuration[cap]}"
+                    ),
+                }
+            )
     if snapshot["repository"]["name_with_owner"] != configuration["repository"]:
         blockers.append(
             {
@@ -2363,7 +2386,8 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
         if required
     }
     captured_sources = set(snapshot["required_check_evidence"]["sources"])
-    for source in sorted(required_sources - captured_sources):
+    missing_sources = required_sources - captured_sources
+    for source in sorted(missing_sources):
         blockers.append(
             {
                 "code": BLOCKED_INCOMPLETE,
@@ -2385,28 +2409,29 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
         for item in snapshot["checks"]
         if item["status"] != "MISSING"
     ]
-    required_specs = required_specs_from_snapshot(snapshot, check_policy)
-    evaluated_checks, _ = evaluate_checks(
-        raw_checks,
-        required_specs,
-        check_policy,
-        sorted(required_sources),
-    )
-    for item in evaluated_checks:
-        if item["evidence_state"] in {
-            "required_pending",
-            "required_failed",
-            "required_missing",
-            "requiredness_unknown",
-        }:
-            blockers.append(
-                {
-                    "code": BLOCKED_INCOMPLETE
-                    if item["evidence_state"] == "requiredness_unknown"
-                    else "BLOCKED_FAILED_OR_PENDING_CI",
-                    "reason": f"{item['name']}: {item['evidence_state']}",
-                }
-            )
+    if not missing_sources:
+        required_specs = required_specs_from_snapshot(snapshot, check_policy)
+        evaluated_checks, _ = evaluate_checks(
+            raw_checks,
+            required_specs,
+            check_policy,
+            sorted(required_sources),
+        )
+        for item in evaluated_checks:
+            if item["evidence_state"] in {
+                "required_pending",
+                "required_failed",
+                "required_missing",
+                "requiredness_unknown",
+            }:
+                blockers.append(
+                    {
+                        "code": BLOCKED_INCOMPLETE
+                        if item["evidence_state"] == "requiredness_unknown"
+                        else "BLOCKED_FAILED_OR_PENDING_CI",
+                        "reason": f"{item['name']}: {item['evidence_state']}",
+                    }
+                )
     unresolved = [item for item in snapshot["review_threads"] if not item["is_resolved"]]
     requested_changes = pr["review_decision"] == "CHANGES_REQUESTED"
     review_required = pr["review_decision"] == "REVIEW_REQUIRED"

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -57,9 +57,9 @@ PROHIBITED_GIT_SUBCOMMANDS = {
     "stash",
     "switch",
 }
-PROHIBITED_GH_PR_SUBCOMMANDS = {"edit", "merge", "ready", "review"}
 SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL"}
 PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+MERGE_STATE_STATUSES = {"DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"}
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 OID_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -183,9 +183,7 @@ def validate_external_command(arguments: list[str]) -> None:
     if len(arguments) < 3:
         raise CommandPolicyError("GitHub CLI subcommand is required")
     if arguments[1] == "pr":
-        subcommand = arguments[2] if len(arguments) > 2 else ""
-        if subcommand in PROHIBITED_GH_PR_SUBCOMMANDS or subcommand:
-            raise CommandPolicyError(f"GitHub PR operation is not allowlisted: {subcommand}")
+        raise CommandPolicyError(f"GitHub PR operation is not allowlisted: {arguments[2]}")
     if arguments[1] != "api":
         raise CommandPolicyError(f"GitHub CLI operation is not allowlisted: {arguments[1]}")
     if arguments[2] == "graphql":
@@ -1070,6 +1068,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             "is_draft",
             "is_merged",
             "mergeable",
+            "merge_state_status",
             "review_decision",
             "author",
             "base_repository",
@@ -1303,6 +1302,12 @@ def _stage_atomic_file(path: Path, content: bytes) -> Path:
 
 
 def atomic_write_many(outputs: dict[Path, bytes]) -> None:
+    normalized_targets: set[Path] = set()
+    for target in outputs:
+        normalized = Path(os.path.abspath(target))
+        if normalized in normalized_targets:
+            raise OutputSafetyError("Output paths must identify distinct files")
+        normalized_targets.add(normalized)
     staged: list[tuple[Path, Path]] = []
     try:
         for target, content in outputs.items():
@@ -1321,7 +1326,7 @@ def prepare_outputs(
     markdown_output: str | None,
 ) -> dict[Path, bytes]:
     outputs: dict[Path, bytes] = {}
-    if output and markdown_output and Path(output).absolute() == Path(markdown_output).absolute():
+    if output and markdown_output and Path(os.path.abspath(output)) == Path(os.path.abspath(markdown_output)):
         raise OutputSafetyError("Canonical JSON and derived Markdown require different output paths")
     if output:
         outputs[Path(output)] = canonical_json_bytes(snapshot)
@@ -1405,6 +1410,8 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
         )
     if pull_request.get("state") not in {"OPEN", "CLOSED", "MERGED"}:
         raise BlockedError(BLOCKED_INCOMPLETE, "Pull request state is unsupported", "pull_request.anchor", None)
+    if pull_request.get("mergeStateStatus") not in MERGE_STATE_STATUSES:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request merge state is unsupported", "pull_request.anchor", None)
     if not isinstance(pull_request.get("number"), int) or isinstance(pull_request.get("number"), bool):
         raise BlockedError(BLOCKED_INCOMPLETE, "Pull request number is unavailable", "pull_request.anchor", None)
     if not isinstance(pull_request.get("isDraft"), bool) or not isinstance(pull_request.get("merged"), bool):
@@ -1449,12 +1456,15 @@ def _empty_signer() -> dict[str, Any]:
 
 def _local_signature_format(output: str) -> str:
     lowered = output.lower()
-    if 'good "git" signature' in lowered or "ssh" in lowered:
-        return "ssh"
-    if "gpgsm" in lowered or "x.509" in lowered or "x509" in lowered or "s/mime" in lowered:
+    if re.search(r"(?m)^gpgsm(?:\[[0-9]+\])?:", lowered):
         return "smime"
-    if "gpg" in lowered or "goodsig" in lowered:
+    if re.search(r"(?m)^gpg(?:\[[0-9]+\])?:", lowered):
         return "openpgp"
+    if re.search(r'(?m)^(?:good|bad) "git" signature\b', lowered) or re.search(
+        r"(?m)^ssh-keygen(?:\[[0-9]+\])?:",
+        lowered,
+    ):
+        return "ssh"
     return "unknown"
 
 
@@ -1587,8 +1597,7 @@ def evaluate_checks(
             if key[0] == name and (key[1] is None or key[1] == app_id)
         ]
         if matching:
-            key = sorted(matching, key=lambda value: (value[0], value[1] or 0))[0]
-            matched.add(key)
+            matched.update(matching)
             item["requiredness"] = "required"
             outcome = _check_outcome(item.get("status"), item.get("conclusion"), policy["expected_skipped"])
             item["evidence_state"] = f"required_{outcome}"
@@ -1651,7 +1660,8 @@ def require_rule_evidence(
             continue
         parameters = rule.get("parameters")
         checks = parameters.get("required_status_checks") if isinstance(parameters, dict) else None
-        if not isinstance(checks, list):
+        strict = parameters.get("strict_required_status_checks_policy") if isinstance(parameters, dict) else None
+        if not isinstance(checks, list) or not isinstance(strict, bool):
             raise BlockedError(
                 BLOCKED_INCOMPLETE,
                 "Required-status-check rule has malformed parameters",
@@ -1665,7 +1675,11 @@ def require_rule_evidence(
             integration_id = item.get("integration_id")
             if not isinstance(context, str) or not context or (
                 integration_id is not None
-                and (isinstance(integration_id, bool) or not isinstance(integration_id, int))
+                and (
+                    isinstance(integration_id, bool)
+                    or not isinstance(integration_id, int)
+                    or integration_id < 1
+                )
             ):
                 raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "rulesets", None)
             specifications[(context, integration_id)] = {
@@ -1673,6 +1687,13 @@ def require_rule_evidence(
                 "integration_id": integration_id,
             }
     if isinstance(branch_protection, dict):
+        if policy["require_branch_protection_evidence"] and not isinstance(branch_protection.get("strict"), bool):
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                "Branch-protection strict-check policy is malformed",
+                "branch_protection",
+                None,
+            )
         contexts = branch_protection.get("contexts")
         checks = branch_protection.get("checks")
         if not isinstance(contexts, list) or not isinstance(checks, list):
@@ -1691,8 +1712,11 @@ def require_rule_evidence(
                 raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check", "branch_protection", None)
             context = item.get("context")
             app_id = item.get("app_id")
+            if app_id == -1:
+                app_id = None
             if not isinstance(context, str) or not context or (
-                app_id is not None and (isinstance(app_id, bool) or not isinstance(app_id, int))
+                app_id is not None
+                and (isinstance(app_id, bool) or not isinstance(app_id, int) or app_id < 1)
             ):
                 raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "branch_protection", None)
             specifications[(context, app_id)] = {"context": context, "integration_id": app_id}
@@ -1712,7 +1736,10 @@ def required_specs_from_snapshot(
             rulesets.append(
                 {
                     "type": "required_status_checks",
-                    "parameters": {"required_status_checks": rule.get("required_checks")},
+                    "parameters": {
+                        "required_status_checks": rule.get("required_checks"),
+                        "strict_required_status_checks_policy": rule.get("strict"),
+                    },
                 }
             )
     branch_protection = snapshot["applicable_rules"]["branch_protection"]
@@ -1721,6 +1748,23 @@ def required_specs_from_snapshot(
         branch_protection if policy["require_branch_protection_evidence"] else None,
         policy,
     )
+
+
+def strict_checks_require_current_base(snapshot: dict[str, Any], policy: dict[str, Any]) -> bool:
+    applicable_rules = snapshot["applicable_rules"]
+    ruleset_strict = policy["require_ruleset_evidence"] and any(
+        rule.get("type") == "required_status_checks"
+        and rule.get("strict") is True
+        and bool(rule.get("required_checks"))
+        for rule in applicable_rules["rulesets"]
+    )
+    branch_protection = applicable_rules["branch_protection"]
+    branch_protection_strict = (
+        policy["require_branch_protection_evidence"]
+        and branch_protection.get("strict") is True
+        and bool(branch_protection.get("contexts") or branch_protection.get("checks"))
+    )
+    return ruleset_strict or branch_protection_strict
 
 
 def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
@@ -1784,6 +1828,13 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                 }
             )
     check_policy = configuration["check_policy"]
+    if pr["merge_state_status"] == "BEHIND" and strict_checks_require_current_base(snapshot, check_policy):
+        blockers.append(
+            {
+                "code": "BLOCKED_HEAD_BEHIND_BASE",
+                "reason": "Strict required checks require the pull request head to include the current base",
+            }
+        )
     required_sources = {
         source
         for source, required in (
@@ -1838,9 +1889,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                 }
             )
     unresolved = [item for item in snapshot["review_threads"] if not item["is_resolved"]]
-    requested_changes = pr["review_decision"] == "CHANGES_REQUESTED" or any(
-        item["state"] == "CHANGES_REQUESTED" for item in snapshot["reviews"]
-    )
+    requested_changes = pr["review_decision"] == "CHANGES_REQUESTED"
     review_required = pr["review_decision"] == "REVIEW_REQUIRED"
     review_requested = bool(pr["requested_reviewers"] or pr["requested_teams"])
     if unresolved or requested_changes or review_required or review_requested:
@@ -2004,6 +2053,7 @@ query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
       isDraft
       merged
       mergeable
+      mergeStateStatus
       reviewDecision
       author {
         __typename
@@ -2632,7 +2682,7 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
             "name": name,
             "application": {
                 "id": creator["node_id"],
-                "database_id": creator["database_id"],
+                "database_id": None,
                 "name": creator["login"],
                 "slug": creator["login"],
             },
@@ -2649,10 +2699,12 @@ def _normalize_applicable_rules(rulesets: list[Any], branch_protection: dict[str
         if not isinstance(rule, dict):
             raise BlockedError(BLOCKED_INCOMPLETE, "Malformed applicable rule", "rulesets", None)
         if rule.get("type") == "required_status_checks":
-            checks = rule.get("parameters", {}).get("required_status_checks", [])
+            parameters = rule.get("parameters", {})
+            checks = parameters.get("required_status_checks", [])
             normalized_rules.append(
                 {
                     "type": "required_status_checks",
+                    "strict": parameters.get("strict_required_status_checks_policy"),
                     "required_checks": sorted(
                         [
                             {
@@ -2918,6 +2970,7 @@ def capture_snapshot(
             "is_draft": bool(before_pr.get("isDraft")),
             "is_merged": bool(before_pr.get("merged")),
             "mergeable": before_pr.get("mergeable"),
+            "merge_state_status": before_pr.get("mergeStateStatus"),
             "review_decision": before_pr.get("reviewDecision"),
             "author": normalize_actor(before_pr.get("author")),
             "base_repository": {

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -60,6 +60,7 @@ PROHIBITED_GIT_SUBCOMMANDS = {
 }
 SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL"}
 PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+UNSUPPORTED_REQUIRED_CHECK_RULE_TYPES = {"workflows"}
 MERGE_STATE_POLICY = {
     "DIRTY": "block",
     "UNKNOWN": "block",
@@ -694,7 +695,7 @@ def validate_config(configuration: dict[str, Any]) -> None:
     if not isinstance(identities, list):
         raise ContractError("reviewer_identities must be a list")
     canonical: set[str] = set()
-    aliases: set[str] = set()
+    aliases: dict[Any, str] = {}
     for identity in identities:
         expected = {
             "canonical_identity",
@@ -719,15 +720,18 @@ def validate_config(configuration: dict[str, Any]) -> None:
             if len(values) != len(set(values)):
                 raise ContractError(f"{key} contains duplicates")
             for value in values:
-                token = f"{key}:{value}"
-                if token in aliases:
+                if value in aliases and aliases[value] != name:
                     raise ContractError(f"Reviewer identity alias is duplicated: {value}")
-                aliases.add(token)
+                aliases[value] = name
         database_ids = identity["database_ids"]
         if not isinstance(database_ids, list) or any(
             isinstance(value, bool) or not isinstance(value, int) or value < 1 for value in database_ids
         ):
             raise ContractError("database_ids must contain positive integers")
+        for value in database_ids:
+            if value in aliases and aliases[value] != name:
+                raise ContractError(f"Reviewer identity alias is duplicated: {value}")
+            aliases[value] = name
     signature_policy = configuration["signature_policy"]
     if not isinstance(signature_policy, dict) or set(signature_policy) != {
         "require_github_verified",
@@ -819,6 +823,7 @@ def load_config(
 
 
 def index_reviewer_identities(configuration: dict[str, Any]) -> dict[Any, str]:
+    validate_config(configuration)
     result: dict[Any, str] = {}
     for identity in configuration["reviewer_identities"]:
         canonical = identity["canonical_identity"]
@@ -2106,7 +2111,15 @@ def require_rule_evidence(
     for rule in rulesets or []:
         if not isinstance(rule, dict):
             raise BlockedError(BLOCKED_INCOMPLETE, "Malformed applicable rule", "rulesets", None)
-        if rule.get("type") != "required_status_checks":
+        rule_type = rule.get("type")
+        if rule_type in UNSUPPORTED_REQUIRED_CHECK_RULE_TYPES:
+            raise BlockedError(
+                BLOCKED_INCOMPLETE,
+                f"Required {rule_type} rule cannot be mapped to complete check evidence",
+                "rulesets",
+                None,
+            )
+        if rule_type != "required_status_checks":
             continue
         parameters = rule.get("parameters")
         checks = parameters.get("required_status_checks") if isinstance(parameters, dict) else None
@@ -2192,6 +2205,8 @@ def required_specs_from_snapshot(
                     },
                 }
             )
+        else:
+            rulesets.append({"type": rule.get("type")})
     branch_protection = snapshot["applicable_rules"]["branch_protection"]
     return require_rule_evidence(
         rulesets if policy["require_ruleset_evidence"] else None,

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -1540,7 +1540,8 @@ def require_rule_evidence(
             ):
                 raise BlockedError(BLOCKED_INCOMPLETE, "Malformed required check identity", "branch_protection", None)
             specifications[(context, app_id)] = {"context": context, "integration_id": app_id}
-            specifications.pop((context, None), None)
+            if app_id is not None:
+                specifications.pop((context, None), None)
     return [specifications[key] for key in sorted(specifications, key=lambda value: (value[0], value[1] or 0))]
 
 

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -101,7 +101,15 @@ SAFE_GIT_CONFIG = (
     ("gpg.x509.program", "gpgsm"),
 )
 REVALIDATION_SUFFIX = ".revalidation"
-ANCHOR_CONNECTIONS = ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits")
+CAPTURED_CONNECTIONS = {
+    "labels": "labels",
+    "review_requests": "reviewRequests",
+    "reviews": "reviews",
+    "conversation_comments": "comments",
+    "review_threads": "reviewThreads",
+    "commits": "commits",
+}
+ANCHOR_CONNECTIONS = tuple(CAPTURED_CONNECTIONS.values())
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 GIT_CONFIG_PAIR = re.compile(r"^GIT_CONFIG_(?:KEY|VALUE)_[0-9]+$")
 GIT_TRACE_VARIABLE = re.compile(r"^GIT_TRACE(?:2)?(?:$|_)")
@@ -993,13 +1001,14 @@ def _require_keys(value: dict[str, Any], required: set[str], location: str) -> N
 
 def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
     pr = snapshot["pull_request"]
+    captured_counts = pr["captured_connection_counts"]
     expected = {
-        "labels": len(pr["labels"]),
-        "review_requests": len(pr["requested_reviewers"]) + len(pr["requested_teams"]),
-        "reviews": len(snapshot["reviews"]),
-        "conversation_comments": len(snapshot["conversation_comments"]),
-        "review_threads": len(snapshot["review_threads"]),
-        "commits": len(snapshot["commits"]),
+        "labels": captured_counts["labels"],
+        "review_requests": captured_counts["review_requests"],
+        "reviews": captured_counts["reviews"],
+        "conversation_comments": captured_counts["conversation_comments"],
+        "review_threads": captured_counts["review_threads"],
+        "commits": captured_counts["commits"],
         "checks": sum(item["status"] != "MISSING" for item in snapshot["checks"]),
     }
     sources = snapshot["required_check_evidence"]["sources"]
@@ -1162,8 +1171,30 @@ def validate_commit_evidence(pull_request: dict[str, Any], commits: list[dict[st
                 "verification_pending",
             }:
                 raise ContractError(f"Invalid {signature_name} evidence")
+            if signature.get("verified") is not (signature["state"] == "valid"):
+                raise ContractError(f"Inconsistent {signature_name} signature evidence")
     if pull_request["head_oid_after"].lower() not in commit_oids:
         raise ContractError("Snapshot commit evidence does not include the pull request head commit")
+
+
+def validate_captured_connection_counts(snapshot: dict[str, Any]) -> None:
+    """Bind stored PR-level anchor counts to the supplied collection evidence."""
+
+    pull_request = snapshot["pull_request"]
+    captured = pull_request["captured_connection_counts"]
+    actual = {
+        "labels": len(pull_request["labels"]),
+        "review_requests": len(pull_request["requested_reviewers"])
+        + len(pull_request["requested_teams"]),
+        "reviews": len(snapshot["reviews"]),
+        "conversation_comments": len(snapshot["conversation_comments"]),
+        "review_threads": len(snapshot["review_threads"]),
+        "commits": len(snapshot["commits"]),
+    }
+    for connection in CAPTURED_CONNECTIONS:
+        if captured[connection] != actual[connection]:
+            label = "commit" if connection == "commits" else connection.replace("_", " ")
+            raise ContractError(f"Snapshot {label} evidence does not match the captured {label} count")
 
 
 def validate_snapshot(snapshot: dict[str, Any]) -> None:
@@ -1220,6 +1251,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             "head_ref",
             "head_oid_before",
             "head_oid_after",
+            "captured_connection_counts",
             "labels",
             "requested_reviewers",
             "requested_teams",
@@ -1236,6 +1268,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
     for collection in ("reviews", "conversation_comments", "review_threads", "commits", "checks"):
         if not isinstance(snapshot[collection], list):
             raise ContractError(f"{collection} must be an array")
+    validate_captured_connection_counts(snapshot)
     validate_commit_evidence(pr, snapshot["commits"])
     completeness = snapshot["completeness"]
     _require_keys(
@@ -2020,6 +2053,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
     for commit in snapshot["commits"]:
         if signature_policy["require_github_verified"] and (
             commit["github_signature"]["state"] != "valid"
+            or not commit["github_signature"]["verified"]
             or commit["github_signature"]["format"] not in accepted_formats
         ):
             blockers.append(
@@ -2030,6 +2064,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
             )
         if signature_policy["require_local_verified"] and (
             commit["local_signature"]["state"] != "valid"
+            or not commit["local_signature"]["verified"]
             or commit["local_signature"]["format"] not in accepted_formats
         ):
             blockers.append(
@@ -3389,6 +3424,10 @@ def capture_snapshot(
             "head_ref": before_pr.get("headRefName"),
             "head_oid_before": head_before,
             "head_oid_after": head_after,
+            "captured_connection_counts": {
+                name: before_pr[connection]["totalCount"]
+                for name, connection in CAPTURED_CONNECTIONS.items()
+            },
             "labels": evidence["labels"],
             "requested_reviewers": evidence["requested_reviewers"],
             "requested_teams": evidence["requested_teams"],

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -93,6 +93,14 @@ GIT_ENVIRONMENT_OVERRIDES = {
     "GIT_SHALLOW_FILE",
     "GIT_WORK_TREE",
 }
+SAFE_GIT_CONFIG = (
+    ("core.fsmonitor", "false"),
+    ("gpg.program", "gpg"),
+    ("gpg.openpgp.program", "gpg"),
+    ("gpg.ssh.program", "ssh-keygen"),
+    ("gpg.x509.program", "gpgsm"),
+)
+REVALIDATION_SUFFIX = ".revalidation"
 ANCHOR_CONNECTIONS = ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits")
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 GIT_CONFIG_PAIR = re.compile(r"^GIT_CONFIG_(?:KEY|VALUE)_[0-9]+$")
@@ -306,6 +314,10 @@ def command_environment(executable: str) -> dict[str, str]:
         environment["GIT_NO_LAZY_FETCH"] = "1"
         environment["GIT_NO_REPLACE_OBJECTS"] = "1"
         environment["GIT_OPTIONAL_LOCKS"] = "0"
+        environment["GIT_CONFIG_COUNT"] = str(len(SAFE_GIT_CONFIG))
+        for index, (key, value) in enumerate(SAFE_GIT_CONFIG):
+            environment[f"GIT_CONFIG_KEY_{index}"] = key
+            environment[f"GIT_CONFIG_VALUE_{index}"] = value
     return environment
 
 
@@ -1005,6 +1017,31 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
             expected[f"review_comment.{comment['id']}.reactions"] = len(comment["reactions"])
     for commit in snapshot["commits"]:
         expected[f"commit.{commit['oid']}.parents"] = len(commit["parents"])
+    expected[f"labels{REVALIDATION_SUFFIX}"] = expected["labels"]
+    expected[f"review_requests{REVALIDATION_SUFFIX}"] = expected["review_requests"]
+    expected[f"reviews{REVALIDATION_SUFFIX}"] = expected["reviews"]
+    expected[f"conversation_comments{REVALIDATION_SUFFIX}"] = len(snapshot["conversation_comments"])
+    expected[f"review_threads{REVALIDATION_SUFFIX}"] = len(snapshot["review_threads"])
+    expected[f"commits{REVALIDATION_SUFFIX}"] = len(snapshot["commits"])
+    expected[f"checks{REVALIDATION_SUFFIX}"] = expected["checks"]
+    if "rulesets" in sources:
+        expected[f"rulesets{REVALIDATION_SUFFIX}"] = len(snapshot["applicable_rules"]["rulesets"])
+    if "branch_protection" in sources:
+        expected[f"branch_protection{REVALIDATION_SUFFIX}"] = 1
+    for comment in snapshot["conversation_comments"]:
+        expected[f"conversation_comment.{comment['id']}.reactions{REVALIDATION_SUFFIX}"] = len(
+            comment["reactions"]
+        )
+    for thread in snapshot["review_threads"]:
+        expected[f"review_thread.{thread['id']}.comments{REVALIDATION_SUFFIX}"] = len(
+            thread["comments"]
+        )
+        for comment in thread["comments"]:
+            expected[f"review_comment.{comment['id']}.reactions{REVALIDATION_SUFFIX}"] = len(
+                comment["reactions"]
+            )
+    for commit in snapshot["commits"]:
+        expected[f"commit.{commit['oid']}.parents{REVALIDATION_SUFFIX}"] = len(commit["parents"])
     return expected
 
 
@@ -1020,9 +1057,9 @@ def expected_api_calls(connections: list[dict[str, Any]]) -> int:
         "rulesets",
         "branch_protection",
     }
-    calls = 2
+    calls = 3
     for item in connections:
-        connection = item["connection"]
+        connection = item["connection"].removesuffix(REVALIDATION_SUFFIX)
         pages = item["pages"]
         if connection in direct_connections or (
             connection.startswith("review_thread.") and connection.endswith(".comments")
@@ -1031,6 +1068,18 @@ def expected_api_calls(connections: list[dict[str, Any]]) -> int:
         elif connection.endswith(".reactions"):
             calls += max(0, pages - 1)
     return calls
+
+
+def ensure_revalidated_evidence(label: str, before: Any, after: Any) -> None:
+    """Reject volatile evidence that changed between bounded observations."""
+
+    if before != after:
+        raise BlockedError(
+            BLOCKED_INCOMPLETE,
+            f"{label} changed during capture",
+            label,
+            None,
+        )
 
 
 def validate_completeness(snapshot: dict[str, Any]) -> None:
@@ -1061,12 +1110,24 @@ def validate_completeness(snapshot: dict[str, Any]) -> None:
     caps = completeness["configured_caps"]
     if completeness["api_calls"] > caps["maximum_api_calls"] or completeness["items"] > caps["maximum_items"]:
         raise ContractError("Completeness totals exceed configured aggregate caps")
-    thread_items = expected["review_threads"]
-    comment_items = expected["conversation_comments"] + sum(
-        count for connection, count in expected.items() if connection.startswith("review_thread.")
+    logical_connections = {
+        connection: connection.removesuffix(REVALIDATION_SUFFIX) for connection in expected
+    }
+    thread_items = sum(
+        expected[connection]
+        for connection, logical in logical_connections.items()
+        if logical == "review_threads"
+    )
+    comment_items = sum(
+        expected[connection]
+        for connection, logical in logical_connections.items()
+        if logical == "conversation_comments"
+        or (logical.startswith("review_thread.") and logical.endswith(".comments"))
     )
     reaction_items = sum(
-        count for connection, count in expected.items() if connection.endswith(".reactions")
+        expected[connection]
+        for connection, logical in logical_connections.items()
+        if logical.endswith(".reactions")
     )
     if (
         thread_items > caps["maximum_threads"]
@@ -2659,6 +2720,64 @@ def _embedded_connection(
     return collect_pages(connection, fetch, budget, kind=kind)
 
 
+def _capture_labels(client: GitHubClient, connection_suffix: str = "") -> list[str]:
+    connection = f"labels{connection_suffix}"
+    raw_labels = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_LABELS_QUERY,
+            "labels",
+            connection,
+        ),
+        client.budget,
+    )
+    if any(not isinstance(item.get("name"), str) or not item.get("name") for item in raw_labels):
+        raise BlockedError(BLOCKED_INCOMPLETE, "Label identity is unavailable", connection, None)
+    return sorted(item["name"] for item in raw_labels)
+
+
+def _capture_review_requests(
+    client: GitHubClient,
+    connection_suffix: str = "",
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    connection = f"review_requests{connection_suffix}"
+    raw_requests = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_REVIEW_REQUESTS_QUERY,
+            "reviewRequests",
+            connection,
+        ),
+        client.budget,
+    )
+    requested_reviewers = []
+    requested_teams = []
+    for request in raw_requests:
+        target = request.get("requestedReviewer") if isinstance(request, dict) else None
+        if not isinstance(target, dict):
+            raise BlockedError(BLOCKED_INCOMPLETE, "Requested reviewer is unavailable", connection, None)
+        if target.get("__typename") == "Team":
+            requested_teams.append(
+                {
+                    "id": target.get("id"),
+                    "slug": target.get("slug"),
+                    "name": target.get("name"),
+                    "url": target.get("url"),
+                }
+            )
+        else:
+            requested_reviewers.append(normalize_actor(target))
+    return (
+        sorted(requested_reviewers, key=_author_sort_key),
+        sorted(
+            requested_teams,
+            key=lambda item: (str(item.get("slug") or ""), str(item.get("id") or "")),
+        ),
+    )
+
+
 def _normalize_review(value: dict[str, Any]) -> dict[str, Any]:
     review_id = value.get("id")
     state = value.get("state")
@@ -2679,6 +2798,28 @@ def _normalize_review(value: dict[str, Any]) -> dict[str, Any]:
         "submitted_at": value.get("submittedAt"),
         "commit_oid": commit.get("oid") if isinstance(commit, dict) else None,
     }
+
+
+def _capture_reviews(client: GitHubClient, connection_suffix: str = "") -> list[dict[str, Any]]:
+    connection = f"reviews{connection_suffix}"
+    raw_reviews = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_REVIEWS_QUERY,
+            "reviews",
+            connection,
+        ),
+        client.budget,
+    )
+    return sorted(
+        [_normalize_review(item) for item in raw_reviews],
+        key=lambda item: (
+            str(item.get("submitted_at") or ""),
+            int(item.get("database_id") or 0),
+            str(item.get("id") or ""),
+        ),
+    )
 
 
 def _normalize_conversation_comment(value: dict[str, Any]) -> dict[str, Any]:
@@ -2707,15 +2848,17 @@ def _capture_comment_reactions(
     comment: dict[str, Any],
     *,
     review_comment: bool,
+    connection_suffix: str = "",
 ) -> list[dict[str, Any]]:
     comment_id = comment.get("id")
     if not isinstance(comment_id, str) or not comment_id:
         raise BlockedError(BLOCKED_INCOMPLETE, "Comment node ID is unavailable", "comment.reactions", None)
-    connection = (
+    base_connection = (
         f"review_comment.{comment_id}.reactions"
         if review_comment
         else f"conversation_comment.{comment_id}.reactions"
     )
+    connection = f"{base_connection}{connection_suffix}"
     query = REVIEW_COMMENT_REACTIONS_QUERY if review_comment else ISSUE_COMMENT_REACTIONS_QUERY
 
     def next_page(cursor: str) -> Page:
@@ -2732,11 +2875,15 @@ def _capture_comment_reactions(
     )
 
 
-def _capture_thread_comments(client: GitHubClient, value: dict[str, Any]) -> list[dict[str, Any]]:
+def _capture_thread_comments(
+    client: GitHubClient,
+    value: dict[str, Any],
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
     thread_id = value.get("id")
     if not isinstance(thread_id, str) or not thread_id:
         raise BlockedError(BLOCKED_INCOMPLETE, "Review thread ID is unavailable", "review_threads", None)
-    connection = f"review_thread.{thread_id}.comments"
+    connection = f"review_thread.{thread_id}.comments{connection_suffix}"
 
     def fetch_page(cursor: str | None) -> Page:
         payload = client.graphql(
@@ -2751,36 +2898,104 @@ def _capture_thread_comments(client: GitHubClient, value: dict[str, Any]) -> lis
     raw_comments = collect_pages(connection, fetch_page, client.budget, kind="comments")
     result = []
     for raw_comment in raw_comments:
-        reactions = _capture_comment_reactions(client, raw_comment, review_comment=True)
+        reactions = _capture_comment_reactions(
+            client,
+            raw_comment,
+            review_comment=True,
+            connection_suffix=connection_suffix,
+        )
         expanded = copy.deepcopy(raw_comment)
         expanded["reactions"] = reactions
         result.append(normalize_review_comment(expanded))
     return result
 
 
-def _normalize_commit(value: dict[str, Any], runner: Any, budget: Budget) -> dict[str, Any]:
+def _capture_conversation_comments(
+    client: GitHubClient,
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    connection = f"conversation_comments{connection_suffix}"
+    raw_comments = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            CONVERSATION_COMMENTS_QUERY,
+            "comments",
+            connection,
+        ),
+        client.budget,
+        kind="comments",
+    )
+    comments = []
+    for raw_comment in raw_comments:
+        reactions = _capture_comment_reactions(
+            client,
+            raw_comment,
+            review_comment=False,
+            connection_suffix=connection_suffix,
+        )
+        expanded = copy.deepcopy(raw_comment)
+        expanded["reactions"] = reactions
+        comments.append(_normalize_conversation_comment(expanded))
+    return comments
+
+
+def _capture_review_threads(
+    client: GitHubClient,
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    connection = f"review_threads{connection_suffix}"
+    raw_threads = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            REVIEW_THREADS_QUERY,
+            "reviewThreads",
+            connection,
+        ),
+        client.budget,
+        kind="threads",
+    )
+    threads = []
+    for raw_thread in raw_threads:
+        expanded = copy.deepcopy(raw_thread)
+        expanded["comments"] = _capture_thread_comments(
+            client,
+            raw_thread,
+            connection_suffix,
+        )
+        threads.append(normalize_review_thread(expanded))
+    return threads
+
+
+def _normalize_commit(
+    value: dict[str, Any],
+    budget: Budget,
+    connection_suffix: str = "",
+) -> dict[str, Any]:
     commit = value.get("commit")
     if not isinstance(commit, dict):
         raise BlockedError(BLOCKED_INCOMPLETE, "PR commit object is unavailable", "commits", None)
     oid = commit.get("oid")
     if not isinstance(oid, str) or not OID_PATTERN.fullmatch(oid):
         raise BlockedError(BLOCKED_INCOMPLETE, "PR commit OID is unavailable", "commits", None)
+    parent_connection = f"commit.{oid}.parents{connection_suffix}"
     parents = commit.get("parents")
-    page = _connection_page(parents, f"commit.{oid}.parents")
+    page = _connection_page(parents, parent_connection)
     if page.has_next_page:
         raise BlockedError(
             BLOCKED_INCOMPLETE,
             "Commit parent connection exceeded the supported bounded page",
-            f"commit.{oid}.parents",
+            parent_connection,
             page.end_cursor,
         )
-    budget.add_items(len(page.nodes), f"commit.{oid}.parents", None)
-    budget.record_connection(f"commit.{oid}.parents", 1, len(page.nodes))
+    budget.add_items(len(page.nodes), parent_connection, None)
+    budget.record_connection(parent_connection, 1, len(page.nodes))
     parent_oids = []
     for parent in page.nodes:
         parent_oid = parent.get("oid") if isinstance(parent, dict) else None
         if not isinstance(parent_oid, str) or not OID_PATTERN.fullmatch(parent_oid):
-            raise BlockedError(BLOCKED_INCOMPLETE, "Commit parent OID is unavailable", f"commit.{oid}.parents", None)
+            raise BlockedError(BLOCKED_INCOMPLETE, "Commit parent OID is unavailable", parent_connection, None)
         parent_oids.append(parent_oid)
     return {
         "oid": oid,
@@ -2788,8 +3003,50 @@ def _normalize_commit(value: dict[str, Any], runner: Any, budget: Budget) -> dic
         "authored_at": str(commit.get("authoredDate") or ""),
         "committed_at": str(commit.get("committedDate") or ""),
         "github_signature": normalize_github_signature(commit.get("signature")),
-        "local_signature": local_signature_for_commit(runner, oid),
     }
+
+
+def _capture_commits(
+    client: GitHubClient,
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    connection = f"commits{connection_suffix}"
+    raw_commits = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_COMMITS_QUERY,
+            "commits",
+            connection,
+        ),
+        client.budget,
+    )
+    commits = [
+        _normalize_commit(
+            item,
+            client.budget,
+            connection_suffix,
+        )
+        for item in raw_commits
+    ]
+    if not commits:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request has no accessible commits", connection, None)
+    return commits
+
+
+def _attach_local_signatures(
+    commits: list[dict[str, Any]],
+    runner: Any,
+) -> list[dict[str, Any]]:
+    """Add checkout-local verification without mixing it into remote revalidation."""
+
+    return [
+        {
+            **copy.deepcopy(commit),
+            "local_signature": local_signature_for_commit(runner, commit["oid"]),
+        }
+        for commit in commits
+    ]
 
 
 def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
@@ -2839,6 +3096,31 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
             "details_url": value.get("targetUrl"),
         }
     raise BlockedError(BLOCKED_INCOMPLETE, f"Unsupported check type: {typename!r}", "checks", None)
+
+
+def _capture_checks(
+    client: GitHubClient,
+    head_oid: str,
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    connection = f"checks{connection_suffix}"
+
+    def fetch(cursor: str | None) -> Page:
+        payload = client.graphql(
+            COMMIT_CHECKS_QUERY,
+            connection,
+            cursor,
+            {"oid": head_oid},
+        )
+        commit_object = _path(payload, ("data", "repository", "object"), connection)
+        if commit_object is None:
+            raise BlockedError(BLOCKED_INCOMPLETE, "Head commit object is inaccessible", connection, cursor)
+        rollup = commit_object.get("statusCheckRollup")
+        if rollup is None:
+            return Page([], False, None)
+        return _connection_page(rollup.get("contexts"), connection)
+
+    return [_normalize_check(item) for item in collect_pages(connection, fetch, client.budget)]
 
 
 def _normalize_applicable_rules(rulesets: list[Any], branch_protection: dict[str, Any]) -> dict[str, Any]:
@@ -2893,46 +3175,49 @@ def _capture_rules(
     client: GitHubClient,
     base_ref: str,
     policy: dict[str, Any],
+    connection_suffix: str = "",
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
     encoded_ref = quote(base_ref, safe="")
     rulesets: list[Any] = []
     branch_protection: dict[str, Any] = {}
     sources: list[str] = []
     if policy["require_ruleset_evidence"]:
+        connection = f"rulesets{connection_suffix}"
         base_endpoint = f"repos/{client.owner}/{client.name}/rules/branches/{encoded_ref}"
         page_number = 1
         while True:
             endpoint = f"{base_endpoint}?per_page=100&page={page_number}"
-            page = client.rest(endpoint, "rulesets", str(page_number))
+            page = client.rest(endpoint, connection, str(page_number))
             if not isinstance(page, list):
                 raise BlockedError(
                     BLOCKED_INCOMPLETE,
                     "Applicable rules response is not an array",
-                    "rulesets",
+                    connection,
                     str(page_number),
                 )
-            client.budget.add_items(len(page), "rulesets", str(page_number))
+            client.budget.add_items(len(page), connection, str(page_number))
             rulesets.extend(page)
             if len(page) < 100:
-                client.budget.record_connection("rulesets", page_number, len(rulesets))
+                client.budget.record_connection(connection, page_number, len(rulesets))
                 break
             page_number += 1
-            client.budget.require_capacity_for_next_page("rulesets", str(page_number), "items")
+            client.budget.require_capacity_for_next_page(connection, str(page_number), "items")
         sources.append("rulesets")
     if policy["require_branch_protection_evidence"]:
+        connection = f"branch_protection{connection_suffix}"
         protection_endpoint = (
             f"repos/{client.owner}/{client.name}/branches/{encoded_ref}/protection/required_status_checks"
         )
-        branch_protection = client.rest(protection_endpoint, "branch_protection")
+        branch_protection = client.rest(protection_endpoint, connection)
         if not isinstance(branch_protection, dict):
             raise BlockedError(
                 BLOCKED_INCOMPLETE,
                 "Branch-protection response is not an object",
-                "branch_protection",
+                connection,
                 None,
             )
-        client.budget.add_items(1, "branch_protection", None)
-        client.budget.record_connection("branch_protection", 1, 1)
+        client.budget.add_items(1, connection, None)
+        client.budget.record_connection(connection, 1, 1)
         sources.append("branch_protection")
     required = require_rule_evidence(
         rulesets if policy["require_ruleset_evidence"] else None,
@@ -2940,6 +3225,48 @@ def _capture_rules(
         policy,
     )
     return _normalize_applicable_rules(rulesets, branch_protection), required, sorted(sources)
+
+
+def _capture_remote_evidence(
+    client: GitHubClient,
+    head_oid: str,
+    base_ref: str,
+    configuration: dict[str, Any],
+    connection_suffix: str = "",
+) -> dict[str, Any]:
+    """Capture one complete, normalized observation of mutable GitHub evidence."""
+
+    labels = _capture_labels(client, connection_suffix)
+    requested_reviewers, requested_teams = _capture_review_requests(client, connection_suffix)
+    reviews = _capture_reviews(client, connection_suffix)
+    conversation_comments = _capture_conversation_comments(client, connection_suffix)
+    review_threads = _capture_review_threads(client, connection_suffix)
+    commits = _capture_commits(client, connection_suffix)
+    raw_checks = _capture_checks(client, head_oid, connection_suffix)
+    applicable_rules, required_specs, rule_sources = _capture_rules(
+        client,
+        base_ref,
+        configuration["check_policy"],
+        connection_suffix,
+    )
+    checks, required_check_evidence = evaluate_checks(
+        raw_checks,
+        required_specs,
+        configuration["check_policy"],
+        rule_sources,
+    )
+    return {
+        "labels": labels,
+        "requested_reviewers": requested_reviewers,
+        "requested_teams": requested_teams,
+        "reviews": reviews,
+        "conversation_comments": conversation_comments,
+        "review_threads": review_threads,
+        "commits": commits,
+        "checks": checks,
+        "applicable_rules": applicable_rules,
+        "required_check_evidence": required_check_evidence,
+    }
 
 
 def capture_snapshot(
@@ -2968,126 +3295,23 @@ def capture_snapshot(
         )
     head_before = before_pr["headRefOid"]
 
-    labels_raw = collect_pages(
-        "labels",
-        _pull_request_connection_fetcher(client, PULL_REQUEST_LABELS_QUERY, "labels", "labels"),
-        budget,
-    )
-    if any(not isinstance(item.get("name"), str) or not item.get("name") for item in labels_raw):
-        raise BlockedError(BLOCKED_INCOMPLETE, "Label identity is unavailable", "labels", None)
-    labels = sorted(item["name"] for item in labels_raw)
-
-    requests_raw = collect_pages(
-        "review_requests",
-        _pull_request_connection_fetcher(
-            client,
-            PULL_REQUEST_REVIEW_REQUESTS_QUERY,
-            "reviewRequests",
-            "review_requests",
-        ),
-        budget,
-    )
-    requested_reviewers = []
-    requested_teams = []
-    for request in requests_raw:
-        target = request.get("requestedReviewer") if isinstance(request, dict) else None
-        if not isinstance(target, dict):
-            raise BlockedError(BLOCKED_INCOMPLETE, "Requested reviewer is unavailable", "review_requests", None)
-        if target.get("__typename") == "Team":
-            requested_teams.append(
-                {
-                    "id": target.get("id"),
-                    "slug": target.get("slug"),
-                    "name": target.get("name"),
-                    "url": target.get("url"),
-                }
-            )
-        else:
-            requested_reviewers.append(normalize_actor(target))
-
-    reviews_raw = collect_pages(
-        "reviews",
-        _pull_request_connection_fetcher(client, PULL_REQUEST_REVIEWS_QUERY, "reviews", "reviews"),
-        budget,
-    )
-    reviews = [_normalize_review(item) for item in reviews_raw]
-
-    conversation_raw = collect_pages(
-        "conversation_comments",
-        _pull_request_connection_fetcher(
-            client,
-            CONVERSATION_COMMENTS_QUERY,
-            "comments",
-            "conversation_comments",
-        ),
-        budget,
-        kind="comments",
-    )
-    conversation_comments = []
-    for raw_comment in conversation_raw:
-        reactions = _capture_comment_reactions(client, raw_comment, review_comment=False)
-        expanded = copy.deepcopy(raw_comment)
-        expanded["reactions"] = reactions
-        conversation_comments.append(_normalize_conversation_comment(expanded))
-
-    threads_raw = collect_pages(
-        "review_threads",
-        _pull_request_connection_fetcher(client, REVIEW_THREADS_QUERY, "reviewThreads", "review_threads"),
-        budget,
-        kind="threads",
-    )
-    review_threads = []
-    for raw_thread in threads_raw:
-        expanded = copy.deepcopy(raw_thread)
-        expanded["comments"] = _capture_thread_comments(client, raw_thread)
-        review_threads.append(normalize_review_thread(expanded))
-
-    commits_raw = collect_pages(
-        "commits",
-        _pull_request_connection_fetcher(client, PULL_REQUEST_COMMITS_QUERY, "commits", "commits"),
-        budget,
-    )
-    commits = [_normalize_commit(item, command_runner, budget) for item in commits_raw]
-    if not commits:
-        raise BlockedError(BLOCKED_INCOMPLETE, "Pull request has no accessible commits", "commits", None)
-
-    def fetch_checks(cursor: str | None) -> Page:
-        payload = client.graphql(
-            COMMIT_CHECKS_QUERY,
-            "checks",
-            cursor,
-            {"oid": head_before},
-        )
-        commit_object = _path(payload, ("data", "repository", "object"), "checks")
-        if commit_object is None:
-            raise BlockedError(BLOCKED_INCOMPLETE, "Head commit object is inaccessible", "checks", cursor)
-        rollup = commit_object.get("statusCheckRollup")
-        if rollup is None:
-            return Page([], False, None)
-        return _connection_page(rollup.get("contexts"), "checks")
-
-    raw_checks = [_normalize_check(item) for item in collect_pages("checks", fetch_checks, budget)]
-    applicable_rules, required_specs, rule_sources = _capture_rules(
+    evidence = _capture_remote_evidence(
         client,
+        head_before,
         before_pr["baseRefName"],
-        configuration["check_policy"],
-    )
-    checks, required_check_evidence = evaluate_checks(
-        raw_checks,
-        required_specs,
-        configuration["check_policy"],
-        rule_sources,
+        configuration,
     )
 
     ensure_anchor_counts_match(
         before_pr,
         {
-            "labels": len(labels_raw),
-            "reviewRequests": len(requests_raw),
-            "reviews": len(reviews_raw),
-            "comments": len(conversation_raw),
-            "reviewThreads": len(threads_raw),
-            "commits": len(commits_raw),
+            "labels": len(evidence["labels"]),
+            "reviewRequests": len(evidence["requested_reviewers"])
+            + len(evidence["requested_teams"]),
+            "reviews": len(evidence["reviews"]),
+            "comments": len(evidence["conversation_comments"]),
+            "reviewThreads": len(evidence["review_threads"]),
+            "commits": len(evidence["commits"]),
         },
     )
 
@@ -3103,6 +3327,23 @@ def capture_snapshot(
             None,
         )
     ensure_unchanged_anchor(before, after)
+
+    revalidated_evidence = _capture_remote_evidence(
+        client,
+        head_before,
+        before_pr["baseRefName"],
+        configuration,
+        REVALIDATION_SUFFIX,
+    )
+
+    terminal_payload = client.graphql(PULL_REQUEST_ANCHOR_QUERY, "pull_request.anchor.terminal")
+    terminal = extract_anchor(terminal_payload)
+    terminal_head = terminal["pull_request"]["headRefOid"]
+    ensure_unchanged_head(head_before, terminal_head)
+    ensure_unchanged_anchor(before, terminal)
+    ensure_revalidated_evidence("remote GitHub evidence", evidence, revalidated_evidence)
+    commits = _attach_local_signatures(evidence["commits"], command_runner)
+    head_after = terminal_head
 
     repository_data = before["repository"]
     base_repository = before_pr.get("baseRepository") or {}
@@ -3148,17 +3389,17 @@ def capture_snapshot(
             "head_ref": before_pr.get("headRefName"),
             "head_oid_before": head_before,
             "head_oid_after": head_after,
-            "labels": labels,
-            "requested_reviewers": requested_reviewers,
-            "requested_teams": requested_teams,
+            "labels": evidence["labels"],
+            "requested_reviewers": evidence["requested_reviewers"],
+            "requested_teams": evidence["requested_teams"],
         },
-        "reviews": reviews,
-        "conversation_comments": conversation_comments,
-        "review_threads": review_threads,
+        "reviews": evidence["reviews"],
+        "conversation_comments": evidence["conversation_comments"],
+        "review_threads": evidence["review_threads"],
         "commits": commits,
-        "checks": checks,
-        "applicable_rules": applicable_rules,
-        "required_check_evidence": required_check_evidence,
+        "checks": evidence["checks"],
+        "applicable_rules": evidence["applicable_rules"],
+        "required_check_evidence": evidence["required_check_evidence"],
         "completeness": {
             "api_calls": budget.api_calls,
             "items": budget.items,

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -30,6 +30,7 @@ DEFAULT_MAXIMUM_ITEMS = 10_000
 DEFAULT_MAXIMUM_THREADS = 500
 DEFAULT_MAXIMUM_COMMENTS = 10_000
 DEFAULT_MAXIMUM_REACTIONS = 10_000
+DEFAULT_EXTERNAL_COMMAND_TIMEOUT_SECONDS = 30
 BLOCKED_INCOMPLETE = "BLOCKED_INCOMPLETE_REVIEW_STATE"
 ZERO_AUTHOR = {
     "kind": "deleted_or_unavailable",
@@ -101,10 +102,19 @@ SAFE_GIT_CONFIG = (
     ("gpg.x509.program", "gpgsm"),
 )
 REVALIDATION_SUFFIX = ".revalidation"
+TRUSTED_COMMAND_DIRECTORIES = (
+    Path("/usr/bin"),
+    Path("/bin"),
+    Path("/usr/local/bin"),
+    Path("/opt/homebrew/bin"),
+    Path("/opt/local/bin"),
+)
+TRUSTED_COMMAND_PATH = os.pathsep.join(str(path) for path in TRUSTED_COMMAND_DIRECTORIES)
 CAPTURED_CONNECTIONS = {
     "labels": "labels",
     "review_requests": "reviewRequests",
     "reviews": "reviews",
+    "pull_request_reactions": "reactions",
     "conversation_comments": "comments",
     "review_threads": "reviewThreads",
     "commits": "commits",
@@ -286,28 +296,82 @@ def validate_external_command(arguments: list[str]) -> None:
 class CommandRunner:
     """Execute only validated, read-only external commands through argument arrays."""
 
+    def __init__(
+        self,
+        executable_paths: dict[str, str] | None = None,
+        timeout_seconds: int = DEFAULT_EXTERNAL_COMMAND_TIMEOUT_SECONDS,
+    ) -> None:
+        if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, int) or timeout_seconds < 1:
+            raise CommandPolicyError("External command timeout must be a positive integer")
+        supplied = executable_paths or {}
+        if not set(supplied) <= {"git", "gh"}:
+            raise CommandPolicyError("Only git and gh executable overrides are supported")
+        self.executable_paths = {
+            name: _validate_injected_executable(name, value) for name, value in supplied.items()
+        }
+        self.timeout_seconds = timeout_seconds
+
     def run(self, arguments: list[str], *, allow_failure: bool = False) -> CommandResult:
         validate_external_command(arguments)
-        environment = command_environment(Path(arguments[0]).name)
-        completed = subprocess.run(
-            arguments,
-            check=False,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            env=environment,
-        )
-        result = CommandResult(completed.returncode, completed.stdout, completed.stderr)
+        executable = Path(arguments[0]).name
+        resolved = self.executable_paths.get(executable) or resolve_trusted_executable(executable)
+        command = [resolved, *arguments[1:]]
+        environment = command_environment(executable)
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=environment,
+                timeout=self.timeout_seconds,
+            )
+            result = CommandResult(completed.returncode, completed.stdout, completed.stderr)
+        except subprocess.TimeoutExpired:
+            result = CommandResult(
+                124,
+                "",
+                f"{executable} timed out after {self.timeout_seconds} seconds",
+            )
         if result.returncode != 0 and not allow_failure:
             raise CommandFailure(arguments, result)
         return result
+
+
+def _validate_injected_executable(name: str, value: str) -> str:
+    """Validate an explicit executable supplied by trusted in-process test orchestration."""
+
+    path = Path(value)
+    if not path.is_absolute() or path.name != name or not path.is_file() or not os.access(path, os.X_OK):
+        raise CommandPolicyError(f"Invalid explicit executable path for {name}")
+    return str(path.resolve())
+
+
+@cache
+def resolve_trusted_executable(executable: str) -> str:
+    """Resolve an allowlisted tool without consulting repository-controlled PATH entries."""
+
+    if executable not in {"git", "gh"}:
+        raise CommandPolicyError(f"Executable is not allowlisted: {executable}")
+    for directory in TRUSTED_COMMAND_DIRECTORIES:
+        candidate = directory / executable
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return str(resolved)
+    raise CommandPolicyError(f"Trusted executable is unavailable: {executable}")
 
 
 def command_environment(executable: str) -> dict[str, str]:
     """Build a deterministic environment for an allowlisted external command."""
 
     environment = os.environ.copy()
+    environment["PATH"] = TRUSTED_COMMAND_PATH
     environment["PAGER"] = "cat"
     if executable == "gh":
         environment["GH_PAGER"] = "cat"
@@ -911,6 +975,7 @@ def normalize_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     pr["requested_teams"] = sorted(
         pr.get("requested_teams", []), key=lambda item: (str(item.get("slug") or ""), str(item.get("id") or ""))
     )
+    pr["reactions"] = normalize_reactions(pr.get("reactions", []))
     result["reviews"] = sorted(
         result.get("reviews", []),
         key=lambda item: (
@@ -921,6 +986,7 @@ def normalize_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     )
     for item in result["reviews"]:
         item["author"] = _normalize_existing_author(item["author"])
+        item["reactions"] = normalize_reactions(item.get("reactions", []))
     result["conversation_comments"] = sorted(
         result.get("conversation_comments", []),
         key=lambda item: (
@@ -993,6 +1059,7 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
         "labels": captured_counts["labels"],
         "review_requests": captured_counts["review_requests"],
         "reviews": captured_counts["reviews"],
+        "pull_request.reactions": captured_counts["pull_request_reactions"],
         "conversation_comments": captured_counts["conversation_comments"],
         "review_threads": captured_counts["review_threads"],
         "commits": captured_counts["commits"],
@@ -1016,6 +1083,8 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
         expected["branch_protection"] = 1
     for comment in snapshot["conversation_comments"]:
         expected[f"conversation_comment.{comment['id']}.reactions"] = len(comment["reactions"])
+    for submitted_review in snapshot["reviews"]:
+        expected[f"review.{submitted_review['id']}.reactions"] = len(submitted_review["reactions"])
     for thread in snapshot["review_threads"]:
         expected[f"review_thread.{thread['id']}.comments"] = len(thread["comments"])
         for comment in thread["comments"]:
@@ -1025,6 +1094,7 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
     expected[f"labels{REVALIDATION_SUFFIX}"] = expected["labels"]
     expected[f"review_requests{REVALIDATION_SUFFIX}"] = expected["review_requests"]
     expected[f"reviews{REVALIDATION_SUFFIX}"] = expected["reviews"]
+    expected[f"pull_request.reactions{REVALIDATION_SUFFIX}"] = expected["pull_request.reactions"]
     expected[f"conversation_comments{REVALIDATION_SUFFIX}"] = len(snapshot["conversation_comments"])
     expected[f"review_threads{REVALIDATION_SUFFIX}"] = len(snapshot["review_threads"])
     expected[f"commits{REVALIDATION_SUFFIX}"] = len(snapshot["commits"])
@@ -1038,6 +1108,10 @@ def expected_connection_items(snapshot: dict[str, Any]) -> dict[str, int]:
     for comment in snapshot["conversation_comments"]:
         expected[f"conversation_comment.{comment['id']}.reactions{REVALIDATION_SUFFIX}"] = len(
             comment["reactions"]
+        )
+    for submitted_review in snapshot["reviews"]:
+        expected[f"review.{submitted_review['id']}.reactions{REVALIDATION_SUFFIX}"] = len(
+            submitted_review["reactions"]
         )
     for thread in snapshot["review_threads"]:
         expected[f"review_thread.{thread['id']}.comments{REVALIDATION_SUFFIX}"] = len(
@@ -1057,6 +1131,7 @@ def expected_api_calls(connections: list[dict[str, Any]]) -> int:
         "labels",
         "review_requests",
         "reviews",
+        "pull_request.reactions",
         "conversation_comments",
         "review_threads",
         "commits",
@@ -1186,6 +1261,7 @@ def validate_captured_connection_counts(snapshot: dict[str, Any]) -> None:
         "review_requests": len(pull_request["requested_reviewers"])
         + len(pull_request["requested_teams"]),
         "reviews": len(snapshot["reviews"]),
+        "pull_request_reactions": len(pull_request["reactions"]),
         "conversation_comments": len(snapshot["conversation_comments"]),
         "review_threads": len(snapshot["review_threads"]),
         "commits": len(snapshot["commits"]),
@@ -1194,6 +1270,38 @@ def validate_captured_connection_counts(snapshot: dict[str, Any]) -> None:
         if captured[connection] != actual[connection]:
             label = "commit" if connection == "commits" else connection.replace("_", " ")
             raise ContractError(f"Snapshot {label} evidence does not match the captured {label} count")
+
+
+def _require_unique_identities(label: str, values: Iterable[Any]) -> None:
+    identities = list(values)
+    if any(not isinstance(identity, str) or not identity for identity in identities):
+        raise ContractError(f"Snapshot contains an invalid {label} identity")
+    if len(identities) != len(set(identities)):
+        raise ContractError(f"Snapshot contains a duplicate {label} identity")
+
+
+def validate_stable_evidence_identities(snapshot: dict[str, Any]) -> None:
+    """Reject duplicated stable GitHub node identities across canonical collections."""
+
+    _require_unique_identities("review", (item.get("id") for item in snapshot["reviews"]))
+    _require_unique_identities(
+        "conversation comment",
+        (item.get("id") for item in snapshot["conversation_comments"]),
+    )
+    _require_unique_identities("review thread", (item.get("id") for item in snapshot["review_threads"]))
+    review_comments = [
+        comment
+        for thread in snapshot["review_threads"]
+        for comment in thread["comments"]
+    ]
+    _require_unique_identities("review comment", (item.get("id") for item in review_comments))
+    reactions = [
+        *snapshot["pull_request"]["reactions"],
+        *(reaction for item in snapshot["reviews"] for reaction in item["reactions"]),
+        *(reaction for item in snapshot["conversation_comments"] for reaction in item["reactions"]),
+        *(reaction for item in review_comments for reaction in item["reactions"]),
+    ]
+    _require_unique_identities("reaction", (item.get("id") for item in reactions))
 
 
 def validate_snapshot(snapshot: dict[str, Any]) -> None:
@@ -1236,6 +1344,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             "number",
             "url",
             "title",
+            "body",
             "state",
             "is_draft",
             "is_merged",
@@ -1257,6 +1366,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             "labels",
             "requested_reviewers",
             "requested_teams",
+            "reactions",
         },
         "pull_request",
     )
@@ -1323,6 +1433,7 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
     for collection in ("reviews", "conversation_comments", "review_threads", "commits", "checks"):
         if not isinstance(snapshot[collection], list):
             raise ContractError(f"{collection} must be an array")
+    validate_stable_evidence_identities(snapshot)
     validate_captured_connection_counts(snapshot)
     validate_commit_evidence(pr, snapshot["commits"])
     completeness = snapshot["completeness"]
@@ -1342,7 +1453,10 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         raise ContractError("An authoritative snapshot cannot contain a blocker")
     if not snapshot["applicable_rules"].get("evidence_complete"):
         raise ContractError("Applicable-rule evidence is incomplete")
-    if snapshot["required_check_evidence"].get("determination") != "complete":
+    required_check_evidence = snapshot["required_check_evidence"]
+    if required_check_evidence.get("unknown_reasons"):
+        raise ContractError("Complete required-check evidence cannot contain unknown reasons")
+    if required_check_evidence.get("determination") != "complete":
         raise ContractError("Required-check evidence is incomplete")
     validate_required_check_metadata(snapshot)
     validate_completeness(snapshot)
@@ -1651,6 +1765,7 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
         "id": pull_request.get("id"),
         "url": pull_request.get("url"),
         "title": pull_request.get("title"),
+        "body": pull_request.get("body"),
         "state": pull_request.get("state"),
         "baseRefName": pull_request.get("baseRefName"),
     }
@@ -2112,9 +2227,9 @@ def validate_required_check_metadata(snapshot: dict[str, Any]) -> None:
         sources,
     )
     stored_evidence = snapshot["required_check_evidence"]
-    if (
-        stored_evidence["required"] != expected_evidence["required"]
-        or stored_evidence["missing"] != expected_evidence["missing"]
+    if any(
+        stored_evidence[key] != expected_evidence[key]
+        for key in ("determination", "required", "missing", "sources", "unknown_reasons")
     ):
         raise ContractError("Required-check metadata disagrees with applicable rules and checks")
     stored_by_id = {item["stable_id"]: item for item in stored_checks}
@@ -2453,6 +2568,7 @@ query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
       number
       url
       title
+      body
       state
       isDraft
       merged
@@ -2466,6 +2582,7 @@ query PullRequestAnchor($owner:String!, $name:String!, $number:Int!) {
       comments { totalCount }
       reviewThreads { totalCount }
       commits { totalCount }
+      reactions { totalCount }
       author {
         __typename
         login
@@ -2542,6 +2659,72 @@ query PullRequestReviews($owner:String!, $name:String!, $number:Int!, $after:Str
           url
           submittedAt
           commit { oid }
+          reactions(first:100) {
+            nodes {
+              id
+              content
+              createdAt
+              user {
+                __typename
+                id
+                databaseId
+                login
+                url
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+REVIEW_REACTIONS_QUERY = r"""
+query ReviewReactions($owner:String!, $name:String!, $number:Int!, $nodeId:ID!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) { id }
+  }
+  node(id:$nodeId) {
+    ... on PullRequestReview {
+      reactions(first:100, after:$after) {
+        nodes {
+          id
+          content
+          createdAt
+          user {
+            __typename
+            id
+            databaseId
+            login
+            url
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_REACTIONS_QUERY = r"""
+query PullRequestReactions($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reactions(first:100, after:$after) {
+        nodes {
+          id
+          content
+          createdAt
+          user {
+            __typename
+            id
+            databaseId
+            login
+            url
+          }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -2990,6 +3173,9 @@ def _normalize_review(value: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(value.get("body"), str) or not isinstance(value.get("url"), str):
         raise BlockedError(BLOCKED_INCOMPLETE, "Review content fields are unavailable", "reviews", None)
     commit = value.get("commit")
+    raw_reactions = value.get("reactions", [])
+    if isinstance(raw_reactions, dict):
+        raw_reactions = raw_reactions.get("nodes", [])
     return {
         "id": review_id,
         "database_id": value.get("databaseId"),
@@ -2999,7 +3185,32 @@ def _normalize_review(value: dict[str, Any]) -> dict[str, Any]:
         "url": value["url"],
         "submitted_at": value.get("submittedAt"),
         "commit_oid": commit.get("oid") if isinstance(commit, dict) else None,
+        "reactions": normalize_reactions(raw_reactions),
     }
+
+
+def _capture_review_reactions(
+    client: GitHubClient,
+    submitted_review: dict[str, Any],
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    review_id = submitted_review.get("id")
+    if not isinstance(review_id, str) or not review_id:
+        raise BlockedError(BLOCKED_INCOMPLETE, "Review node ID is unavailable", "review.reactions", None)
+    connection = f"review.{review_id}.reactions{connection_suffix}"
+
+    def next_page(cursor: str) -> Page:
+        payload = client.graphql(REVIEW_REACTIONS_QUERY, connection, cursor, {"nodeId": review_id})
+        value = _path(payload, ("data", "node", "reactions"), connection)
+        return _connection_page(value, connection)
+
+    return _embedded_connection(
+        submitted_review.get("reactions"),
+        next_page,
+        connection,
+        client.budget,
+        "reactions",
+    )
 
 
 def _capture_reviews(client: GitHubClient, connection_suffix: str = "") -> list[dict[str, Any]]:
@@ -3014,14 +3225,38 @@ def _capture_reviews(client: GitHubClient, connection_suffix: str = "") -> list[
         ),
         client.budget,
     )
+    reviews = []
+    for raw_review in raw_reviews:
+        expanded = copy.deepcopy(raw_review)
+        expanded["reactions"] = _capture_review_reactions(client, raw_review, connection_suffix)
+        reviews.append(_normalize_review(expanded))
     return sorted(
-        [_normalize_review(item) for item in raw_reviews],
+        reviews,
         key=lambda item: (
             str(item.get("submitted_at") or ""),
             int(item.get("database_id") or 0),
             str(item.get("id") or ""),
         ),
     )
+
+
+def _capture_pull_request_reactions(
+    client: GitHubClient,
+    connection_suffix: str = "",
+) -> list[dict[str, Any]]:
+    connection = f"pull_request.reactions{connection_suffix}"
+    raw_reactions = collect_pages(
+        connection,
+        _pull_request_connection_fetcher(
+            client,
+            PULL_REQUEST_REACTIONS_QUERY,
+            "reactions",
+            connection,
+        ),
+        client.budget,
+        kind="reactions",
+    )
+    return normalize_reactions(raw_reactions)
 
 
 def _normalize_conversation_comment(value: dict[str, Any]) -> dict[str, Any]:
@@ -3480,6 +3715,7 @@ def _capture_remote_evidence(
     labels = _capture_labels(client, connection_suffix)
     requested_reviewers, requested_teams = _capture_review_requests(client, connection_suffix)
     reviews = _capture_reviews(client, connection_suffix)
+    pull_request_reactions = _capture_pull_request_reactions(client, connection_suffix)
     conversation_comments = _capture_conversation_comments(client, connection_suffix)
     review_threads = _capture_review_threads(client, connection_suffix)
     commits = _capture_commits(client, connection_suffix)
@@ -3506,6 +3742,7 @@ def _capture_remote_evidence(
         "requested_reviewers": requested_reviewers,
         "requested_teams": requested_teams,
         "reviews": reviews,
+        "pull_request_reactions": pull_request_reactions,
         "conversation_comments": conversation_comments,
         "review_threads": review_threads,
         "commits": commits,
@@ -3562,6 +3799,7 @@ def capture_snapshot(
             "reviewRequests": len(evidence["requested_reviewers"])
             + len(evidence["requested_teams"]),
             "reviews": len(evidence["reviews"]),
+            "reactions": len(evidence["pull_request_reactions"]),
             "comments": len(evidence["conversation_comments"]),
             "reviewThreads": len(evidence["review_threads"]),
             "commits": len(evidence["commits"]),
@@ -3621,6 +3859,7 @@ def capture_snapshot(
             "number": int(before_pr.get("number")),
             "url": str(before_pr.get("url") or ""),
             "title": str(before_pr.get("title") or ""),
+            "body": str(before_pr.get("body") or ""),
             "state": state,
             "is_draft": bool(before_pr.get("isDraft")),
             "is_merged": bool(before_pr.get("merged")),
@@ -3653,6 +3892,7 @@ def capture_snapshot(
             "labels": evidence["labels"],
             "requested_reviewers": evidence["requested_reviewers"],
             "requested_teams": evidence["requested_teams"],
+            "reactions": evidence["pull_request_reactions"],
         },
         "reviews": evidence["reviews"],
         "conversation_comments": evidence["conversation_comments"],

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -1948,43 +1948,6 @@ query ReviewThreads($owner:String!, $name:String!, $number:Int!, $after:String) 
           diffSide
           startLine
           startDiffSide
-          comments(first:100) {
-            nodes {
-              id
-              databaseId
-              author {
-                __typename
-                login
-                url
-                ... on User { id databaseId }
-                ... on Bot { id databaseId }
-                ... on Organization { id databaseId }
-                ... on Mannequin { id databaseId }
-              }
-              body
-              url
-              createdAt
-              updatedAt
-              replyTo { id }
-              pullRequestReview { id }
-              reactions(first:100) {
-                nodes {
-                  id
-                  content
-                  createdAt
-                  user {
-                    __typename
-                    id
-                    databaseId
-                    login
-                    url
-                  }
-                }
-                pageInfo { hasNextPage endCursor }
-              }
-            }
-            pageInfo { hasNextPage endCursor }
-          }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -2350,7 +2313,7 @@ def _capture_thread_comments(client: GitHubClient, value: dict[str, Any]) -> lis
         raise BlockedError(BLOCKED_INCOMPLETE, "Review thread ID is unavailable", "review_threads", None)
     connection = f"review_thread.{thread_id}.comments"
 
-    def next_page(cursor: str) -> Page:
+    def fetch_page(cursor: str | None) -> Page:
         payload = client.graphql(
             REVIEW_THREAD_COMMENTS_QUERY,
             connection,
@@ -2360,13 +2323,7 @@ def _capture_thread_comments(client: GitHubClient, value: dict[str, Any]) -> lis
         nested = _path(payload, ("data", "node", "comments"), connection)
         return _connection_page(nested, connection)
 
-    raw_comments = _embedded_connection(
-        value.get("comments"),
-        next_page,
-        connection,
-        client.budget,
-        "comments",
-    )
+    raw_comments = collect_pages(connection, fetch_page, client.budget, kind="comments")
     result = []
     for raw_comment in raw_comments:
         reactions = _capture_comment_reactions(client, raw_comment, review_comment=True)

--- a/tests/fixtures/secpal-pr-review/config.json
+++ b/tests/fixtures/secpal-pr-review/config.json
@@ -1,0 +1,46 @@
+{
+  "$comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors; SPDX-License-Identifier: CC0-1.0",
+  "schema_version": "1.0",
+  "repository": "SecPal/.github",
+  "default_branch": "main",
+  "allowed_base_repositories": ["SecPal/.github"],
+  "reviewer_identities": [
+    {
+      "canonical_identity": "copilot",
+      "kind": "bot",
+      "graphql_aliases": ["copilot-pull-request-reviewer"],
+      "rest_event_aliases": ["copilot-pull-request-reviewer[bot]"],
+      "node_ids": [],
+      "database_ids": []
+    },
+    {
+      "canonical_identity": "codex",
+      "kind": "bot",
+      "graphql_aliases": ["chatgpt-codex-connector"],
+      "rest_event_aliases": ["chatgpt-codex-connector[bot]"],
+      "node_ids": [],
+      "database_ids": []
+    }
+  ],
+  "required_local_validation": [
+    {
+      "name": "unit",
+      "command": ["python3", "-m", "unittest", "tests/secpal-pr-review-unit.py"]
+    }
+  ],
+  "signature_policy": {
+    "require_github_verified": true,
+    "require_local_verified": true,
+    "accepted_formats": ["ssh", "openpgp"]
+  },
+  "check_policy": {
+    "require_ruleset_evidence": true,
+    "require_branch_protection_evidence": true,
+    "expected_skipped": "block"
+  },
+  "maximum_api_calls": 200,
+  "maximum_items": 10000,
+  "maximum_threads": 500,
+  "maximum_comments": 10000,
+  "maximum_reactions": 10000
+}

--- a/tests/fixtures/secpal-pr-review/config.json
+++ b/tests/fixtures/secpal-pr-review/config.json
@@ -22,12 +22,6 @@
       "database_ids": []
     }
   ],
-  "required_local_validation": [
-    {
-      "name": "unit",
-      "command": ["python3", "-m", "unittest", "tests/secpal-pr-review-unit.py"]
-    }
-  ],
   "signature_policy": {
     "require_github_verified": true,
     "require_local_verified": true,

--- a/tests/fixtures/secpal-pr-review/config.json.license
+++ b/tests/fixtures/secpal-pr-review/config.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0

--- a/tests/fixtures/secpal-pr-review/fake-cli.py
+++ b/tests/fixtures/secpal-pr-review/fake-cli.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Run the PR-state CLI with explicit fixture executables for integration tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+if len(sys.argv) < 4:
+    raise SystemExit("usage: fake-cli.py HELPER FIXTURE_BIN COMMAND [ARG ...]")
+
+helper = Path(sys.argv[1]).resolve()
+fixture_bin = Path(sys.argv[2]).resolve()
+spec = importlib.util.spec_from_file_location("secpal_pr_review_fixture", helper)
+if spec is None or spec.loader is None:
+    raise SystemExit(f"cannot load helper: {helper}")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+real_command_runner = module.CommandRunner
+
+
+class FixtureCommandRunner(real_command_runner):
+    def __init__(self) -> None:
+        super().__init__(
+            {
+                "git": str(fixture_bin / "git"),
+                "gh": str(fixture_bin / "gh"),
+            }
+        )
+
+
+module.CommandRunner = FixtureCommandRunner
+raise SystemExit(module.main(sys.argv[3:]))

--- a/tests/fixtures/secpal-pr-review/fake-gh.py
+++ b/tests/fixtures/secpal-pr-review/fake-gh.py
@@ -55,14 +55,7 @@ if len(arguments) > 1 and arguments[1] == "graphql":
     print(json.dumps(response, ensure_ascii=False, separators=(",", ":")))
     raise SystemExit(0)
 
-endpoint = next(
-    (
-        value
-        for value in reversed(arguments[1:])
-        if not value.startswith("-") and "=" not in value and value != method
-    ),
-    "",
-)
+endpoint = arguments[-1] if arguments[-1] != method and not arguments[-1].startswith("-") else ""
 response = fixture.get("rest", {}).get(endpoint)
 if response is None:
     fail(f"no fake REST response for {endpoint}")

--- a/tests/fixtures/secpal-pr-review/fake-gh.py
+++ b/tests/fixtures/secpal-pr-review/fake-gh.py
@@ -24,6 +24,8 @@ if log_path:
 
 if not arguments or arguments[0] != "api":
     fail(f"fake gh rejected non-api operation: {arguments!r}")
+if arguments[1:3] != ["--hostname", "github.com"]:
+    fail(f"fake gh rejected unpinned API host: {arguments!r}")
 
 method = "GET"
 for index, value in enumerate(arguments):
@@ -37,7 +39,7 @@ if not fixture_path:
     fail("FAKE_GH_FIXTURE is required")
 fixture = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
 
-if len(arguments) > 1 and arguments[1] == "graphql":
+if len(arguments) > 3 and arguments[3] == "graphql":
     query = next((value.split("=", 1)[1] for value in arguments if value.startswith("query=")), "")
     if re.search(r"\bmutation\b", query, re.IGNORECASE):
         fail("fake gh rejected GraphQL mutation")

--- a/tests/fixtures/secpal-pr-review/fake-gh.py
+++ b/tests/fixtures/secpal-pr-review/fake-gh.py
@@ -46,10 +46,16 @@ if len(arguments) > 1 and arguments[1] == "graphql":
         fail("fake gh could not identify GraphQL operation")
     operation = match.group(1)
     cursor = "null"
+    node_id = None
     for value in arguments:
         if value.startswith("after="):
             cursor = value.split("=", 1)[1]
-    response = fixture.get("graphql", {}).get(operation, {}).get(cursor)
+        if value.startswith("nodeId="):
+            node_id = value.split("=", 1)[1]
+    operation_responses = fixture.get("graphql", {}).get(operation, {})
+    response = operation_responses.get(f"{node_id}:{cursor}") if node_id else None
+    if response is None:
+        response = operation_responses.get(cursor)
     if response is None:
         fail(f"no fake GraphQL response for {operation} cursor={cursor}")
     print(json.dumps(response, ensure_ascii=False, separators=(",", ":")))

--- a/tests/fixtures/secpal-pr-review/fake-gh.py
+++ b/tests/fixtures/secpal-pr-review/fake-gh.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+arguments = sys.argv[1:]
+log_path = os.environ.get("FAKE_GH_LOG")
+if log_path:
+    with Path(log_path).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(arguments, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+if not arguments or arguments[0] != "api":
+    fail(f"fake gh rejected non-api operation: {arguments!r}")
+
+method = "GET"
+for index, value in enumerate(arguments):
+    if value == "--method" and index + 1 < len(arguments):
+        method = arguments[index + 1]
+if method != "GET":
+    fail(f"fake gh rejected write method: {method}")
+
+fixture_path = os.environ.get("FAKE_GH_FIXTURE")
+if not fixture_path:
+    fail("FAKE_GH_FIXTURE is required")
+fixture = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
+
+if len(arguments) > 1 and arguments[1] == "graphql":
+    query = next((value.split("=", 1)[1] for value in arguments if value.startswith("query=")), "")
+    if re.search(r"\bmutation\b", query, re.IGNORECASE):
+        fail("fake gh rejected GraphQL mutation")
+    match = re.search(r"\bquery\s+([A-Za-z0-9_]+)", query)
+    if not match:
+        fail("fake gh could not identify GraphQL operation")
+    operation = match.group(1)
+    cursor = "null"
+    for value in arguments:
+        if value.startswith("after="):
+            cursor = value.split("=", 1)[1]
+    response = fixture.get("graphql", {}).get(operation, {}).get(cursor)
+    if response is None:
+        fail(f"no fake GraphQL response for {operation} cursor={cursor}")
+    print(json.dumps(response, ensure_ascii=False, separators=(",", ":")))
+    raise SystemExit(0)
+
+endpoint = next(
+    (
+        value
+        for value in reversed(arguments[1:])
+        if not value.startswith("-") and "=" not in value and value != method
+    ),
+    "",
+)
+response = fixture.get("rest", {}).get(endpoint)
+if response is None:
+    fail(f"no fake REST response for {endpoint}")
+print(json.dumps(response, ensure_ascii=False, separators=(",", ":")))

--- a/tests/fixtures/secpal-pr-review/fake-git.py
+++ b/tests/fixtures/secpal-pr-review/fake-git.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+HEAD = "a" * 40
+arguments = sys.argv[1:]
+log_path = os.environ.get("FAKE_GIT_LOG")
+if log_path:
+    with Path(log_path).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(arguments, separators=(",", ":")) + "\n")
+
+if not arguments:
+    raise SystemExit(2)
+
+prohibited = {"push", "commit", "checkout", "switch", "reset", "clean", "stash", "fetch"}
+if arguments[0] in prohibited:
+    print(f"fake git rejected write operation: {arguments[0]}", file=sys.stderr)
+    raise SystemExit(1)
+
+responses = {
+    ("rev-parse", "--show-toplevel"): "/fixture/repository\n",
+    ("remote", "get-url", "origin"): "git@github.com:SecPal/.github.git\n",
+    ("status", "--porcelain=v2", "--untracked-files=all"): "",
+    ("branch", "--show-current"): "feat/test\n",
+    ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): "origin/feat/test\n",
+    ("rev-parse", "HEAD"): f"{HEAD}\n",
+    ("rev-parse", "@{upstream}"): f"{HEAD}\n",
+    ("cat-file", "-e", f"{HEAD}^{{commit}}"): "",
+}
+
+key = tuple(arguments)
+if key == ("verify-commit", "--raw", HEAD):
+    print('Good "git" signature for aroviqen with ED25519 key SHA256:fixture', file=sys.stderr)
+    raise SystemExit(0)
+if key not in responses:
+    print(f"fake git has no response for {arguments!r}", file=sys.stderr)
+    raise SystemExit(2)
+sys.stdout.write(responses[key])

--- a/tests/fixtures/secpal-pr-review/fake-git.py
+++ b/tests/fixtures/secpal-pr-review/fake-git.py
@@ -34,7 +34,11 @@ responses = {
     ("rev-parse", "HEAD"): f"{HEAD}\n",
     ("rev-parse", "@{upstream}"): f"{HEAD}\n",
     ("rev-list", "--reverse", f"{'b' * 40}..{HEAD}"): f"{HEAD}\n",
-    ("cat-file", "-e", f"{HEAD}^{{commit}}"): "",
+    (
+        "cat-file",
+        "commit",
+        HEAD,
+    ): "tree deadbeef\ngpgsig -----BEGIN SSH SIGNATURE-----\n signature\n -----END SSH SIGNATURE-----\n\nmessage\n",
 }
 
 key = tuple(arguments)

--- a/tests/fixtures/secpal-pr-review/fake-git.py
+++ b/tests/fixtures/secpal-pr-review/fake-git.py
@@ -33,6 +33,7 @@ responses = {
     ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): "origin/feat/test\n",
     ("rev-parse", "HEAD"): f"{HEAD}\n",
     ("rev-parse", "@{upstream}"): f"{HEAD}\n",
+    ("rev-list", "--reverse", f"{'b' * 40}..{HEAD}"): f"{HEAD}\n",
     ("cat-file", "-e", f"{HEAD}^{{commit}}"): "",
 }
 

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -313,7 +313,40 @@
       }
     },
     "ReviewThreadComments": {
-      "thread-comments-1": {
+      "THREAD_1:null": {
+        "data": {
+          "repository": { "pullRequest": { "id": "PR_1" } },
+          "node": {
+            "comments": {
+              "nodes": [
+                {
+                  "id": "REVIEW_COMMENT_1",
+                  "databaseId": 51,
+                  "author": {
+                    "__typename": "Bot",
+                    "id": "BOT_COPILOT",
+                    "databaseId": 12,
+                    "login": "copilot-pull-request-reviewer",
+                    "url": "https://github.com/apps/copilot-pull-request-reviewer"
+                  },
+                  "body": "Original inline context.",
+                  "url": "https://github.com/SecPal/.github/pull/1#discussion_r51",
+                  "createdAt": "2026-07-19T00:05:00Z",
+                  "updatedAt": "2026-07-19T00:05:00Z",
+                  "replyTo": null,
+                  "pullRequestReview": { "id": "REVIEW_1" },
+                  "reactions": {
+                    "nodes": [],
+                    "pageInfo": { "hasNextPage": false, "endCursor": null }
+                  }
+                }
+              ],
+              "pageInfo": { "hasNextPage": true, "endCursor": "thread-comments-1" }
+            }
+          }
+        }
+      },
+      "THREAD_1:thread-comments-1": {
         "data": {
           "repository": { "pullRequest": { "id": "PR_1" } },
           "node": {
@@ -342,6 +375,33 @@
                 }
               ],
               "pageInfo": { "hasNextPage": false, "endCursor": "thread-comments-2" }
+            }
+          }
+        }
+      },
+      "THREAD_2:null": {
+        "data": {
+          "repository": { "pullRequest": { "id": "PR_1" } },
+          "node": {
+            "comments": {
+              "nodes": [
+                {
+                  "id": "REVIEW_COMMENT_3",
+                  "databaseId": 53,
+                  "author": null,
+                  "body": "Outdated context from an unavailable author.",
+                  "url": "https://github.com/SecPal/.github/pull/1#discussion_r53",
+                  "createdAt": "2026-07-19T00:07:00Z",
+                  "updatedAt": "2026-07-19T00:07:00Z",
+                  "replyTo": null,
+                  "pullRequestReview": { "id": "REVIEW_2" },
+                  "reactions": {
+                    "nodes": [],
+                    "pageInfo": { "hasNextPage": false, "endCursor": null }
+                  }
+                }
+              ],
+              "pageInfo": { "hasNextPage": false, "endCursor": null }
             }
           }
         }

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -16,6 +16,7 @@
               "number": 1,
               "url": "https://github.com/SecPal/.github/pull/1",
               "title": "Fixture pull request",
+              "body": "Fixture pull request body.",
               "state": "OPEN",
               "isDraft": false,
               "merged": false,
@@ -58,6 +59,7 @@
                 "pageInfo": { "hasNextPage": false, "endCursor": null }
               },
               "reviews": { "totalCount": 2 },
+              "reactions": { "totalCount": 1 },
               "comments": { "totalCount": 1 },
               "reviewThreads": { "totalCount": 2 },
               "commits": { "totalCount": 1 }
@@ -115,7 +117,24 @@
                     "body": "Informational review only.",
                     "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-11",
                     "submittedAt": "2026-07-19T00:00:00Z",
-                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+                    "reactions": {
+                      "nodes": [
+                        {
+                          "id": "REVIEW_REACTION_1",
+                          "content": "THUMBS_UP",
+                          "createdAt": "2026-07-19T00:00:30Z",
+                          "user": {
+                            "__typename": "User",
+                            "id": "USER_REVIEW_REACTOR_1",
+                            "databaseId": 51,
+                            "login": "review-reactor-one",
+                            "url": "https://github.com/review-reactor-one"
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": true, "endCursor": "review-reaction-1" }
+                    }
                   }
                 ],
                 "pageInfo": { "hasNextPage": true, "endCursor": "review-1" }
@@ -144,10 +163,67 @@
                     "body": "Second informational review.",
                     "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-12",
                     "submittedAt": "2026-07-19T00:01:00Z",
-                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+                    "reactions": {
+                      "nodes": [],
+                      "pageInfo": { "hasNextPage": false, "endCursor": null }
+                    }
                   }
                 ],
                 "pageInfo": { "hasNextPage": false, "endCursor": "review-2" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ReviewReactions": {
+      "REVIEW_1:review-reaction-1": {
+        "data": {
+          "repository": { "pullRequest": { "id": "PR_1" } },
+          "node": {
+            "reactions": {
+              "nodes": [
+                {
+                  "id": "REVIEW_REACTION_2",
+                  "content": "EYES",
+                  "createdAt": "2026-07-19T00:00:45Z",
+                  "user": {
+                    "__typename": "User",
+                    "id": "USER_REVIEW_REACTOR_2",
+                    "databaseId": 52,
+                    "login": "review-reactor-two",
+                    "url": "https://github.com/review-reactor-two"
+                  }
+                }
+              ],
+              "pageInfo": { "hasNextPage": false, "endCursor": "review-reaction-2" }
+            }
+          }
+        }
+      }
+    },
+    "PullRequestReactions": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reactions": {
+                "nodes": [
+                  {
+                    "id": "PR_REACTION_1",
+                    "content": "ROCKET",
+                    "createdAt": "2026-07-19T00:00:15Z",
+                    "user": {
+                      "__typename": "User",
+                      "id": "USER_PR_REACTOR_1",
+                      "databaseId": 50,
+                      "login": "pr-reactor",
+                      "url": "https://github.com/pr-reactor"
+                    }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
               }
             }
           }

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -22,6 +22,7 @@
               "mergeable": "MERGEABLE",
               "mergeStateStatus": "CLEAN",
               "reviewDecision": null,
+              "updatedAt": "2026-07-19T00:08:00Z",
               "author": {
                 "__typename": "User",
                 "id": "USER_AUTHOR",
@@ -44,13 +45,19 @@
               "headRefName": "feat/test",
               "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
               "labels": {
+                "totalCount": 0,
                 "nodes": [],
                 "pageInfo": { "hasNextPage": false, "endCursor": null }
               },
               "reviewRequests": {
+                "totalCount": 0,
                 "nodes": [],
                 "pageInfo": { "hasNextPage": false, "endCursor": null }
-              }
+              },
+              "reviews": { "totalCount": 2 },
+              "comments": { "totalCount": 1 },
+              "reviewThreads": { "totalCount": 2 },
+              "commits": { "totalCount": 1 }
             }
           }
         }

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -1,0 +1,205 @@
+{
+  "$comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors; SPDX-License-Identifier: CC0-1.0",
+  "graphql": {
+    "PullRequestAnchor": {
+      "null": {
+        "data": {
+          "repository": {
+            "id": "REPO_1",
+            "name": ".github",
+            "nameWithOwner": "SecPal/.github",
+            "url": "https://github.com/SecPal/.github",
+            "defaultBranchRef": { "name": "main" },
+            "pullRequest": {
+              "id": "PR_1",
+              "databaseId": 1,
+              "number": 1,
+              "url": "https://github.com/SecPal/.github/pull/1",
+              "title": "Fixture pull request",
+              "state": "OPEN",
+              "isDraft": false,
+              "merged": false,
+              "mergeable": "MERGEABLE",
+              "reviewDecision": null,
+              "author": {
+                "__typename": "User",
+                "id": "USER_AUTHOR",
+                "databaseId": 8,
+                "login": "author",
+                "url": "https://github.com/author"
+              },
+              "baseRepository": {
+                "id": "REPO_1",
+                "nameWithOwner": "SecPal/.github",
+                "url": "https://github.com/SecPal/.github"
+              },
+              "baseRefName": "main",
+              "baseRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "headRepository": {
+                "id": "REPO_1",
+                "nameWithOwner": "SecPal/.github",
+                "url": "https://github.com/SecPal/.github"
+              },
+              "headRefName": "feat/test",
+              "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "labels": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              },
+              "reviewRequests": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              }
+            }
+          }
+        }
+      }
+    },
+    "PullRequestReviews": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reviews": {
+                "nodes": [
+                  {
+                    "id": "REVIEW_1",
+                    "databaseId": 11,
+                    "author": {
+                      "__typename": "Bot",
+                      "id": "BOT_COPILOT",
+                      "databaseId": 12,
+                      "login": "copilot-pull-request-reviewer",
+                      "url": "https://github.com/apps/copilot-pull-request-reviewer"
+                    },
+                    "state": "COMMENTED",
+                    "body": "Informational review only.",
+                    "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-11",
+                    "submittedAt": "2026-07-19T00:00:00Z",
+                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": "review-1" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ConversationComments": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "comments": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ReviewThreads": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reviewThreads": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              }
+            }
+          }
+        }
+      }
+    },
+    "PullRequestCommits": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "commits": {
+                "nodes": [
+                  {
+                    "commit": {
+                      "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "authoredDate": "2026-07-19T00:00:00Z",
+                      "committedDate": "2026-07-19T00:00:00Z",
+                      "parents": {
+                        "nodes": [{ "oid": "cccccccccccccccccccccccccccccccccccccccc" }],
+                        "pageInfo": { "hasNextPage": false, "endCursor": "parent-1" }
+                      },
+                      "signature": {
+                        "__typename": "SshSignature",
+                        "isValid": true,
+                        "state": "VALID",
+                        "wasSignedByGitHub": false,
+                        "signer": {
+                          "__typename": "User",
+                          "id": "USER_AUTHOR",
+                          "databaseId": 8,
+                          "login": "author",
+                          "url": "https://github.com/author"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": "commit-1" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "CommitChecks": {
+      "null": {
+        "data": {
+          "repository": {
+            "object": {
+              "statusCheckRollup": {
+                "contexts": {
+                  "nodes": [
+                    {
+                      "__typename": "CheckRun",
+                      "id": "CHECK_1",
+                      "name": "tests",
+                      "status": "COMPLETED",
+                      "conclusion": "SUCCESS",
+                      "detailsUrl": "https://github.com/SecPal/.github/actions/runs/1",
+                      "checkSuite": {
+                        "app": {
+                          "id": "APP_1",
+                          "databaseId": 1,
+                          "name": "GitHub Actions",
+                          "slug": "github-actions"
+                        }
+                      }
+                    }
+                  ],
+                  "pageInfo": { "hasNextPage": false, "endCursor": "check-1" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "rest": {
+    "repos/SecPal/.github/rules/branches/main": [
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "required_status_checks": [{ "context": "tests", "integration_id": 1 }]
+        }
+      }
+    ],
+    "repos/SecPal/.github/branches/main/protection/required_status_checks": {
+      "strict": true,
+      "contexts": ["tests"],
+      "checks": [{ "context": "tests", "app_id": 1 }]
+    }
+  }
+}

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -44,6 +44,9 @@
               },
               "headRefName": "feat/test",
               "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "potentialMergeCommit": {
+                "oid": "dddddddddddddddddddddddddddddddddddddddd"
+              },
               "labels": {
                 "totalCount": 0,
                 "nodes": [],

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -20,6 +20,7 @@
               "isDraft": false,
               "merged": false,
               "mergeable": "MERGEABLE",
+              "mergeStateStatus": "CLEAN",
               "reviewDecision": null,
               "author": {
                 "__typename": "User",
@@ -516,6 +517,7 @@
       {
         "type": "required_status_checks",
         "parameters": {
+          "strict_required_status_checks_policy": true,
           "required_status_checks": [{ "context": "tests", "integration_id": 1 }]
         }
       }

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json
@@ -55,6 +55,34 @@
         }
       }
     },
+    "PullRequestLabels": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "labels": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              }
+            }
+          }
+        }
+      }
+    },
+    "PullRequestReviewRequests": {
+      "null": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reviewRequests": {
+                "nodes": [],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+              }
+            }
+          }
+        }
+      }
+    },
     "PullRequestReviews": {
       "null": {
         "data": {
@@ -79,7 +107,36 @@
                     "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
                   }
                 ],
-                "pageInfo": { "hasNextPage": false, "endCursor": "review-1" }
+                "pageInfo": { "hasNextPage": true, "endCursor": "review-1" }
+              }
+            }
+          }
+        }
+      },
+      "review-1": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reviews": {
+                "nodes": [
+                  {
+                    "id": "REVIEW_2",
+                    "databaseId": 12,
+                    "author": {
+                      "__typename": "Bot",
+                      "id": "BOT_CODEX",
+                      "databaseId": 13,
+                      "login": "chatgpt-codex-connector",
+                      "url": "https://github.com/apps/chatgpt-codex-connector"
+                    },
+                    "state": "COMMENTED",
+                    "body": "Second informational review.",
+                    "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-12",
+                    "submittedAt": "2026-07-19T00:01:00Z",
+                    "commit": { "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": "review-2" }
               }
             }
           }
@@ -92,9 +149,68 @@
           "repository": {
             "pullRequest": {
               "comments": {
-                "nodes": [],
+                "nodes": [
+                  {
+                    "id": "ISSUE_COMMENT_1",
+                    "databaseId": 31,
+                    "author": {
+                      "__typename": "User",
+                      "id": "USER_AUTHOR",
+                      "databaseId": 8,
+                      "login": "author",
+                      "url": "https://github.com/author"
+                    },
+                    "body": "Top-level context with ](javascript:alert(1)).",
+                    "url": "https://github.com/SecPal/.github/pull/1#issuecomment-31",
+                    "createdAt": "2026-07-19T00:02:00Z",
+                    "updatedAt": "2026-07-19T00:02:00Z",
+                    "reactions": {
+                      "nodes": [
+                        {
+                          "id": "REACTION_1",
+                          "content": "THUMBS_UP",
+                          "createdAt": "2026-07-19T00:03:00Z",
+                          "user": {
+                            "__typename": "User",
+                            "id": "USER_REACTOR_1",
+                            "databaseId": 41,
+                            "login": "reactor-one",
+                            "url": "https://github.com/reactor-one"
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": true, "endCursor": "reaction-1" }
+                    }
+                  }
+                ],
                 "pageInfo": { "hasNextPage": false, "endCursor": null }
               }
+            }
+          }
+        }
+      }
+    },
+    "IssueCommentReactions": {
+      "reaction-1": {
+        "data": {
+          "repository": { "pullRequest": { "id": "PR_1" } },
+          "node": {
+            "reactions": {
+              "nodes": [
+                {
+                  "id": "REACTION_2",
+                  "content": "EYES",
+                  "createdAt": "2026-07-19T00:04:00Z",
+                  "user": {
+                    "__typename": "User",
+                    "id": "USER_REACTOR_2",
+                    "databaseId": 42,
+                    "login": "reactor-two",
+                    "url": "https://github.com/reactor-two"
+                  }
+                }
+              ],
+              "pageInfo": { "hasNextPage": false, "endCursor": "reaction-2" }
             }
           }
         }
@@ -106,9 +222,126 @@
           "repository": {
             "pullRequest": {
               "reviewThreads": {
-                "nodes": [],
-                "pageInfo": { "hasNextPage": false, "endCursor": null }
+                "nodes": [
+                  {
+                    "id": "THREAD_1",
+                    "isResolved": true,
+                    "isOutdated": false,
+                    "path": "scripts/example.py",
+                    "line": 7,
+                    "originalLine": 7,
+                    "diffSide": "RIGHT",
+                    "startLine": null,
+                    "startDiffSide": null,
+                    "comments": {
+                      "nodes": [
+                        {
+                          "id": "REVIEW_COMMENT_1",
+                          "databaseId": 51,
+                          "author": {
+                            "__typename": "Bot",
+                            "id": "BOT_COPILOT",
+                            "databaseId": 12,
+                            "login": "copilot-pull-request-reviewer",
+                            "url": "https://github.com/apps/copilot-pull-request-reviewer"
+                          },
+                          "body": "Original inline context.",
+                          "url": "https://github.com/SecPal/.github/pull/1#discussion_r51",
+                          "createdAt": "2026-07-19T00:05:00Z",
+                          "updatedAt": "2026-07-19T00:05:00Z",
+                          "replyTo": null,
+                          "pullRequestReview": { "id": "REVIEW_1" },
+                          "reactions": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": true, "endCursor": "thread-comments-1" }
+                    }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": true, "endCursor": "thread-1" }
               }
+            }
+          }
+        }
+      },
+      "thread-1": {
+        "data": {
+          "repository": {
+            "pullRequest": {
+              "reviewThreads": {
+                "nodes": [
+                  {
+                    "id": "THREAD_2",
+                    "isResolved": true,
+                    "isOutdated": true,
+                    "path": null,
+                    "line": null,
+                    "originalLine": 3,
+                    "diffSide": "RIGHT",
+                    "startLine": null,
+                    "startDiffSide": null,
+                    "comments": {
+                      "nodes": [
+                        {
+                          "id": "REVIEW_COMMENT_3",
+                          "databaseId": 53,
+                          "author": null,
+                          "body": "Outdated context from an unavailable author.",
+                          "url": "https://github.com/SecPal/.github/pull/1#discussion_r53",
+                          "createdAt": "2026-07-19T00:07:00Z",
+                          "updatedAt": "2026-07-19T00:07:00Z",
+                          "replyTo": null,
+                          "pullRequestReview": { "id": "REVIEW_2" },
+                          "reactions": {
+                            "nodes": [],
+                            "pageInfo": { "hasNextPage": false, "endCursor": null }
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": false, "endCursor": null }
+                    }
+                  }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": "thread-2" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ReviewThreadComments": {
+      "thread-comments-1": {
+        "data": {
+          "repository": { "pullRequest": { "id": "PR_1" } },
+          "node": {
+            "comments": {
+              "nodes": [
+                {
+                  "id": "REVIEW_COMMENT_2",
+                  "databaseId": 52,
+                  "author": {
+                    "__typename": "User",
+                    "id": "USER_AUTHOR",
+                    "databaseId": 8,
+                    "login": "author",
+                    "url": "https://github.com/author"
+                  },
+                  "body": "Human reply retained.",
+                  "url": "https://github.com/SecPal/.github/pull/1#discussion_r52",
+                  "createdAt": "2026-07-19T00:06:00Z",
+                  "updatedAt": "2026-07-19T00:06:00Z",
+                  "replyTo": { "id": "REVIEW_COMMENT_1" },
+                  "pullRequestReview": { "id": "REVIEW_1" },
+                  "reactions": {
+                    "nodes": [],
+                    "pageInfo": { "hasNextPage": false, "endCursor": null }
+                  }
+                }
+              ],
+              "pageInfo": { "hasNextPage": false, "endCursor": "thread-comments-2" }
             }
           }
         }
@@ -178,7 +411,38 @@
                       }
                     }
                   ],
-                  "pageInfo": { "hasNextPage": false, "endCursor": "check-1" }
+                  "pageInfo": { "hasNextPage": true, "endCursor": "check-1" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "check-1": {
+        "data": {
+          "repository": {
+            "object": {
+              "statusCheckRollup": {
+                "contexts": {
+                  "nodes": [
+                    {
+                      "__typename": "CheckRun",
+                      "id": "CHECK_2",
+                      "name": "optional-lint",
+                      "status": "COMPLETED",
+                      "conclusion": "FAILURE",
+                      "detailsUrl": "https://github.com/SecPal/.github/actions/runs/2",
+                      "checkSuite": {
+                        "app": {
+                          "id": "APP_1",
+                          "databaseId": 1,
+                          "name": "GitHub Actions",
+                          "slug": "github-actions"
+                        }
+                      }
+                    }
+                  ],
+                  "pageInfo": { "hasNextPage": false, "endCursor": "check-2" }
                 }
               }
             }
@@ -188,7 +452,7 @@
     }
   },
   "rest": {
-    "repos/SecPal/.github/rules/branches/main": [
+    "repos/SecPal/.github/rules/branches/main?per_page=100&page=1": [
       {
         "type": "required_status_checks",
         "parameters": {

--- a/tests/fixtures/secpal-pr-review/fake-github-pages.json.license
+++ b/tests/fixtures/secpal-pr-review/fake-github-pages.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -20,38 +20,39 @@ export PATH="$workspace/bin:$PATH"
 export FAKE_GH_FIXTURE="$FIXTURES/fake-github-pages.json"
 export FAKE_GH_LOG="$workspace/gh.log"
 export FAKE_GIT_LOG="$workspace/git.log"
+helper=(python3 "$FIXTURES/fake-cli.py" "$HELPER" "$workspace/bin")
 
 first="$workspace/first.json"
 second="$workspace/second.json"
 markdown="$workspace/output/snapshot.md"
 json_output="$workspace/output/snapshot.json"
 
-python3 "$HELPER" snapshot \
+"${helper[@]}" snapshot \
   --repo SecPal/.github \
   --pr 1 \
   --config "$FIXTURES/config.json" >"$first"
 
-python3 "$HELPER" snapshot \
+"${helper[@]}" snapshot \
   --repo SecPal/.github \
   --pr 1 \
   --config "$FIXTURES/config.json" >"$second"
 
 cmp "$first" "$second"
 
-python3 "$HELPER" verify-gate \
+"${helper[@]}" verify-gate \
   --snapshot "$first" \
   --config "$FIXTURES/config.json" >"$workspace/gate.json"
 
-python3 "$HELPER" verify-local \
+"${helper[@]}" verify-local \
   --repo SecPal/.github \
   --pr 1 \
   --config "$FIXTURES/config.json" \
   --expected-head aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$workspace/local.json"
 
-python3 "$HELPER" render --snapshot "$first" --format markdown >"$workspace/rendered.md"
+"${helper[@]}" render --snapshot "$first" --format markdown >"$workspace/rendered.md"
 grep -Fq 'Canonical authority: JSON snapshot and SHA-256 digest' "$workspace/rendered.md"
 
-python3 "$HELPER" snapshot \
+"${helper[@]}" snapshot \
   --repo SecPal/.github \
   --pr 1 \
   --config "$FIXTURES/config.json" \
@@ -81,6 +82,9 @@ assert gate["raw_review_state"]["unresolved_threads"] == 0
 assert gate["technical_classification_required"] is True
 
 assert len(snapshot["conversation_comments"][0]["reactions"]) == 2
+assert len(snapshot["pull_request"]["reactions"]) == 1
+assert len(snapshot["reviews"][0]["reactions"]) == 2
+assert snapshot["reviews"][1]["reactions"] == []
 assert len(snapshot["review_threads"][0]["comments"]) == 2
 assert snapshot["review_threads"][1]["is_outdated"] is True
 assert snapshot["pull_request"]["captured_connection_counts"] == {
@@ -88,6 +92,7 @@ assert snapshot["pull_request"]["captured_connection_counts"] == {
     "review_requests": len(snapshot["pull_request"]["requested_reviewers"])
     + len(snapshot["pull_request"]["requested_teams"]),
     "reviews": len(snapshot["reviews"]),
+    "pull_request_reactions": len(snapshot["pull_request"]["reactions"]),
     "conversation_comments": len(snapshot["conversation_comments"]),
     "review_threads": len(snapshot["review_threads"]),
     "commits": len(snapshot["commits"]),
@@ -97,6 +102,9 @@ assert snapshot["pull_request"]["check_commit_oid"] == "d" * 40
 assert snapshot["pull_request"]["check_commit_source"] == "test_merge"
 connections = {item["connection"]: item for item in snapshot["completeness"]["fully_paginated_connections"]}
 assert connections["reviews"]["pages"] == 2
+assert connections["pull_request.reactions"]["pages"] == 1
+assert connections["review.REVIEW_1.reactions"]["pages"] == 2
+assert connections["review.REVIEW_2.reactions"]["pages"] == 1
 assert connections["review_threads"]["pages"] == 2
 assert connections["review_thread.THREAD_1.comments"]["pages"] == 2
 assert connections["conversation_comment.ISSUE_COMMENT_1.reactions"]["pages"] == 2
@@ -104,6 +112,9 @@ assert connections["test_merge_checks"]["pages"] == 2
 assert connections["labels.revalidation"]["pages"] == 1
 assert connections["review_requests.revalidation"]["pages"] == 1
 assert connections["reviews.revalidation"]["pages"] == 2
+assert connections["pull_request.reactions.revalidation"]["pages"] == 1
+assert connections["review.REVIEW_1.reactions.revalidation"]["pages"] == 2
+assert connections["review.REVIEW_2.reactions.revalidation"]["pages"] == 1
 assert connections["conversation_comments.revalidation"]["pages"] == 1
 assert connections["review_threads.revalidation"]["pages"] == 2
 assert connections["review_thread.THREAD_1.comments.revalidation"]["pages"] == 2

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/secpal-pr-review.py"
+FIXTURES="$SCRIPT_DIR/fixtures/secpal-pr-review"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/secpal-pr-review.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+mkdir -p "$workspace/bin" "$workspace/output"
+cp "$FIXTURES/fake-gh.py" "$workspace/bin/gh"
+cp "$FIXTURES/fake-git.py" "$workspace/bin/git"
+chmod 0700 "$workspace/bin/gh" "$workspace/bin/git"
+
+export PATH="$workspace/bin:$PATH"
+export FAKE_GH_FIXTURE="$FIXTURES/fake-github-pages.json"
+export FAKE_GH_LOG="$workspace/gh.log"
+export FAKE_GIT_LOG="$workspace/git.log"
+
+first="$workspace/first.json"
+second="$workspace/second.json"
+markdown="$workspace/output/snapshot.md"
+json_output="$workspace/output/snapshot.json"
+
+python3 "$HELPER" snapshot \
+  --repo SecPal/.github \
+  --pr 1 \
+  --config "$FIXTURES/config.json" >"$first"
+
+python3 "$HELPER" snapshot \
+  --repo SecPal/.github \
+  --pr 1 \
+  --config "$FIXTURES/config.json" >"$second"
+
+cmp "$first" "$second"
+
+python3 "$HELPER" verify-gate \
+  --snapshot "$first" \
+  --config "$FIXTURES/config.json" >"$workspace/gate.json"
+
+python3 "$HELPER" verify-local \
+  --repo SecPal/.github \
+  --pr 1 \
+  --config "$FIXTURES/config.json" \
+  --expected-head aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$workspace/local.json"
+
+python3 "$HELPER" render --snapshot "$first" --format markdown >"$workspace/rendered.md"
+grep -Fq 'Canonical authority: JSON snapshot and SHA-256 digest' "$workspace/rendered.md"
+
+python3 "$HELPER" snapshot \
+  --repo SecPal/.github \
+  --pr 1 \
+  --config "$FIXTURES/config.json" \
+  --output "$json_output" \
+  --markdown-output "$markdown" >"$workspace/output-message.json"
+
+test "$(stat -c '%a' "$json_output")" = "600"
+test "$(stat -c '%a' "$markdown")" = "600"
+cmp "$first" "$json_output"
+
+python3 - "$first" "$workspace/gate.json" "$workspace/local.json" <<'PY'
+import hashlib
+import json
+import sys
+
+snapshot_path, gate_path, local_path = sys.argv[1:]
+snapshot = json.load(open(snapshot_path, encoding="utf-8"))
+provided = snapshot.pop("snapshot_digest")
+canonical = json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+assert hashlib.sha256(canonical).hexdigest() == provided
+
+gate = json.load(open(gate_path, encoding="utf-8"))
+assert gate["raw_review_state"]["reviews"] == 1
+assert gate["technical_classification_required"] is True
+
+local = json.load(open(local_path, encoding="utf-8"))
+assert local["blockers"] == []
+assert local["local_head"] == "a" * 40
+PY
+
+python3 - "$workspace/gh.log" "$workspace/git.log" <<'PY'
+import json
+import sys
+
+gh_log, git_log = sys.argv[1:]
+gh_calls = [json.loads(line) for line in open(gh_log, encoding="utf-8")]
+git_calls = [json.loads(line) for line in open(git_log, encoding="utf-8")]
+
+assert gh_calls
+assert git_calls
+for call in gh_calls:
+    assert call[0] == "api", call
+    if "--method" in call:
+        assert call[call.index("--method") + 1] == "GET", call
+    query = next((arg.split("=", 1)[1] for arg in call if arg.startswith("query=")), "")
+    assert "mutation" not in query.lower(), call
+
+prohibited_git = {"push", "commit", "checkout", "switch", "reset", "clean", "stash", "fetch"}
+assert all(not call or call[0] not in prohibited_git for call in git_calls)
+PY
+
+if grep -Eiq '(^|[^[:alnum:]_])(mutation|POST|PUT|PATCH|DELETE)([^[:alnum:]_]|$)' "$workspace/gh.log"; then
+  echo "Fake gh observed a prohibited GitHub mutation operation." >&2
+  exit 1
+fi
+
+printf '✓ deterministic PR evidence integration checks passed\n'

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -74,8 +74,21 @@ canonical = json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=
 assert hashlib.sha256(canonical).hexdigest() == provided
 
 gate = json.load(open(gate_path, encoding="utf-8"))
-assert gate["raw_review_state"]["reviews"] == 1
+assert gate["raw_review_state"]["reviews"] == 2
+assert gate["raw_review_state"]["conversation_comments"] == 1
+assert gate["raw_review_state"]["review_threads"] == 2
+assert gate["raw_review_state"]["unresolved_threads"] == 0
 assert gate["technical_classification_required"] is True
+
+assert len(snapshot["conversation_comments"][0]["reactions"]) == 2
+assert len(snapshot["review_threads"][0]["comments"]) == 2
+assert snapshot["review_threads"][1]["is_outdated"] is True
+connections = {item["connection"]: item for item in snapshot["completeness"]["fully_paginated_connections"]}
+assert connections["reviews"]["pages"] == 2
+assert connections["review_threads"]["pages"] == 2
+assert connections["review_thread.THREAD_1.comments"]["pages"] == 2
+assert connections["conversation_comment.ISSUE_COMMENT_1.reactions"]["pages"] == 2
+assert connections["checks"]["pages"] == 2
 
 local = json.load(open(local_path, encoding="utf-8"))
 assert local["blockers"] == []

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HELPER="$REPO_ROOT/scripts/secpal-pr-review.py"
 FIXTURES="$SCRIPT_DIR/fixtures/secpal-pr-review"
-workspace="$(mktemp -d "${TMPDIR:-/tmp}/secpal-pr-review.XXXXXX")"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/secpal-pr-review-integration.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/bin" "$workspace/output"

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -89,6 +89,17 @@ assert connections["review_threads"]["pages"] == 2
 assert connections["review_thread.THREAD_1.comments"]["pages"] == 2
 assert connections["conversation_comment.ISSUE_COMMENT_1.reactions"]["pages"] == 2
 assert connections["checks"]["pages"] == 2
+assert connections["labels.revalidation"]["pages"] == 1
+assert connections["review_requests.revalidation"]["pages"] == 1
+assert connections["reviews.revalidation"]["pages"] == 2
+assert connections["conversation_comments.revalidation"]["pages"] == 1
+assert connections["review_threads.revalidation"]["pages"] == 2
+assert connections["review_thread.THREAD_1.comments.revalidation"]["pages"] == 2
+assert connections["conversation_comment.ISSUE_COMMENT_1.reactions.revalidation"]["pages"] == 2
+assert connections["commits.revalidation"]["pages"] == 1
+assert connections["checks.revalidation"]["pages"] == 2
+assert connections["rulesets.revalidation"]["pages"] == 1
+assert connections["branch_protection.revalidation"]["pages"] == 1
 
 local = json.load(open(local_path, encoding="utf-8"))
 assert local["blockers"] == []
@@ -105,12 +116,17 @@ git_calls = [json.loads(line) for line in open(git_log, encoding="utf-8")]
 
 assert gh_calls
 assert git_calls
+anchor_calls = 0
 for call in gh_calls:
     assert call[0] == "api", call
     if "--method" in call:
         assert call[call.index("--method") + 1] == "GET", call
     query = next((arg.split("=", 1)[1] for arg in call if arg.startswith("query=")), "")
     assert "mutation" not in query.lower(), call
+    if "query PullRequestAnchor" in query:
+        anchor_calls += 1
+
+assert anchor_calls == 12, anchor_calls
 
 prohibited_git = {"push", "commit", "checkout", "switch", "reset", "clean", "stash", "fetch"}
 assert all(not call or call[0] not in prohibited_git for call in git_calls)

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -83,6 +83,15 @@ assert gate["technical_classification_required"] is True
 assert len(snapshot["conversation_comments"][0]["reactions"]) == 2
 assert len(snapshot["review_threads"][0]["comments"]) == 2
 assert snapshot["review_threads"][1]["is_outdated"] is True
+assert snapshot["pull_request"]["captured_connection_counts"] == {
+    "labels": len(snapshot["pull_request"]["labels"]),
+    "review_requests": len(snapshot["pull_request"]["requested_reviewers"])
+    + len(snapshot["pull_request"]["requested_teams"]),
+    "reviews": len(snapshot["reviews"]),
+    "conversation_comments": len(snapshot["conversation_comments"]),
+    "review_threads": len(snapshot["review_threads"]),
+    "commits": len(snapshot["commits"]),
+}
 connections = {item["connection"]: item for item in snapshot["completeness"]["fully_paginated_connections"]}
 assert connections["reviews"]["pages"] == 2
 assert connections["review_threads"]["pages"] == 2

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -92,12 +92,15 @@ assert snapshot["pull_request"]["captured_connection_counts"] == {
     "review_threads": len(snapshot["review_threads"]),
     "commits": len(snapshot["commits"]),
 }
+assert snapshot["pull_request"]["potential_merge_commit_oid"] == "d" * 40
+assert snapshot["pull_request"]["check_commit_oid"] == "d" * 40
+assert snapshot["pull_request"]["check_commit_source"] == "test_merge"
 connections = {item["connection"]: item for item in snapshot["completeness"]["fully_paginated_connections"]}
 assert connections["reviews"]["pages"] == 2
 assert connections["review_threads"]["pages"] == 2
 assert connections["review_thread.THREAD_1.comments"]["pages"] == 2
 assert connections["conversation_comment.ISSUE_COMMENT_1.reactions"]["pages"] == 2
-assert connections["checks"]["pages"] == 2
+assert connections["test_merge_checks"]["pages"] == 2
 assert connections["labels.revalidation"]["pages"] == 1
 assert connections["review_requests.revalidation"]["pages"] == 1
 assert connections["reviews.revalidation"]["pages"] == 2
@@ -106,7 +109,7 @@ assert connections["review_threads.revalidation"]["pages"] == 2
 assert connections["review_thread.THREAD_1.comments.revalidation"]["pages"] == 2
 assert connections["conversation_comment.ISSUE_COMMENT_1.reactions.revalidation"]["pages"] == 2
 assert connections["commits.revalidation"]["pages"] == 1
-assert connections["checks.revalidation"]["pages"] == 2
+assert connections["test_merge_checks.revalidation"]["pages"] == 2
 assert connections["rulesets.revalidation"]["pages"] == 1
 assert connections["branch_protection.revalidation"]["pages"] == 1
 

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -46,6 +46,13 @@ def uncontrolled_git_test_environment() -> dict[str, str]:
     return environment
 
 
+def fake_executable(directory: str, name: str) -> str:
+    path = Path(directory) / name
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return str(path)
+
+
 def actor(login: str | None = "reviewer", kind: str = "user") -> dict[str, Any]:
     if login is None:
         kind = "deleted_or_unavailable"
@@ -1475,6 +1482,33 @@ class SignatureAndCheckTests(unittest.TestCase):
         with self.assertRaises(review.BlockedError):
             review.require_rule_evidence(None, {}, config()["check_policy"])
 
+    def test_required_workflow_rule_blocks_as_unsupported_requiredness(self) -> None:
+        with self.assertRaisesRegex(review.BlockedError, "workflow"):
+            review.require_rule_evidence(
+                [
+                    {
+                        "type": "workflows",
+                        "parameters": {
+                            "workflows": [
+                                {
+                                    "path": ".github/workflows/quality.yml",
+                                    "repository_id": 1,
+                                }
+                            ]
+                        },
+                    }
+                ],
+                {"strict": True, "contexts": [], "checks": []},
+                config()["check_policy"],
+            )
+
+    def test_normalized_required_workflow_rule_cannot_bypass_gate_validation(self) -> None:
+        value = snapshot()
+        value["applicable_rules"]["rulesets"] = [{"type": "workflows"}]
+        value = review.attach_digest(value)
+        with self.assertRaisesRegex(review.ContractError, "workflow"):
+            review.validate_snapshot(value)
+
     def test_branch_protection_preserves_required_check_with_null_app_id(self) -> None:
         required = review.require_rule_evidence(
             [],
@@ -1696,9 +1730,10 @@ class SecurityAndOutputTests(unittest.TestCase):
             None,
             "query X { viewer { login } }",
         )
-        completed = mock.Mock(returncode=0, stdout="{}", stderr="")
-        with mock.patch.object(review.subprocess, "run", return_value=completed) as run:
-            review.CommandRunner().run(arguments)
+        with tempfile.TemporaryDirectory() as directory:
+            completed = mock.Mock(returncode=0, stdout="{}", stderr="")
+            with mock.patch.object(review.subprocess, "run", return_value=completed) as run:
+                review.CommandRunner({"gh": fake_executable(directory, "gh")}).run(arguments)
         environment = run.call_args.kwargs["env"]
         self.assertEqual(environment["GH_HOST"], "github.com")
         self.assertEqual(environment["PATH"], review.TRUSTED_COMMAND_PATH)
@@ -1723,10 +1758,13 @@ class SecurityAndOutputTests(unittest.TestCase):
             self.assertFalse(marker.exists())
 
     def test_command_runner_bounds_execution_and_closes_stdin(self) -> None:
-        expired = review.subprocess.TimeoutExpired(["git", "rev-parse", "HEAD"], 1)
-        with mock.patch.object(review.subprocess, "run", side_effect=expired) as run:
-            with self.assertRaises(review.CommandFailure):
-                review.CommandRunner().run(["git", "rev-parse", "HEAD"])
+        with tempfile.TemporaryDirectory() as directory:
+            expired = review.subprocess.TimeoutExpired(["git", "rev-parse", "HEAD"], 1)
+            with mock.patch.object(review.subprocess, "run", side_effect=expired) as run:
+                with self.assertRaises(review.CommandFailure):
+                    review.CommandRunner({"git": fake_executable(directory, "git")}).run(
+                        ["git", "rev-parse", "HEAD"]
+                    )
         self.assertEqual(run.call_args.kwargs["stdin"], review.subprocess.DEVNULL)
         self.assertEqual(
             run.call_args.kwargs["timeout"],
@@ -1770,10 +1808,12 @@ class SecurityAndOutputTests(unittest.TestCase):
         }
         completed = mock.Mock(returncode=0, stdout="", stderr="")
 
-        with mock.patch.dict(review.os.environ, poisoned_environment, clear=True), mock.patch.object(
-            review.subprocess, "run", return_value=completed
-        ) as run:
-            review.CommandRunner().run(["git", "status", "--porcelain=v2", "--untracked-files=all"])
+        with tempfile.TemporaryDirectory() as directory, mock.patch.dict(
+            review.os.environ, poisoned_environment, clear=True
+        ), mock.patch.object(review.subprocess, "run", return_value=completed) as run:
+            review.CommandRunner({"git": fake_executable(directory, "git")}).run(
+                ["git", "status", "--porcelain=v2", "--untracked-files=all"]
+            )
 
         environment = run.call_args.kwargs["env"]
         inherited_overrides = repository_overrides | {
@@ -1983,6 +2023,42 @@ class SecurityAndOutputTests(unittest.TestCase):
         broken["reviewer_identities"][0]["canonical_identity"] = ""
         with self.assertRaises(review.ContractError):
             review.validate_config(broken)
+
+    def test_reviewer_database_ids_must_be_globally_unique(self) -> None:
+        candidate = config()
+        candidate["reviewer_identities"][0]["database_ids"] = [42]
+        candidate["reviewer_identities"][1]["database_ids"] = [42]
+        with self.assertRaisesRegex(review.ContractError, "alias is duplicated"):
+            review.validate_config(candidate)
+        with self.assertRaisesRegex(review.ContractError, "alias is duplicated"):
+            review.index_reviewer_identities(candidate)
+
+    def test_reviewer_string_aliases_must_be_unique_across_namespaces(self) -> None:
+        string_namespaces = ("graphql_aliases", "rest_event_aliases", "node_ids")
+        for first_namespace in string_namespaces:
+            for second_namespace in string_namespaces:
+                with self.subTest(first=first_namespace, second=second_namespace):
+                    candidate = config()
+                    candidate["reviewer_identities"][0][first_namespace] = ["SHARED_ALIAS"]
+                    candidate["reviewer_identities"][1][second_namespace] = ["SHARED_ALIAS"]
+                    with self.assertRaisesRegex(review.ContractError, "alias is duplicated"):
+                        review.validate_config(candidate)
+                    with self.assertRaisesRegex(review.ContractError, "alias is duplicated"):
+                        review.index_reviewer_identities(candidate)
+
+    def test_one_reviewer_may_share_an_alias_across_namespaces(self) -> None:
+        string_namespaces = ("graphql_aliases", "rest_event_aliases", "node_ids")
+        for first_namespace in string_namespaces:
+            for second_namespace in string_namespaces:
+                with self.subTest(first=first_namespace, second=second_namespace):
+                    candidate = config()
+                    candidate["reviewer_identities"][0][first_namespace] = ["SHARED_ALIAS"]
+                    candidate["reviewer_identities"][0][second_namespace] = ["SHARED_ALIAS"]
+                    review.validate_config(candidate)
+                    self.assertEqual(
+                        review.index_reviewer_identities(candidate)["SHARED_ALIAS"],
+                        "copilot",
+                    )
 
     def test_unenforced_local_validation_commands_are_rejected(self) -> None:
         candidate = config()

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -368,6 +368,10 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         budget = review.Budget(config())
         self.assertEqual(review.collect_pages("review_threads.T1.comments", pages.__getitem__, budget), ["first", "reply"])
 
+    def test_thread_metadata_query_does_not_multiply_nested_connections(self) -> None:
+        self.assertNotIn("comments(first:", review.REVIEW_THREADS_QUERY)
+        self.assertIn("comments(first:100", review.REVIEW_THREAD_COMMENTS_QUERY)
+
     def test_11_unequal_connection_page_counts_do_not_refetch(self) -> None:
         calls: dict[str, list[str | None]] = {"reviews": [], "comments": []}
 

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -175,7 +175,13 @@ def check(
     }
 
 
-def finalize_snapshot(value: dict[str, Any]) -> dict[str, Any]:
+def finalize_snapshot(
+    value: dict[str, Any],
+    *,
+    preserve_captured_counts: bool = False,
+) -> dict[str, Any]:
+    if not preserve_captured_counts:
+        value["pull_request"]["captured_connection_counts"] = captured_connection_counts(value)
     counts = review.expected_connection_items(value)
     value["completeness"]["items"] = sum(counts.values())
     value["completeness"]["fully_paginated_connections"] = [
@@ -186,6 +192,21 @@ def finalize_snapshot(value: dict[str, Any]) -> dict[str, Any]:
         value["completeness"]["fully_paginated_connections"]
     )
     return review.attach_digest(value)
+
+
+def captured_connection_counts(value: dict[str, Any]) -> dict[str, int]:
+    """Return the PR-level counts supplied by the capture anchors."""
+
+    pull_request = value["pull_request"]
+    return {
+        "labels": len(pull_request["labels"]),
+        "review_requests": len(pull_request["requested_reviewers"])
+        + len(pull_request["requested_teams"]),
+        "reviews": len(value["reviews"]),
+        "conversation_comments": len(value["conversation_comments"]),
+        "review_threads": len(value["review_threads"]),
+        "commits": len(value["commits"]),
+    }
 
 
 def snapshot() -> dict[str, Any]:
@@ -287,6 +308,7 @@ def snapshot() -> dict[str, Any]:
             "blocked_reason": None,
         },
     }
+    value["pull_request"]["captured_connection_counts"] = captured_connection_counts(value)
     return finalize_snapshot(value)
 
 
@@ -566,6 +588,33 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         value["commits"].append(duplicate)
         with self.assertRaisesRegex(review.ContractError, "duplicate commit OID"):
             review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_a_commit_omitted_from_the_captured_count(self) -> None:
+        value = snapshot()
+        value["pull_request"]["captured_connection_counts"] = captured_connection_counts(value)
+        value["pull_request"]["captured_connection_counts"]["commits"] = 2
+        with self.assertRaisesRegex(review.ContractError, "captured commit count"):
+            review.validate_snapshot(finalize_snapshot(value, preserve_captured_counts=True))
+
+    def test_snapshot_rejects_every_mismatched_captured_connection_count(self) -> None:
+        for connection in review.CAPTURED_CONNECTIONS:
+            with self.subTest(connection=connection):
+                value = snapshot()
+                value["pull_request"]["captured_connection_counts"][connection] += 1
+                with self.assertRaisesRegex(review.ContractError, "captured .* count"):
+                    review.validate_snapshot(
+                        finalize_snapshot(value, preserve_captured_counts=True)
+                    )
+
+    def test_snapshot_rejects_inconsistent_signature_verification_flags(self) -> None:
+        for signature_name in ("github_signature", "local_signature"):
+            for state, verified in (("valid", False), ("invalid", True)):
+                with self.subTest(signature=signature_name, state=state, verified=verified):
+                    value = snapshot()
+                    value["commits"][0][signature_name]["state"] = state
+                    value["commits"][0][signature_name]["verified"] = verified
+                    with self.assertRaisesRegex(review.ContractError, "signature evidence"):
+                        review.validate_snapshot(finalize_snapshot(value))
 
     def test_completeness_accounts_for_volatile_evidence_revalidation(self) -> None:
         value = snapshot()
@@ -1428,6 +1477,14 @@ class SecurityAndOutputTests(unittest.TestCase):
             ).stdout.decode().strip()
             review.subprocess.run(
                 ["git", "config", "gpg.ssh.program", str(verifier)],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+            )
+            allowed_signers = root / "allowed-signers"
+            allowed_signers.write_text("", encoding="utf-8")
+            review.subprocess.run(
+                ["git", "config", "gpg.ssh.allowedSignersFile", str(allowed_signers)],
                 cwd=root,
                 env=subprocess_environment,
                 check=True,

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -309,7 +309,11 @@ class FakeGitRunner:
             ("git", "rev-list", "--reverse", f"{'b' * 40}..{HEAD}"): review.CommandResult(
                 0, f"{HEAD}\n", ""
             ),
-            ("git", "cat-file", "-e", f"{HEAD}^{{commit}}"): review.CommandResult(0, "", ""),
+            ("git", "cat-file", "commit", HEAD): review.CommandResult(
+                0,
+                "tree deadbeef\ngpgsig -----BEGIN SSH SIGNATURE-----\n signature\n -----END SSH SIGNATURE-----\n\nmessage\n",
+                "",
+            ),
             ("git", "verify-commit", "--raw", HEAD): review.CommandResult(
                 0, "", 'Good "git" signature for aroviqen with ED25519 key SHA256:test\n'
             ),
@@ -609,6 +613,21 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         anchor = review.extract_anchor(fixture)
         self.assertEqual(anchor["pull_request"]["state"], "MERGED")
 
+    def test_draft_merge_state_is_captured_and_blocked_by_lifecycle_gate(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        fixture["data"]["repository"]["pullRequest"]["isDraft"] = True
+        fixture["data"]["repository"]["pullRequest"]["mergeStateStatus"] = "DRAFT"
+        anchor = review.extract_anchor(fixture)
+        self.assertEqual(anchor["pull_request"]["mergeStateStatus"], "DRAFT")
+
+        value = snapshot()
+        value["pull_request"]["is_draft"] = True
+        value["pull_request"]["merge_state_status"] = "DRAFT"
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertIn("BLOCKED_UNSAFE_GITHUB_STATE", [item["code"] for item in result["blockers"]])
+
     def test_19_deleted_author_is_explicit(self) -> None:
         self.assertEqual(review.normalize_actor(None), actor(None))
 
@@ -682,6 +701,45 @@ class LocalGitTests(unittest.TestCase):
         with self.assertRaises(review.BlockedError):
             review.ensure_unchanged_anchor(before, after)
 
+    def test_anchor_query_captures_review_update_sentinels(self) -> None:
+        self.assertIn("updatedAt", review.PULL_REQUEST_ANCHOR_QUERY)
+        for connection in ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits"):
+            with self.subTest(connection=connection):
+                self.assertIn(f"{connection} {{ totalCount }}", review.PULL_REQUEST_ANCHOR_QUERY)
+
+    def test_anchor_requires_review_update_sentinels(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        pull_request = fixture["data"]["repository"]["pullRequest"]
+        pull_request["updatedAt"] = "2026-07-19T00:00:00Z"
+        for connection in ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits"):
+            pull_request[connection] = {"totalCount": 0}
+        before = review.extract_anchor(copy.deepcopy(fixture))
+        changed = copy.deepcopy(fixture)
+        changed["data"]["repository"]["pullRequest"]["updatedAt"] = "2026-07-19T00:01:00Z"
+        after = review.extract_anchor(changed)
+        with self.assertRaises(review.BlockedError):
+            review.ensure_unchanged_anchor(before, after)
+
+        del fixture["data"]["repository"]["pullRequest"]["updatedAt"]
+        with self.assertRaises(review.BlockedError):
+            review.extract_anchor(fixture)
+
+    def test_anchor_counts_must_match_captured_collections(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        pull_request = review.extract_anchor(fixture)["pull_request"]
+        captured = {
+            connection: pull_request[connection]["totalCount"]
+            for connection in review.ANCHOR_CONNECTIONS
+        }
+        review.ensure_anchor_counts_match(pull_request, captured)
+        captured["reviews"] -= 1
+        with self.assertRaises(review.BlockedError):
+            review.ensure_anchor_counts_match(pull_request, captured)
+
     def test_30_unexpected_base_branch(self) -> None:
         value = snapshot()
         value["pull_request"]["base_ref"] = "develop"
@@ -690,7 +748,7 @@ class LocalGitTests(unittest.TestCase):
 
     def test_31_unavailable_commit_object(self) -> None:
         runner = FakeGitRunner()
-        runner.set(["git", "cat-file", "-e", f"{HEAD}^{{commit}}"], 1, stderr="missing")
+        runner.set(["git", "cat-file", "commit", HEAD], 1, stderr="missing")
         result = review.verify_local_against_snapshot(snapshot(), config(), runner, None)
         self.assertEqual(result["commit_signatures"][0]["state"], "object_unavailable")
 
@@ -740,6 +798,36 @@ class SignatureAndCheckTests(unittest.TestCase):
             "[GNUPG:] GOODSIG 0123456789ABCDEF signer@example.com",
         )
         self.assertEqual((value["state"], value["format"]), ("valid", "unknown"))
+
+    def test_raw_openpgp_status_uses_commit_signature_envelope(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(
+            ["git", "cat-file", "commit", HEAD],
+            0,
+            "tree deadbeef\ngpgsig -----BEGIN PGP SIGNATURE-----\n signature\n -----END PGP SIGNATURE-----\n\nmessage\n",
+        )
+        runner.set(
+            ["git", "verify-commit", "--raw", HEAD],
+            0,
+            stderr="[GNUPG:] GOODSIG 0123456789ABCDEF signer@example.com",
+        )
+        value = review.local_signature_for_commit(runner, HEAD)
+        self.assertEqual((value["state"], value["format"]), ("valid", "openpgp"))
+
+    def test_raw_x509_status_uses_commit_signature_envelope(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(
+            ["git", "cat-file", "commit", HEAD],
+            0,
+            "tree deadbeef\ngpgsig -----BEGIN SIGNED MESSAGE-----\n signature\n -----END SIGNED MESSAGE-----\n\nmessage\n",
+        )
+        runner.set(
+            ["git", "verify-commit", "--raw", HEAD],
+            0,
+            stderr="[GNUPG:] GOODSIG 0123456789ABCDEF signer@example.com",
+        )
+        value = review.local_signature_for_commit(runner, HEAD)
+        self.assertEqual((value["state"], value["format"]), ("valid", "smime"))
 
     def test_failed_x509_signature_is_not_mislabeled_openpgp(self) -> None:
         value = review.interpret_local_signature(1, "gpgsm: BAD signature from user")
@@ -985,9 +1073,31 @@ class SecurityAndOutputTests(unittest.TestCase):
         self.assertEqual(before, after)
 
     def test_56_read_only_api_policy_rejects_mutations(self) -> None:
-        review.validate_external_command(["gh", "api", "graphql", "-f", "query=query X { viewer { login } }"])
+        query_arguments = review.graphql_arguments(
+            "SecPal",
+            ".github",
+            1,
+            None,
+            "query X { viewer { login } }",
+        )
+        self.assertEqual(query_arguments[2:4], ["--hostname", "github.com"])
+        review.validate_external_command(query_arguments)
         with self.assertRaises(review.CommandPolicyError):
-            review.validate_external_command(["gh", "api", "--method", "POST", "repos/SecPal/.github/issues"])
+            review.validate_external_command(
+                ["gh", "api", "graphql", "-f", "query=query X { viewer { login } }"]
+            )
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(
+                [
+                    "gh",
+                    "api",
+                    "--hostname",
+                    "github.com",
+                    "--method",
+                    "POST",
+                    "repos/SecPal/.github/issues",
+                ]
+            )
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["gh", "pr", "view"])
         for arguments in (
@@ -1011,6 +1121,21 @@ class SecurityAndOutputTests(unittest.TestCase):
         index = arguments.index("after=@/etc/passwd")
         self.assertEqual(arguments[index - 1], "-f")
         review.validate_external_command(arguments)
+
+    def test_command_runner_pins_github_host(self) -> None:
+        arguments = review.graphql_arguments(
+            "SecPal",
+            ".github",
+            1,
+            None,
+            "query X { viewer { login } }",
+        )
+        completed = mock.Mock(returncode=0, stdout="{}", stderr="")
+        with mock.patch.object(review.subprocess, "run", return_value=completed) as run:
+            review.CommandRunner().run(arguments)
+        environment = run.call_args.kwargs["env"]
+        self.assertEqual(environment["GH_HOST"], "github.com")
+        self.assertEqual(run.call_args.args[0][2:4], ["--hostname", "github.com"])
 
     def test_disabled_rule_sources_are_not_called(self) -> None:
         configuration = config()
@@ -1050,8 +1175,11 @@ class SecurityAndOutputTests(unittest.TestCase):
                 review.validate_external_command(["git", command])
 
     def test_git_allowlist_rejects_unexpected_read_subcommand_arguments(self) -> None:
+        review.validate_external_command(["git", "cat-file", "commit", HEAD])
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["git", "show", "--output=/tmp/unexpected", "HEAD"])
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["git", "cat-file", "commit", "HEAD"])
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["git", "status", "--porcelain=v2", "--ignored"])
 

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -10,6 +10,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import stat
 import sys
 import tempfile
@@ -72,6 +73,15 @@ def signature(state: str = "valid", signature_format: str | None = "ssh") -> dic
         "format": signature_format,
         "reason": "valid" if state == "valid" else state,
         "signer": actor(),
+    }
+
+
+def reaction(reaction_id: str = "REACTION_1", content: str = "THUMBS_DOWN") -> dict[str, Any]:
+    return {
+        "id": reaction_id,
+        "content": content,
+        "created_at": "2026-07-19T00:01:00Z",
+        "user": actor("reactor"),
     }
 
 
@@ -390,6 +400,37 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         self.assertEqual(result["raw_review_state"]["reviews"], 1)
         self.assertTrue(result["technical_classification_required"])
 
+    def test_reaction_only_feedback_requires_classification(self) -> None:
+        value = snapshot()
+        value["pull_request"]["reactions"] = [reaction()]
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
+        self.assertEqual(result["raw_review_state"]["reactions"], 1)
+        self.assertTrue(result["technical_classification_required"])
+
+    def test_raw_review_state_counts_reactions_on_every_supported_subject(self) -> None:
+        value = snapshot()
+        value["pull_request"]["reactions"] = [reaction("REACTION_PR")]
+        submitted_review = review_record()
+        submitted_review["reactions"] = [reaction("REACTION_REVIEW")]
+        value["reviews"] = [submitted_review]
+        comment = review_comment()
+        comment["reactions"] = [reaction("REACTION_REVIEW_COMMENT")]
+        value["review_threads"] = [thread(comments=[comment])]
+        value["conversation_comments"] = [
+            {
+                "id": "CONVERSATION_1",
+                "database_id": 12,
+                "author": actor(),
+                "body": "Reaction subject",
+                "url": "https://github.com/SecPal/.github/pull/1#issuecomment-12",
+                "created_at": "2026-07-19T00:00:00Z",
+                "updated_at": "2026-07-19T00:00:00Z",
+                "reactions": [reaction("REACTION_CONVERSATION")],
+            }
+        ]
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
+        self.assertEqual(result["raw_review_state"]["reactions"], 4)
+
     def test_03_resolved_and_unresolved_threads(self) -> None:
         value = snapshot()
         value["review_threads"] = [
@@ -681,6 +722,22 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         with self.assertRaises(review.ContractError):
             review.validate_snapshot(value)
 
+    def test_snapshot_rejects_every_connection_that_exceeds_its_page_capacity(self) -> None:
+        value = finalize_snapshot(snapshot())
+        connections = value["completeness"]["fully_paginated_connections"]
+        for index, item in enumerate(connections):
+            with self.subTest(connection=item["connection"]):
+                candidate = copy.deepcopy(value)
+                candidate["completeness"]["fully_paginated_connections"][index]["items"] = 101
+                candidate = review.attach_digest(candidate)
+                with self.assertRaisesRegex(review.ContractError, "page capacity"):
+                    review.validate_snapshot(candidate)
+
+    def test_snapshot_accepts_an_exact_full_page(self) -> None:
+        value = snapshot()
+        value["pull_request"]["labels"] = [f"label-{index}" for index in range(100)]
+        review.validate_snapshot(finalize_snapshot(value))
+
     def test_snapshot_rejects_commit_evidence_without_the_head_commit(self) -> None:
         value = snapshot()
         value["commits"][0]["oid"] = PARENT
@@ -918,6 +975,15 @@ class SnapshotAndPaginationTests(unittest.TestCase):
     def test_thread_metadata_query_does_not_multiply_nested_connections(self) -> None:
         self.assertNotIn("comments(first:", review.REVIEW_THREADS_QUERY)
         self.assertIn("comments(first:100", review.REVIEW_THREAD_COMMENTS_QUERY)
+
+    def test_all_graphql_page_sizes_match_the_snapshot_capacity_invariant(self) -> None:
+        sizes = {
+            int(size)
+            for name, document in vars(review).items()
+            if name.endswith("_QUERY") and isinstance(document, str)
+            for size in re.findall(r"first:(\d+)", document)
+        }
+        self.assertEqual(sizes, {review.CAPTURE_PAGE_SIZE})
 
     def test_review_and_pull_request_reactions_have_independent_paginated_queries(self) -> None:
         self.assertIn("reactions(first:100)", review.PULL_REQUEST_REVIEWS_QUERY)
@@ -1508,6 +1574,70 @@ class SignatureAndCheckTests(unittest.TestCase):
         value = review.attach_digest(value)
         with self.assertRaisesRegex(review.ContractError, "workflow"):
             review.validate_snapshot(value)
+
+    def test_ruleset_generic_requirement_survives_app_bound_branch_protection(self) -> None:
+        required = review.require_rule_evidence(
+            [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "required_status_checks": [
+                            {"context": "tests", "integration_id": None}
+                        ],
+                        "strict_required_status_checks_policy": True,
+                    },
+                }
+            ],
+            {
+                "strict": True,
+                "contexts": ["tests"],
+                "checks": [{"context": "tests", "app_id": 1}],
+            },
+            config()["check_policy"],
+        )
+        self.assertEqual(
+            required,
+            [
+                {"context": "tests", "integration_id": None},
+                {"context": "tests", "integration_id": 1},
+            ],
+        )
+        checks, evidence = review.evaluate_checks(
+            [
+                check() | {"requiredness": None, "evidence_state": None},
+                {
+                    "stable_id": "status_context:STATUS_1",
+                    "name": "tests",
+                    "application": {
+                        "id": None,
+                        "database_id": None,
+                        "name": "legacy-status",
+                        "slug": "legacy-status",
+                    },
+                    "status": "FAILURE",
+                    "conclusion": "FAILURE",
+                    "details_url": None,
+                },
+            ],
+            required,
+            config()["check_policy"],
+        )
+        self.assertEqual(evidence["missing"], [])
+        states = {item["stable_id"]: item["evidence_state"] for item in checks}
+        self.assertEqual(states["check:1:tests"], "required_successful")
+        self.assertEqual(states["status_context:STATUS_1"], "required_failed")
+
+    def test_branch_protection_app_requirement_still_refines_its_legacy_context(self) -> None:
+        required = review.require_rule_evidence(
+            [],
+            {
+                "strict": True,
+                "contexts": ["tests"],
+                "checks": [{"context": "tests", "app_id": 1}],
+            },
+            config()["check_policy"],
+        )
+        self.assertEqual(required, [{"context": "tests", "integration_id": 1}])
 
     def test_branch_protection_preserves_required_check_with_null_app_id(self) -> None:
         required = review.require_rule_evidence(

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -119,6 +119,7 @@ def review_record(state: str = "COMMENTED", login: str = "reviewer", commit: str
         "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-11",
         "submitted_at": "2026-07-19T00:00:00Z",
         "commit_oid": commit,
+        "reactions": [],
     }
 
 
@@ -205,6 +206,7 @@ def captured_connection_counts(value: dict[str, Any]) -> dict[str, int]:
         "review_requests": len(pull_request["requested_reviewers"])
         + len(pull_request["requested_teams"]),
         "reviews": len(value["reviews"]),
+        "pull_request_reactions": len(pull_request["reactions"]),
         "conversation_comments": len(value["conversation_comments"]),
         "review_threads": len(value["review_threads"]),
         "commits": len(value["commits"]),
@@ -230,6 +232,7 @@ def snapshot() -> dict[str, Any]:
             "number": 1,
             "url": "https://github.com/SecPal/.github/pull/1",
             "title": "Fixture pull request",
+            "body": "Fixture pull request body.",
             "state": "OPEN",
             "is_draft": False,
             "is_merged": False,
@@ -258,6 +261,7 @@ def snapshot() -> dict[str, Any]:
             "labels": [],
             "requested_reviewers": [],
             "requested_teams": [],
+            "reactions": [],
         },
         "reviews": [],
         "conversation_comments": [],
@@ -380,7 +384,10 @@ class SnapshotAndPaginationTests(unittest.TestCase):
 
     def test_03_resolved_and_unresolved_threads(self) -> None:
         value = snapshot()
-        value["review_threads"] = [thread("T1", resolved=True), thread("T2", resolved=False)]
+        value["review_threads"] = [
+            thread("T1", resolved=True),
+            thread("T2", resolved=False, comments=[review_comment("RC_2")]),
+        ]
         value = finalize_snapshot(value)
         result = review.verify_snapshot_gate(value, config())
         self.assertEqual(result["raw_review_state"]["resolved_threads"], 1)
@@ -623,6 +630,12 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         with self.assertRaisesRegex(review.ContractError, "Required-check metadata"):
             review.validate_snapshot(review.attach_digest(value))
 
+    def test_snapshot_rejects_unknown_reasons_for_complete_required_check_evidence(self) -> None:
+        value = snapshot()
+        value["required_check_evidence"]["unknown_reasons"] = ["required checks may be incomplete"]
+        with self.assertRaises(review.ContractError):
+            review.validate_snapshot(review.attach_digest(value))
+
     def test_snapshot_rejects_a_duplicate_check_identity(self) -> None:
         value = snapshot()
         duplicate = copy.deepcopy(value["checks"][0])
@@ -631,6 +644,27 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         duplicate["evidence_state"] = "non_required_successful"
         value["checks"].append(duplicate)
         with self.assertRaisesRegex(review.ContractError, "duplicate check identity"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_duplicate_review_identities(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record(), review_record()]
+        with self.assertRaisesRegex(review.ContractError, "duplicate review identity"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_duplicate_reaction_identities_across_subjects(self) -> None:
+        duplicate = {
+            "id": "REACTION_1",
+            "content": "EYES",
+            "created_at": "2026-07-19T00:01:00Z",
+            "user": actor("reactor"),
+        }
+        value = snapshot()
+        value["pull_request"]["reactions"] = [copy.deepcopy(duplicate)]
+        submitted_review = review_record()
+        submitted_review["reactions"] = [copy.deepcopy(duplicate)]
+        value["reviews"] = [submitted_review]
+        with self.assertRaisesRegex(review.ContractError, "duplicate reaction identity"):
             review.validate_snapshot(finalize_snapshot(value))
 
     def test_snapshot_rejects_check_requiredness_that_disagrees_with_rules(self) -> None:
@@ -792,6 +826,49 @@ class SnapshotAndPaginationTests(unittest.TestCase):
     def test_thread_metadata_query_does_not_multiply_nested_connections(self) -> None:
         self.assertNotIn("comments(first:", review.REVIEW_THREADS_QUERY)
         self.assertIn("comments(first:100", review.REVIEW_THREAD_COMMENTS_QUERY)
+
+    def test_review_and_pull_request_reactions_have_independent_paginated_queries(self) -> None:
+        self.assertIn("reactions(first:100)", review.PULL_REQUEST_REVIEWS_QUERY)
+        self.assertIn("... on PullRequestReview", review.REVIEW_REACTIONS_QUERY)
+        self.assertIn("reactions(first:100", review.REVIEW_REACTIONS_QUERY)
+        self.assertIn("reactions(first:100", review.PULL_REQUEST_REACTIONS_QUERY)
+        self.assertIn("reactions { totalCount }", review.PULL_REQUEST_ANCHOR_QUERY)
+
+    def test_review_normalization_retains_summary_reactions(self) -> None:
+        value = {
+            "id": "REVIEW_1",
+            "databaseId": 11,
+            "author": {
+                "__typename": "User",
+                "id": "USER_1",
+                "databaseId": 1,
+                "login": "reviewer",
+                "url": "https://github.com/reviewer",
+            },
+            "state": "COMMENTED",
+            "body": "Summary",
+            "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-11",
+            "submittedAt": "2026-07-19T00:00:00Z",
+            "commit": {"oid": HEAD},
+            "reactions": {
+                "nodes": [
+                    {
+                        "id": "REACTION_1",
+                        "content": "EYES",
+                        "createdAt": "2026-07-19T00:01:00Z",
+                        "user": {
+                            "__typename": "User",
+                            "id": "USER_2",
+                            "databaseId": 2,
+                            "login": "reactor",
+                            "url": "https://github.com/reactor",
+                        },
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            },
+        }
+        self.assertEqual(review._normalize_review(value)["reactions"][0]["content"], "EYES")
 
     def test_11_unequal_connection_page_counts_do_not_refetch(self) -> None:
         calls: dict[str, list[str | None]] = {"reviews": [], "comments": []}
@@ -961,7 +1038,15 @@ class LocalGitTests(unittest.TestCase):
 
     def test_anchor_query_captures_review_update_sentinels(self) -> None:
         self.assertIn("updatedAt", review.PULL_REQUEST_ANCHOR_QUERY)
-        for connection in ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits"):
+        for connection in (
+            "labels",
+            "reviewRequests",
+            "reviews",
+            "comments",
+            "reviewThreads",
+            "commits",
+            "reactions",
+        ):
             with self.subTest(connection=connection):
                 self.assertIn(f"{connection} {{ totalCount }}", review.PULL_REQUEST_ANCHOR_QUERY)
 
@@ -1008,7 +1093,15 @@ class LocalGitTests(unittest.TestCase):
         )["graphql"]["PullRequestAnchor"]["null"]
         pull_request = fixture["data"]["repository"]["pullRequest"]
         pull_request["updatedAt"] = "2026-07-19T00:00:00Z"
-        for connection in ("labels", "reviewRequests", "reviews", "comments", "reviewThreads", "commits"):
+        for connection in (
+            "labels",
+            "reviewRequests",
+            "reviews",
+            "comments",
+            "reviewThreads",
+            "commits",
+            "reactions",
+        ):
             pull_request[connection] = {"totalCount": 0}
         before = review.extract_anchor(copy.deepcopy(fixture))
         changed = copy.deepcopy(fixture)
@@ -1490,7 +1583,37 @@ class SecurityAndOutputTests(unittest.TestCase):
             review.CommandRunner().run(arguments)
         environment = run.call_args.kwargs["env"]
         self.assertEqual(environment["GH_HOST"], "github.com")
+        self.assertEqual(environment["PATH"], review.TRUSTED_COMMAND_PATH)
+        self.assertTrue(Path(run.call_args.args[0][0]).is_absolute())
         self.assertEqual(run.call_args.args[0][2:4], ["--hostname", "github.com"])
+
+    def test_command_runner_does_not_resolve_allowlisted_tools_from_inherited_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "shim-ran"
+            shim = root / "git"
+            shim.write_text(
+                "#!/bin/sh\n"
+                f": > {str(marker)!r}\n"
+                f"printf '%s\\n' {HEAD!r}\n",
+                encoding="utf-8",
+            )
+            shim.chmod(0o700)
+            inherited_path = f"{root}{os.pathsep}{os.environ.get('PATH', '')}"
+            with mock.patch.dict(review.os.environ, {"PATH": inherited_path}):
+                review.CommandRunner().run(["git", "rev-parse", "HEAD"], allow_failure=True)
+            self.assertFalse(marker.exists())
+
+    def test_command_runner_bounds_execution_and_closes_stdin(self) -> None:
+        expired = review.subprocess.TimeoutExpired(["git", "rev-parse", "HEAD"], 1)
+        with mock.patch.object(review.subprocess, "run", side_effect=expired) as run:
+            with self.assertRaises(review.CommandFailure):
+                review.CommandRunner().run(["git", "rev-parse", "HEAD"])
+        self.assertEqual(run.call_args.kwargs["stdin"], review.subprocess.DEVNULL)
+        self.assertEqual(
+            run.call_args.kwargs["timeout"],
+            review.DEFAULT_EXTERNAL_COMMAND_TIMEOUT_SECONDS,
+        )
 
     def test_command_runner_sanitizes_git_repository_and_object_overrides(self) -> None:
         repository_overrides = {

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import importlib.util
+import io
 import json
 import os
 import stat
@@ -552,6 +553,48 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         result = review.verify_snapshot_gate(value, config())
         self.assertIn(review.BLOCKED_INCOMPLETE, [item["code"] for item in result["blockers"]])
 
+    def test_gate_preserves_report_when_current_branch_protection_evidence_is_absent(self) -> None:
+        value = snapshot()
+        value["required_check_evidence"]["sources"] = ["rulesets"]
+        value["applicable_rules"]["branch_protection"] = {
+            "strict": None,
+            "contexts": [],
+            "checks": [],
+        }
+        value = finalize_snapshot(value)
+
+        result = review.verify_snapshot_gate(value, config())
+
+        self.assertEqual(result["snapshot_digest"], value["snapshot_digest"])
+        self.assertIn(review.BLOCKED_INCOMPLETE, [item["code"] for item in result["blockers"]])
+
+    def test_gate_enforces_all_current_capture_caps(self) -> None:
+        value = snapshot()
+        comment = review_comment()
+        comment["reactions"] = [
+            {
+                "id": "REACTION_CAP",
+                "content": "EYES",
+                "created_at": "2026-07-19T00:01:00Z",
+                "user": actor("reactor"),
+            }
+        ]
+        value["review_threads"] = [thread(comments=[comment])]
+        value = finalize_snapshot(value)
+        for cap in (
+            "maximum_api_calls",
+            "maximum_items",
+            "maximum_threads",
+            "maximum_comments",
+            "maximum_reactions",
+        ):
+            with self.subTest(cap=cap):
+                configuration = config()
+                configuration[cap] = 1
+                result = review.verify_snapshot_gate(value, configuration)
+                blockers = [item for item in result["blockers"] if item["code"] == review.BLOCKED_INCOMPLETE]
+                self.assertTrue(any(cap in item["reason"] for item in blockers), blockers)
+
     def test_gate_accepts_intentionally_disabled_rule_sources(self) -> None:
         value = snapshot()
         value["required_check_evidence"] = {
@@ -574,6 +617,48 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         configuration["check_policy"]["require_branch_protection_evidence"] = False
         result = review.verify_snapshot_gate(value, configuration)
         self.assertEqual(result["blockers"], [])
+
+    def test_gate_source_policy_transition_matrix_is_fail_closed_without_exceptions(self) -> None:
+        source_names = {"rulesets", "branch_protection"}
+        source_sets = (
+            set(),
+            {"rulesets"},
+            {"branch_protection"},
+            source_names,
+        )
+        for captured_sources in source_sets:
+            value = snapshot()
+            value["required_check_evidence"]["sources"] = sorted(captured_sources)
+            if "rulesets" not in captured_sources:
+                value["applicable_rules"]["rulesets"] = []
+            if "branch_protection" not in captured_sources:
+                value["applicable_rules"]["branch_protection"] = {
+                    "strict": None,
+                    "contexts": [],
+                    "checks": [],
+                }
+            if not captured_sources:
+                value["required_check_evidence"]["required"] = []
+                value["checks"][0]["requiredness"] = "non_required"
+                value["checks"][0]["evidence_state"] = "non_required_successful"
+            value = finalize_snapshot(value)
+            for required_sources in source_sets:
+                with self.subTest(
+                    captured=sorted(captured_sources),
+                    required=sorted(required_sources),
+                ):
+                    configuration = config()
+                    configuration["check_policy"]["require_ruleset_evidence"] = (
+                        "rulesets" in required_sources
+                    )
+                    configuration["check_policy"]["require_branch_protection_evidence"] = (
+                        "branch_protection" in required_sources
+                    )
+                    result = review.verify_snapshot_gate(value, configuration)
+                    incomplete = review.BLOCKED_INCOMPLETE in {
+                        item["code"] for item in result["blockers"]
+                    }
+                    self.assertEqual(incomplete, bool(required_sources - captured_sources))
 
     def test_snapshot_rejects_mismatched_connection_item_count(self) -> None:
         value = snapshot()
@@ -1432,6 +1517,39 @@ class SignatureAndCheckTests(unittest.TestCase):
 
 
 class SecurityAndOutputTests(unittest.TestCase):
+    def test_non_object_json_roots_return_structured_invalid_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, value in enumerate(([], None, "configuration", 1, True)):
+                with self.subTest(config=value):
+                    config_path = root / f"config-{index}.json"
+                    config_path.write_text(json.dumps(value), encoding="utf-8")
+                    stderr = io.StringIO()
+                    with contextlib.redirect_stderr(stderr):
+                        exit_code = review.main(
+                            [
+                                "snapshot",
+                                "--repo",
+                                "SecPal/.github",
+                                "--pr",
+                                "1",
+                                "--config",
+                                str(config_path),
+                            ]
+                        )
+                    self.assertEqual(exit_code, 2)
+                    self.assertEqual(
+                        json.loads(stderr.getvalue())["status"],
+                        "INVALID_OR_UNSAFE_INPUT",
+                    )
+            snapshot_path = root / "snapshot.json"
+            snapshot_path.write_text("[]\n", encoding="utf-8")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                exit_code = review.main(["verify-gate", "--snapshot", str(snapshot_path)])
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(json.loads(stderr.getvalue())["status"], "INVALID_OR_UNSAFE_INPUT")
+
     def test_46_hostile_markdown_is_escaped(self) -> None:
         self.assertNotIn("<script>", review.escape_markdown("<script>alert(1)</script>"))
 

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -399,6 +399,44 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         result = review.verify_snapshot_gate(review.attach_digest(value), config())
         self.assertNotIn("BLOCKED_HEAD_BEHIND_BASE", [item["code"] for item in result["blockers"]])
 
+    def test_unsafe_merge_states_block_the_gate(self) -> None:
+        for merge_state in ("DIRTY", "UNKNOWN", "BLOCKED", "DRAFT"):
+            with self.subTest(merge_state=merge_state):
+                value = snapshot()
+                value["pull_request"]["merge_state_status"] = merge_state
+                result = review.verify_snapshot_gate(review.attach_digest(value), config())
+                self.assertIn(
+                    "BLOCKED_UNSAFE_GITHUB_STATE",
+                    [item["code"] for item in result["blockers"]],
+                )
+
+    def test_merge_states_delegated_to_granular_checks_do_not_add_a_state_blocker(self) -> None:
+        for merge_state in ("CLEAN", "HAS_HOOKS", "UNSTABLE"):
+            with self.subTest(merge_state=merge_state):
+                value = snapshot()
+                value["pull_request"]["merge_state_status"] = merge_state
+                result = review.verify_snapshot_gate(review.attach_digest(value), config())
+                self.assertNotIn(
+                    "BLOCKED_UNSAFE_GITHUB_STATE",
+                    [item["code"] for item in result["blockers"]],
+                )
+
+    def test_merge_state_policy_covers_the_authoritative_enum(self) -> None:
+        self.assertEqual(
+            review.MERGE_STATE_POLICY,
+            {
+                "DIRTY": "block",
+                "UNKNOWN": "block",
+                "BLOCKED": "block",
+                "BEHIND": "strict_base",
+                "DRAFT": "block",
+                "UNSTABLE": "required_checks",
+                "HAS_HOOKS": "allow",
+                "CLEAN": "allow",
+            },
+        )
+        self.assertEqual(review.MERGE_STATE_STATUSES, set(review.MERGE_STATE_POLICY))
+
     def test_strict_policy_without_required_checks_does_not_require_current_base(self) -> None:
         value = snapshot()
         value["applicable_rules"]["rulesets"][0]["required_checks"] = []
@@ -501,6 +539,20 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         value = review.attach_digest(value)
         with self.assertRaises(review.ContractError):
             review.validate_snapshot(value)
+
+    def test_snapshot_rejects_commit_evidence_without_the_head_commit(self) -> None:
+        value = snapshot()
+        value["commits"][0]["oid"] = PARENT
+        with self.assertRaisesRegex(review.ContractError, "head commit"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_duplicate_commit_oids(self) -> None:
+        value = snapshot()
+        duplicate = copy.deepcopy(value["commits"][0])
+        duplicate["oid"] = duplicate["oid"].upper()
+        value["commits"].append(duplicate)
+        with self.assertRaisesRegex(review.ContractError, "duplicate commit OID"):
+            review.validate_snapshot(finalize_snapshot(value))
 
     def test_07_copilot_and_codex_are_distinct_configured_identities(self) -> None:
         identities = review.index_reviewer_identities(config())
@@ -677,7 +729,8 @@ class LocalGitTests(unittest.TestCase):
         value = snapshot()
         value["pull_request"]["head_oid_before"] = "d" * 40
         value["pull_request"]["head_oid_after"] = "d" * 40
-        value = review.attach_digest(value)
+        value["commits"][0]["oid"] = "d" * 40
+        value = finalize_snapshot(value)
         self.assert_blocker(review.verify_local_against_snapshot(value, config(), FakeGitRunner(), None), "BLOCKED_HEAD_MOVED")
 
     def test_28_pr_head_mismatch(self) -> None:
@@ -1136,6 +1189,58 @@ class SecurityAndOutputTests(unittest.TestCase):
         environment = run.call_args.kwargs["env"]
         self.assertEqual(environment["GH_HOST"], "github.com")
         self.assertEqual(run.call_args.args[0][2:4], ["--hostname", "github.com"])
+
+    def test_command_runner_sanitizes_git_repository_and_object_overrides(self) -> None:
+        repository_overrides = {
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_CEILING_DIRECTORIES",
+            "GIT_COMMON_DIR",
+            "GIT_CONFIG",
+            "GIT_CONFIG_COUNT",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_NOSYSTEM",
+            "GIT_CONFIG_PARAMETERS",
+            "GIT_CONFIG_SYSTEM",
+            "GIT_DIR",
+            "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+            "GIT_EXEC_PATH",
+            "GIT_GRAFT_FILE",
+            "GIT_IMPLICIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_NAMESPACE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_PREFIX",
+            "GIT_REPLACE_REF_BASE",
+            "GIT_SHALLOW_FILE",
+            "GIT_WORK_TREE",
+        }
+        poisoned_environment = {key: f"hostile-{key.lower()}" for key in repository_overrides}
+        poisoned_environment |= {
+            "GIT_CONFIG_KEY_0": "core.sshCommand",
+            "GIT_CONFIG_VALUE_0": "hostile-command",
+            "GIT_NO_REPLACE_OBJECTS": "0",
+            "GIT_OPTIONAL_LOCKS": "1",
+            "GIT_TRACE": "/tmp/hostile-trace",
+            "GIT_TRACE2_EVENT": "/tmp/hostile-trace2",
+        }
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.dict(review.os.environ, poisoned_environment, clear=True), mock.patch.object(
+            review.subprocess, "run", return_value=completed
+        ) as run:
+            review.CommandRunner().run(["git", "status", "--porcelain=v2", "--untracked-files=all"])
+
+        environment = run.call_args.kwargs["env"]
+        inherited_overrides = repository_overrides | {
+            "GIT_CONFIG_KEY_0",
+            "GIT_CONFIG_VALUE_0",
+            "GIT_TRACE",
+            "GIT_TRACE2_EVENT",
+        }
+        self.assertEqual(sorted(inherited_overrides & environment.keys()), [])
+        self.assertEqual(environment["GIT_NO_REPLACE_OBJECTS"], "1")
+        self.assertEqual(environment["GIT_OPTIONAL_LOCKS"], "0")
+        self.assertEqual(environment["GIT_NO_LAZY_FETCH"], "1")
 
     def test_disabled_rule_sources_are_not_called(self) -> None:
         configuration = config()

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -7,14 +7,13 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
-import os
 import stat
 import sys
 import tempfile
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 from typing import Any
-from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -589,6 +589,18 @@ class SignatureAndCheckTests(unittest.TestCase):
         with self.assertRaises(review.BlockedError):
             review.require_rule_evidence(None, {}, config()["check_policy"])
 
+    def test_branch_protection_preserves_required_check_with_null_app_id(self) -> None:
+        required = review.require_rule_evidence(
+            [],
+            {
+                "strict": True,
+                "contexts": ["tests"],
+                "checks": [{"context": "tests", "app_id": None}],
+            },
+            config()["check_policy"],
+        )
+        self.assertEqual(required, [{"context": "tests", "integration_id": None}])
+
 
 class SecurityAndOutputTests(unittest.TestCase):
     def test_46_hostile_markdown_is_escaped(self) -> None:

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -9,6 +9,7 @@ import importlib.util
 import json
 import os
 import stat
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -22,6 +23,7 @@ SPEC = importlib.util.spec_from_file_location("secpal_pr_review", HELPER)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"Cannot load helper at {HELPER}")
 review = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = review
 SPEC.loader.exec_module(review)
 
 HEAD = "a" * 40
@@ -280,6 +282,9 @@ class FakeGitRunner:
             ): review.CommandResult(0, "origin/feat/test\n", ""),
             ("git", "rev-parse", "HEAD"): review.CommandResult(0, f"{HEAD}\n", ""),
             ("git", "rev-parse", "@{upstream}"): review.CommandResult(0, f"{HEAD}\n", ""),
+            ("git", "rev-list", "--reverse", f"{'b' * 40}..{HEAD}"): review.CommandResult(
+                0, f"{HEAD}\n", ""
+            ),
             ("git", "cat-file", "-e", f"{HEAD}^{{commit}}"): review.CommandResult(0, "", ""),
             ("git", "verify-commit", "--raw", HEAD): review.CommandResult(
                 0, "", 'Good "git" signature for aroviqen with ED25519 key SHA256:test\n'
@@ -340,7 +345,10 @@ class SnapshotAndPaginationTests(unittest.TestCase):
 
     def test_08_multiple_review_submissions_keep_commit_oids(self) -> None:
         value = snapshot()
-        value["reviews"] = [review_record(commit=PARENT), review_record(commit=HEAD)]
+        first = review_record(commit=PARENT)
+        second = review_record(commit=HEAD)
+        second["submitted_at"] = "2026-07-19T00:01:00Z"
+        value["reviews"] = [first, second]
         normalized = review.normalize_snapshot(value)
         self.assertEqual([item["commit_oid"] for item in normalized["reviews"]], [PARENT, HEAD])
 
@@ -500,6 +508,12 @@ class LocalGitTests(unittest.TestCase):
         runner.set(["git", "cat-file", "-e", f"{HEAD}^{{commit}}"], 1, stderr="missing")
         result = review.verify_local_against_snapshot(snapshot(), config(), runner, None)
         self.assertEqual(result["commit_signatures"][0]["state"], "object_unavailable")
+
+    def test_local_commit_set_must_match_pr(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "rev-list", "--reverse", f"{'b' * 40}..{HEAD}"], 0, "")
+        result = review.verify_local_against_snapshot(snapshot(), config(), runner, None)
+        self.assert_blocker(result, "BLOCKED_UNEXPLAINED_COMMIT")
 
 
 class SignatureAndCheckTests(unittest.TestCase):
@@ -671,6 +685,12 @@ class SecurityAndOutputTests(unittest.TestCase):
             with self.subTest(command=command), self.assertRaises(review.CommandPolicyError):
                 review.validate_external_command(["git", command])
 
+    def test_git_allowlist_rejects_unexpected_read_subcommand_arguments(self) -> None:
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["git", "show", "--output=/tmp/unexpected", "HEAD"])
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["git", "status", "--porcelain=v2", "--ignored"])
+
     def test_59_review_request_operations_are_rejected(self) -> None:
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["gh", "pr", "review", "1"])
@@ -688,6 +708,14 @@ class SecurityAndOutputTests(unittest.TestCase):
         with self.assertRaises(review.ContractError):
             review.validate_config(broken)
 
+    def test_nested_snapshot_schema_is_enforced(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record()]
+        value["reviews"][0]["unexpected"] = True
+        value = review.attach_digest(value)
+        with self.assertRaises(review.ContractError):
+            review.validate_snapshot(value)
+
     def test_digest_excludes_only_digest_field(self) -> None:
         value = snapshot()
         digest = value["snapshot_digest"]
@@ -704,6 +732,7 @@ class SecurityAndOutputTests(unittest.TestCase):
 
     def test_unvalidated_non_github_url_is_not_a_link(self) -> None:
         self.assertFalse(review.trusted_github_url("https://evil.example/SecPal/.github"))
+        self.assertFalse(review.trusted_github_url("https://github.com:invalid/path"))
         self.assertTrue(review.trusted_github_url("https://github.com/SecPal/.github/pull/1"))
 
 

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -31,6 +31,7 @@ SPEC.loader.exec_module(review)
 HEAD = "a" * 40
 BASE = "b" * 40
 PARENT = "c" * 40
+MERGE = "d" * 40
 
 
 def uncontrolled_git_test_environment() -> dict[str, str]:
@@ -90,7 +91,6 @@ def config() -> dict[str, Any]:
                 "database_ids": [],
             },
         ],
-        "required_local_validation": [{"name": "unit", "command": ["python3", "-m", "unittest"]}],
         "signature_policy": {
             "require_github_verified": True,
             "require_local_verified": True,
@@ -161,7 +161,9 @@ def thread(
 
 
 def check(
-    name: str = "tests", status: str = "COMPLETED", conclusion: str | None = "SUCCESS"
+    name: str = "tests",
+    status: str = "COMPLETED",
+    conclusion: str | None = "SUCCESS",
 ) -> dict[str, Any]:
     return {
         "stable_id": f"check:1:{name}",
@@ -250,6 +252,9 @@ def snapshot() -> dict[str, Any]:
             "head_ref": "feat/test",
             "head_oid_before": HEAD,
             "head_oid_after": HEAD,
+            "potential_merge_commit_oid": MERGE,
+            "check_commit_oid": HEAD,
+            "check_commit_source": "head",
             "labels": [],
             "requested_reviewers": [],
             "requested_teams": [],
@@ -549,6 +554,8 @@ class SnapshotAndPaginationTests(unittest.TestCase):
             "sources": [],
             "unknown_reasons": [],
         }
+        value["checks"][0]["requiredness"] = "non_required"
+        value["checks"][0]["evidence_state"] = "non_required_successful"
         value["applicable_rules"] = {
             "rulesets": [],
             "branch_protection": {"strict": None, "contexts": [], "checks": []},
@@ -580,6 +587,76 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         value["commits"][0]["oid"] = PARENT
         with self.assertRaisesRegex(review.ContractError, "head commit"):
             review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_checks_bound_to_the_wrong_commit(self) -> None:
+        value = snapshot()
+        value["pull_request"]["check_commit_oid"] = MERGE
+        with self.assertRaisesRegex(review.ContractError, "wrong commit"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_an_indeterminate_open_mergeable_check_target(self) -> None:
+        value = snapshot()
+        value["pull_request"]["potential_merge_commit_oid"] = None
+        with self.assertRaisesRegex(review.ContractError, "Potential merge commit"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_accepts_nonempty_checks_bound_to_the_test_merge_commit(self) -> None:
+        value = snapshot()
+        value["pull_request"]["potential_merge_commit_oid"] = MERGE
+        value["pull_request"]["check_commit_oid"] = MERGE
+        value["pull_request"]["check_commit_source"] = "test_merge"
+        review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_an_empty_test_merge_check_selection(self) -> None:
+        value = snapshot()
+        value["pull_request"]["potential_merge_commit_oid"] = MERGE
+        value["pull_request"]["check_commit_oid"] = MERGE
+        value["pull_request"]["check_commit_source"] = "test_merge"
+        value["checks"] = []
+        value["required_check_evidence"]["missing"] = ["check:1:tests"]
+        with self.assertRaisesRegex(review.ContractError, "cannot be empty"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_required_check_metadata_that_disagrees_with_rules(self) -> None:
+        value = snapshot()
+        value["required_check_evidence"]["required"] = []
+        with self.assertRaisesRegex(review.ContractError, "Required-check metadata"):
+            review.validate_snapshot(review.attach_digest(value))
+
+    def test_snapshot_rejects_a_duplicate_check_identity(self) -> None:
+        value = snapshot()
+        duplicate = copy.deepcopy(value["checks"][0])
+        duplicate["name"] = "another-name"
+        duplicate["requiredness"] = "non_required"
+        duplicate["evidence_state"] = "non_required_successful"
+        value["checks"].append(duplicate)
+        with self.assertRaisesRegex(review.ContractError, "duplicate check identity"):
+            review.validate_snapshot(finalize_snapshot(value))
+
+    def test_snapshot_rejects_check_requiredness_that_disagrees_with_rules(self) -> None:
+        value = snapshot()
+        value["checks"][0]["requiredness"] = "non_required"
+        value["checks"][0]["evidence_state"] = "non_required_successful"
+        with self.assertRaisesRegex(review.ContractError, "requiredness"):
+            review.validate_snapshot(review.attach_digest(value))
+
+    def test_snapshot_rejects_repository_identity_components_that_disagree(self) -> None:
+        value = snapshot()
+        value["repository"]["owner"] = "Other"
+        with self.assertRaisesRegex(review.ContractError, "repository identity"):
+            review.validate_snapshot(review.attach_digest(value))
+
+    def test_snapshot_rejects_a_base_repository_unrelated_to_the_queried_repository(self) -> None:
+        value = snapshot()
+        value["pull_request"]["base_repository"]["name_with_owner"] = "SecPal/other"
+        with self.assertRaisesRegex(review.ContractError, "base repository"):
+            review.validate_snapshot(review.attach_digest(value))
+
+    def test_snapshot_rejects_inconsistent_merged_state(self) -> None:
+        value = snapshot()
+        value["pull_request"]["state"] = "MERGED"
+        with self.assertRaisesRegex(review.ContractError, "merged state"):
+            review.validate_snapshot(review.attach_digest(value))
 
     def test_snapshot_rejects_duplicate_commit_oids(self) -> None:
         value = snapshot()
@@ -625,7 +702,7 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         self.assertEqual(expected["reviews.revalidation"], 0)
         self.assertEqual(expected["commits.revalidation"], 1)
         self.assertEqual(expected[f"commit.{HEAD}.parents.revalidation"], 1)
-        self.assertEqual(expected["checks.revalidation"], 1)
+        self.assertEqual(expected["head_checks.revalidation"], 1)
         self.assertEqual(expected["rulesets.revalidation"], 1)
         self.assertEqual(expected["branch_protection.revalidation"], 1)
         self.assertEqual(expected["review_threads.revalidation"], 1)
@@ -856,6 +933,7 @@ class LocalGitTests(unittest.TestCase):
         value = snapshot()
         value["pull_request"]["head_oid_before"] = "d" * 40
         value["pull_request"]["head_oid_after"] = "d" * 40
+        value["pull_request"]["check_commit_oid"] = "d" * 40
         value["commits"][0]["oid"] = "d" * 40
         value = finalize_snapshot(value)
         self.assert_blocker(review.verify_local_against_snapshot(value, config(), FakeGitRunner(), None), "BLOCKED_HEAD_MOVED")
@@ -887,6 +965,43 @@ class LocalGitTests(unittest.TestCase):
             with self.subTest(connection=connection):
                 self.assertIn(f"{connection} {{ totalCount }}", review.PULL_REQUEST_ANCHOR_QUERY)
 
+    def test_anchor_captures_the_potential_test_merge_commit(self) -> None:
+        self.assertIn("potentialMergeCommit { oid }", review.PULL_REQUEST_ANCHOR_QUERY)
+
+    def test_test_merge_checks_take_precedence_when_present(self) -> None:
+        self.assertEqual(
+            review.select_effective_check_target(HEAD, MERGE, [check()]),
+            (MERGE, "test_merge"),
+        )
+        self.assertEqual(
+            review.select_effective_check_target(HEAD, MERGE, []),
+            (HEAD, "head"),
+        )
+
+    def test_effective_check_capture_falls_back_to_head_only_for_an_empty_test_merge(self) -> None:
+        client = object()
+        with mock.patch.object(
+            review,
+            "_capture_checks",
+            side_effect=[[], [check()]],
+        ) as capture:
+            checks, oid, source = review._capture_effective_checks(client, HEAD, MERGE)
+        self.assertEqual((checks, oid, source), ([check()], HEAD, "head"))
+        self.assertEqual(
+            capture.call_args_list,
+            [
+                mock.call(client, MERGE, "test_merge_checks"),
+                mock.call(client, HEAD, "head_checks"),
+            ],
+        )
+
+    def test_effective_check_capture_does_not_mix_head_and_test_merge_contexts(self) -> None:
+        client = object()
+        with mock.patch.object(review, "_capture_checks", return_value=[check()]) as capture:
+            checks, oid, source = review._capture_effective_checks(client, HEAD, MERGE)
+        self.assertEqual((checks, oid, source), ([check()], MERGE, "test_merge"))
+        capture.assert_called_once_with(client, MERGE, "test_merge_checks")
+
     def test_anchor_requires_review_update_sentinels(self) -> None:
         fixture = json.loads(
             (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
@@ -905,6 +1020,34 @@ class LocalGitTests(unittest.TestCase):
         del fixture["data"]["repository"]["pullRequest"]["updatedAt"]
         with self.assertRaises(review.BlockedError):
             review.extract_anchor(fixture)
+
+    def test_anchor_requires_well_formed_potential_merge_commit_evidence(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        del fixture["data"]["repository"]["pullRequest"]["potentialMergeCommit"]
+        with self.assertRaisesRegex(review.BlockedError, "Potential merge commit"):
+            review.extract_anchor(fixture)
+
+    def test_anchor_blocks_when_test_merge_generation_is_still_indeterminate(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        pull_request = fixture["data"]["repository"]["pullRequest"]
+        pull_request["mergeable"] = "UNKNOWN"
+        pull_request["potentialMergeCommit"] = None
+        with self.assertRaisesRegex(review.BlockedError, "still being generated"):
+            review.extract_anchor(fixture)
+
+    def test_conflicting_anchor_can_have_no_potential_merge_commit(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        pull_request = fixture["data"]["repository"]["pullRequest"]
+        pull_request["mergeable"] = "CONFLICTING"
+        pull_request["mergeStateStatus"] = "DIRTY"
+        pull_request["potentialMergeCommit"] = None
+        self.assertIsNone(review.extract_anchor(fixture)["pull_request"]["potentialMergeCommit"])
 
     def test_anchor_counts_must_match_captured_collections(self) -> None:
         fixture = json.loads(
@@ -1065,7 +1208,7 @@ class SignatureAndCheckTests(unittest.TestCase):
         self.assertEqual(checks[0]["evidence_state"], "required_missing")
         self.assertEqual(evidence["missing"], ["check:1:tests"])
 
-    def test_app_check_satisfies_generic_and_exact_requirements(self) -> None:
+    def test_generic_requirement_is_satisfied_by_the_only_present_context_kind(self) -> None:
         raw = [check() | {"requiredness": None, "evidence_state": None}]
         _, evidence = review.evaluate_checks(
             raw,
@@ -1076,6 +1219,38 @@ class SignatureAndCheckTests(unittest.TestCase):
             config()["check_policy"],
         )
         self.assertEqual(evidence["missing"], [])
+
+    def test_same_named_check_and_status_are_both_evaluated_as_required(self) -> None:
+        raw = [
+            check() | {"requiredness": None, "evidence_state": None},
+            {
+                "stable_id": "status_context:STATUS_1",
+                "name": "tests",
+                "application": {
+                    "id": None,
+                    "database_id": None,
+                    "name": "legacy-status",
+                    "slug": "legacy-status",
+                },
+                "status": "FAILURE",
+                "conclusion": "FAILURE",
+                "details_url": None,
+            },
+        ]
+        checks, evidence = review.evaluate_checks(
+            raw,
+            [{"context": "tests", "integration_id": None}],
+            config()["check_policy"],
+        )
+        self.assertEqual(evidence["missing"], [])
+        states = {item["stable_id"]: item["evidence_state"] for item in checks}
+        self.assertEqual(
+            states,
+            {
+                "check:1:tests": "required_successful",
+                "status_context:STATUS_1": "required_failed",
+            },
+        )
 
     def test_status_creator_id_does_not_satisfy_app_requirement(self) -> None:
         raw = review._normalize_check(
@@ -1567,6 +1742,14 @@ class SecurityAndOutputTests(unittest.TestCase):
         broken["reviewer_identities"][0]["canonical_identity"] = ""
         with self.assertRaises(review.ContractError):
             review.validate_config(broken)
+
+    def test_unenforced_local_validation_commands_are_rejected(self) -> None:
+        candidate = config()
+        candidate.setdefault("required_local_validation", []).append(
+            {"name": "must-run", "command": ["false"]}
+        )
+        with self.assertRaisesRegex(review.ContractError, "required_local_validation"):
+            review.validate_config(candidate)
 
     def test_nested_snapshot_schema_is_enforced(self) -> None:
         value = snapshot()

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "scripts" / "secpal-pr-review.py"
+SPEC = importlib.util.spec_from_file_location("secpal_pr_review", HELPER)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load helper at {HELPER}")
+review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(review)
+
+HEAD = "a" * 40
+BASE = "b" * 40
+PARENT = "c" * 40
+
+
+def actor(login: str | None = "reviewer", kind: str = "user") -> dict[str, Any]:
+    if login is None:
+        kind = "deleted_or_unavailable"
+    return {
+        "kind": kind,
+        "login": login,
+        "database_id": 7 if login else None,
+        "node_id": f"ACTOR_{login}" if login else None,
+        "url": f"https://github.com/{login}" if login else None,
+    }
+
+
+def signature(state: str = "valid", signature_format: str | None = "ssh") -> dict[str, Any]:
+    return {
+        "state": state,
+        "verified": state == "valid",
+        "format": signature_format,
+        "reason": "valid" if state == "valid" else state,
+        "signer": actor(),
+    }
+
+
+def config() -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "repository": "SecPal/.github",
+        "default_branch": "main",
+        "allowed_base_repositories": ["SecPal/.github"],
+        "reviewer_identities": [
+            {
+                "canonical_identity": "copilot",
+                "kind": "bot",
+                "graphql_aliases": ["copilot-pull-request-reviewer"],
+                "rest_event_aliases": ["copilot-pull-request-reviewer[bot]"],
+                "node_ids": [],
+                "database_ids": [],
+            },
+            {
+                "canonical_identity": "codex",
+                "kind": "bot",
+                "graphql_aliases": ["chatgpt-codex-connector"],
+                "rest_event_aliases": ["chatgpt-codex-connector[bot]"],
+                "node_ids": [],
+                "database_ids": [],
+            },
+        ],
+        "required_local_validation": [{"name": "unit", "command": ["python3", "-m", "unittest"]}],
+        "signature_policy": {
+            "require_github_verified": True,
+            "require_local_verified": True,
+            "accepted_formats": ["ssh", "openpgp"],
+        },
+        "check_policy": {
+            "require_ruleset_evidence": True,
+            "require_branch_protection_evidence": True,
+            "expected_skipped": "block",
+        },
+        "maximum_api_calls": 200,
+        "maximum_items": 10000,
+        "maximum_threads": 500,
+        "maximum_comments": 10000,
+        "maximum_reactions": 10000,
+    }
+
+
+def review_record(state: str = "COMMENTED", login: str = "reviewer", commit: str = HEAD) -> dict[str, Any]:
+    return {
+        "id": f"REVIEW_{state}_{login}_{commit[:4]}",
+        "database_id": 11,
+        "author": actor(login, "bot" if login != "reviewer" else "user"),
+        "state": state,
+        "body": "Informational review.",
+        "url": "https://github.com/SecPal/.github/pull/1#pullrequestreview-11",
+        "submitted_at": "2026-07-19T00:00:00Z",
+        "commit_oid": commit,
+    }
+
+
+def review_comment(
+    comment_id: str = "RC_1", login: str = "reviewer", body: str = "Finding"
+) -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "database_id": 21,
+        "author": actor(login, "bot" if login != "reviewer" else "user"),
+        "body": body,
+        "url": f"https://github.com/SecPal/.github/pull/1#discussion_r{comment_id[-1]}",
+        "created_at": "2026-07-19T00:00:00Z",
+        "updated_at": "2026-07-19T00:00:00Z",
+        "reply_to_id": None,
+        "review_id": "REVIEW_1",
+        "reactions": [],
+    }
+
+
+def thread(
+    thread_id: str = "THREAD_1",
+    *,
+    resolved: bool = False,
+    outdated: bool = False,
+    comments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": thread_id,
+        "is_resolved": resolved,
+        "is_outdated": outdated,
+        "path": "scripts/example.py",
+        "line": 7,
+        "original_line": 7,
+        "side": "RIGHT",
+        "start_line": None,
+        "start_side": None,
+        "comments": comments or [review_comment()],
+    }
+
+
+def check(
+    name: str = "tests", status: str = "COMPLETED", conclusion: str | None = "SUCCESS"
+) -> dict[str, Any]:
+    return {
+        "stable_id": f"check:1:{name}",
+        "name": name,
+        "application": {"id": "APP_1", "database_id": 1, "name": "Actions", "slug": "github-actions"},
+        "status": status,
+        "conclusion": conclusion,
+        "requiredness": "required",
+        "evidence_state": "required_successful",
+        "details_url": "https://github.com/SecPal/.github/actions/runs/1",
+    }
+
+
+def snapshot() -> dict[str, Any]:
+    value = {
+        "schema_version": "1.0",
+        "snapshot_digest_algorithm": "sha256",
+        "snapshot_digest": "0" * 64,
+        "repository": {
+            "id": "REPO_1",
+            "owner": "SecPal",
+            "name": ".github",
+            "name_with_owner": "SecPal/.github",
+            "url": "https://github.com/SecPal/.github",
+            "default_branch": "main",
+        },
+        "pull_request": {
+            "id": "PR_1",
+            "database_id": 1,
+            "number": 1,
+            "url": "https://github.com/SecPal/.github/pull/1",
+            "title": "Fixture pull request",
+            "state": "OPEN",
+            "is_draft": False,
+            "is_merged": False,
+            "mergeable": "MERGEABLE",
+            "review_decision": None,
+            "author": actor("author"),
+            "base_repository": {
+                "id": "REPO_1",
+                "name_with_owner": "SecPal/.github",
+                "url": "https://github.com/SecPal/.github",
+            },
+            "base_ref": "main",
+            "base_oid": BASE,
+            "head_repository": {
+                "id": "REPO_1",
+                "name_with_owner": "SecPal/.github",
+                "url": "https://github.com/SecPal/.github",
+            },
+            "head_ref": "feat/test",
+            "head_oid_before": HEAD,
+            "head_oid_after": HEAD,
+            "labels": [],
+            "requested_reviewers": [],
+            "requested_teams": [],
+        },
+        "reviews": [],
+        "conversation_comments": [],
+        "review_threads": [],
+        "commits": [
+            {
+                "oid": HEAD,
+                "parents": [PARENT],
+                "authored_at": "2026-07-19T00:00:00Z",
+                "committed_at": "2026-07-19T00:00:00Z",
+                "github_signature": signature(),
+                "local_signature": signature(),
+            }
+        ],
+        "checks": [check()],
+        "applicable_rules": {
+            "rulesets": [{"type": "required_status_checks", "required_checks": [{"context": "tests", "integration_id": 1}]}],
+            "branch_protection": {"contexts": ["tests"], "checks": [{"context": "tests", "app_id": 1}]},
+            "evidence_complete": True,
+        },
+        "required_check_evidence": {
+            "determination": "complete",
+            "required": ["check:1:tests"],
+            "missing": [],
+            "sources": ["rulesets", "branch_protection"],
+            "unknown_reasons": [],
+        },
+        "completeness": {
+            "api_calls": 10,
+            "items": 2,
+            "configured_caps": {
+                "maximum_api_calls": 200,
+                "maximum_items": 10000,
+                "maximum_threads": 500,
+                "maximum_comments": 10000,
+                "maximum_reactions": 10000,
+            },
+            "fully_paginated_connections": [
+                {"connection": "reviews", "pages": 1, "items": 0},
+                {"connection": "review_threads", "pages": 1, "items": 0},
+            ],
+            "warnings": [],
+            "blocked_reason": None,
+        },
+    }
+    return review.attach_digest(value)
+
+
+class FakeGitRunner:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.overrides: dict[tuple[str, ...], review.CommandResult] = {}
+
+    def set(self, arguments: list[str], returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.overrides[tuple(arguments)] = review.CommandResult(returncode, stdout, stderr)
+
+    def run(self, arguments: list[str], *, allow_failure: bool = False) -> review.CommandResult:
+        self.calls.append(arguments)
+        key = tuple(arguments)
+        if key in self.overrides:
+            return self.overrides[key]
+        defaults = {
+            ("git", "rev-parse", "--show-toplevel"): review.CommandResult(0, "/repo\n", ""),
+            ("git", "remote", "get-url", "origin"): review.CommandResult(
+                0, "git@github.com:SecPal/.github.git\n", ""
+            ),
+            ("git", "status", "--porcelain=v2", "--untracked-files=all"): review.CommandResult(0, "", ""),
+            ("git", "branch", "--show-current"): review.CommandResult(0, "feat/test\n", ""),
+            (
+                "git",
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ): review.CommandResult(0, "origin/feat/test\n", ""),
+            ("git", "rev-parse", "HEAD"): review.CommandResult(0, f"{HEAD}\n", ""),
+            ("git", "rev-parse", "@{upstream}"): review.CommandResult(0, f"{HEAD}\n", ""),
+            ("git", "cat-file", "-e", f"{HEAD}^{{commit}}"): review.CommandResult(0, "", ""),
+            ("git", "verify-commit", "--raw", HEAD): review.CommandResult(
+                0, "", 'Good "git" signature for aroviqen with ED25519 key SHA256:test\n'
+            ),
+        }
+        result = defaults.get(key, review.CommandResult(2, "", f"unexpected command: {arguments}"))
+        if result.returncode and not allow_failure:
+            raise review.CommandFailure(arguments, result)
+        return result
+
+
+class SnapshotAndPaginationTests(unittest.TestCase):
+    def test_01_zero_findings(self) -> None:
+        result = review.verify_snapshot_gate(snapshot(), config())
+        self.assertEqual(result["raw_review_state"]["unresolved_threads"], 0)
+        self.assertFalse(result["raw_review_state"]["requested_changes"])
+
+    def test_02_informational_review_only(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record()]
+        value = review.attach_digest(value)
+        result = review.verify_snapshot_gate(value, config())
+        self.assertEqual(result["raw_review_state"]["reviews"], 1)
+        self.assertTrue(result["technical_classification_required"])
+
+    def test_03_resolved_and_unresolved_threads(self) -> None:
+        value = snapshot()
+        value["review_threads"] = [thread("T1", resolved=True), thread("T2", resolved=False)]
+        value = review.attach_digest(value)
+        result = review.verify_snapshot_gate(value, config())
+        self.assertEqual(result["raw_review_state"]["resolved_threads"], 1)
+        self.assertEqual(result["raw_review_state"]["unresolved_threads"], 1)
+
+    def test_04_outdated_thread_is_retained(self) -> None:
+        value = snapshot()
+        value["review_threads"] = [thread(outdated=True)]
+        review.validate_snapshot(review.attach_digest(value))
+        self.assertTrue(value["review_threads"][0]["is_outdated"])
+
+    def test_05_requested_changes_review(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record("CHANGES_REQUESTED")]
+        value["pull_request"]["review_decision"] = "CHANGES_REQUESTED"
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertTrue(result["raw_review_state"]["requested_changes"])
+
+    def test_06_unresolved_human_thread(self) -> None:
+        value = snapshot()
+        value["review_threads"] = [thread(comments=[review_comment(login="human")])]
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertEqual(result["raw_review_state"]["unresolved_threads"], 1)
+
+    def test_07_copilot_and_codex_are_distinct_configured_identities(self) -> None:
+        identities = review.index_reviewer_identities(config())
+        self.assertEqual(identities["copilot-pull-request-reviewer"], "copilot")
+        self.assertEqual(identities["copilot-pull-request-reviewer[bot]"], "copilot")
+        self.assertEqual(identities["chatgpt-codex-connector"], "codex")
+
+    def test_08_multiple_review_submissions_keep_commit_oids(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record(commit=PARENT), review_record(commit=HEAD)]
+        normalized = review.normalize_snapshot(value)
+        self.assertEqual([item["commit_oid"] for item in normalized["reviews"]], [PARENT, HEAD])
+
+    def test_09_multiple_outer_pages(self) -> None:
+        pages = {
+            None: review.Page([1], True, "cursor-1"),
+            "cursor-1": review.Page([2], False, "cursor-2"),
+        }
+        budget = review.Budget(config())
+        self.assertEqual(review.collect_pages("review_threads", pages.__getitem__, budget), [1, 2])
+
+    def test_10_multiple_comment_pages_in_one_thread(self) -> None:
+        pages = {
+            None: review.Page(["first"], True, "comment-1"),
+            "comment-1": review.Page(["reply"], False, "comment-2"),
+        }
+        budget = review.Budget(config())
+        self.assertEqual(review.collect_pages("review_threads.T1.comments", pages.__getitem__, budget), ["first", "reply"])
+
+    def test_11_unequal_connection_page_counts_do_not_refetch(self) -> None:
+        calls: dict[str, list[str | None]] = {"reviews": [], "comments": []}
+
+        def reviews(cursor: str | None) -> review.Page:
+            calls["reviews"].append(cursor)
+            return review.Page(["review"], False, "r1")
+
+        comment_pages = {None: review.Page([1], True, "c1"), "c1": review.Page([2], False, "c2")}
+
+        def comments(cursor: str | None) -> review.Page:
+            calls["comments"].append(cursor)
+            return comment_pages[cursor]
+
+        budget = review.Budget(config())
+        review.collect_pages("reviews", reviews, budget)
+        review.collect_pages("comments", comments, budget)
+        self.assertEqual(calls, {"reviews": [None], "comments": [None, "c1"]})
+
+    def test_12_multiple_reaction_pages(self) -> None:
+        pages = {
+            None: review.Page(["THUMBS_UP"], True, "reaction-1"),
+            "reaction-1": review.Page(["THUMBS_DOWN"], False, "reaction-2"),
+        }
+        budget = review.Budget(config())
+        self.assertEqual(
+            review.collect_pages("review_comment.R1.reactions", pages.__getitem__, budget, kind="reactions"),
+            ["THUMBS_UP", "THUMBS_DOWN"],
+        )
+
+    def test_13_exact_cap_exhaustion_blocks_when_more_pages_exist(self) -> None:
+        limited = config()
+        limited["maximum_items"] = 1
+        pages = {None: review.Page([1], True, "next")}
+        with self.assertRaises(review.BlockedError) as raised:
+            review.collect_pages("reviews", pages.__getitem__, review.Budget(limited))
+        self.assertEqual(raised.exception.code, "BLOCKED_INCOMPLETE_REVIEW_STATE")
+        self.assertEqual(raised.exception.connection, "reviews")
+        self.assertEqual(raised.exception.cursor, "next")
+
+    def test_14_mid_page_api_failure_is_terminal(self) -> None:
+        def fetch(cursor: str | None) -> review.Page:
+            if cursor is not None:
+                raise review.BlockedError("BLOCKED_INCOMPLETE_REVIEW_STATE", "partial API failure", "reviews", cursor)
+            return review.Page([1], True, "next")
+
+        with self.assertRaises(review.BlockedError):
+            review.collect_pages("reviews", fetch, review.Budget(config()))
+
+    def test_15_rate_limit_failure_is_terminal_without_retry(self) -> None:
+        failure = review.classify_api_failure("API rate limit exceeded")
+        self.assertEqual(failure.code, "BLOCKED_INCOMPLETE_REVIEW_STATE")
+        self.assertIn("rate limit", failure.message.lower())
+
+    def test_16_malformed_json(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.parse_api_json("not-json", "reviews")
+
+    def test_17_graphql_errors_with_http_success(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.parse_graphql_payload('{"data": {}, "errors": [{"message": "denied"}]}', "reviews")
+
+    def test_18_null_repository_or_pull_request(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.extract_anchor({"data": {"repository": None}})
+        with self.assertRaises(review.BlockedError):
+            review.extract_anchor({"data": {"repository": {"pullRequest": None}}})
+
+    def test_19_deleted_author_is_explicit(self) -> None:
+        self.assertEqual(review.normalize_actor(None), actor(None))
+
+    def test_20_null_path_and_line_are_preserved(self) -> None:
+        value = thread()
+        value["path"] = None
+        value["line"] = None
+        normalized = review.normalize_review_thread(value)
+        self.assertIsNone(normalized["path"])
+        self.assertIsNone(normalized["line"])
+
+
+class LocalGitTests(unittest.TestCase):
+    def assert_blocker(self, result: dict[str, Any], code: str) -> None:
+        self.assertIn(code, [item["code"] for item in result["blockers"]])
+
+    def test_21_clean_matching_local_remote_pr_head(self) -> None:
+        result = review.verify_local_against_snapshot(snapshot(), config(), FakeGitRunner(), None)
+        self.assertEqual(result["blockers"], [])
+
+    def test_22_dirty_tracked_state(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "status", "--porcelain=v2", "--untracked-files=all"], 0, "1 .M N... file\n")
+        self.assert_blocker(review.verify_local_against_snapshot(snapshot(), config(), runner, None), "BLOCKED_UNCLEAN_WORKTREE")
+
+    def test_23_untracked_state(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "status", "--porcelain=v2", "--untracked-files=all"], 0, "? hostile name\n")
+        self.assert_blocker(review.verify_local_against_snapshot(snapshot(), config(), runner, None), "BLOCKED_UNCLEAN_WORKTREE")
+
+    def test_24_wrong_branch(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "branch", "--show-current"], 0, "other\n")
+        self.assert_blocker(review.verify_local_against_snapshot(snapshot(), config(), runner, None), "BLOCKED_HEAD_MOVED")
+
+    def test_25_missing_upstream(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], 128, stderr="no upstream")
+        self.assert_blocker(review.verify_local_against_snapshot(snapshot(), config(), runner, None), "BLOCKED_HEAD_MOVED")
+
+    def test_26_remote_ahead_of_local(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "rev-parse", "@{upstream}"], 0, f"{'d' * 40}\n")
+        self.assert_blocker(review.verify_local_against_snapshot(snapshot(), config(), runner, None), "BLOCKED_HEAD_MOVED")
+
+    def test_27_local_ahead_of_remote(self) -> None:
+        value = snapshot()
+        value["pull_request"]["head_oid_before"] = "d" * 40
+        value["pull_request"]["head_oid_after"] = "d" * 40
+        value = review.attach_digest(value)
+        self.assert_blocker(review.verify_local_against_snapshot(value, config(), FakeGitRunner(), None), "BLOCKED_HEAD_MOVED")
+
+    def test_28_pr_head_mismatch(self) -> None:
+        self.assert_blocker(
+            review.verify_local_against_snapshot(snapshot(), config(), FakeGitRunner(), "d" * 40),
+            "BLOCKED_HEAD_MOVED",
+        )
+
+    def test_29_head_movement_during_capture(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.ensure_unchanged_head(HEAD, "d" * 40)
+
+    def test_30_unexpected_base_branch(self) -> None:
+        value = snapshot()
+        value["pull_request"]["base_ref"] = "develop"
+        value = review.attach_digest(value)
+        self.assert_blocker(review.verify_local_against_snapshot(value, config(), FakeGitRunner(), None), "BLOCKED_UNSAFE_GITHUB_STATE")
+
+    def test_31_unavailable_commit_object(self) -> None:
+        runner = FakeGitRunner()
+        runner.set(["git", "cat-file", "-e", f"{HEAD}^{{commit}}"], 1, stderr="missing")
+        result = review.verify_local_against_snapshot(snapshot(), config(), runner, None)
+        self.assertEqual(result["commit_signatures"][0]["state"], "object_unavailable")
+
+
+class SignatureAndCheckTests(unittest.TestCase):
+    def test_32_valid_ssh_signature(self) -> None:
+        value = review.interpret_local_signature(0, 'Good "git" signature for user with ED25519 key')
+        self.assertEqual((value["state"], value["format"]), ("valid", "ssh"))
+
+    def test_33_valid_openpgp_signature(self) -> None:
+        value = review.interpret_local_signature(0, "gpg: Good signature from user")
+        self.assertEqual((value["state"], value["format"]), ("valid", "openpgp"))
+
+    def test_34_unsigned_commit(self) -> None:
+        self.assertEqual(review.interpret_local_signature(1, "does not have a signature")["state"], "unsigned")
+
+    def test_35_invalid_signature(self) -> None:
+        self.assertEqual(review.interpret_local_signature(1, "BAD signature")["state"], "invalid")
+
+    def test_36_unknown_signing_key(self) -> None:
+        self.assertEqual(review.interpret_local_signature(1, "No public key")["state"], "unknown_key")
+
+    def test_37_verification_pending_or_unavailable(self) -> None:
+        value = review.normalize_github_signature({"isValid": False, "state": "PENDING", "__typename": "SshSignature"})
+        self.assertEqual(value["state"], "verification_pending")
+
+    def evaluated(self, status: str, conclusion: str | None, expected_skipped: str = "block") -> list[dict[str, Any]]:
+        raw = [
+            {
+                "stable_id": "check:1:tests",
+                "name": "tests",
+                "application": {"id": "APP_1", "database_id": 1, "name": "Actions", "slug": "github-actions"},
+                "status": status,
+                "conclusion": conclusion,
+                "details_url": None,
+            }
+        ]
+        policy = config()["check_policy"] | {"expected_skipped": expected_skipped}
+        return review.evaluate_checks(raw, [{"context": "tests", "integration_id": 1}], policy)[0]
+
+    def test_38_all_required_checks_successful(self) -> None:
+        self.assertEqual(self.evaluated("COMPLETED", "SUCCESS")[0]["evidence_state"], "required_successful")
+
+    def test_39_required_check_pending(self) -> None:
+        self.assertEqual(self.evaluated("IN_PROGRESS", None)[0]["evidence_state"], "required_pending")
+
+    def test_40_required_check_failed(self) -> None:
+        self.assertEqual(self.evaluated("COMPLETED", "FAILURE")[0]["evidence_state"], "required_failed")
+
+    def test_41_required_check_missing(self) -> None:
+        checks, evidence = review.evaluate_checks([], [{"context": "tests", "integration_id": 1}], config()["check_policy"])
+        self.assertEqual(checks[0]["evidence_state"], "required_missing")
+        self.assertEqual(evidence["missing"], ["check:1:tests"])
+
+    def test_42_requiredness_unknown(self) -> None:
+        raw = [check() | {"requiredness": None, "evidence_state": None}]
+        checks, evidence = review.evaluate_checks(raw, None, config()["check_policy"])
+        self.assertEqual(checks[0]["evidence_state"], "requiredness_unknown")
+        self.assertEqual(evidence["determination"], "incomplete")
+
+    def test_43_optional_check_failed(self) -> None:
+        raw = [check("optional", conclusion="FAILURE") | {"requiredness": None, "evidence_state": None}]
+        checks, _ = review.evaluate_checks(raw, [], config()["check_policy"])
+        self.assertEqual(checks[0]["evidence_state"], "non_required_failed")
+
+    def test_44_expected_skipped_check_follows_policy(self) -> None:
+        self.assertEqual(self.evaluated("COMPLETED", "SKIPPED", "block")[0]["evidence_state"], "required_failed")
+        self.assertEqual(self.evaluated("COMPLETED", "SKIPPED", "allow")[0]["evidence_state"], "required_successful")
+
+    def test_45_inaccessible_ruleset_evidence(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.require_rule_evidence(None, {}, config()["check_policy"])
+
+
+class SecurityAndOutputTests(unittest.TestCase):
+    def test_46_hostile_markdown_is_escaped(self) -> None:
+        self.assertNotIn("<script>", review.escape_markdown("<script>alert(1)</script>"))
+
+    def test_47_html_comment_terminator_is_escaped(self) -> None:
+        self.assertNotIn("-->", review.escape_markdown("payload --> tail"))
+
+    def test_48_code_fences_inside_body_cannot_close_renderer_block(self) -> None:
+        value = snapshot()
+        value["conversation_comments"] = [
+            {
+                "id": "IC_1",
+                "database_id": 1,
+                "author": actor(),
+                "body": "```\nhostile\n```",
+                "url": "https://github.com/SecPal/.github/pull/1#issuecomment-1",
+                "created_at": "2026-07-19T00:00:00Z",
+                "updated_at": "2026-07-19T00:00:00Z",
+                "reactions": [],
+            }
+        ]
+        rendered = review.render_markdown(review.attach_digest(value))
+        self.assertNotIn("```\nhostile", rendered)
+
+    def test_49_deceptive_links_and_images_are_not_trusted(self) -> None:
+        rendered = review.escape_markdown("![x](https://evil.example) [login](https://evil.example)")
+        self.assertNotIn("](https://evil.example)", rendered)
+
+    def test_50_unicode_and_control_characters_are_deterministic(self) -> None:
+        first = review.escape_markdown("Grüße\x00🙂")
+        second = review.escape_markdown("Grüße\x00🙂")
+        self.assertEqual(first, second)
+        self.assertNotIn("\x00", first)
+
+    def test_51_shell_significant_data_stays_an_argument(self) -> None:
+        arguments = review.graphql_arguments("SecPal", "repo;$(touch nope)", 1, "cursor`id`", "query X { viewer { login } }")
+        self.assertIn("name=repo;$(touch nope)", arguments)
+        self.assertNotIn("sh", arguments[:2])
+
+    def test_52_symlink_output_target_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            target.write_text("original")
+            link = root / "output"
+            link.symlink_to(target)
+            with self.assertRaises(review.OutputSafetyError):
+                review.atomic_write_many({link: b"replacement"})
+            self.assertEqual(target.read_text(), "original")
+
+    def test_53_partial_staging_failure_preserves_existing_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first"
+            second = Path(directory) / "second"
+            first.write_text("old-one")
+            second.write_text("old-two")
+            with mock.patch.object(review, "_stage_atomic_file", side_effect=[Path(directory) / "temp", OSError("fail")]):
+                with self.assertRaises(OSError):
+                    review.atomic_write_many({first: b"new-one", second: b"new-two"})
+            self.assertEqual(first.read_text(), "old-one")
+            self.assertEqual(second.read_text(), "old-two")
+
+    def test_54_deterministic_repeated_output(self) -> None:
+        value = snapshot()
+        first = review.canonical_json_bytes(value)
+        second = review.canonical_json_bytes(copy.deepcopy(value))
+        self.assertEqual(first, second)
+        self.assertTrue(review.verify_digest(value))
+
+    def test_55_stdout_mode_has_zero_persistent_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            before = list(Path(directory).iterdir())
+            payloads = review.prepare_outputs(snapshot(), None, None)
+            after = list(Path(directory).iterdir())
+        self.assertEqual(payloads, {})
+        self.assertEqual(before, after)
+
+    def test_56_read_only_api_policy_rejects_mutations(self) -> None:
+        review.validate_external_command(["gh", "api", "graphql", "-f", "query=query X { viewer { login } }"])
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["gh", "api", "--method", "POST", "repos/SecPal/.github/issues"])
+
+    def test_57_no_polling_or_retries(self) -> None:
+        calls = 0
+
+        def fail(_: str | None) -> review.Page:
+            nonlocal calls
+            calls += 1
+            raise review.BlockedError("BLOCKED_INCOMPLETE_REVIEW_STATE", "failure", "reviews", None)
+
+        with self.assertRaises(review.BlockedError):
+            review.collect_pages("reviews", fail, review.Budget(config()))
+        self.assertEqual(calls, 1)
+
+    def test_58_git_write_commands_are_rejected(self) -> None:
+        for command in ("push", "commit", "checkout", "switch", "reset", "clean", "stash"):
+            with self.subTest(command=command), self.assertRaises(review.CommandPolicyError):
+                review.validate_external_command(["git", command])
+
+    def test_59_review_request_operations_are_rejected(self) -> None:
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["gh", "pr", "review", "1"])
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["gh", "pr", "ready", "1"])
+
+    def test_60_merge_operations_are_rejected(self) -> None:
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["gh", "pr", "merge", "1"])
+
+    def test_configuration_schema_and_identity_aliases(self) -> None:
+        review.validate_config(config())
+        broken = config()
+        broken["reviewer_identities"][0]["canonical_identity"] = ""
+        with self.assertRaises(review.ContractError):
+            review.validate_config(broken)
+
+    def test_digest_excludes_only_digest_field(self) -> None:
+        value = snapshot()
+        digest = value["snapshot_digest"]
+        value["snapshot_digest"] = "f" * 64
+        self.assertEqual(review.compute_digest(value), digest)
+        value["snapshot_digest_algorithm"] = "sha512"
+        self.assertNotEqual(review.compute_digest(value), digest)
+
+    def test_atomic_output_mode_is_0600(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "snapshot.json"
+            review.atomic_write_many({path: b"{}\n"})
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_unvalidated_non_github_url_is_not_a_link(self) -> None:
+        self.assertFalse(review.trusted_github_url("https://evil.example/SecPal/.github"))
+        self.assertTrue(review.trusted_github_url("https://github.com/SecPal/.github/pull/1"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -198,6 +198,7 @@ def snapshot() -> dict[str, Any]:
             "is_draft": False,
             "is_merged": False,
             "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
             "review_decision": None,
             "author": actor("author"),
             "base_repository": {
@@ -234,8 +235,18 @@ def snapshot() -> dict[str, Any]:
         ],
         "checks": [check()],
         "applicable_rules": {
-            "rulesets": [{"type": "required_status_checks", "required_checks": [{"context": "tests", "integration_id": 1}]}],
-            "branch_protection": {"contexts": ["tests"], "checks": [{"context": "tests", "app_id": 1}]},
+            "rulesets": [
+                {
+                    "type": "required_status_checks",
+                    "strict": True,
+                    "required_checks": [{"context": "tests", "integration_id": 1}],
+                }
+            ],
+            "branch_protection": {
+                "strict": True,
+                "contexts": ["tests"],
+                "checks": [{"context": "tests", "app_id": 1}],
+            },
             "evidence_complete": True,
         },
         "required_check_evidence": {
@@ -343,6 +354,53 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         value["pull_request"]["review_decision"] = "CHANGES_REQUESTED"
         result = review.verify_snapshot_gate(finalize_snapshot(value), config())
         self.assertTrue(result["raw_review_state"]["requested_changes"])
+
+    def test_superseded_changes_request_does_not_block(self) -> None:
+        value = snapshot()
+        value["reviews"] = [review_record("CHANGES_REQUESTED"), review_record("APPROVED")]
+        value["reviews"][1]["id"] = "REVIEW_2"
+        value["reviews"][1]["submitted_at"] = "2026-07-19T00:01:00Z"
+        value["pull_request"]["review_decision"] = "APPROVED"
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
+        self.assertFalse(result["raw_review_state"]["requested_changes"])
+        self.assertNotIn("NOT_READY_FOR_MERGE", [item["code"] for item in result["blockers"]])
+
+    def test_strict_required_checks_block_a_behind_branch(self) -> None:
+        value = snapshot()
+        value["pull_request"]["merge_state_status"] = "BEHIND"
+        value["applicable_rules"]["branch_protection"]["strict"] = True
+        value["applicable_rules"]["rulesets"][0]["strict"] = True
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertIn("BLOCKED_HEAD_BEHIND_BASE", [item["code"] for item in result["blockers"]])
+
+    def test_ruleset_strictness_blocks_behind_without_branch_protection(self) -> None:
+        value = snapshot()
+        value["pull_request"]["merge_state_status"] = "BEHIND"
+        value["required_check_evidence"]["sources"] = ["rulesets"]
+        value["applicable_rules"]["branch_protection"] = {
+            "strict": None,
+            "contexts": [],
+            "checks": [],
+        }
+        configuration = config()
+        configuration["check_policy"]["require_branch_protection_evidence"] = False
+        result = review.verify_snapshot_gate(finalize_snapshot(value), configuration)
+        self.assertIn("BLOCKED_HEAD_BEHIND_BASE", [item["code"] for item in result["blockers"]])
+
+    def test_loose_required_checks_do_not_block_a_behind_branch(self) -> None:
+        value = snapshot()
+        value["pull_request"]["merge_state_status"] = "BEHIND"
+        value["applicable_rules"]["branch_protection"]["strict"] = False
+        value["applicable_rules"]["rulesets"][0]["strict"] = False
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertNotIn("BLOCKED_HEAD_BEHIND_BASE", [item["code"] for item in result["blockers"]])
+
+    def test_strict_policy_without_required_checks_does_not_require_current_base(self) -> None:
+        value = snapshot()
+        value["applicable_rules"]["rulesets"][0]["required_checks"] = []
+        value["applicable_rules"]["branch_protection"]["contexts"] = []
+        value["applicable_rules"]["branch_protection"]["checks"] = []
+        self.assertFalse(review.strict_checks_require_current_base(value, config()["check_policy"]))
 
     def test_06_unresolved_human_thread(self) -> None:
         value = snapshot()
@@ -669,6 +727,20 @@ class SignatureAndCheckTests(unittest.TestCase):
         value = review.interpret_local_signature(0, "gpgsm: Good signature from user")
         self.assertEqual((value["state"], value["format"]), ("valid", "smime"))
 
+    def test_openpgp_status_record_wins_over_signer_uid_text(self) -> None:
+        value = review.interpret_local_signature(
+            0,
+            "gpg: Signature made\n[GNUPG:] GOODSIG 0123456789ABCDEF ssh@example.com",
+        )
+        self.assertEqual((value["state"], value["format"]), ("valid", "openpgp"))
+
+    def test_ambiguous_gnupg_record_is_not_assumed_openpgp(self) -> None:
+        value = review.interpret_local_signature(
+            0,
+            "[GNUPG:] GOODSIG 0123456789ABCDEF signer@example.com",
+        )
+        self.assertEqual((value["state"], value["format"]), ("valid", "unknown"))
+
     def test_failed_x509_signature_is_not_mislabeled_openpgp(self) -> None:
         value = review.interpret_local_signature(1, "gpgsm: BAD signature from user")
         self.assertEqual((value["state"], value["format"]), ("invalid", "smime"))
@@ -725,6 +797,44 @@ class SignatureAndCheckTests(unittest.TestCase):
         self.assertEqual(checks[0]["evidence_state"], "required_missing")
         self.assertEqual(evidence["missing"], ["check:1:tests"])
 
+    def test_app_check_satisfies_generic_and_exact_requirements(self) -> None:
+        raw = [check() | {"requiredness": None, "evidence_state": None}]
+        _, evidence = review.evaluate_checks(
+            raw,
+            [
+                {"context": "tests", "integration_id": None},
+                {"context": "tests", "integration_id": 1},
+            ],
+            config()["check_policy"],
+        )
+        self.assertEqual(evidence["missing"], [])
+
+    def test_status_creator_id_does_not_satisfy_app_requirement(self) -> None:
+        raw = review._normalize_check(
+            {
+                "__typename": "StatusContext",
+                "id": "STATUS_1",
+                "context": "tests",
+                "state": "SUCCESS",
+                "targetUrl": None,
+                "creator": {
+                    "__typename": "User",
+                    "id": "USER_1",
+                    "databaseId": 1,
+                    "login": "reviewer",
+                    "url": "https://github.com/reviewer",
+                },
+            }
+        )
+        checks, evidence = review.evaluate_checks(
+            [raw],
+            [{"context": "tests", "integration_id": 1}],
+            config()["check_policy"],
+        )
+        status_context = next(item for item in checks if item["stable_id"] == "status_context:STATUS_1")
+        self.assertEqual(status_context["requiredness"], "non_required")
+        self.assertEqual(evidence["missing"], ["check:1:tests"])
+
     def test_42_requiredness_unknown(self) -> None:
         raw = [check() | {"requiredness": None, "evidence_state": None}]
         checks, evidence = review.evaluate_checks(raw, None, config()["check_policy"])
@@ -755,6 +865,34 @@ class SignatureAndCheckTests(unittest.TestCase):
             config()["check_policy"],
         )
         self.assertEqual(required, [{"context": "tests", "integration_id": None}])
+
+    def test_branch_protection_any_app_sentinel_is_generic(self) -> None:
+        required = review.require_rule_evidence(
+            [],
+            {
+                "strict": True,
+                "contexts": [],
+                "checks": [{"context": "tests", "app_id": -1}],
+            },
+            config()["check_policy"],
+        )
+        self.assertEqual(required, [{"context": "tests", "integration_id": None}])
+
+    def test_malformed_strict_check_policy_is_incomplete(self) -> None:
+        with self.assertRaises(review.BlockedError):
+            review.require_rule_evidence(
+                [
+                    {
+                        "type": "required_status_checks",
+                        "parameters": {
+                            "required_status_checks": [],
+                            "strict_required_status_checks_policy": None,
+                        },
+                    }
+                ],
+                {"strict": True, "contexts": [], "checks": []},
+                config()["check_policy"],
+            )
 
 
 class SecurityAndOutputTests(unittest.TestCase):
@@ -826,6 +964,18 @@ class SecurityAndOutputTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertTrue(review.verify_digest(value))
 
+    def test_output_path_aliases_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            nested = root / "nested"
+            nested.mkdir()
+            output = root / "snapshot.json"
+            alias = nested / ".." / "snapshot.json"
+            with self.assertRaises(review.OutputSafetyError):
+                review.prepare_outputs(snapshot(), str(output), str(alias))
+            with self.assertRaises(review.OutputSafetyError):
+                review.atomic_write_many({output: b"json", alias: b"markdown"})
+
     def test_55_stdout_mode_has_zero_persistent_writes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             before = list(Path(directory).iterdir())
@@ -838,6 +988,8 @@ class SecurityAndOutputTests(unittest.TestCase):
         review.validate_external_command(["gh", "api", "graphql", "-f", "query=query X { viewer { login } }"])
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["gh", "api", "--method", "POST", "repos/SecPal/.github/issues"])
+        with self.assertRaises(review.CommandPolicyError):
+            review.validate_external_command(["gh", "pr", "view"])
         for arguments in (
             ["gh", "api", "repos/SecPal/.github/issues/1/comments", "-f", "body=write"],
             ["gh", "api", "repos/SecPal/.github/issues/1/labels", "-F", "labels[]=security"],

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -162,6 +162,19 @@ def check(
     }
 
 
+def finalize_snapshot(value: dict[str, Any]) -> dict[str, Any]:
+    counts = review.expected_connection_items(value)
+    value["completeness"]["items"] = sum(counts.values())
+    value["completeness"]["fully_paginated_connections"] = [
+        {"connection": connection, "pages": 1, "items": count}
+        for connection, count in sorted(counts.items())
+    ]
+    value["completeness"]["api_calls"] = review.expected_api_calls(
+        value["completeness"]["fully_paginated_connections"]
+    )
+    return review.attach_digest(value)
+
+
 def snapshot() -> dict[str, Any]:
     value = {
         "schema_version": "1.0",
@@ -250,7 +263,7 @@ def snapshot() -> dict[str, Any]:
             "blocked_reason": None,
         },
     }
-    return review.attach_digest(value)
+    return finalize_snapshot(value)
 
 
 class FakeGitRunner:
@@ -305,7 +318,7 @@ class SnapshotAndPaginationTests(unittest.TestCase):
     def test_02_informational_review_only(self) -> None:
         value = snapshot()
         value["reviews"] = [review_record()]
-        value = review.attach_digest(value)
+        value = finalize_snapshot(value)
         result = review.verify_snapshot_gate(value, config())
         self.assertEqual(result["raw_review_state"]["reviews"], 1)
         self.assertTrue(result["technical_classification_required"])
@@ -313,7 +326,7 @@ class SnapshotAndPaginationTests(unittest.TestCase):
     def test_03_resolved_and_unresolved_threads(self) -> None:
         value = snapshot()
         value["review_threads"] = [thread("T1", resolved=True), thread("T2", resolved=False)]
-        value = review.attach_digest(value)
+        value = finalize_snapshot(value)
         result = review.verify_snapshot_gate(value, config())
         self.assertEqual(result["raw_review_state"]["resolved_threads"], 1)
         self.assertEqual(result["raw_review_state"]["unresolved_threads"], 1)
@@ -321,21 +334,111 @@ class SnapshotAndPaginationTests(unittest.TestCase):
     def test_04_outdated_thread_is_retained(self) -> None:
         value = snapshot()
         value["review_threads"] = [thread(outdated=True)]
-        review.validate_snapshot(review.attach_digest(value))
+        review.validate_snapshot(finalize_snapshot(value))
         self.assertTrue(value["review_threads"][0]["is_outdated"])
 
     def test_05_requested_changes_review(self) -> None:
         value = snapshot()
         value["reviews"] = [review_record("CHANGES_REQUESTED")]
         value["pull_request"]["review_decision"] = "CHANGES_REQUESTED"
-        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
         self.assertTrue(result["raw_review_state"]["requested_changes"])
 
     def test_06_unresolved_human_thread(self) -> None:
         value = snapshot()
         value["review_threads"] = [thread(comments=[review_comment(login="human")])]
-        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
         self.assertEqual(result["raw_review_state"]["unresolved_threads"], 1)
+
+    def test_review_required_is_a_mechanical_blocker(self) -> None:
+        value = snapshot()
+        value["pull_request"]["review_decision"] = "REVIEW_REQUIRED"
+        result = review.verify_snapshot_gate(review.attach_digest(value), config())
+        self.assertIn("NOT_READY_FOR_MERGE", [item["code"] for item in result["blockers"]])
+
+    def test_requested_review_is_a_mechanical_blocker(self) -> None:
+        value = snapshot()
+        value["pull_request"]["requested_reviewers"] = [actor("pending-reviewer")]
+        result = review.verify_snapshot_gate(finalize_snapshot(value), config())
+        self.assertIn("NOT_READY_FOR_MERGE", [item["code"] for item in result["blockers"]])
+        self.assertTrue(result["raw_review_state"]["review_requested"])
+
+    def test_gate_reapplies_current_skipped_check_policy(self) -> None:
+        capture_configuration = config()
+        capture_configuration["check_policy"]["expected_skipped"] = "allow"
+        raw = [check(status="COMPLETED", conclusion="SKIPPED") | {"requiredness": None, "evidence_state": None}]
+        checks, evidence = review.evaluate_checks(
+            raw,
+            [{"context": "tests", "integration_id": 1}],
+            capture_configuration["check_policy"],
+        )
+        value = snapshot()
+        value["checks"] = checks
+        value["required_check_evidence"] = evidence
+        value = review.attach_digest(value)
+
+        gate_configuration = config()
+        gate_configuration["check_policy"]["expected_skipped"] = "block"
+        result = review.verify_snapshot_gate(value, gate_configuration)
+
+        self.assertIn("BLOCKED_FAILED_OR_PENDING_CI", [item["code"] for item in result["blockers"]])
+
+    def test_gate_rejects_missing_pagination_evidence(self) -> None:
+        value = snapshot()
+        value["completeness"]["fully_paginated_connections"] = []
+        value = review.attach_digest(value)
+        with self.assertRaises(review.ContractError):
+            review.verify_snapshot_gate(value, config())
+
+    def test_gate_rejects_capture_warnings(self) -> None:
+        value = snapshot()
+        value["completeness"]["warnings"] = ["partial capture"]
+        value = review.attach_digest(value)
+        with self.assertRaises(review.ContractError):
+            review.verify_snapshot_gate(value, config())
+
+    def test_gate_rejects_required_rule_source_missing_from_snapshot(self) -> None:
+        value = snapshot()
+        value["required_check_evidence"]["sources"].remove("rulesets")
+        value["applicable_rules"]["rulesets"] = []
+        value = finalize_snapshot(value)
+        result = review.verify_snapshot_gate(value, config())
+        self.assertIn(review.BLOCKED_INCOMPLETE, [item["code"] for item in result["blockers"]])
+
+    def test_gate_accepts_intentionally_disabled_rule_sources(self) -> None:
+        value = snapshot()
+        value["required_check_evidence"] = {
+            "determination": "complete",
+            "required": [],
+            "missing": [],
+            "sources": [],
+            "unknown_reasons": [],
+        }
+        value["applicable_rules"] = {
+            "rulesets": [],
+            "branch_protection": {"strict": None, "contexts": [], "checks": []},
+            "evidence_complete": True,
+        }
+        value = finalize_snapshot(value)
+        configuration = config()
+        configuration["check_policy"]["require_ruleset_evidence"] = False
+        configuration["check_policy"]["require_branch_protection_evidence"] = False
+        result = review.verify_snapshot_gate(value, configuration)
+        self.assertEqual(result["blockers"], [])
+
+    def test_snapshot_rejects_mismatched_connection_item_count(self) -> None:
+        value = snapshot()
+        value["completeness"]["fully_paginated_connections"][0]["items"] += 1
+        value = review.attach_digest(value)
+        with self.assertRaises(review.ContractError):
+            review.validate_snapshot(value)
+
+    def test_snapshot_rejects_mismatched_api_call_count(self) -> None:
+        value = snapshot()
+        value["completeness"]["api_calls"] -= 1
+        value = review.attach_digest(value)
+        with self.assertRaises(review.ContractError):
+            review.validate_snapshot(value)
 
     def test_07_copilot_and_codex_are_distinct_configured_identities(self) -> None:
         identities = review.index_reviewer_identities(config())
@@ -510,6 +613,17 @@ class LocalGitTests(unittest.TestCase):
         with self.assertRaises(review.BlockedError):
             review.ensure_unchanged_head(HEAD, "d" * 40)
 
+    def test_non_head_anchor_movement_during_capture(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        before = review.extract_anchor(copy.deepcopy(fixture))
+        changed = copy.deepcopy(fixture)
+        changed["data"]["repository"]["pullRequest"]["isDraft"] = True
+        after = review.extract_anchor(changed)
+        with self.assertRaises(review.BlockedError):
+            review.ensure_unchanged_anchor(before, after)
+
     def test_30_unexpected_base_branch(self) -> None:
         value = snapshot()
         value["pull_request"]["base_ref"] = "develop"
@@ -550,6 +664,38 @@ class SignatureAndCheckTests(unittest.TestCase):
     def test_37_verification_pending_or_unavailable(self) -> None:
         value = review.normalize_github_signature({"isValid": False, "state": "PENDING", "__typename": "SshSignature"})
         self.assertEqual(value["state"], "verification_pending")
+
+    def test_successful_x509_signature_is_not_mislabeled_openpgp(self) -> None:
+        value = review.interpret_local_signature(0, "gpgsm: Good signature from user")
+        self.assertEqual((value["state"], value["format"]), ("valid", "smime"))
+
+    def test_failed_x509_signature_is_not_mislabeled_openpgp(self) -> None:
+        value = review.interpret_local_signature(1, "gpgsm: BAD signature from user")
+        self.assertEqual((value["state"], value["format"]), ("invalid", "smime"))
+
+    def test_local_verification_enforces_accepted_signature_formats(self) -> None:
+        configuration = config()
+        configuration["signature_policy"]["accepted_formats"] = ["ssh"]
+        runner = FakeGitRunner()
+        runner.set(
+            ["git", "verify-commit", "--raw", HEAD],
+            0,
+            stderr="gpg: Good signature from reviewer",
+        )
+        result = review.verify_local_against_snapshot(snapshot(), configuration, runner, None)
+        self.assertIn("BLOCKED_INVALID_SIGNATURE", [item["code"] for item in result["blockers"]])
+
+    def test_local_verification_honors_disabled_signature_requirement(self) -> None:
+        configuration = config()
+        configuration["signature_policy"]["require_local_verified"] = False
+        runner = FakeGitRunner()
+        runner.set(
+            ["git", "verify-commit", "--raw", HEAD],
+            1,
+            stderr="does not have a signature",
+        )
+        result = review.verify_local_against_snapshot(snapshot(), configuration, runner, None)
+        self.assertNotIn("BLOCKED_INVALID_SIGNATURE", [item["code"] for item in result["blockers"]])
 
     def evaluated(self, status: str, conclusion: str | None, expected_skipped: str = "block") -> list[dict[str, Any]]:
         raw = [
@@ -632,7 +778,7 @@ class SecurityAndOutputTests(unittest.TestCase):
                 "reactions": [],
             }
         ]
-        rendered = review.render_markdown(review.attach_digest(value))
+        rendered = review.render_markdown(finalize_snapshot(value))
         self.assertNotIn("```\nhostile", rendered)
 
     def test_49_deceptive_links_and_images_are_not_trusted(self) -> None:
@@ -692,6 +838,47 @@ class SecurityAndOutputTests(unittest.TestCase):
         review.validate_external_command(["gh", "api", "graphql", "-f", "query=query X { viewer { login } }"])
         with self.assertRaises(review.CommandPolicyError):
             review.validate_external_command(["gh", "api", "--method", "POST", "repos/SecPal/.github/issues"])
+        for arguments in (
+            ["gh", "api", "repos/SecPal/.github/issues/1/comments", "-f", "body=write"],
+            ["gh", "api", "repos/SecPal/.github/issues/1/labels", "-F", "labels[]=security"],
+            ["gh", "api", "repos/SecPal/.github/issues/1", "--input", "payload.json"],
+            ["gh", "api", "-X", "PATCH", "repos/SecPal/.github/issues/1"],
+            ["gh", "api", "--method=DELETE", "repos/SecPal/.github/issues/1"],
+        ):
+            with self.subTest(arguments=arguments), self.assertRaises(review.CommandPolicyError):
+                review.validate_external_command(arguments)
+
+    def test_graphql_string_variables_cannot_trigger_field_file_reads(self) -> None:
+        arguments = review.graphql_arguments(
+            "SecPal",
+            ".github",
+            1,
+            "@/etc/passwd",
+            "query X($after:String) { viewer { login } }",
+        )
+        index = arguments.index("after=@/etc/passwd")
+        self.assertEqual(arguments[index - 1], "-f")
+        review.validate_external_command(arguments)
+
+    def test_disabled_rule_sources_are_not_called(self) -> None:
+        configuration = config()
+        policy = configuration["check_policy"] | {
+            "require_ruleset_evidence": False,
+            "require_branch_protection_evidence": False,
+        }
+
+        class Client:
+            owner = "SecPal"
+            name = ".github"
+            budget = review.Budget(configuration)
+
+            def rest(self, *_: Any, **__: Any) -> Any:
+                raise AssertionError("disabled evidence source was called")
+
+        applicable, required, sources = review._capture_rules(Client(), "main", policy)
+        self.assertEqual(required, [])
+        self.assertEqual(sources, [])
+        self.assertEqual(applicable["rulesets"], [])
 
     def test_57_no_polling_or_retries(self) -> None:
         calls = 0

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import importlib.util
 import json
+import os
 import stat
 import sys
 import tempfile
@@ -29,6 +31,17 @@ SPEC.loader.exec_module(review)
 HEAD = "a" * 40
 BASE = "b" * 40
 PARENT = "c" * 40
+
+
+def uncontrolled_git_test_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for key in review.GIT_ENVIRONMENT_OVERRIDES:
+        environment.pop(key, None)
+    for key in tuple(environment):
+        if review.GIT_CONFIG_PAIR.fullmatch(key) or review.GIT_TRACE_VARIABLE.match(key):
+            environment.pop(key)
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return environment
 
 
 def actor(login: str | None = "reviewer", kind: str = "user") -> dict[str, Any]:
@@ -553,6 +566,71 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         value["commits"].append(duplicate)
         with self.assertRaisesRegex(review.ContractError, "duplicate commit OID"):
             review.validate_snapshot(finalize_snapshot(value))
+
+    def test_completeness_accounts_for_volatile_evidence_revalidation(self) -> None:
+        value = snapshot()
+        value["review_threads"] = [thread()]
+        expected = review.expected_connection_items(value)
+        self.assertEqual(expected["labels.revalidation"], 0)
+        self.assertEqual(expected["review_requests.revalidation"], 0)
+        self.assertEqual(expected["reviews.revalidation"], 0)
+        self.assertEqual(expected["commits.revalidation"], 1)
+        self.assertEqual(expected[f"commit.{HEAD}.parents.revalidation"], 1)
+        self.assertEqual(expected["checks.revalidation"], 1)
+        self.assertEqual(expected["rulesets.revalidation"], 1)
+        self.assertEqual(expected["branch_protection.revalidation"], 1)
+        self.assertEqual(expected["review_threads.revalidation"], 1)
+        self.assertEqual(expected["review_thread.THREAD_1.comments.revalidation"], 1)
+        self.assertEqual(expected["review_comment.RC_1.reactions.revalidation"], 0)
+
+    def test_revalidation_observations_count_against_item_kind_caps(self) -> None:
+        value = snapshot()
+        comment = review_comment()
+        comment["reactions"] = [
+            {
+                "id": "REACTION_1",
+                "content": "THUMBS_UP",
+                "created_at": "2026-07-19T00:01:00Z",
+                "user": actor(),
+            }
+        ]
+        value["review_threads"] = [thread(comments=[comment])]
+        for cap in ("maximum_threads", "maximum_comments", "maximum_reactions"):
+            with self.subTest(cap=cap):
+                candidate = copy.deepcopy(value)
+                candidate["completeness"]["configured_caps"][cap] = 1
+                with self.assertRaises(review.ContractError):
+                    review.validate_snapshot(finalize_snapshot(candidate))
+
+    def test_reaction_change_during_capture_is_terminal(self) -> None:
+        before = [review_comment()]
+        after = copy.deepcopy(before)
+        after[0]["reactions"] = [
+            {
+                "id": "REACTION_1",
+                "content": "THUMBS_UP",
+                "created_at": "2026-07-19T00:01:00Z",
+                "user": actor(),
+            }
+        ]
+        with self.assertRaises(review.BlockedError) as raised:
+            review.ensure_revalidated_evidence("review reactions", before, after)
+        self.assertEqual(raised.exception.code, review.BLOCKED_INCOMPLETE)
+
+    def test_check_change_during_capture_is_terminal(self) -> None:
+        before = [check()]
+        after = [check(status="COMPLETED", conclusion="FAILURE")]
+        with self.assertRaises(review.BlockedError):
+            review.ensure_revalidated_evidence("head checks", before, after)
+
+    def test_required_rule_change_during_capture_is_terminal(self) -> None:
+        before = snapshot()["applicable_rules"]
+        after = copy.deepcopy(before)
+        after["rulesets"][0]["required_checks"].append(
+            {"context": "new-required-check", "integration_id": 1}
+        )
+        with self.assertRaises(review.BlockedError):
+            review.ensure_revalidated_evidence("required rules", before, after)
 
     def test_07_copilot_and_codex_are_distinct_configured_identities(self) -> None:
         identities = review.index_reviewer_identities(config())
@@ -1218,6 +1296,8 @@ class SecurityAndOutputTests(unittest.TestCase):
         poisoned_environment |= {
             "GIT_CONFIG_KEY_0": "core.sshCommand",
             "GIT_CONFIG_VALUE_0": "hostile-command",
+            "GIT_CONFIG_KEY_99": "gpg.ssh.program",
+            "GIT_CONFIG_VALUE_99": "hostile-verifier",
             "GIT_NO_REPLACE_OBJECTS": "0",
             "GIT_OPTIONAL_LOCKS": "1",
             "GIT_TRACE": "/tmp/hostile-trace",
@@ -1232,15 +1312,141 @@ class SecurityAndOutputTests(unittest.TestCase):
 
         environment = run.call_args.kwargs["env"]
         inherited_overrides = repository_overrides | {
-            "GIT_CONFIG_KEY_0",
-            "GIT_CONFIG_VALUE_0",
+            "GIT_CONFIG_KEY_99",
+            "GIT_CONFIG_VALUE_99",
             "GIT_TRACE",
             "GIT_TRACE2_EVENT",
         }
-        self.assertEqual(sorted(inherited_overrides & environment.keys()), [])
+        self.assertEqual(sorted((inherited_overrides - {"GIT_CONFIG_COUNT"}) & environment.keys()), [])
+        configured_count = int(environment["GIT_CONFIG_COUNT"])
+        safe_config = {
+            environment[f"GIT_CONFIG_KEY_{index}"]: environment[f"GIT_CONFIG_VALUE_{index}"]
+            for index in range(configured_count)
+        }
+        self.assertEqual(safe_config, dict(review.SAFE_GIT_CONFIG))
+        self.assertEqual(
+            set(safe_config),
+            {
+                "core.fsmonitor",
+                "gpg.program",
+                "gpg.openpgp.program",
+                "gpg.ssh.program",
+                "gpg.x509.program",
+            },
+        )
+        self.assertEqual(safe_config["core.fsmonitor"], "false")
         self.assertEqual(environment["GIT_NO_REPLACE_OBJECTS"], "1")
         self.assertEqual(environment["GIT_OPTIONAL_LOCKS"], "0")
         self.assertEqual(environment["GIT_NO_LAZY_FETCH"], "1")
+
+    def test_command_runner_disables_a_configured_fsmonitor_hook(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "fsmonitor-ran"
+            hook = root / "fsmonitor-hook"
+            hook.write_text(
+                "#!/usr/bin/env python3\n"
+                "from pathlib import Path\n"
+                f"Path({str(marker)!r}).write_text('executed', encoding='utf-8')\n"
+                "print('token')\n",
+                encoding="utf-8",
+            )
+            hook.chmod(0o700)
+            subprocess_environment = uncontrolled_git_test_environment()
+            review.subprocess.run(
+                ["git", "init", "--quiet"],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+            )
+            review.subprocess.run(
+                ["git", "config", "core.fsmonitor", str(hook)],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+            )
+            review.subprocess.run(
+                ["git", "status", "--porcelain=v2", "--untracked-files=all"],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertTrue(marker.exists())
+            marker.unlink()
+
+            with contextlib.chdir(root):
+                review.CommandRunner().run(
+                    ["git", "status", "--porcelain=v2", "--untracked-files=all"]
+                )
+            self.assertFalse(marker.exists())
+
+    def test_command_runner_pins_the_ssh_signature_verifier(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "verifier-ran"
+            verifier = root / "hostile-verifier"
+            verifier.write_text(
+                "#!/bin/sh\n"
+                f": > \"{marker}\"\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            verifier.chmod(0o700)
+            subprocess_environment = uncontrolled_git_test_environment()
+            review.subprocess.run(
+                ["git", "init", "--quiet"],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+            )
+            tree = review.subprocess.run(
+                ["git", "hash-object", "-t", "tree", "-w", "--stdin"],
+                cwd=root,
+                env=subprocess_environment,
+                input=b"",
+                capture_output=True,
+                check=True,
+            ).stdout.decode().strip()
+            commit = (
+                f"tree {tree}\n"
+                "author Reviewer <reviewer@example.com> 0 +0000\n"
+                "committer Reviewer <reviewer@example.com> 0 +0000\n"
+                "gpgsig -----BEGIN SSH SIGNATURE-----\n"
+                " invalid\n"
+                " -----END SSH SIGNATURE-----\n\n"
+                "message\n"
+            ).encode()
+            oid = review.subprocess.run(
+                ["git", "hash-object", "-t", "commit", "-w", "--stdin"],
+                cwd=root,
+                env=subprocess_environment,
+                input=commit,
+                capture_output=True,
+                check=True,
+            ).stdout.decode().strip()
+            review.subprocess.run(
+                ["git", "config", "gpg.ssh.program", str(verifier)],
+                cwd=root,
+                env=subprocess_environment,
+                check=True,
+            )
+            review.subprocess.run(
+                ["git", "verify-commit", "--raw", oid],
+                cwd=root,
+                env=subprocess_environment,
+                check=False,
+            )
+            self.assertTrue(marker.exists())
+            marker.unlink()
+
+            with contextlib.chdir(root):
+                review.CommandRunner().run(
+                    ["git", "verify-commit", "--raw", oid],
+                    allow_failure=True,
+                )
+            self.assertFalse(marker.exists())
 
     def test_disabled_rule_sources_are_not_called(self) -> None:
         configuration = config()

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HELPER = REPO_ROOT / "scripts" / "secpal-pr-review.py"
+FIXTURES = REPO_ROOT / "tests/fixtures/secpal-pr-review"
 SPEC = importlib.util.spec_from_file_location("secpal_pr_review", HELPER)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"Cannot load helper at {HELPER}")
@@ -438,6 +439,15 @@ class SnapshotAndPaginationTests(unittest.TestCase):
             review.extract_anchor({"data": {"repository": None}})
         with self.assertRaises(review.BlockedError):
             review.extract_anchor({"data": {"repository": {"pullRequest": None}}})
+
+    def test_merged_pull_request_anchor_is_supported(self) -> None:
+        fixture = json.loads(
+            (FIXTURES / "fake-github-pages.json").read_text(encoding="utf-8")
+        )["graphql"]["PullRequestAnchor"]["null"]
+        fixture["data"]["repository"]["pullRequest"]["state"] = "MERGED"
+        fixture["data"]["repository"]["pullRequest"]["merged"] = True
+        anchor = review.extract_anchor(fixture)
+        self.assertEqual(anchor["pull_request"]["state"], "MERGED")
 
     def test_19_deleted_author_is_explicit(self) -> None:
         self.assertEqual(review.normalize_actor(None), actor(None))


### PR DESCRIPTION
## Description

Implements Governance Package 2.1: the deterministic, strictly read-only Git/GitHub state and evidence layer required by a later finite `secpal-pr-review` Codex skill.

This PR addresses the Package 2 audit findings that the predecessor truncated outer and nested GraphQL connections, omitted material review context, lacked functional data-contract tests, treated rendered review content too trustingly, and could not provide canonical structured evidence for guarded future remediation.

### Schema contract

- Adds snapshot schema version `1.0` with repository/PR anchors, review submissions, top-level comments, thread-aware inline comments and replies, reactions, PR commits, dual signature evidence, check rollups, applicable rules, required-check evidence, and explicit completeness counters.
- Adds repository-configuration schema version `1.0` with stable canonical reviewer identities and GraphQL, REST/event, numeric, and node-ID aliases; local validation/signature/check policy; allowed bases; and finite API/item/thread/comment/reaction caps.
- Uses deterministic UTF-8 canonical JSON with sorted object keys and stable array ordering. SHA-256 excludes only its own digest field and includes no output path or wall-clock capture timestamp.
- Keeps Markdown strictly derived and visibly identifies the JSON snapshot plus SHA-256 digest as canonical authority.

### Complete bounded capture

- Anchors the PR head before capture, fully paginates each independent outer connection and every nested thread-comment/reaction connection, and reads the head once after capture.
- Records exact API calls, items, configured caps, and completed connection page/item counts.
- Reaching a cap, receiving partial/malformed/GraphQL-error state, losing ruleset evidence, encountering an unsupported check type, or observing head movement returns a structured terminal blocker. It never warns and claims completeness.
- Performs no retries, sleeps, polling, or recurring review loop.

### Signature and required-check verification

- Captures GitHub signature evidence and local `git verify-commit --raw` evidence for every PR commit.
- Accepts valid SSH and OpenPGP signatures according to configuration while distinguishing invalid, unsigned, unknown-key, unavailable-object, and pending verification states.
- Derives required checks from current applicable branch rulesets and branch-protection evidence, matches governed application IDs where present, and distinguishes required success/pending/failure/missing from non-required outcomes and unknown requiredness.
- Verifies clean local state, branch/upstream, local/remote-tracking/PR heads, allowed base, exact base-to-head commit set, and local signatures without fetching. `GIT_NO_LAZY_FETCH=1` prevents implicit partial-clone fetches.

### Read-only and security boundary

- External commands use argument arrays and exact command-shape allowlisting; there is no `shell=True`, dynamic execution, or configuration execution.
- All GraphQL documents are static query operations with variables. REST access is GET-only.
- Explicit outputs are staged in the target directory, atomically replaced, mode `0600`, and reject symlink/non-regular targets and symlinked parent chains.
- Review titles, paths, bodies, URLs, Markdown/HTML delimiters, Unicode, and control characters are treated as untrusted in derived Markdown. Unvalidated non-GitHub URLs are not rendered as trusted links.
- The helper exposes no GitHub mutation operation.

## Related Issues

No issue is linked or closed by this Package 2.1 PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [x] Manual testing performed

Local validation passed:

- `python3 -m unittest tests/secpal-pr-review-unit.py` — 70 tests passed
- `bash tests/secpal-pr-review-integration.sh`
- `python3 -m py_compile scripts/secpal-pr-review.py`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/copilot-review-memory.sh`
- `bash tests/copilot-review-memory-errors.sh`
- `bash tests/reusable-workflow-policy.sh`
- `shellcheck tests/secpal-pr-review-integration.sh`
- `bash -n tests/secpal-pr-review-integration.sh`
- `npm run lint:markdown`
- `reuse lint`
- `git diff --check origin/main`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-pr-review-unit.py` failed with `FileNotFoundError` because `scripts/secpal-pr-review.py` did not exist; `bash tests/secpal-pr-review-integration.sh` failed because the helper was absent.
- Passing proof after implementation: the same commands pass with 70 deterministic unit tests and the fake-`gh`/fake-Git integration suite green.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Every CHANGELOG claim was checked against the implementation, tests, and schemas changed in this PR
- [x] Comments added for complex logic
- [x] Documentation updated
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] No related issue was inferred or created

## Non-goals

This PR does not implement reactions, replies, thread resolution, reviewer requests, Draft/Ready changes, labels, issue/tracking writes, pushes performed by the helper, merges, auto-merge, AI review dispatch, polling, technical finding classification, remediation cycles, the `secpal-pr-review` skill, skill installation, a production repository registry, or review-memory workflow changes.

Package 2.2 has not begun. The finite workflow is not operational until Package 2.2 and post-merge acceptance. Merge authorization remains a separate explicit user decision.

