### PR TITLE
fix(polyscope): serialize API workspace bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-20 - Serialize Polyscope API Workspace Bootstrap
+
+**Fixed:**
+
+- serialized each API worktree's complete Preview bootstrap through a private,
+  canonical-path lock shared by native setup, background provisioning, direct
+  setup, and refresh, preventing concurrent Laravel migration plans for the
+  same physical workspace while preserving parallel setup of distinct API
+  worktrees and bounded tenant-key recovery
+
 ## 2026-07-20 - Separate Post-Merge Evidence From Merge Readiness
 
 **Fixed:**

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -108,6 +108,10 @@ def default_provision_lock_path() -> pathlib.Path:
     return pathlib.Path.home() / ".local" / "state" / "polyscope" / "worktree-provision.lock"
 
 
+def default_api_worktree_bootstrap_lock_directory() -> pathlib.Path:
+    return default_provision_lock_path().parent / "api-worktree-bootstrap-locks"
+
+
 @contextlib.contextmanager
 def provision_worktree_lock(lock_path: pathlib.Path):
     """Serialize provisioners without making the lock itself a watched input."""
@@ -130,6 +134,105 @@ def provision_worktree_lock(lock_path: pathlib.Path):
         yield
     finally:
         os.close(descriptor)
+
+
+def canonical_api_worktree_path(worktree_path: pathlib.Path) -> pathlib.Path:
+    try:
+        resolved_worktree = worktree_path.resolve(strict=True)
+    except OSError as error:
+        raise RuntimeError(f"API worktree cannot be resolved for bootstrap locking: {worktree_path}") from error
+    if not resolved_worktree.is_dir():
+        raise RuntimeError(f"API worktree is not a directory: {resolved_worktree}")
+    return resolved_worktree
+
+
+def api_worktree_bootstrap_lock_path(worktree_path: pathlib.Path) -> pathlib.Path:
+    resolved_worktree = canonical_api_worktree_path(worktree_path)
+    lock_identifier = hashlib.sha256(os.fsencode(resolved_worktree)).hexdigest()
+    return default_api_worktree_bootstrap_lock_directory() / f"{lock_identifier}.lock"
+
+
+def validate_private_lock_directory(descriptor: int, directory_path: pathlib.Path) -> None:
+    directory_stat = os.fstat(descriptor)
+    if not stat.S_ISDIR(directory_stat.st_mode):
+        raise RuntimeError(f"API bootstrap lock directory is not a directory: {directory_path}")
+    if directory_stat.st_uid != os.geteuid():
+        raise RuntimeError(f"API bootstrap lock directory is not owned by the caller: {directory_path}")
+    if stat.S_IMODE(directory_stat.st_mode) & 0o077:
+        raise RuntimeError(f"API bootstrap lock directory is not private: {directory_path}")
+
+
+def open_api_worktree_bootstrap_lock_directory() -> tuple[int, pathlib.Path]:
+    lock_directory = default_api_worktree_bootstrap_lock_directory()
+    state_directory = lock_directory.parent
+    state_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    try:
+        state_descriptor = os.open(state_directory, directory_flags)
+    except OSError as error:
+        raise RuntimeError(f"unable to open private Polyscope state directory: {state_directory}") from error
+    try:
+        validate_private_lock_directory(state_descriptor, state_directory)
+        try:
+            os.mkdir(lock_directory.name, 0o700, dir_fd=state_descriptor)
+        except FileExistsError:
+            pass
+        try:
+            lock_directory_descriptor = os.open(
+                lock_directory.name,
+                directory_flags,
+                dir_fd=state_descriptor,
+            )
+        except OSError as error:
+            raise RuntimeError(f"unable to open private API bootstrap lock directory: {lock_directory}") from error
+    finally:
+        os.close(state_descriptor)
+
+    try:
+        validate_private_lock_directory(lock_directory_descriptor, lock_directory)
+    except BaseException:
+        os.close(lock_directory_descriptor)
+        raise
+    return lock_directory_descriptor, lock_directory
+
+
+@contextlib.contextmanager
+def acquire_api_worktree_bootstrap_lock(worktree_path: pathlib.Path):
+    """Serialize the complete API bootstrap for one canonical physical worktree."""
+    resolved_worktree = canonical_api_worktree_path(worktree_path)
+    lock_path = api_worktree_bootstrap_lock_path(resolved_worktree)
+    lock_directory_descriptor, lock_directory = open_api_worktree_bootstrap_lock_directory()
+    descriptor = -1
+    try:
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(
+                lock_path.name,
+                flags,
+                0o600,
+                dir_fd=lock_directory_descriptor,
+            )
+        except OSError as error:
+            raise RuntimeError(f"unable to open API bootstrap lock in {lock_directory}") from error
+        lock_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(lock_stat.st_mode):
+            raise RuntimeError(f"API bootstrap lock must be a regular file: {lock_path}")
+        if lock_stat.st_uid != os.geteuid() or lock_stat.st_nlink != 1:
+            raise RuntimeError(f"API bootstrap lock must be owned by the caller and have one link: {lock_path}")
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        if canonical_api_worktree_path(worktree_path) != resolved_worktree:
+            raise RuntimeError(f"API worktree changed while waiting for bootstrap lock: {worktree_path}")
+        yield resolved_worktree
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(lock_directory_descriptor)
 
 
 def resolve_path_for_matching(path: pathlib.Path) -> str:
@@ -573,15 +676,6 @@ def build_fail_closed_setup_command(commands: list[str]) -> str:
 
     setup_script = "set -euo pipefail\n" + "\n".join(grouped_commands)
     return f"bash -c {shlex.quote(setup_script)}"
-
-
-def build_api_preview_env_setup_command(source_repo_path: pathlib.Path) -> str:
-    rollout_script = shlex.quote(str(ROLLOUT_SCRIPT_PATH))
-    source_repo = shlex.quote(str(source_repo_path))
-    return (
-        f"python3 {rollout_script} --prepare-api-worktree \"$PWD\" "
-        f"--source-repo-path {source_repo}"
-    )
 
 
 def build_api_preview_runtime_shell_command(command: str, source_repo_path: pathlib.Path) -> str:
@@ -1185,26 +1279,18 @@ def discard_stale_preview_kek(
     return True
 
 
-def bootstrap_api_worktree(
+def _bootstrap_api_worktree_locked(
     worktree_path: pathlib.Path,
     source_repo_path: pathlib.Path,
     *,
     db_path: pathlib.Path | None = None,
+    preview_storage_target: str | None = None,
     migration_command: list[str] | None = None,
     migration_label: str = "running migrations",
     allow_tenant_key_recovery: bool = True,
 ) -> tuple[bool, str | None]:
+    """Run the API mutation pipeline while the caller holds its worktree lock."""
     env_path = worktree_path / ".env"
-    preview_storage_target: str | None = None
-    if not env_path.exists():
-        ready, preview_storage_target = ensure_api_worktree_ready(
-            worktree_path,
-            source_repo_path,
-            db_path=db_path,
-        )
-        if not ready:
-            return ready, preview_storage_target
-
     env_values = load_env_assignments(env_path)
     if preview_storage_target is None:
         preview_storage_target = build_api_preview_storage_target(env_values)
@@ -1275,10 +1361,11 @@ def bootstrap_api_worktree(
             raise
 
         print(f"{prefix} recovering stale preview tenant key material")
-        return bootstrap_api_worktree(
+        return _bootstrap_api_worktree_locked(
             worktree_path,
             source_repo_path,
             db_path=db_path,
+            preview_storage_target=preview_storage_target,
             migration_command=["php", "artisan", "migrate:fresh", "--force"],
             migration_label="resetting preview database after tenant key recovery",
             allow_tenant_key_recovery=False,
@@ -1294,19 +1381,54 @@ def bootstrap_api_worktree(
     return True, preview_storage_target
 
 
+def prepare_api_worktree(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    db_path: pathlib.Path | None = None,
+) -> tuple[bool, str | None]:
+    with acquire_api_worktree_bootstrap_lock(worktree_path) as locked_worktree_path:
+        return ensure_api_worktree_ready(
+            locked_worktree_path,
+            source_repo_path,
+            db_path=db_path,
+        )
+
+
+def bootstrap_api_worktree(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    db_path: pathlib.Path | None = None,
+    migration_command: list[str] | None = None,
+    migration_label: str = "running migrations",
+    allow_tenant_key_recovery: bool = True,
+) -> tuple[bool, str | None]:
+    with acquire_api_worktree_bootstrap_lock(worktree_path) as locked_worktree_path:
+        ready, preview_storage_target = ensure_api_worktree_ready(
+            locked_worktree_path,
+            source_repo_path,
+            db_path=db_path,
+        )
+        if not ready:
+            return ready, preview_storage_target
+        return _bootstrap_api_worktree_locked(
+            locked_worktree_path,
+            source_repo_path,
+            db_path=db_path,
+            preview_storage_target=preview_storage_target,
+            migration_command=migration_command,
+            migration_label=migration_label,
+            allow_tenant_key_recovery=allow_tenant_key_recovery,
+        )
+
+
 def refresh_api_worktree(
     worktree_path: pathlib.Path,
     source_repo_path: pathlib.Path,
     *,
     db_path: pathlib.Path | None = None,
 ) -> tuple[bool, str | None]:
-    ready, preview_storage_target = ensure_api_worktree_ready(
-        worktree_path,
-        source_repo_path,
-        db_path=db_path,
-    )
-    if not ready:
-        return ready, preview_storage_target
     return bootstrap_api_worktree(
         worktree_path,
         source_repo_path,
@@ -2323,7 +2445,6 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "preview": {"url": build_preview_url_template("api")},
             "scripts": {
                 "setup": [
-                    "test -d vendor || composer install",
                     API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,
                 ],
                 "run": [
@@ -2873,7 +2994,6 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
         spec["copilot_instructions"] = repo_path / settings["copilot_instructions"]
         spec["focus_instruction_paths"] = [repo_path / path for path in settings["focus_instruction_paths"]]
         if repo_name == "api":
-            spec["local_config"]["scripts"]["setup"].insert(0, build_api_preview_env_setup_command(repo_path))
             spec["local_config"]["scripts"]["setup"] = [
                 build_api_preview_bootstrap_command(repo_path)
                 if command == API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER
@@ -3213,11 +3333,15 @@ def validate_local_config_command(
     package_lock_path = repo_path / "package-lock.json"
     composer_json_path = repo_path / "composer.json"
     artisan_path = repo_path / "artisan"
+    references_api_bootstrap = "--bootstrap-api-worktree" in command
 
-    if re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command) and not composer_json_path.exists():
+    if (
+        re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command)
+        or references_api_bootstrap
+    ) and not composer_json_path.exists():
         raise SystemExit(f"{repo_name} polyscope config references composer without a composer.json at the repo root")
 
-    if re.search(r"\bphp\s+artisan\b", command) and not artisan_path.exists():
+    if (re.search(r"\bphp\s+artisan\b", command) or references_api_bootstrap) and not artisan_path.exists():
         raise SystemExit(f"{repo_name} polyscope config references artisan without an artisan file at the repo root")
 
     references_npm = any(
@@ -3469,7 +3593,10 @@ def collect_setup_inputs(worktree_path: pathlib.Path, setup_commands: list[str])
     if re.search(r"\bnpm\s+(?:ci|install|run)\b|\bnpx\b", command_text):
         candidate_paths.extend([worktree_path / "package.json", worktree_path / "package-lock.json"])
 
-    if re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command_text):
+    if (
+        re.search(r"\bcomposer\s+(?:install|run(?:-script)?)\b", command_text)
+        or "--bootstrap-api-worktree" in command_text
+    ):
         candidate_paths.extend([worktree_path / "composer.json", worktree_path / "composer.lock"])
 
     for path in candidate_paths:
@@ -3860,11 +3987,6 @@ def provision_worktrees(
     for repo_name, spec in repo_specs.items():
         validation_commands = list(spec[NATIVE_SETUP_COMMANDS_KEY])
         setup_commands = validation_commands
-        if repo_name == "api":
-            # The external provisioner already validated the candidate and the
-            # API bootstrap command performs its own readiness preparation.
-            # Skip the native runner's prepare entry here.
-            setup_commands = setup_commands[1:]
 
         for worktree_path in registered_worktrees[repo_name]:
             if not worktree_path.is_dir() or worktree_path.is_symlink():
@@ -3947,45 +4069,70 @@ def provision_worktrees(
             ensure_workspace_alias(worktree_path, db_path=db_path)
             sync_worktree_auxiliary_files(repo_name, worktree_path)
             ensure_worktree_hooks(worktree_path)
-            linked_setup_context = collect_linked_setup_context(worktree_path, db_path=db_path)
-            workspace = resolve_current_workspace_name(worktree_path, db_path=db_path)
-            setup_hash = build_setup_hash(
-                worktree_path,
-                setup_commands,
-                db_path=db_path,
-                linked_context=linked_setup_context,
+            lock_context = (
+                acquire_api_worktree_bootstrap_lock(worktree_path)
+                if repo_name == "api"
+                else contextlib.nullcontext(worktree_path)
             )
+            with lock_context as locked_worktree_path:
+                # API state is intentionally derived only after the same lock
+                # used by native setup, direct bootstrap, and refresh callers.
+                linked_setup_context = collect_linked_setup_context(locked_worktree_path, db_path=db_path)
+                workspace = resolve_current_workspace_name(locked_worktree_path, db_path=db_path)
+                setup_hash = build_setup_hash(
+                    locked_worktree_path,
+                    setup_commands,
+                    db_path=db_path,
+                    linked_context=linked_setup_context,
+                )
 
-            preview_storage_target: str | None = None
-            if repo_name == "api":
-                ready, preview_storage_target = ensure_api_worktree_ready(worktree_path, spec["path"], db_path=db_path)
-                if not ready:
-                    continue
+                preview_storage_target: str | None = None
+                if repo_name == "api":
+                    ready, preview_storage_target = ensure_api_worktree_ready(
+                        locked_worktree_path,
+                        spec["path"],
+                        db_path=db_path,
+                    )
+                    if not ready:
+                        continue
 
-            marker_path = worktree_path / PROVISION_MARKER_FILENAME
-            marker = load_provision_marker(marker_path)
-            if marker is not None and marker.get("setup_hash") == setup_hash:
-                if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
-                    continue
+                marker_path = locked_worktree_path / PROVISION_MARKER_FILENAME
+                marker = load_provision_marker(marker_path)
+                if marker is not None and marker.get("setup_hash") == setup_hash:
+                    if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
+                        continue
 
-            if setup_commands:
-                print(f"Provisioning {repo_name} worktree {worktree_path.name} at {worktree_path}")
-                run_setup_commands(worktree_path, setup_commands, db_path=db_path)
+                if setup_commands:
+                    print(
+                        f"Provisioning {repo_name} worktree {locked_worktree_path.name} "
+                        f"at {locked_worktree_path}"
+                    )
+                    if repo_name == "api":
+                        ready, preview_storage_target = _bootstrap_api_worktree_locked(
+                            locked_worktree_path,
+                            spec["path"],
+                            db_path=db_path,
+                            preview_storage_target=preview_storage_target,
+                        )
+                        if not ready:
+                            continue
+                    else:
+                        run_setup_commands(locked_worktree_path, setup_commands, db_path=db_path)
 
-            marker_payload: dict[str, Any] = {
-                "repo": repo_name,
-                "workspace": workspace,
-                "physical_workspace": worktree_path.name,
-                "setup_hash": setup_hash,
-                "provisioned_at": datetime.now(timezone.utc).isoformat(),
-            }
-            if repo_name == "api" and preview_storage_target is not None:
-                marker_payload["preview_storage_target"] = preview_storage_target
-            if linked_setup_context:
-                marker_payload["linked_workspaces"] = linked_setup_context
+                marker_payload: dict[str, Any] = {
+                    "repo": repo_name,
+                    "workspace": workspace,
+                    "physical_workspace": locked_worktree_path.name,
+                    "setup_hash": setup_hash,
+                    "provisioned_at": datetime.now(timezone.utc).isoformat(),
+                }
+                if repo_name == "api" and preview_storage_target is not None:
+                    marker_payload["preview_storage_target"] = preview_storage_target
+                if linked_setup_context:
+                    marker_payload["linked_workspaces"] = linked_setup_context
 
-            marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
-            provisioned_worktrees.append(f"{repo_name}:{workspace}")
+                marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
+                provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)
             print(
@@ -4642,7 +4789,7 @@ def dispatch_instruction_dependent_direct_api_mode(args: argparse.Namespace) -> 
     )
 
     if mode == "prepare_api_worktree":
-        ready, _preview_storage_target = ensure_api_worktree_ready(
+        ready, _preview_storage_target = prepare_api_worktree(
             worktree_path,
             source_repo_path,
             db_path=args.db_path,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -179,6 +179,7 @@ def open_api_worktree_bootstrap_lock_directory() -> tuple[int, pathlib.Path]:
         try:
             os.mkdir(lock_directory.name, 0o700, dir_fd=state_descriptor)
         except FileExistsError:
+            # A concurrent bootstrap may create it first; the open and validation below still fail closed.
             pass
         try:
             lock_directory_descriptor = os.open(

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1185,6 +1185,220 @@ assert not (isolated_root / "polyscope.db").exists()
 assert "All tests passed" not in isolated_result.stderr
 PY
 
+# Concurrent direct API bootstrap invocations must serialize the complete
+# mutation sequence for a physical worktree and an alias to that worktree. The
+# fake migration deliberately holds the first process after it has loaded a
+# pending plan; without serialization the alias invocation records the same
+# migration first and the held process reports PostgreSQL duplicate-column
+# behavior when it resumes.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace" "$REPO_ROOT"
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+repo_root = pathlib.Path(sys.argv[3])
+fixture = workspace / "concurrent-api-bootstrap-fixture"
+source_api = fixture / "source-api"
+physical_worktree = fixture / "clones" / "api12345" / "quiet-finch-d35c0cdc"
+alias_worktree = physical_worktree.parent / "quiet-finch"
+fake_bin = fixture / "fake-bin"
+race_state = fixture / "migration-state"
+command_log = fixture / "commands.log"
+release_first = fixture / "release-first"
+
+
+def write_valid_instruction_root(root: pathlib.Path) -> None:
+    (root / ".github").mkdir(parents=True)
+    shutil.copy2(repo_root / ".markdownlint.json", root / ".markdownlint.json")
+    (root / "AGENTS.md").write_text(
+        "<!--\n"
+        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-License" "-Identifier: CC0-1.0\n"
+        "-->\n\n"
+        "# Test Runtime Instructions\n\n"
+        "- Preserve existing work.\n"
+    )
+    (root / ".github" / "copilot-instructions.md").write_text(
+        "<!--\n"
+        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-License" "-Identifier: CC0-1.0\n"
+        "-->\n\n"
+        "# Test Review Profile\n\n"
+        "- Review the complete diff.\n"
+    )
+
+
+write_valid_instruction_root(source_api)
+write_valid_instruction_root(physical_worktree)
+fake_bin.mkdir(parents=True)
+race_state.mkdir()
+alias_worktree.symlink_to(physical_worktree.name)
+os.mkfifo(release_first)
+
+source_api.joinpath(".env.example").write_text(
+    "APP_ENV=local\n"
+    "APP_KEY=\n"
+    "APP_URL=http://localhost\n"
+    "FRONTEND_URL=http://localhost\n"
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal\n"
+    "DB_PASSWORD=\n"
+)
+source_api.joinpath(".env").write_text(
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal\n"
+    "DB_USERNAME=secpal\n"
+    "DB_PASSWORD=fixture-db-password\n"
+)
+physical_worktree.joinpath(".env").write_text(
+    "APP_ENV=local\n"
+    "APP_KEY=base64:fixture-app-key\n"
+    "DB_CONNECTION=pgsql\n"
+    "DB_HOST=127.0.0.1\n"
+    "DB_PORT=5432\n"
+    "DB_DATABASE=secpal__preview__quiet_finch\n"
+    "DB_USERNAME=secpal\n"
+    "DB_PASSWORD=fixture-db-password\n"
+    "POLYSCOPE_BASE_DB_DATABASE=secpal\n"
+    "POLYSCOPE_PREVIEW_STORAGE_MODE=database\n"
+)
+
+fake_bin.joinpath("composer").write_text(
+    """#!/usr/bin/env python3
+import os
+from pathlib import Path
+
+with Path(os.environ["RACE_COMMAND_LOG"]).open("a") as handle:
+    handle.write(f'{os.environ["RACE_LABEL"]}:composer\\n')
+Path("vendor").mkdir(exist_ok=True)
+Path("vendor/autoload.php").touch()
+"""
+)
+fake_bin.joinpath("psql").write_text(
+    """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+sql = sys.argv[-1]
+with Path(os.environ["RACE_COMMAND_LOG"]).open("a") as handle:
+    handle.write(f'{os.environ["RACE_LABEL"]}:psql:{sql}\\n')
+if "rolcreatedb" in sql:
+    print("t")
+elif "FROM pg_database" in sql:
+    print("1")
+"""
+)
+fake_bin.joinpath("php").write_text(
+    """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.environ["RACE_LABEL"]
+state = Path(os.environ["RACE_STATE"])
+command = sys.argv[1:]
+with Path(os.environ["RACE_COMMAND_LOG"]).open("a") as handle:
+    handle.write(f"{label}:php:{' '.join(command)}\\n")
+if command[:2] != ["artisan", "migrate"]:
+    raise SystemExit(0)
+
+recorded = state / "migration-recorded"
+column = state / "column-present"
+if recorded.exists():
+    (state / f"{label}-revalidated").touch()
+    raise SystemExit(0)
+
+(state / f"{label}-pending").touch()
+if os.environ.get("RACE_HOLD") == "1":
+    with Path(os.environ["RACE_RELEASE_FIFO"]).open("rb") as release:
+        release.read(1)
+
+if column.exists():
+    print('SQLSTATE[42701]: Duplicate column: column "firearms_license_number_enc" already exists')
+    raise SystemExit(17)
+column.touch()
+recorded.touch()
+"""
+)
+for executable in ("composer", "psql", "php"):
+    fake_bin.joinpath(executable).chmod(0o755)
+
+
+def wait_for(path: pathlib.Path, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.01)
+    return path.exists()
+
+
+def start_bootstrap(target: pathlib.Path, label: str, *, hold: bool = False) -> subprocess.Popen[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(fixture / "home"),
+            "PATH": str(fake_bin) + os.pathsep + environment["PATH"],
+            "RACE_COMMAND_LOG": str(command_log),
+            "RACE_LABEL": label,
+            "RACE_RELEASE_FIFO": str(release_first),
+            "RACE_STATE": str(race_state),
+        }
+    )
+    if hold:
+        environment["RACE_HOLD"] = "1"
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(script_path),
+            "--bootstrap-api-worktree",
+            str(target),
+            "--source-repo-path",
+            str(source_api),
+        ],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+first = start_bootstrap(physical_worktree, "physical", hold=True)
+assert wait_for(race_state / "physical-pending", 10), "first migration did not load its pending plan"
+second = start_bootstrap(alias_worktree, "alias")
+alias_loaded_concurrently = wait_for(race_state / "alias-pending", 2)
+commands_while_held = command_log.read_text()
+
+with release_first.open("wb") as release:
+    release.write(b"1")
+first_output, _ = first.communicate(timeout=10)
+second_output, _ = second.communicate(timeout=10)
+
+assert not alias_loaded_concurrently, (
+    "alias bootstrap loaded the same pending migration before the physical bootstrap finished\n"
+    f"commands while held:\n{commands_while_held}\n"
+    f"physical output:\n{first_output}\n"
+    f"alias output:\n{second_output}"
+)
+assert "alias:" not in commands_while_held, commands_while_held
+assert first.returncode == 0, first_output
+assert second.returncode == 0, second_output
+assert race_state.joinpath("alias-revalidated").is_file()
+assert race_state.joinpath("migration-recorded").is_file()
+assert race_state.joinpath("column-present").is_file()
+PY
+
 python3 "$PYTHON_SCRIPT" \
     --workspace-root "$workspace_root" \
     --db-path "$db_path" \

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -38,6 +38,7 @@ trap 'rm -rf "$workspace"' EXIT
 workspace_root="$workspace/SecPal"
 home_dir="$workspace/home"
 mkdir -p "$workspace_root" "$home_dir"
+export HOME="$home_dir"
 
 create_repo() {
     local repo_name="$1"
@@ -1192,9 +1193,13 @@ PY
 # migration first and the held process reports PostgreSQL duplicate-column
 # behavior when it resumes.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace" "$REPO_ROOT"
+import importlib.util
 import os
 import pathlib
+import re
 import shutil
+import sqlite3
+import stat
 import subprocess
 import sys
 import time
@@ -1203,7 +1208,8 @@ script_path = pathlib.Path(sys.argv[1])
 workspace = pathlib.Path(sys.argv[2])
 repo_root = pathlib.Path(sys.argv[3])
 fixture = workspace / "concurrent-api-bootstrap-fixture"
-source_api = fixture / "source-api"
+source_workspace = fixture / "source-workspace"
+source_api = source_workspace / "api"
 physical_worktree = fixture / "clones" / "api12345" / "quiet-finch-d35c0cdc"
 alias_worktree = physical_worktree.parent / "quiet-finch"
 fake_bin = fixture / "fake-bin"
@@ -1235,6 +1241,24 @@ def write_valid_instruction_root(root: pathlib.Path) -> None:
 
 write_valid_instruction_root(source_api)
 write_valid_instruction_root(physical_worktree)
+(source_api / ".github" / "instructions").mkdir()
+for instruction_name, instruction_title in (
+    ("org-shared.instructions.md", "Shared Test Rules"),
+    ("php-laravel.instructions.md", "PHP Test Rules"),
+):
+    source_api.joinpath(".github", "instructions", instruction_name).write_text(
+        "---\n"
+        f"name: {instruction_title}\n"
+        "applyTo: '**'\n"
+        "---\n\n"
+        f"# {instruction_title}\n\n"
+        "- Preserve deterministic fixtures.\n"
+    )
+(physical_worktree / ".git" / "info").mkdir(parents=True)
+(physical_worktree / ".git" / "hooks").mkdir()
+for repository_root in (source_api, physical_worktree):
+    repository_root.joinpath("composer.json").write_text("{}\n")
+    repository_root.joinpath("artisan").write_text("#!/usr/bin/env php\n")
 fake_bin.mkdir(parents=True)
 race_state.mkdir()
 alias_worktree.symlink_to(physical_worktree.name)
@@ -1310,7 +1334,7 @@ state = Path(os.environ["RACE_STATE"])
 command = sys.argv[1:]
 with Path(os.environ["RACE_COMMAND_LOG"]).open("a") as handle:
     handle.write(f"{label}:php:{' '.join(command)}\\n")
-if command[:2] != ["artisan", "migrate"]:
+if len(command) < 2 or command[0] != "artisan" or command[1] not in {"migrate", "migrate:fresh"}:
     raise SystemExit(0)
 
 recorded = state / "migration-recorded"
@@ -1324,6 +1348,9 @@ if os.environ.get("RACE_HOLD") == "1":
     with Path(os.environ["RACE_RELEASE_FIFO"]).open("rb") as release:
         release.read(1)
 
+if os.environ.get("RACE_FAIL") == "1":
+    print("representative migration failure")
+    raise SystemExit(19)
 if column.exists():
     print('SQLSTATE[42701]: Duplicate column: column "firearms_license_number_enc" already exists')
     raise SystemExit(17)
@@ -1344,7 +1371,15 @@ def wait_for(path: pathlib.Path, timeout: float) -> bool:
     return path.exists()
 
 
-def start_bootstrap(target: pathlib.Path, label: str, *, hold: bool = False) -> subprocess.Popen[str]:
+def start_api_mode(
+    target: pathlib.Path,
+    label: str,
+    *,
+    mode: str = "bootstrap",
+    hold: bool = False,
+    fail: bool = False,
+    state: pathlib.Path = race_state,
+) -> subprocess.Popen[str]:
     environment = os.environ.copy()
     environment.update(
         {
@@ -1353,16 +1388,18 @@ def start_bootstrap(target: pathlib.Path, label: str, *, hold: bool = False) -> 
             "RACE_COMMAND_LOG": str(command_log),
             "RACE_LABEL": label,
             "RACE_RELEASE_FIFO": str(release_first),
-            "RACE_STATE": str(race_state),
+            "RACE_STATE": str(state),
         }
     )
     if hold:
         environment["RACE_HOLD"] = "1"
+    if fail:
+        environment["RACE_FAIL"] = "1"
     return subprocess.Popen(
         [
             sys.executable,
             str(script_path),
-            "--bootstrap-api-worktree",
+            f"--{mode}-api-worktree",
             str(target),
             "--source-repo-path",
             str(source_api),
@@ -1374,9 +1411,9 @@ def start_bootstrap(target: pathlib.Path, label: str, *, hold: bool = False) -> 
     )
 
 
-first = start_bootstrap(physical_worktree, "physical", hold=True)
+first = start_api_mode(physical_worktree, "physical", hold=True)
 assert wait_for(race_state / "physical-pending", 10), "first migration did not load its pending plan"
-second = start_bootstrap(alias_worktree, "alias")
+second = start_api_mode(alias_worktree, "alias")
 alias_loaded_concurrently = wait_for(race_state / "alias-pending", 2)
 commands_while_held = command_log.read_text()
 
@@ -1397,6 +1434,254 @@ assert second.returncode == 0, second_output
 assert race_state.joinpath("alias-revalidated").is_file()
 assert race_state.joinpath("migration-recorded").is_file()
 assert race_state.joinpath("column-present").is_file()
+
+
+def reset_case_state(state: pathlib.Path) -> None:
+    state.mkdir(exist_ok=True)
+    for entry in state.iterdir():
+        entry.unlink()
+    command_log.write_text("")
+
+
+# Refresh shares the same boundary and cannot begin config or destructive
+# migration work while a normal bootstrap holds the target lock.
+reset_case_state(race_state)
+first = start_api_mode(physical_worktree, "bootstrap-before-refresh", hold=True)
+assert wait_for(race_state / "bootstrap-before-refresh-pending", 10)
+second = start_api_mode(alias_worktree, "refresh", mode="refresh")
+refresh_loaded_concurrently = wait_for(race_state / "refresh-pending", 2)
+refresh_commands_while_held = command_log.read_text()
+with release_first.open("wb") as release:
+    release.write(b"1")
+first_output, _ = first.communicate(timeout=10)
+second_output, _ = second.communicate(timeout=10)
+assert not refresh_loaded_concurrently, refresh_commands_while_held
+assert not any(
+    line.startswith("refresh:")
+    for line in refresh_commands_while_held.splitlines()
+), refresh_commands_while_held
+assert first.returncode == second.returncode == 0, (first_output, second_output)
+assert "refresh:php:artisan migrate:fresh --force" in command_log.read_text()
+
+# An exception releases the lock; the already-waiting invocation then derives
+# fresh migration state and completes normally.
+reset_case_state(race_state)
+first = start_api_mode(physical_worktree, "failing", hold=True, fail=True)
+assert wait_for(race_state / "failing-pending", 10)
+second = start_api_mode(alias_worktree, "after-failure")
+failure_contender_started = wait_for(race_state / "after-failure-pending", 2)
+with release_first.open("wb") as release:
+    release.write(b"1")
+first_output, _ = first.communicate(timeout=10)
+second_output, _ = second.communicate(timeout=10)
+assert not failure_contender_started, command_log.read_text()
+assert first.returncode != 0 and second.returncode == 0, (first_output, second_output)
+assert race_state.joinpath("migration-recorded").is_file()
+
+# A distinct physical API worktree uses a distinct lock and may complete while
+# the first worktree remains deliberately paused.
+reset_case_state(race_state)
+other_worktree = physical_worktree.parent / "brisk-fox-a1b2c3d4"
+other_state = fixture / "other-migration-state"
+write_valid_instruction_root(other_worktree)
+other_state.mkdir()
+other_worktree.joinpath(".env").write_text(
+    physical_worktree.joinpath(".env").read_text().replace(
+        "secpal__preview__quiet_finch",
+        "secpal__preview__brisk_fox",
+    )
+)
+first = start_api_mode(physical_worktree, "held-worktree", hold=True)
+assert wait_for(race_state / "held-worktree-pending", 10)
+second = start_api_mode(other_worktree, "other-worktree", state=other_state)
+different_worktree_overlapped = wait_for(other_state / "other-worktree-pending", 2)
+if different_worktree_overlapped:
+    second_output, _ = second.communicate(timeout=10)
+else:
+    second_output = ""
+with release_first.open("wb") as release:
+    release.write(b"1")
+first_output, _ = first.communicate(timeout=10)
+if second.poll() is None:
+    second_output, _ = second.communicate(timeout=10)
+assert different_worktree_overlapped, command_log.read_text()
+assert first.returncode == second.returncode == 0, (first_output, second_output)
+
+# A service-style background provision call and direct setup call meet at the
+# same per-worktree boundary even though only the background process also owns
+# the existing global provision lock.
+reset_case_state(race_state)
+background_db = fixture / "background-polyscope.db"
+with sqlite3.connect(background_db) as connection:
+    connection.executescript(
+        """
+        create table repositories (id text primary key, name text not null, path text not null);
+        create table worktrees (
+            id text primary key,
+            repo_id text not null,
+            branch text not null,
+            path text not null,
+            status text default 'active' not null,
+            created_at text default (datetime('now')) not null
+        );
+        """
+    )
+    connection.execute(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        ("api12345", "SecPal/api", str(source_api)),
+    )
+    connection.execute(
+        "insert into worktrees (id, repo_id, branch, path) values (?, ?, ?, ?)",
+        ("quiet-finch", "api12345", "fixture", str(physical_worktree)),
+    )
+background_lock_attempted = fixture / "background-lock-attempted"
+background_probe = """
+import contextlib
+import importlib.util
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+source_workspace = pathlib.Path(sys.argv[2])
+clone_root = pathlib.Path(sys.argv[3])
+db_path = pathlib.Path(sys.argv[4])
+attempted = pathlib.Path(sys.argv[5])
+global_lock = pathlib.Path(sys.argv[6])
+spec = importlib.util.spec_from_file_location("polyscope_rollout_background", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+original_lock = module.acquire_api_worktree_bootstrap_lock
+
+@contextlib.contextmanager
+def observed_lock(worktree_path):
+    attempted.touch()
+    with original_lock(worktree_path) as locked_worktree:
+        yield locked_worktree
+
+module.acquire_api_worktree_bootstrap_lock = observed_lock
+repo_state = {
+    "api": {
+        "id": "api12345",
+        "name": "SecPal/api",
+        "path": str(source_workspace / "api"),
+    }
+}
+repo_specs = {"api": module.build_repo_specs(source_workspace)["api"]}
+with module.provision_worktree_lock(global_lock):
+    provisioned, _cleaned, failures = module.provision_worktrees(
+        repo_state,
+        repo_specs,
+        clone_root,
+        db_path=db_path,
+    )
+assert failures == [], failures
+assert provisioned == ["api:quiet-finch"], provisioned
+"""
+first = start_api_mode(physical_worktree, "direct-before-background", hold=True)
+assert wait_for(race_state / "direct-before-background-pending", 10)
+background_environment = os.environ.copy()
+background_environment.update(
+    {
+        "HOME": str(fixture / "home"),
+        "PATH": str(fake_bin) + os.pathsep + background_environment["PATH"],
+        "RACE_COMMAND_LOG": str(command_log),
+        "RACE_LABEL": "background",
+        "RACE_RELEASE_FIFO": str(release_first),
+        "RACE_STATE": str(race_state),
+    }
+)
+background = subprocess.Popen(
+    [
+        sys.executable,
+        "-B",
+        "-c",
+        background_probe,
+        str(script_path),
+        str(source_workspace),
+        str(fixture / "clones"),
+        str(background_db),
+        str(background_lock_attempted),
+        str(fixture / "global-provision.lock"),
+    ],
+    env=background_environment,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+)
+assert wait_for(background_lock_attempted, 10), "background provision did not reach the API lock"
+background_commands_while_held = command_log.read_text()
+assert not any(
+    line.startswith(("background:php:", "background:composer"))
+    for line in background_commands_while_held.splitlines()
+), background_commands_while_held
+with release_first.open("wb") as release:
+    release.write(b"1")
+first_output, _ = first.communicate(timeout=10)
+background_output, _ = background.communicate(timeout=20)
+assert first.returncode == background.returncode == 0, (first_output, background_output)
+assert race_state.joinpath("background-revalidated").is_file()
+assert physical_worktree.joinpath(".polyscope-secpal-provisioned.json").is_file()
+
+# Lock identities are canonical, deterministic, private, and secret-free.
+module_spec = importlib.util.spec_from_file_location("polyscope_rollout_locking", script_path)
+module = importlib.util.module_from_spec(module_spec)
+assert module_spec.loader is not None
+module_spec.loader.exec_module(module)
+original_home = os.environ["HOME"]
+security_home = fixture / "security-home"
+os.environ["HOME"] = str(security_home)
+physical_lock = module.api_worktree_bootstrap_lock_path(physical_worktree)
+alias_lock = module.api_worktree_bootstrap_lock_path(alias_worktree)
+other_lock = module.api_worktree_bootstrap_lock_path(other_worktree)
+assert physical_lock == alias_lock
+assert physical_lock != other_lock
+assert re.fullmatch(r"[0-9a-f]{64}\.lock", physical_lock.name), physical_lock
+assert not any(
+    secret in str(physical_lock)
+    for secret in ("fixture-db-password", "fixture-app-key", "secpal__preview__quiet_finch")
+)
+with module.acquire_api_worktree_bootstrap_lock(physical_worktree):
+    pass
+assert stat.S_IMODE(physical_lock.parent.stat().st_mode) == 0o700
+assert stat.S_IMODE(physical_lock.stat().st_mode) == 0o600
+
+unsafe_mode_home = fixture / "unsafe-mode-home"
+unsafe_state = unsafe_mode_home / ".local" / "state" / "polyscope"
+unsafe_state.mkdir(parents=True)
+unsafe_state.chmod(0o777)
+os.environ["HOME"] = str(unsafe_mode_home)
+try:
+    with module.acquire_api_worktree_bootstrap_lock(physical_worktree):
+        raise AssertionError("world-accessible lock directory must fail closed")
+except RuntimeError as error:
+    assert "not private" in str(error), error
+
+symlink_home = fixture / "symlink-lock-home"
+symlink_state_parent = symlink_home / ".local" / "state"
+symlink_target = fixture / "replaceable-lock-state"
+symlink_state_parent.mkdir(parents=True)
+symlink_target.mkdir()
+symlink_state_parent.joinpath("polyscope").symlink_to(symlink_target)
+os.environ["HOME"] = str(symlink_home)
+try:
+    with module.acquire_api_worktree_bootstrap_lock(physical_worktree):
+        raise AssertionError("symlinked lock directory must fail closed")
+except RuntimeError as error:
+    assert "state directory" in str(error), error
+
+os.environ["HOME"] = str(security_home)
+physical_lock.unlink()
+lock_sentinel = fixture / "lock-sentinel"
+lock_sentinel.write_text("unchanged")
+physical_lock.symlink_to(lock_sentinel)
+try:
+    with module.acquire_api_worktree_bootstrap_lock(physical_worktree):
+        raise AssertionError("symlinked API bootstrap lock must fail closed")
+except RuntimeError as error:
+    assert "unable to open API bootstrap lock" in str(error), error
+assert lock_sentinel.read_text() == "unchanged"
+os.environ["HOME"] = original_home
 PY
 
 python3 "$PYTHON_SCRIPT" \
@@ -1571,8 +1856,12 @@ assert_rollout_rejects_invalid_local_config \
 grep -q 'https://api-{{worktree}}.preview.secpal.dev' "$workspace_root/api/polyscope.local.json"
 grep -q 'Apply the current SecPal instructions from ' "$workspace_root/api/polyscope.local.json"
 grep -q 'AGENTS.md' "$workspace_root/api/polyscope.local.json"
-grep -qF "python3 $PYTHON_SCRIPT --prepare-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --bootstrap-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api" "$workspace_root/api/polyscope.local.json"
+if grep -qF -- '--prepare-api-worktree' "$workspace_root/api/polyscope.local.json" \
+    || grep -qF 'test -d vendor || composer install' "$workspace_root/api/polyscope.local.json"; then
+    echo "generated API setup must enter the locked bootstrap boundary exactly once" >&2
+    exit 1
+fi
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default --sleep=3 --tries=3'" "$workspace_root/api/polyscope.local.json"
 grep -qF '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan schedule:work'" "$workspace_root/api/polyscope.local.json"
@@ -3495,6 +3784,7 @@ PY
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import pathlib
+import signal
 import subprocess
 import sys
 
@@ -3538,7 +3828,16 @@ def fake_run_api_worktree_bootstrap_command(worktree_path, command, *, command_e
         )
 module.run_api_worktree_bootstrap_command = fake_run_api_worktree_bootstrap_command
 
-ready, target = module.bootstrap_api_worktree(api_worktree, source_api)
+def fail_on_deadlock(_signum, _frame):
+    raise AssertionError("tenant-key recovery deadlocked while holding the API bootstrap lock")
+
+previous_alarm_handler = signal.signal(signal.SIGALRM, fail_on_deadlock)
+signal.alarm(5)
+try:
+    ready, target = module.bootstrap_api_worktree(api_worktree, source_api)
+finally:
+    signal.alarm(0)
+    signal.signal(signal.SIGALRM, previous_alarm_handler)
 assert ready is True
 assert target == "database:secpal__preview__coral_crow", target
 assert not kek_path.exists(), "recovery must remove the stale isolated-preview KEK"
@@ -4990,7 +5289,11 @@ grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clon
 grep -qF 'VITE_API_URL=https://api-auto-hawk.preview.secpal.dev' "$frontend_clone/.env.production.local"
 test -f "$api_clone/polyscope.local.json"
 test -f "$frontend_clone/polyscope.local.json"
-grep -qF 'prepare-api-worktree' "$api_clone/polyscope.local.json"
+grep -qF 'bootstrap-api-worktree' "$api_clone/polyscope.local.json"
+if grep -qF 'prepare-api-worktree' "$api_clone/polyscope.local.json"; then
+    echo "provisioned API config must not split readiness from locked bootstrap" >&2
+    exit 1
+fi
 grep -qF 'source-repo-path' "$api_clone/polyscope.local.json"
 grep -qF 'resolve_linked_workspace(\"SecPal/api\", workspace)' "$frontend_clone/polyscope.local.json"
 python3 - "$api_clone/.polyscope-secpal-provisioned.json" "$frontend_clone/.polyscope-secpal-provisioned.json" <<'PY'
@@ -5464,7 +5767,7 @@ assert 'secpal__preview__broken_mole' not in cleaned, cleaned
 assert any(
     entry.get('repo') == 'api'
     and entry.get('workspace') == 'abort-hawk'
-    and '--bootstrap-api-worktree "$PWD"' in entry.get('error', '')
+    and "Command '['php', 'artisan', 'config:clear']'" in entry.get('error', '')
     for entry in failed
 ), failed
 assert any(
@@ -5794,8 +6097,8 @@ grep -qF 'DROP SCHEMA IF EXISTS "secpal__preview__schema_badger" CASCADE' "$fake
 
 assert_rollout_rejects_invalid_local_config \
     "$PYTHON_SCRIPT" \
-    '"test -d vendor || composer install",' \
-    '"test -d vendor || composer install",\n                    "npm ci",' \
+    'API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,' \
+    'API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,\n                    "npm ci",' \
     "api polyscope config references npm without a package.json at the repo root"
 
 assert_rollout_rejects_invalid_local_config \


### PR DESCRIPTION
## Incident evidence

Creating API workspace `quiet-finch` ran `php artisan migrate --force` against `secpal__preview__quiet_finch`. One setup invocation failed with PostgreSQL `SQLSTATE[42701]` because `firearms_license_number_enc` already existed. Immediately afterward, the migration table recorded `2026_04_12_160000_add_employee_certification_expiry_fields_to_employees_table` and the column was present.

The read-only follow-up in this change again found database `secpal__preview__quiet_finch`, `migration_recorded=true`, and `column_present=true`; no migration process was active.

## Root cause

The existing process-wide provision lock covers `--provision-worktrees` callers only. Generated/native setup, direct `--bootstrap-api-worktree`, and direct `--refresh-api-worktree` dispatch before that global lock. Two processes could therefore load the same pending Laravel migration plan for one API worktree and Preview target.

## Change

- Add a host-local `fcntl.flock` per canonical physical API worktree.
- Store locks under the caller-owned private `~/.local/state/polyscope/api-worktree-bootstrap-locks` directory.
- Derive each filename only from the SHA-256 digest of the resolved physical worktree path.
- Revalidate the worktree path and derive readiness, environment, Preview storage, migration state, and provision-marker state after acquisition.
- Hold the lock across environment healing, Preview database/schema creation, Composer, config clearing, migrations, address import, seeding, test-user normalization, tenant-key recovery, and the successful background provision marker.
- Collapse generated API setup to the single locked bootstrap command; Composer and readiness remain part of that pipeline.
- Route native setup/background provision, direct bootstrap, direct prepare, and refresh through the same per-worktree boundary.
- Keep the existing global provision lock and event coalescing unchanged.
- Call the internal already-locked implementation during one bounded tenant-key recovery, avoiding recursive lock acquisition.

Aliases resolving to one physical worktree use the same digest and lock. Distinct physical API worktrees use different locks and remain parallel.

## Failing-first reproduction

Signed commit `30d39c13542067ca4bac7f1bcc33cc58ca6ef898` adds a real two-process CLI reproduction using a physical path, alias path, fake PHP/Composer/psql executables, durable migration state, and FIFO synchronization.

Against the baseline, `bash tests/polyscope-rollout.sh` exited 1: both processes reached `artisan migrate --force`; the alias recorded the migration; the held physical invocation resumed with representative `SQLSTATE[42701]` duplicate-column output and exit 17.

## Regression matrix

The process fixtures prove:

- same-worktree normal bootstrap serialization;
- direct setup versus service-style background provision serialization;
- direct setup versus refresh serialization;
- physical/alias path convergence;
- distinct-worktree overlap;
- zero second-target PHP/Composer/bootstrap mutation before release;
- post-acquisition migration-state revalidation;
- successful continuation after the first completes;
- lock release and successful continuation after first-invocation failure;
- bounded non-deadlocking tenant-key recovery;
- deterministic private lock paths;
- fail-closed world-accessible and symlinked lock directories/files;
- secret-free lock identifiers.

Existing suites retain event coalescing, global provision locking, refresh behavior, Preview database/schema cleanup, and official deletion coverage.

## Validation

Passed:

- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-package-1-closure.sh`
- `bash tests/polyscope-clone-reaper.sh`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/reusable-workflow-policy.sh`
- `python3 -m py_compile scripts/polyscope-rollout.py`
- `shellcheck tests/polyscope-rollout.sh`
- `bash -n tests/polyscope-rollout.sh`
- `npm run lint:markdown`
- `reuse lint`
- `git diff --check`
- Prettier check for changed Markdown
- `pre-commit run --files CHANGELOG.md scripts/polyscope-rollout.py tests/polyscope-rollout.sh`

Both commits verify with the configured ED25519 signing key.

## Security analysis

The lock is per canonical physical worktree, not global. It is outside the replaceable worktree, in caller-owned directories that must have no group/other access. Directory and lock opens use directory file descriptors and `O_NOFOLLOW` where available; non-regular, wrong-owner, multiply linked, symlinked, or unsafe-directory conditions fail closed. Lock names and logs contain no database password, APP key, KEK, or other secret. Exceptions release the descriptor automatically.

There is no polling or retry loop in the implementation, no SQL-error suppression, no duplicate-column special case, no PostgreSQL advisory lock, and no Laravel migration change.

## Non-goals and isolation

No API repository or migration file changed. No migration history, Package 2.1, Package 2.2, review memory, AI instruction architecture, GitHub rule, systemd installation, nginx privilege, sudo policy, product repository, active database, or global AGENTS link changed.

No live installation, workspace setup rerun, migration, seed, database mutation, or mutating acceptance was performed. Draft PR #574 and its `feat/secpal-pr-review-workflow` head remained untouched.

## TDD / Validate-First Evidence

- Failing proof before implementation: Signed test commit `30d39c13542067ca4bac7f1bcc33cc58ca6ef898`; on baseline `833eef2afc063ae777e7e2b64b2f252e3fe1e49e`, `bash tests/polyscope-rollout.sh` exited 1 after both independent OS processes reached `artisan migrate --force`, then the held process resumed with representative `SQLSTATE[42701]` duplicate-column output and exit 17.
- Passing proof after implementation: On signed fix commit `707656205b81c3d31a6c43de82aa2f7c0dae2073`, the same process fixture passed with same-target serialization, alias convergence, post-lock state derivation, different-worktree overlap, failure release, and bounded tenant-key recovery; all validation commands listed above passed.
- Validate-first exception reference: N/A
- No executable change reason: N/A
