### PR TITLE
fix(review): separate merged evidence from merge readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added merged-state consistency and fake-GitHub regression coverage while
   preserving the helper's zero-mutation, zero-polling, and zero-merge-authority
   boundary
+- retained every repeated check observation while selecting the latest
+  timestamped run from the same check producer for required-check outcomes, so
+  obsolete failures cannot override a newer success and missing ordering
+  evidence continues to fail closed
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-20 - Separate Post-Merge Evidence From Merge Readiness
+
+**Fixed:**
+
+- added a read-only `verify-evidence` command that validates canonical snapshot,
+  pagination, identity, commit, signature, rule, check, cap, and raw review-state
+  evidence for open, closed, or merged pull requests without treating a merged
+  PR's `UNKNOWN` mergeability fields as current merge-candidate evidence
+- retained `verify-gate` as the strict open, non-Draft PR readiness command while
+  sharing the same evidence-verification path, keeping merged PRs ineligible for
+  the open gate without misreporting their immutable evidence as invalid
+- added merged-state consistency and fake-GitHub regression coverage while
+  preserving the helper's zero-mutation, zero-polling, and zero-merge-authority
+  boundary
+
+---
+
 ## 2026-07-19 - Add Deterministic PR Evidence State Layer
 
 **Added:**

--- a/docs/schemas/secpal-pr-review-snapshot.schema.json
+++ b/docs/schemas/secpal-pr-review-snapshot.schema.json
@@ -415,6 +415,9 @@
         },
         "status": { "$ref": "#/$defs/nullable_string" },
         "conclusion": { "$ref": "#/$defs/nullable_string" },
+        "started_at": { "$ref": "#/$defs/nullable_string" },
+        "created_at": { "$ref": "#/$defs/nullable_string" },
+        "is_effective": { "type": "boolean" },
         "requiredness": { "enum": ["required", "non_required", "unknown"] },
         "evidence_state": {
           "enum": [

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -314,6 +314,17 @@ hide a failed same-named counterpart. It does not invent an absent context
 kind; application-specific requirements remain bound to a check run from that
 application.
 
+GitHub can retain several runs of the same check name and application on one
+commit after reruns or pull-request metadata events. The snapshot retains every
+run and its stable identity, plus the check-run start time or status-context
+creation time used to identify the effective observation from that producer.
+An older failure from the same producer cannot override a newer success, while
+a newer failure or pending run still blocks. If repeated observations lack
+usable ordering evidence or share the latest timestamp, they all remain
+effective and the result fails closed. Check runs and legacy status contexts
+remain separate producers, matching GitHub's requirement that both kinds pass
+when they share a required name.
+
 Evidence distinguishes required success, pending, failure, and absence;
 non-required success, pending, and failure; and unknown requiredness. Required
 skipped checks follow the explicit `check_policy.expected_skipped` value.

--- a/docs/secpal-pr-review-state-layer.md
+++ b/docs/secpal-pr-review-state-layer.md
@@ -7,8 +7,9 @@ SPDX-License-Identifier: CC0-1.0
 
 Governance Package 2.1 provides a deterministic, read-only Git and GitHub data
 layer for a later finite pull-request review procedure. It captures canonical
-evidence, verifies local Git state, evaluates mechanical merge-gate evidence,
-and produces a safely escaped display rendering.
+evidence, verifies immutable snapshot evidence and local Git state, evaluates
+open-pull-request merge-gate evidence, and produces a safely escaped display
+rendering.
 
 Package 2.1 does not classify technical findings, remediate code, resolve
 threads, authorize a merge, or make the finite workflow operational. The
@@ -129,7 +130,39 @@ are pinned to their standard names within that trusted command path. Standard
 input is closed and each external command has a 30-second timeout. The
 `fetched` result is always `false`.
 
-### Verify the mechanical gate
+### Verify immutable evidence
+
+```bash
+python3 scripts/secpal-pr-review.py verify-evidence \
+  --snapshot snapshot.json \
+  --config path/to/repository-config.json
+```
+
+`verify-evidence` validates the schema, canonical digest, repository and PR
+identity, stable head anchors, lifecycle-state consistency, captured commit
+set, signature policy, applicable-rule evidence, required-check identities and
+outcomes, configured capture caps, pagination completeness, and raw review
+state. It is suitable for open, closed, and merged snapshots, including
+historical read-only audits and post-merge acceptance.
+
+A merged snapshot must consistently report `state: MERGED`, `is_merged: true`,
+`is_draft: false`, and equal before/after head OIDs. Post-merge
+`mergeable: UNKNOWN` or `null` and `merge_state_status: UNKNOWN` do not make
+otherwise complete immutable evidence invalid: those live merge-candidate
+fields are no longer meaningful after merge. The final PR head must still be
+present in the captured commit evidence, and every configured signature,
+ruleset, branch-protection, required-check, cap, and completeness policy
+continues to apply.
+
+The structured report uses `EVIDENCE_VERIFIED` only when the evidence contract
+and current repository policy succeed. It always sets `merge_authorized` to
+`false`, retains raw review counts and effective review state, and states when
+Package 2.2 technical classification remains necessary. Unresolved or
+historical review evidence is reported rather than silently discarded;
+evidence integrity alone does not classify a finding or establish merge
+readiness.
+
+### Verify the open-PR mechanical gate
 
 ```bash
 python3 scripts/secpal-pr-review.py verify-gate \
@@ -137,15 +170,12 @@ python3 scripts/secpal-pr-review.py verify-gate \
   --config path/to/repository-config.json
 ```
 
-The gate verifies schema version, digest, complete pagination, stored anchor
-counts, an unchanged repository and pull-request anchor, safe repository and PR
-identity, the current signature and check policies, required-check evidence,
-strict up-to-date-base requirements, check outcomes, required or requested
-reviews, reactions on every supported PR subject, and raw unresolved thread
-state. It reports separately whether raw unresolved items exist and whether
-Package 2.2 technical classification remains necessary. Direct PR reactions
-therefore cannot disappear merely because no review or comment accompanies
-them.
+The gate first invokes the same evidence-verification path as
+`verify-evidence`. It then adds current merge-candidate requirements for an
+open, non-Draft PR: an available head branch, mergeable state, safe GitHub merge
+state, strict up-to-date-base requirements, and the absence of required,
+requested, or unresolved review blockers. Direct PR reactions remain visible
+even when no review or comment accompanies them.
 
 The current repository configuration is authoritative at gate time. Recorded
 API calls, aggregate items, threads, comments, and reactions must fit its current
@@ -154,13 +184,20 @@ required by the current configuration was not captured, the gate retains the
 snapshot digest and all accumulated blockers in its structured report and does
 not attempt to infer missing required checks from placeholder evidence.
 
-A clean mechanical result is named `PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is
-not merge readiness or merge authorization. Draft, closed, merged, conflicting,
-or not-yet-computed mergeability states block the mechanical gate. GitHub merge
-states `DIRTY`, `UNKNOWN`, `BLOCKED`, and `DRAFT` fail closed. `UNSTABLE`
+A clean open-PR mechanical result is named
+`PACKAGE_2_2_CLASSIFICATION_REQUIRED`; it is not merge authorization. Draft,
+closed, merged, conflicting, or not-yet-computed mergeability states block this
+open-PR gate. A closed or merged PR receives the lifecycle blocker without
+having its post-merge mergeability values reinterpreted as evidence-integrity
+failures. GitHub merge states `DIRTY`, `UNKNOWN`, `BLOCKED`, and `DRAFT` fail
+closed for an open candidate. `UNSTABLE`
 continues through the granular required-check policy so an optional failure is
 not promoted into a required failure; `CLEAN` and `HAS_HOOKS` add no merge-state
 blocker, while `BEHIND` follows the configured strict up-to-date-base policy.
+
+In short: `verify-evidence` validates evidence integrity; `verify-gate`
+additionally evaluates open-PR merge readiness. Neither command authorizes
+merge.
 
 ### Render Markdown
 
@@ -242,7 +279,8 @@ The evidence distinguishes `valid`, `invalid`, `unsigned`, `unknown_key`,
 reported as cryptographically verified. A `valid` state requires
 `verified: true`; every other state requires `verified: false`. Required
 invalid, unsigned, unknown, pending, unavailable, or internally inconsistent
-verification blocks the gate. The helper does not import keys or persist
+verification blocks evidence verification, and therefore also blocks the
+open-PR gate. The helper does not import keys or persist
 signing configuration. Verification still uses the configured trust material,
 while command-scoped overrides prevent configuration from substituting the
 verifier executables themselves.
@@ -254,7 +292,8 @@ enabled by configuration. Disabled sources are not called. It is not derived
 from a hard-coded workflow name or from visible green checks alone. Check runs
 and status contexts retain stable GitHub identities and are matched to required
 contexts plus application IDs when those IDs are governed. Gate verification
-rebuilds requiredness and outcomes from the supplied current policy rather than
+is preceded by evidence verification, which rebuilds requiredness and outcomes
+from the supplied current policy rather than
 trusting capture-time outcome labels. Enabled rulesets and branch protection
 layer together: an application-specific branch-protection requirement cannot
 erase a generic same-named ruleset requirement. Within branch-protection
@@ -337,8 +376,8 @@ handling are explicit non-goals.
 
 ## Exit behavior and testing
 
-- `0` means the requested capture, render, or verification completed without a
-  mechanical blocker.
+- `0` means the requested capture, render, evidence verification, or gate
+  completed without its applicable mechanical blocker.
 - `2` means invalid or unsafe local input or output handling.
 - `3` means a deterministic state, API, completeness, signature, check, or
   review-state blocker.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,10 @@ This directory contains utility scripts for SecPal development.
 ### `secpal-pr-review.py`
 
 Captures deterministic, thread-aware GitHub pull-request evidence and verifies
-local Git state through a strict read-only command boundary. Canonical JSON is
+immutable evidence and local Git state through a strict read-only command
+boundary. `verify-evidence` supports open, closed, and merged snapshots;
+`verify-gate` reuses that evidence path and additionally evaluates current
+open-PR merge readiness. Neither command authorizes merge. Canonical JSON is
 the authority; Markdown is an escaped derived view. The helper performs no
 review request, reaction, reply, thread resolution, push, or merge operation.
 

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -1417,6 +1417,10 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         raise ContractError("Pull request URL does not match its repository and number")
     if pr["is_merged"] is not (pr["state"] == "MERGED"):
         raise ContractError("Pull request merged state is internally inconsistent")
+    if pr["state"] == "MERGED" and pr["is_draft"]:
+        raise ContractError("A merged pull request cannot remain Draft")
+    if pr["state"] == "OPEN" and pr["mergeable"] is None:
+        raise ContractError("Open pull request mergeability is unavailable")
     head_repository = pr["head_repository"]
     head_values = (
         head_repository["id"],
@@ -1766,7 +1770,10 @@ def extract_anchor(payload: dict[str, Any]) -> dict[str, Any]:
             None,
         )
     mergeable = pull_request.get("mergeable")
-    if mergeable not in {"MERGEABLE", "CONFLICTING", "UNKNOWN"}:
+    state = pull_request.get("state")
+    if mergeable not in {"MERGEABLE", "CONFLICTING", "UNKNOWN"} and not (
+        mergeable is None and state in {"CLOSED", "MERGED"}
+    ):
         raise BlockedError(
             BLOCKED_INCOMPLETE,
             "Pull request mergeability is unavailable",
@@ -2332,7 +2339,39 @@ def merge_state_blocker(snapshot: dict[str, Any], policy: dict[str, Any]) -> dic
     return None
 
 
-def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
+def evaluate_raw_review_state(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Summarize captured review evidence without classifying technical findings."""
+
+    pull_request = snapshot["pull_request"]
+    unresolved = [item for item in snapshot["review_threads"] if not item["is_resolved"]]
+    requested_changes = pull_request["review_decision"] == "CHANGES_REQUESTED"
+    review_required = pull_request["review_decision"] == "REVIEW_REQUIRED"
+    review_requested = bool(
+        pull_request["requested_reviewers"] or pull_request["requested_teams"]
+    )
+    return {
+        "reviews": len(snapshot["reviews"]),
+        "conversation_comments": len(snapshot["conversation_comments"]),
+        "review_threads": len(snapshot["review_threads"]),
+        "reactions": len(snapshot_reactions(snapshot)),
+        "resolved_threads": len(snapshot["review_threads"]) - len(unresolved),
+        "unresolved_threads": len(unresolved),
+        "outdated_threads": sum(item["is_outdated"] for item in snapshot["review_threads"]),
+        "requested_changes": requested_changes,
+        "requested_changes_reviews": sum(
+            item["state"] == "CHANGES_REQUESTED" for item in snapshot["reviews"]
+        ),
+        "review_required": review_required,
+        "review_requested": review_requested,
+    }
+
+
+def verify_snapshot_evidence(
+    snapshot: dict[str, Any],
+    configuration: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify immutable snapshot evidence without evaluating merge candidacy."""
+
     validate_config(configuration)
     validate_snapshot(snapshot)
     blockers: list[dict[str, str]] = []
@@ -2365,25 +2404,7 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                 "reason": "PR base branch does not match configuration",
             }
         )
-    if pr["head_repository"]["name_with_owner"] is None or pr["head_ref"] is None:
-        blockers.append(
-            {
-                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
-                "reason": "PR head repository or branch is unavailable",
-            }
-        )
-    if pr["state"] != "OPEN" or pr["is_merged"] or pr["is_draft"]:
-        blockers.append(
-            {
-                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
-                "reason": "PR is not an open non-draft merge candidate",
-            }
-        )
-    if pr["mergeable"] != "MERGEABLE":
-        blockers.append({"code": "BLOCKED_UNSAFE_GITHUB_STATE", "reason": "PR mergeability is conflicting or unknown"})
     check_policy = configuration["check_policy"]
-    if blocker := merge_state_blocker(snapshot, check_policy):
-        blockers.append(blocker)
     signature_policy = configuration["signature_policy"]
     accepted_formats = set(signature_policy["accepted_formats"])
     for commit in snapshot["commits"]:
@@ -2464,12 +2485,71 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
                         "reason": f"{item['name']}: {item['evidence_state']}",
                     }
                 )
-    unresolved = [item for item in snapshot["review_threads"] if not item["is_resolved"]]
-    requested_changes = pr["review_decision"] == "CHANGES_REQUESTED"
-    review_required = pr["review_decision"] == "REVIEW_REQUIRED"
-    review_requested = bool(pr["requested_reviewers"] or pr["requested_teams"])
-    reaction_count = len(snapshot_reactions(snapshot))
-    if unresolved or requested_changes or review_required or review_requested:
+    raw_review_state = evaluate_raw_review_state(snapshot)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "snapshot_digest": snapshot["snapshot_digest"],
+        "status": "BLOCKED" if blockers else "EVIDENCE_VERIFIED",
+        "evidence_verified": not blockers,
+        "pull_request_state": pr["state"],
+        "blockers": blockers,
+        "raw_review_state": raw_review_state,
+        "technical_classification_required": bool(
+            snapshot["reviews"]
+            or snapshot["conversation_comments"]
+            or snapshot["review_threads"]
+            or raw_review_state["reactions"]
+        ),
+        "merge_authorized": False,
+    }
+
+
+def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]) -> dict[str, Any]:
+    """Verify evidence, then apply strict readiness rules for an open pull request."""
+
+    evidence = verify_snapshot_evidence(snapshot, configuration)
+    blockers = copy.deepcopy(evidence["blockers"])
+    pull_request = snapshot["pull_request"]
+    open_candidate = (
+        pull_request["state"] == "OPEN"
+        and not pull_request["is_merged"]
+        and not pull_request["is_draft"]
+    )
+    if not open_candidate:
+        blockers.append(
+            {
+                "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                "reason": "PR is not an open non-draft merge candidate",
+            }
+        )
+    else:
+        if (
+            pull_request["head_repository"]["name_with_owner"] is None
+            or pull_request["head_ref"] is None
+        ):
+            blockers.append(
+                {
+                    "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                    "reason": "PR head repository or branch is unavailable",
+                }
+            )
+        if pull_request["mergeable"] != "MERGEABLE":
+            blockers.append(
+                {
+                    "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                    "reason": "PR mergeability is conflicting or unknown",
+                }
+            )
+        if blocker := merge_state_blocker(snapshot, configuration["check_policy"]):
+            blockers.append(blocker)
+
+    raw_review_state = evidence["raw_review_state"]
+    if (
+        raw_review_state["unresolved_threads"]
+        or raw_review_state["requested_changes"]
+        or raw_review_state["review_required"]
+        or raw_review_state["review_requested"]
+    ):
         blockers.append(
             {
                 "code": "NOT_READY_FOR_MERGE",
@@ -2477,28 +2557,9 @@ def verify_snapshot_gate(snapshot: dict[str, Any], configuration: dict[str, Any]
             }
         )
     return {
-        "schema_version": SCHEMA_VERSION,
-        "snapshot_digest": snapshot["snapshot_digest"],
+        **evidence,
         "status": "BLOCKED" if blockers else "PACKAGE_2_2_CLASSIFICATION_REQUIRED",
         "blockers": blockers,
-        "raw_review_state": {
-            "reviews": len(snapshot["reviews"]),
-            "conversation_comments": len(snapshot["conversation_comments"]),
-            "review_threads": len(snapshot["review_threads"]),
-            "reactions": reaction_count,
-            "resolved_threads": len(snapshot["review_threads"]) - len(unresolved),
-            "unresolved_threads": len(unresolved),
-            "requested_changes": requested_changes,
-            "review_required": review_required,
-            "review_requested": review_requested,
-        },
-        "technical_classification_required": bool(
-            snapshot["reviews"]
-            or snapshot["conversation_comments"]
-            or snapshot["review_threads"]
-            or reaction_count
-        ),
-        "merge_authorized": False,
     }
 
 
@@ -4031,6 +4092,13 @@ def build_parser() -> argparse.ArgumentParser:
     gate_parser.add_argument("--snapshot", required=True, help="Canonical snapshot JSON.")
     gate_parser.add_argument("--config", help="Repository configuration JSON.")
 
+    evidence_parser = subparsers.add_parser(
+        "verify-evidence",
+        help="Verify immutable snapshot evidence without evaluating merge candidacy.",
+    )
+    evidence_parser.add_argument("--snapshot", required=True, help="Canonical snapshot JSON.")
+    evidence_parser.add_argument("--config", help="Repository configuration JSON.")
+
     render_parser = subparsers.add_parser("render", help="Render derived non-authoritative evidence.")
     render_parser.add_argument("--snapshot", required=True, help="Canonical snapshot JSON.")
     render_parser.add_argument("--format", required=True, choices=("markdown",))
@@ -4091,6 +4159,15 @@ def _command_verify_gate(arguments: argparse.Namespace) -> int:
     return 0 if not result["blockers"] else 3
 
 
+def _command_verify_evidence(arguments: argparse.Namespace) -> int:
+    value = _load_snapshot_file(arguments.snapshot)
+    repository = value["repository"]["name_with_owner"]
+    configuration = load_config(arguments.config, repository)
+    result = verify_snapshot_evidence(value, configuration)
+    print(_json_report(result), end="")
+    return 0 if result["evidence_verified"] else 3
+
+
 def _command_render(arguments: argparse.Namespace) -> int:
     value = _load_snapshot_file(arguments.snapshot)
     if arguments.format != "markdown":
@@ -4109,6 +4186,8 @@ def main(argv: list[str] | None = None) -> int:
             return _command_verify_local(arguments)
         if arguments.command == "verify-gate":
             return _command_verify_gate(arguments)
+        if arguments.command == "verify-evidence":
+            return _command_verify_evidence(arguments)
         if arguments.command == "render":
             return _command_render(arguments)
         raise ContractError(f"Unknown command: {arguments.command}")

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -2408,26 +2408,36 @@ def verify_snapshot_evidence(
     signature_policy = configuration["signature_policy"]
     accepted_formats = set(signature_policy["accepted_formats"])
     for commit in snapshot["commits"]:
+        github_signature = commit["github_signature"]
         if signature_policy["require_github_verified"] and (
-            commit["github_signature"]["state"] != "valid"
-            or not commit["github_signature"]["verified"]
-            or commit["github_signature"]["format"] not in accepted_formats
+            github_signature["state"] != "valid"
+            or not github_signature["verified"]
+            or github_signature["format"] not in accepted_formats
         ):
             blockers.append(
                 {
                     "code": "BLOCKED_INVALID_SIGNATURE",
-                    "reason": f"GitHub signature invalid for {commit['oid']}",
+                    "reason": (
+                        "GitHub signature policy rejected "
+                        f"state={github_signature['state']}, "
+                        f"format={github_signature['format']} for {commit['oid']}"
+                    ),
                 }
             )
+        local_signature = commit["local_signature"]
         if signature_policy["require_local_verified"] and (
-            commit["local_signature"]["state"] != "valid"
-            or not commit["local_signature"]["verified"]
-            or commit["local_signature"]["format"] not in accepted_formats
+            local_signature["state"] != "valid"
+            or not local_signature["verified"]
+            or local_signature["format"] not in accepted_formats
         ):
             blockers.append(
                 {
                     "code": "BLOCKED_INVALID_SIGNATURE",
-                    "reason": f"Local signature invalid for {commit['oid']}",
+                    "reason": (
+                        "Local signature policy rejected "
+                        f"state={local_signature['state']}, "
+                        f"format={local_signature['format']} for {commit['oid']}"
+                    ),
                 }
             )
     required_sources = {

--- a/scripts/secpal-pr-review.py
+++ b/scripts/secpal-pr-review.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from datetime import datetime
 from functools import cache
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -2039,6 +2040,61 @@ def _check_outcome(status: str | None, conclusion: str | None, expected_skipped:
     return "failed"
 
 
+def _check_observed_at(item: dict[str, Any]) -> datetime | None:
+    """Return comparable GitHub ordering evidence for one check observation."""
+
+    stable_id = str(item.get("stable_id") or "")
+    value = item.get("started_at") if stable_id.startswith("check_run:") else item.get("created_at")
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        observed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return observed if observed.tzinfo is not None else None
+
+
+def _check_producer_key(item: dict[str, Any]) -> tuple[Any, ...]:
+    """Identify repeated observations from the same check producer."""
+
+    stable_id = str(item.get("stable_id") or "")
+    name = str(item.get("name") or "")
+    if stable_id.startswith("status_context:"):
+        return ("status_context", name)
+    if stable_id.startswith("check_run:"):
+        application = item.get("application")
+        if not isinstance(application, dict):
+            return ("check_run", name, stable_id)
+        producer = (
+            application.get("database_id"),
+            application.get("id"),
+            application.get("slug"),
+        )
+        if all(value is None for value in producer):
+            return ("check_run", name, stable_id)
+        return ("check_run", name, *producer)
+    return ("unrecognized", stable_id)
+
+
+def _mark_effective_checks(checks: list[dict[str, Any]]) -> None:
+    """Mark the latest same-producer observation without hiding ambiguous state."""
+
+    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+    for item in checks:
+        item.setdefault("started_at", None)
+        item.setdefault("created_at", None)
+        groups.setdefault(_check_producer_key(item), []).append(item)
+    for group in groups.values():
+        observations = [_check_observed_at(item) for item in group]
+        if len(group) == 1 or any(value is None for value in observations):
+            for item in group:
+                item["is_effective"] = True
+            continue
+        latest = max(value for value in observations if value is not None)
+        for item, observed in zip(group, observations, strict=True):
+            item["is_effective"] = observed == latest
+
+
 def evaluate_checks(
     raw_checks: list[dict[str, Any]],
     required_specs: list[dict[str, Any]] | None,
@@ -2046,6 +2102,7 @@ def evaluate_checks(
     sources: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     checks = [copy.deepcopy(item) for item in raw_checks]
+    _mark_effective_checks(checks)
     if required_specs is None:
         for item in checks:
             item["requiredness"] = "unknown"
@@ -2070,7 +2127,8 @@ def evaluate_checks(
             if key[0] == name and (key[1] is None or key[1] == app_id)
         ]
         if matching:
-            matched.update(matching)
+            if item["is_effective"]:
+                matched.update(matching)
             item["requiredness"] = "required"
             outcome = _check_outcome(item.get("status"), item.get("conclusion"), policy["expected_skipped"])
             item["evidence_state"] = f"required_{outcome}"
@@ -2097,6 +2155,9 @@ def evaluate_checks(
                 },
                 "status": "MISSING",
                 "conclusion": None,
+                "started_at": None,
+                "created_at": None,
+                "is_effective": True,
                 "requiredness": "required",
                 "evidence_state": "required_missing",
                 "details_url": None,
@@ -2263,10 +2324,12 @@ def validate_required_check_metadata(snapshot: dict[str, Any]) -> None:
         "application",
         "status",
         "conclusion",
+        "started_at",
+        "created_at",
         "details_url",
     )
     raw_checks = [
-        {key: copy.deepcopy(item[key]) for key in raw_fields}
+        {key: copy.deepcopy(item.get(key)) for key in raw_fields}
         for item in stored_checks
         if item["status"] != "MISSING"
     ]
@@ -2289,8 +2352,10 @@ def validate_required_check_metadata(snapshot: dict[str, Any]) -> None:
     for stable_id, expected in expected_by_id.items():
         stored = stored_by_id[stable_id]
         for key in (*raw_fields[1:], "requiredness"):
-            if stored[key] != expected[key]:
+            if stored.get(key) != expected[key]:
                 raise ContractError(f"Check requiredness or identity is inconsistent for {stable_id}")
+        if stored.get("is_effective", True) != expected["is_effective"]:
+            raise ContractError(f"Effective check selection is inconsistent for {stable_id}")
         if stored["status"] == "MISSING":
             allowed_states = {"required_missing"}
         else:
@@ -2466,8 +2531,11 @@ def verify_snapshot_evidence(
                 "application",
                 "status",
                 "conclusion",
+                "started_at",
+                "created_at",
                 "details_url",
             )
+            if key in item
         }
         for item in snapshot["checks"]
         if item["status"] != "MISSING"
@@ -2481,7 +2549,7 @@ def verify_snapshot_evidence(
             sorted(required_sources),
         )
         for item in evaluated_checks:
-            if item["evidence_state"] in {
+            if item["is_effective"] and item["evidence_state"] in {
                 "required_pending",
                 "required_failed",
                 "required_missing",
@@ -3087,6 +3155,7 @@ query CommitChecks($owner:String!, $name:String!, $number:Int!, $oid:GitObjectID
                 name
                 status
                 conclusion
+                startedAt
                 detailsUrl
                 checkSuite {
                   app { id databaseId name slug }
@@ -3096,6 +3165,7 @@ query CommitChecks($owner:String!, $name:String!, $number:Int!, $oid:GitObjectID
                 id
                 context
                 state
+                createdAt
                 targetUrl
                 creator {
                   __typename
@@ -3641,6 +3711,8 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
             "application": application,
             "status": value.get("status"),
             "conclusion": value.get("conclusion"),
+            "started_at": value.get("startedAt"),
+            "created_at": None,
             "details_url": value.get("detailsUrl"),
         }
     if typename == "StatusContext":
@@ -3663,6 +3735,8 @@ def _normalize_check(value: dict[str, Any]) -> dict[str, Any]:
             },
             "status": state,
             "conclusion": state if str(state).upper() != "PENDING" else None,
+            "started_at": None,
+            "created_at": value.get("createdAt"),
             "details_url": value.get("targetUrl"),
         }
     raise BlockedError(BLOCKED_INCOMPLETE, f"Unsupported check type: {typename!r}", "checks", None)

--- a/tests/fixtures/secpal-pr-review/fake-gh.py
+++ b/tests/fixtures/secpal-pr-review/fake-gh.py
@@ -60,6 +60,14 @@ if len(arguments) > 3 and arguments[3] == "graphql":
         response = operation_responses.get(cursor)
     if response is None:
         fail(f"no fake GraphQL response for {operation} cursor={cursor}")
+    if operation == "PullRequestAnchor" and os.environ.get("FAKE_GH_MERGED") == "1":
+        pull_request = response["data"]["repository"]["pullRequest"]
+        pull_request["state"] = "MERGED"
+        pull_request["merged"] = True
+        pull_request["isDraft"] = False
+        pull_request["mergeable"] = "UNKNOWN"
+        pull_request["mergeStateStatus"] = "UNKNOWN"
+        pull_request["potentialMergeCommit"] = None
     print(json.dumps(response, ensure_ascii=False, separators=(",", ":")))
     raise SystemExit(0)
 

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -43,6 +43,29 @@ cmp "$first" "$second"
   --snapshot "$first" \
   --config "$FIXTURES/config.json" >"$workspace/gate.json"
 
+"${helper[@]}" verify-evidence \
+  --snapshot "$first" \
+  --config "$FIXTURES/config.json" >"$workspace/evidence.json"
+
+merged="$workspace/merged.json"
+FAKE_GH_MERGED=1 "${helper[@]}" snapshot \
+  --repo SecPal/.github \
+  --pr 1 \
+  --config "$FIXTURES/config.json" >"$merged"
+
+"${helper[@]}" verify-evidence \
+  --snapshot "$merged" \
+  --config "$FIXTURES/config.json" >"$workspace/merged-evidence.json"
+
+if "${helper[@]}" verify-gate \
+  --snapshot "$merged" \
+  --config "$FIXTURES/config.json" >"$workspace/merged-gate.json"; then
+  echo "Merged evidence unexpectedly passed the open-PR merge gate." >&2
+  exit 1
+else
+  test "$?" -eq 3
+fi
+
 "${helper[@]}" verify-local \
   --repo SecPal/.github \
   --pr 1 \
@@ -63,18 +86,29 @@ test "$(stat -c '%a' "$json_output")" = "600"
 test "$(stat -c '%a' "$markdown")" = "600"
 cmp "$first" "$json_output"
 
-python3 - "$first" "$workspace/gate.json" "$workspace/local.json" <<'PY'
+python3 - \
+  "$first" \
+  "$workspace/gate.json" \
+  "$workspace/evidence.json" \
+  "$workspace/local.json" \
+  "$workspace/merged-evidence.json" \
+  "$workspace/merged-gate.json" <<'PY'
 import hashlib
 import json
 import sys
 
-snapshot_path, gate_path, local_path = sys.argv[1:]
+snapshot_path, gate_path, evidence_path, local_path, merged_evidence_path, merged_gate_path = sys.argv[1:]
 snapshot = json.load(open(snapshot_path, encoding="utf-8"))
 provided = snapshot.pop("snapshot_digest")
 canonical = json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
 assert hashlib.sha256(canonical).hexdigest() == provided
 
 gate = json.load(open(gate_path, encoding="utf-8"))
+evidence = json.load(open(evidence_path, encoding="utf-8"))
+assert evidence["status"] == "EVIDENCE_VERIFIED"
+assert evidence["evidence_verified"] is True
+assert evidence["pull_request_state"] == "OPEN"
+assert evidence["merge_authorized"] is False
 assert gate["raw_review_state"]["reviews"] == 2
 assert gate["raw_review_state"]["conversation_comments"] == 1
 assert gate["raw_review_state"]["review_threads"] == 2
@@ -127,6 +161,22 @@ assert connections["branch_protection.revalidation"]["pages"] == 1
 local = json.load(open(local_path, encoding="utf-8"))
 assert local["blockers"] == []
 assert local["local_head"] == "a" * 40
+
+merged_evidence = json.load(open(merged_evidence_path, encoding="utf-8"))
+assert merged_evidence["status"] == "EVIDENCE_VERIFIED"
+assert merged_evidence["evidence_verified"] is True
+assert merged_evidence["pull_request_state"] == "MERGED"
+assert merged_evidence["merge_authorized"] is False
+assert merged_evidence["blockers"] == []
+
+merged_gate = json.load(open(merged_gate_path, encoding="utf-8"))
+assert merged_gate["status"] == "BLOCKED"
+assert merged_gate["evidence_verified"] is True
+assert merged_gate["blockers"] == [{
+    "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+    "reason": "PR is not an open non-draft merge candidate",
+}]
+assert merged_gate["merge_authorized"] is False
 PY
 
 python3 - "$workspace/gh.log" "$workspace/git.log" <<'PY'

--- a/tests/secpal-pr-review-integration.sh
+++ b/tests/secpal-pr-review-integration.sh
@@ -199,7 +199,7 @@ for call in gh_calls:
     if "query PullRequestAnchor" in query:
         anchor_calls += 1
 
-assert anchor_calls == 12, anchor_calls
+assert anchor_calls == 15, anchor_calls
 
 prohibited_git = {"push", "commit", "checkout", "switch", "reset", "clean", "stash", "fetch"}
 assert all(not call or call[0] not in prohibited_git for call in git_calls)

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -437,6 +437,42 @@ class SnapshotAndPaginationTests(unittest.TestCase):
         self.assertEqual(gate["status"], "PACKAGE_2_2_CLASSIFICATION_REQUIRED")
         self.assertEqual(gate["blockers"], [])
 
+    def test_closed_pr_evidence_is_verified_but_cannot_pass_the_open_gate(self) -> None:
+        value = snapshot()
+        value["pull_request"]["state"] = "CLOSED"
+        value["pull_request"]["mergeable"] = None
+        value["pull_request"]["merge_state_status"] = "UNKNOWN"
+        value["pull_request"]["potential_merge_commit_oid"] = None
+        value = finalize_snapshot(value)
+        evidence = review.verify_snapshot_evidence(value, config())
+        gate = review.verify_snapshot_gate(value, config())
+        self.assertTrue(evidence["evidence_verified"])
+        self.assertEqual(evidence["pull_request_state"], "CLOSED")
+        self.assertEqual(
+            gate["blockers"],
+            [
+                {
+                    "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                    "reason": "PR is not an open non-draft merge candidate",
+                }
+            ],
+        )
+
+    def test_open_pr_unknown_or_conflicting_mergeability_still_blocks_the_gate(self) -> None:
+        for mergeable in ("UNKNOWN", "CONFLICTING"):
+            with self.subTest(mergeable=mergeable):
+                value = snapshot()
+                value["pull_request"]["mergeable"] = mergeable
+                result = review.verify_snapshot_gate(finalize_snapshot(value), config())
+                self.assertTrue(result["evidence_verified"])
+                self.assertIn(
+                    {
+                        "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                        "reason": "PR mergeability is conflicting or unknown",
+                    },
+                    result["blockers"],
+                )
+
     def test_merged_raw_review_state_remains_visible_to_evidence_verification(self) -> None:
         value = merged_snapshot()
         informational = review_record("COMMENTED")

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -567,6 +567,7 @@ class SnapshotAndPaginationTests(unittest.TestCase):
             ("github_invalid", "github_signature", "invalid"),
             ("local_unsigned", "local_signature", "unsigned"),
             ("local_unknown_key", "local_signature", "unknown_key"),
+            ("local_object_unavailable", "local_signature", "object_unavailable"),
         )
         for name, signature_name, state in cases:
             with self.subTest(case=name):
@@ -577,6 +578,10 @@ class SnapshotAndPaginationTests(unittest.TestCase):
                 self.assertIn(
                     "BLOCKED_INVALID_SIGNATURE",
                     [item["code"] for item in result["blockers"]],
+                )
+                self.assertTrue(
+                    any(state in item["reason"] for item in result["blockers"]),
+                    result["blockers"],
                 )
 
     def test_evidence_blocks_every_non_successful_required_check_outcome(self) -> None:

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -1703,6 +1703,115 @@ class SignatureAndCheckTests(unittest.TestCase):
         self.assertEqual(checks[0]["evidence_state"], "required_missing")
         self.assertEqual(evidence["missing"], ["check:1:tests"])
 
+    def test_newer_check_run_supersedes_an_older_failure_from_the_same_app(self) -> None:
+        raw = []
+        for stable_id, conclusion, started_at in (
+            ("check_run:OLD", "FAILURE", "2026-07-20T08:45:24Z"),
+            ("check_run:NEW", "SUCCESS", "2026-07-20T09:04:05Z"),
+        ):
+            raw.append(
+                {
+                    "stable_id": stable_id,
+                    "name": "tests",
+                    "application": {
+                        "id": "APP_1",
+                        "database_id": 1,
+                        "name": "Actions",
+                        "slug": "github-actions",
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": conclusion,
+                    "started_at": started_at,
+                    "created_at": None,
+                    "details_url": f"https://github.com/SecPal/.github/actions/runs/{stable_id[-3:]}",
+                }
+            )
+
+        checks, evidence = review.evaluate_checks(
+            raw,
+            [{"context": "tests", "integration_id": 1}],
+            config()["check_policy"],
+        )
+        by_id = {item["stable_id"]: item for item in checks}
+        self.assertFalse(by_id["check_run:OLD"]["is_effective"])
+        self.assertTrue(by_id["check_run:NEW"]["is_effective"])
+
+        value = snapshot()
+        value["checks"] = checks
+        value["required_check_evidence"] = evidence
+        result = review.verify_snapshot_evidence(finalize_snapshot(value), config())
+        self.assertTrue(result["evidence_verified"])
+        self.assertEqual(result["blockers"], [])
+
+    def test_latest_required_check_failure_cannot_be_hidden_by_an_older_success(self) -> None:
+        raw = []
+        for stable_id, conclusion, started_at in (
+            ("check_run:OLD", "SUCCESS", "2026-07-20T08:45:24Z"),
+            ("check_run:NEW", "FAILURE", "2026-07-20T09:04:05Z"),
+        ):
+            raw.append(
+                {
+                    "stable_id": stable_id,
+                    "name": "tests",
+                    "application": {
+                        "id": "APP_1",
+                        "database_id": 1,
+                        "name": "Actions",
+                        "slug": "github-actions",
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": conclusion,
+                    "started_at": started_at,
+                    "created_at": None,
+                    "details_url": f"https://github.com/SecPal/.github/actions/runs/{stable_id[-3:]}",
+                }
+            )
+
+        checks, evidence = review.evaluate_checks(
+            raw,
+            [{"context": "tests", "integration_id": 1}],
+            config()["check_policy"],
+        )
+        value = snapshot()
+        value["checks"] = checks
+        value["required_check_evidence"] = evidence
+        result = review.verify_snapshot_evidence(finalize_snapshot(value), config())
+        self.assertFalse(result["evidence_verified"])
+        self.assertEqual(
+            [item["reason"] for item in result["blockers"]],
+            ["tests: required_failed"],
+        )
+
+    def test_duplicate_check_runs_without_ordering_evidence_remain_fail_closed(self) -> None:
+        raw = [
+            {
+                "stable_id": f"check_run:{suffix}",
+                "name": "tests",
+                "application": {
+                    "id": "APP_1",
+                    "database_id": 1,
+                    "name": "Actions",
+                    "slug": "github-actions",
+                },
+                "status": "COMPLETED",
+                "conclusion": conclusion,
+                "details_url": None,
+            }
+            for suffix, conclusion in (("OLD", "FAILURE"), ("NEW", "SUCCESS"))
+        ]
+        checks, evidence = review.evaluate_checks(
+            raw,
+            [{"context": "tests", "integration_id": 1}],
+            config()["check_policy"],
+        )
+        self.assertTrue(all(item["is_effective"] for item in checks))
+        value = snapshot()
+        value["checks"] = checks
+        value["required_check_evidence"] = evidence
+        result = review.verify_snapshot_evidence(finalize_snapshot(value), config())
+        self.assertFalse(result["evidence_verified"])
+        self.assertIn("tests: required_failed", [item["reason"] for item in result["blockers"]])
+
     def test_generic_requirement_is_satisfied_by_the_only_present_context_kind(self) -> None:
         raw = [check() | {"requiredness": None, "evidence_state": None}]
         _, evidence = review.evaluate_checks(

--- a/tests/secpal-pr-review-unit.py
+++ b/tests/secpal-pr-review-unit.py
@@ -339,6 +339,22 @@ def snapshot() -> dict[str, Any]:
     return finalize_snapshot(value)
 
 
+def merged_snapshot(*, mergeable: str | None = "UNKNOWN") -> dict[str, Any]:
+    """Return complete immutable evidence for an already-merged pull request."""
+
+    value = snapshot()
+    pull_request = value["pull_request"]
+    pull_request["state"] = "MERGED"
+    pull_request["is_merged"] = True
+    pull_request["is_draft"] = False
+    pull_request["mergeable"] = mergeable
+    pull_request["merge_state_status"] = "UNKNOWN"
+    pull_request["potential_merge_commit_oid"] = None
+    pull_request["check_commit_oid"] = HEAD
+    pull_request["check_commit_source"] = "head"
+    return finalize_snapshot(value)
+
+
 class FakeGitRunner:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
@@ -387,6 +403,193 @@ class FakeGitRunner:
 
 
 class SnapshotAndPaginationTests(unittest.TestCase):
+    def test_merged_evidence_is_verified_without_authorizing_merge(self) -> None:
+        for mergeable in ("UNKNOWN", None):
+            with self.subTest(mergeable=mergeable):
+                result = review.verify_snapshot_evidence(
+                    merged_snapshot(mergeable=mergeable),
+                    config(),
+                )
+                self.assertEqual(result["status"], "EVIDENCE_VERIFIED")
+                self.assertTrue(result["evidence_verified"])
+                self.assertEqual(result["pull_request_state"], "MERGED")
+                self.assertFalse(result["merge_authorized"])
+                self.assertEqual(result["blockers"], [])
+
+    def test_merged_evidence_remains_ineligible_for_the_open_pr_gate(self) -> None:
+        result = review.verify_snapshot_gate(merged_snapshot(), config())
+        self.assertTrue(result["evidence_verified"])
+        self.assertEqual(
+            result["blockers"],
+            [
+                {
+                    "code": "BLOCKED_UNSAFE_GITHUB_STATE",
+                    "reason": "PR is not an open non-draft merge candidate",
+                }
+            ],
+        )
+
+    def test_open_pr_gate_retains_its_existing_ready_result(self) -> None:
+        evidence = review.verify_snapshot_evidence(snapshot(), config())
+        gate = review.verify_snapshot_gate(snapshot(), config())
+        self.assertTrue(evidence["evidence_verified"])
+        self.assertEqual(evidence["status"], "EVIDENCE_VERIFIED")
+        self.assertEqual(gate["status"], "PACKAGE_2_2_CLASSIFICATION_REQUIRED")
+        self.assertEqual(gate["blockers"], [])
+
+    def test_merged_raw_review_state_remains_visible_to_evidence_verification(self) -> None:
+        value = merged_snapshot()
+        informational = review_record("COMMENTED")
+        informational["reactions"] = [reaction("REACTION_REVIEW")]
+        historical_changes = review_record("CHANGES_REQUESTED", commit=PARENT)
+        historical_changes["id"] = "REVIEW_HISTORICAL_CHANGES"
+        historical_changes["database_id"] = 12
+        historical_changes["submitted_at"] = "2026-07-18T00:00:00Z"
+        value["reviews"] = [historical_changes, informational]
+        value["conversation_comments"] = [
+            {
+                "id": "CONVERSATION_1",
+                "database_id": 12,
+                "author": actor("human"),
+                "body": "Top-level context",
+                "url": "https://github.com/SecPal/.github/pull/1#issuecomment-12",
+                "created_at": "2026-07-19T00:00:00Z",
+                "updated_at": "2026-07-19T00:00:00Z",
+                "reactions": [reaction("REACTION_CONVERSATION")],
+            }
+        ]
+        resolved_comment = review_comment("RC_RESOLVED")
+        resolved_comment["reactions"] = [reaction("REACTION_THREAD")]
+        value["review_threads"] = [
+            thread("THREAD_RESOLVED", resolved=True, outdated=True, comments=[resolved_comment]),
+            thread(
+                "THREAD_UNRESOLVED",
+                resolved=False,
+                comments=[review_comment("RC_UNRESOLVED", login="human")],
+            ),
+        ]
+        value["pull_request"]["reactions"] = [reaction("REACTION_PR")]
+        value["pull_request"]["requested_reviewers"] = [actor("pending-reviewer")]
+        value = finalize_snapshot(value)
+
+        evidence = review.verify_snapshot_evidence(value, config())
+        raw = evidence["raw_review_state"]
+        self.assertTrue(evidence["evidence_verified"])
+        self.assertEqual(raw["reviews"], 2)
+        self.assertEqual(raw["conversation_comments"], 1)
+        self.assertEqual(raw["review_threads"], 2)
+        self.assertEqual(raw["resolved_threads"], 1)
+        self.assertEqual(raw["unresolved_threads"], 1)
+        self.assertEqual(raw["outdated_threads"], 1)
+        self.assertEqual(raw["reactions"], 4)
+        self.assertEqual(raw["requested_changes_reviews"], 1)
+        self.assertFalse(raw["requested_changes"])
+        self.assertTrue(raw["review_requested"])
+        self.assertTrue(evidence["technical_classification_required"])
+        self.assertIn(
+            "NOT_READY_FOR_MERGE",
+            [item["code"] for item in review.verify_snapshot_gate(value, config())["blockers"]],
+        )
+
+    def test_inconsistent_pr_lifecycle_states_are_rejected(self) -> None:
+        cases = (
+            ("merged_without_flag", {"state": "MERGED", "is_merged": False}),
+            ("open_with_merged_flag", {"state": "OPEN", "is_merged": True}),
+            ("closed_with_merged_flag", {"state": "CLOSED", "is_merged": True}),
+            ("merged_draft", {"state": "MERGED", "is_merged": True, "is_draft": True}),
+        )
+        for name, changes in cases:
+            with self.subTest(case=name):
+                value = merged_snapshot()
+                value["pull_request"].update(changes)
+                with self.assertRaises(review.ContractError):
+                    review.verify_snapshot_evidence(review.attach_digest(value), config())
+
+    def test_evidence_rejects_unstable_or_incomplete_snapshot_contracts(self) -> None:
+        cases = []
+        moved = merged_snapshot()
+        moved["pull_request"]["head_oid_after"] = PARENT
+        cases.append(("moved_head", moved))
+        missing_head = merged_snapshot()
+        missing_head["commits"][0]["oid"] = PARENT
+        cases.append(("missing_head_commit", finalize_snapshot(missing_head)))
+        incomplete = merged_snapshot()
+        incomplete["completeness"]["fully_paginated_connections"] = []
+        cases.append(("incomplete_pagination", review.attach_digest(incomplete)))
+        invalid_digest = merged_snapshot()
+        invalid_digest["snapshot_digest"] = "0" * 64
+        cases.append(("invalid_digest", invalid_digest))
+        for name, value in cases:
+            with self.subTest(case=name), self.assertRaises(review.ContractError):
+                review.verify_snapshot_evidence(
+                    review.attach_digest(value) if name == "moved_head" else value,
+                    config(),
+                )
+
+    def test_evidence_blocks_required_signature_failures(self) -> None:
+        cases = (
+            ("github_invalid", "github_signature", "invalid"),
+            ("local_unsigned", "local_signature", "unsigned"),
+            ("local_unknown_key", "local_signature", "unknown_key"),
+        )
+        for name, signature_name, state in cases:
+            with self.subTest(case=name):
+                value = merged_snapshot()
+                value["commits"][0][signature_name] = signature(state)
+                result = review.verify_snapshot_evidence(finalize_snapshot(value), config())
+                self.assertFalse(result["evidence_verified"])
+                self.assertIn(
+                    "BLOCKED_INVALID_SIGNATURE",
+                    [item["code"] for item in result["blockers"]],
+                )
+
+    def test_evidence_blocks_every_non_successful_required_check_outcome(self) -> None:
+        outcomes = (
+            ("pending", [check(status="IN_PROGRESS", conclusion=None)]),
+            ("failed", [check(status="COMPLETED", conclusion="FAILURE")]),
+            ("missing", []),
+        )
+        for name, raw_checks in outcomes:
+            with self.subTest(outcome=name):
+                value = merged_snapshot()
+                raw = [
+                    {
+                        key: item[key]
+                        for key in (
+                            "stable_id",
+                            "name",
+                            "application",
+                            "status",
+                            "conclusion",
+                            "details_url",
+                        )
+                    }
+                    for item in raw_checks
+                ]
+                value["checks"], value["required_check_evidence"] = review.evaluate_checks(
+                    raw,
+                    [{"context": "tests", "integration_id": 1}],
+                    config()["check_policy"],
+                )
+                result = review.verify_snapshot_evidence(finalize_snapshot(value), config())
+                self.assertFalse(result["evidence_verified"])
+                self.assertIn(
+                    "BLOCKED_FAILED_OR_PENDING_CI",
+                    [item["code"] for item in result["blockers"]],
+                )
+
+    def test_evidence_rejects_unknown_requiredness_and_incomplete_rules(self) -> None:
+        unknown = merged_snapshot()
+        unknown["checks"][0]["requiredness"] = "unknown"
+        unknown["checks"][0]["evidence_state"] = "requiredness_unknown"
+        unknown["required_check_evidence"]["determination"] = "incomplete"
+        unknown["required_check_evidence"]["unknown_reasons"] = ["unknown"]
+        incomplete_rules = merged_snapshot()
+        incomplete_rules["applicable_rules"]["evidence_complete"] = False
+        for value in (unknown, incomplete_rules):
+            with self.assertRaises(review.ContractError):
+                review.verify_snapshot_evidence(review.attach_digest(value), config())
+
     def test_01_zero_findings(self) -> None:
         result = review.verify_snapshot_gate(snapshot(), config())
         self.assertEqual(result["raw_review_state"]["unresolved_threads"], 0)


### PR DESCRIPTION
## Package 2.1 follow-up scope

Corrects the post-merge recovery defect found after #572 by separating immutable evidence verification from current open-PR merge readiness.

## Root cause and reproduction

`verify-gate` previously applied open-candidate requirements to every snapshot. A complete merged snapshot was therefore blocked by its expected post-merge lifecycle values:

```bash
python3 scripts/secpal-pr-review.py verify-gate --snapshot merged-pr.json
```

The old result included lifecycle, mergeability, and merge-state blockers even though the immutable evidence was complete.

## Architectural correction

- Adds read-only `verify-evidence` for open, closed, merged, and historical snapshots.
- Reuses the same evidence-policy evaluator from `verify-gate`.
- Keeps `verify-gate` strict for current open, non-Draft merge candidates.
- Treats merged `mergeable: UNKNOWN|null` and `merge_state_status: UNKNOWN` as post-merge lifecycle values, not evidence-integrity failures.
- Preserves signature, rule, required-check, cap, pagination, identity, commit-set, and raw review-state enforcement.
- Neither command authorizes merge.

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-pr-review-unit.py` ran 172 tests with 20 expected errors; `bash tests/secpal-pr-review-integration.sh` exited 2 because `verify-evidence` was absent.
- Passing proof after implementation: `python3 -m unittest tests/secpal-pr-review-unit.py` passed 174 tests and `bash tests/secpal-pr-review-integration.sh` passed.
- Validate-first exception reference: N/A
- No executable change reason: N/A
Before implementation:

- `python3 -m unittest tests/secpal-pr-review-unit.py`: 172 tests ran; 20 expected errors because `verify_snapshot_evidence` did not exist and gate reports lacked the new separation.
- `bash tests/secpal-pr-review-integration.sh`: exit 2 because `verify-evidence` was not a recognized command.

The contract was committed separately before the implementation.

## Coverage

The focused tests cover:

- stable merged evidence with `UNKNOWN` and null mergeability;
- closed and open evidence;
- merged PR rejection by the open gate with exactly one lifecycle blocker;
- unchanged successful open-PR behavior;
- inconsistent lifecycle states and head anchors;
- missing head commit, invalid digest, and incomplete pagination;
- invalid, unsigned, and unknown-key signature evidence;
- pending, failed, missing, and unknown required-check evidence;
- informational, historical requested-changes, resolved, unresolved, outdated, comment, reviewer-request, and reaction evidence;
- fake-`gh` proof of the read-only command boundary.

## Local validation

Passed:

- `python3 -m unittest tests/secpal-pr-review-unit.py` — 174 tests
- `bash tests/secpal-pr-review-integration.sh`
- `python3 -m py_compile scripts/secpal-pr-review.py`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/copilot-review-memory.sh`
- `bash tests/copilot-review-memory-errors.sh`
- `bash tests/reusable-workflow-policy.sh`
- `shellcheck tests/secpal-pr-review-integration.sh`
- `bash -n tests/secpal-pr-review-integration.sh`
- `npm run lint:markdown`
- `reuse lint`
- Prettier checks for changed Markdown
- pre-commit for every changed file
- `git diff --check`

## Live read-only acceptance

- `SecPal/.github#572`: evidence verified; merged gate returned only the expected open-candidate lifecycle blocker.
- `SecPal/.github#571`: merged evidence verified.
- `SecPal/.github#570`: merged evidence verified with resolved/outdated history retained.
- `SecPal/api#503`: correctly remained blocked by strict local-signature and historical required-check evidence; requested changes and four unresolved threads remained visible.

Every capture used stable before/after anchors. No polling or retry was performed.

## Security boundary

The helper still exposes no GitHub mutation, Git write, fetch, review request, reaction, reply, thread resolution, label, issue, Draft/Ready transition, push, or merge operation. Live acceptance caused no GitHub or Git writes.

## Non-goals

- No Package 2.2 orchestration or finding classification
- No `secpal-pr-review` skill or symlink
- No repository registry
- No review-memory changes
- No Package 1, Polyscope, workflow, settings, ruleset, branch-protection, App, secret, or variable changes

Package 2.2 has not begun.