### PR TITLE
fix(ci): restore js-yaml 5 compatibility

### DIFF
--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -190,9 +190,10 @@ Installation is deliberately split. An administrator runs
 sudo prompt to install the root-owned helper bundle, exact sudoers drop-in, and
 system server drop-in. Before activation it verifies the canonical rollout
 source bundle under `/home/secpal/code/SecPal/.github/scripts/`; the drop-in
-executes that source directly after its pinned Markdown validator dependencies
-and a `secpal`-executable Node.js path have been checked and does not depend on
-a user-local link that has not been installed yet. The `secpal` user then runs
+executes that source directly after its pinned Markdown and YAML validator
+dependencies, required parser API, and a `secpal`-executable Node.js path have
+been checked and does not depend on a user-local link that has not been installed
+yet. The `secpal` user then runs
 `scripts/install-polyscope-rollout.sh` without sudo to install and enable the
 rollout path, worktree provision path and timer, and clone reaper timer. The
 user installer resets cached sudo credentials before checking the exact fixed

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -433,10 +433,11 @@ authorization is unavailable.
 `--source-script` accepts a custom rollout implementation only as part of a
 complete source bundle: the script must be executable, have the constrained
 `polyscope_nginx.py` library and executable nginx helper beside it, and have an
-executable `validate-ai-instructions.sh` sibling with the committed npm
-validator dependencies installed. The installer resolves this bundle before
-any installation writes and watches these files and the npm lock state for
-rollout changes and dependency-install recovery.
+executable `validate-ai-instructions.sh` sibling plus the canonical js-yaml
+verifier with the committed npm validator dependencies installed. The installer
+loads the pinned parser and verifies its required API before any installation
+writes, then watches the runtime files and npm lock state for rollout changes
+and dependency-install recovery.
 
 After installation, the user-level `polyscope-rollout-sync.service` and
 `polyscope-worktree-provision.service` units take care of provisioning new
@@ -502,12 +503,13 @@ always resolves the target host's `secpal` UID and an executable Node.js path
 before activation. Packaging tests may pass `--node-bin` to render the intended
 service `PATH` without inspecting the target account.
 
-Before activation, the installer verifies the executable canonical rollout
-and validator source bundle, committed lockfile, and installed pinned Markdown
-dependencies under `/home/secpal/code/SecPal/.github/`. The system drop-in
-executes that source directly, so a fresh installation does not depend on the
-user-local rollout link created during the following unprivileged installation
-step.
+Before activation, the installer verifies the executable canonical rollout and
+validator source bundle, committed lockfile, and installed pinned Markdown and
+YAML dependencies under `/home/secpal/code/SecPal/.github/`. The parser must
+resolve and expose the required loading API to the `secpal` service account.
+The system drop-in executes that source directly, so a fresh installation does
+not depend on the user-local rollout link created during the following
+unprivileged installation step.
 
 The installed `/usr/local/libexec/secpal-polyscope-nginx-apply` accepts only no
 arguments (apply) or `--check` (non-mutating boundary check). It reads the fixed

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -12,7 +12,7 @@
 
 import fs from "fs";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 /** @type {readonly [method: string, pathTemplate: string][]} */
 const REQUIRED_OPERATIONS = [

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -209,6 +209,11 @@ if [[ ! -x "$VALIDATOR_SOURCE" ]]; then
     echo "Error: canonical instruction validator is missing or not executable next to the rollout source: $VALIDATOR_SOURCE" >&2
     exit 1
 fi
+VALIDATOR_YAML_CHECK="$(dirname -- "$SOURCE_SCRIPT")/verify-js-yaml-package.cjs"
+if [[ ! -f "$VALIDATOR_YAML_CHECK" ]]; then
+    echo "Error: canonical js-yaml verifier is missing next to the rollout source: $VALIDATOR_YAML_CHECK" >&2
+    exit 1
+fi
 NGINX_LIBRARY_SOURCE="$(dirname -- "$SOURCE_SCRIPT")/polyscope_nginx.py"
 NGINX_HELPER_SOURCE="$(dirname -- "$SOURCE_SCRIPT")/secpal-polyscope-nginx-apply.py"
 if [[ ! -f "$NGINX_LIBRARY_SOURCE" || ! -x "$NGINX_HELPER_SOURCE" ]]; then
@@ -229,20 +234,15 @@ for _validator_tool in bash basename dirname find grep head node python3 wc; do
     fi
 done
 
-validator_yaml_available() {
-    PATH="$SERVICE_PATH" node - "$VALIDATOR_YAML_PACKAGE" <<'JS' >/dev/null 2>&1
-try {
-    require.resolve(process.argv[2]);
-} catch (_error) {
-    process.exit(1);
-}
-JS
+validator_yaml_usable() {
+    PATH="$SERVICE_PATH" node \
+        "$VALIDATOR_YAML_CHECK" "$VALIDATOR_YAML_PACKAGE" >/dev/null 2>&1
 }
 
 if [[ ! -f "$VALIDATOR_PACKAGE_LOCK" \
     || ! -f "$VALIDATOR_INSTALLED_PACKAGE_LOCK" \
     || ! -x "$VALIDATOR_MARKDOWNLINT" ]] \
-    || ! validator_yaml_available; then
+    || ! validator_yaml_usable; then
     echo "Error: rollout validator toolchain is incomplete; install the source bundle's committed npm dependencies before installing the rollout." >&2
     exit 1
 fi

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -220,7 +220,7 @@ VALIDATOR_TOOLCHAIN_ROOT="$(cd -- "$(dirname -- "$SOURCE_SCRIPT")/.." && pwd)"
 VALIDATOR_PACKAGE_LOCK="$VALIDATOR_TOOLCHAIN_ROOT/package-lock.json"
 VALIDATOR_INSTALLED_PACKAGE_LOCK="$VALIDATOR_TOOLCHAIN_ROOT/node_modules/.package-lock.json"
 VALIDATOR_MARKDOWNLINT="$VALIDATOR_TOOLCHAIN_ROOT/node_modules/.bin/markdownlint"
-VALIDATOR_YAML_MODULE="$VALIDATOR_TOOLCHAIN_ROOT/node_modules/js-yaml/index.js"
+VALIDATOR_YAML_PACKAGE="$VALIDATOR_TOOLCHAIN_ROOT/node_modules/js-yaml"
 
 for _validator_tool in bash basename dirname find grep head node python3 wc; do
     if ! PATH="$SERVICE_PATH" command -v "$_validator_tool" >/dev/null 2>&1; then
@@ -229,10 +229,20 @@ for _validator_tool in bash basename dirname find grep head node python3 wc; do
     fi
 done
 
+validator_yaml_available() {
+    PATH="$SERVICE_PATH" node - "$VALIDATOR_YAML_PACKAGE" <<'JS' >/dev/null 2>&1
+try {
+    require.resolve(process.argv[2]);
+} catch (_error) {
+    process.exit(1);
+}
+JS
+}
+
 if [[ ! -f "$VALIDATOR_PACKAGE_LOCK" \
     || ! -f "$VALIDATOR_INSTALLED_PACKAGE_LOCK" \
-    || ! -x "$VALIDATOR_MARKDOWNLINT" \
-    || ! -f "$VALIDATOR_YAML_MODULE" ]]; then
+    || ! -x "$VALIDATOR_MARKDOWNLINT" ]] \
+    || ! validator_yaml_available; then
     echo "Error: rollout validator toolchain is incomplete; install the source bundle's committed npm dependencies before installing the rollout." >&2
     exit 1
 fi

--- a/scripts/install-polyscope-system-components.sh
+++ b/scripts/install-polyscope-system-components.sh
@@ -12,6 +12,8 @@ ROLLOUT_SOURCE="$SCRIPT_DIR/polyscope-rollout.py"
 RUNTIME_ROLLOUT_SOURCE="/home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py"
 RUNTIME_SCRIPT_DIR="${RUNTIME_ROLLOUT_SOURCE%/*}"
 RUNTIME_TOOLCHAIN_ROOT="${RUNTIME_SCRIPT_DIR%/scripts}"
+RUNTIME_YAML_CHECK="$RUNTIME_SCRIPT_DIR/verify-js-yaml-package.cjs"
+RUNTIME_YAML_PACKAGE="$RUNTIME_TOOLCHAIN_ROOT/node_modules/js-yaml"
 DESTDIR="${DESTDIR:-}"
 NODE_BIN=""
 STAGE_ONLY=0
@@ -106,6 +108,7 @@ if [[ "$STAGE_ONLY" -eq 0 ]]; then
         "$RUNTIME_ROLLOUT_SOURCE" \
         "$RUNTIME_SCRIPT_DIR/validate-ai-instructions.sh" \
         "$RUNTIME_SCRIPT_DIR/polyscope_nginx.py" \
+        "$RUNTIME_YAML_CHECK" \
         "$RUNTIME_TOOLCHAIN_ROOT/package-lock.json" \
         "$RUNTIME_TOOLCHAIN_ROOT/node_modules/.package-lock.json" \
         "$RUNTIME_TOOLCHAIN_ROOT/node_modules/js-yaml/package.json"; do
@@ -118,6 +121,11 @@ if [[ "$STAGE_ONLY" -eq 0 ]]; then
         || ! -x "$RUNTIME_SCRIPT_DIR/validate-ai-instructions.sh" \
         || ! -x "$RUNTIME_TOOLCHAIN_ROOT/node_modules/.bin/markdownlint" ]]; then
         echo "Error: canonical Polyscope runtime scripts and pinned validator must be executable below $RUNTIME_TOOLCHAIN_ROOT." >&2
+        exit 1
+    fi
+    if ! /usr/bin/sudo -u secpal -- \
+        "$NODE_BIN" "$RUNTIME_YAML_CHECK" "$RUNTIME_YAML_PACKAGE"; then
+        echo "Error: canonical Polyscope runtime js-yaml package is unusable; reinstall the committed dependencies before activation." >&2
         exit 1
     fi
 fi

--- a/scripts/install-polyscope-system-components.sh
+++ b/scripts/install-polyscope-system-components.sh
@@ -108,7 +108,7 @@ if [[ "$STAGE_ONLY" -eq 0 ]]; then
         "$RUNTIME_SCRIPT_DIR/polyscope_nginx.py" \
         "$RUNTIME_TOOLCHAIN_ROOT/package-lock.json" \
         "$RUNTIME_TOOLCHAIN_ROOT/node_modules/.package-lock.json" \
-        "$RUNTIME_TOOLCHAIN_ROOT/node_modules/js-yaml/index.js"; do
+        "$RUNTIME_TOOLCHAIN_ROOT/node_modules/js-yaml/package.json"; do
         if [[ ! -f "$runtime_file" ]]; then
             echo "Error: canonical Polyscope runtime source is missing: $runtime_file" >&2
             exit 1

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -216,7 +216,8 @@ test_markdown_lint() {
 test_instruction_frontmatter() {
     local file
     local -a files=()
-    local yaml_module="$SCRIPT_DIR/../node_modules/js-yaml"
+    local yaml_package="$SCRIPT_DIR/../node_modules/js-yaml"
+    local yaml_module
 
     while IFS= read -r -d '' file; do
         files+=("$file")
@@ -228,7 +229,15 @@ test_instruction_frontmatter() {
         return
     fi
 
-    if ! command -v node >/dev/null 2>&1 || [ ! -f "$yaml_module/index.js" ]; then
+    if ! command -v node >/dev/null 2>&1 \
+        || ! yaml_module="$(node - "$yaml_package" <<'JS'
+try {
+    process.stdout.write(require.resolve(process.argv[2]));
+} catch (_error) {
+    process.exit(1);
+}
+JS
+        )"; then
         print_result "instruction overlays include valid frontmatter" "FAIL" \
             "repository-pinned js-yaml is unavailable; install the committed lockfile dependencies"
         return

--- a/scripts/verify-js-yaml-package.cjs
+++ b/scripts/verify-js-yaml-package.cjs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: MIT
+
+"use strict";
+
+const packagePath = process.argv[2];
+
+if (!packagePath) {
+  process.exit(2);
+}
+
+try {
+  const yaml = require(require.resolve(packagePath));
+  if (typeof yaml.load !== "function") {
+    process.exit(1);
+  }
+} catch (_error) {
+  process.exit(1);
+}

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6341,6 +6341,8 @@ mkdir -p "$missing_toolchain_source_dir" \
 cp "$PYTHON_SCRIPT" "$missing_toolchain_source_script"
 cp "$REPO_ROOT/scripts/validate-ai-instructions.sh" \
     "$missing_toolchain_source_dir/validate-ai-instructions.sh"
+cp "$REPO_ROOT/scripts/verify-js-yaml-package.cjs" \
+    "$missing_toolchain_source_dir/verify-js-yaml-package.cjs"
 cp "$REPO_ROOT/scripts/polyscope_nginx.py" \
     "$missing_toolchain_source_dir/polyscope_nginx.py"
 cp "$REPO_ROOT/scripts/secpal-polyscope-nginx-apply.py" \

--- a/tests/polyscope-system-installer.sh
+++ b/tests/polyscope-system-installer.sh
@@ -7,8 +7,39 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 INSTALLER="$REPO_ROOT/scripts/install-polyscope-system-components.sh"
+YAML_CHECK="$REPO_ROOT/scripts/verify-js-yaml-package.cjs"
 WORKSPACE="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-system-installer.XXXXXX")"
 trap 'rm -rf "$WORKSPACE"' EXIT
+
+node "$YAML_CHECK" "$REPO_ROOT/node_modules/js-yaml"
+
+missing_yaml_entry="$WORKSPACE/missing-yaml-entry/js-yaml"
+mkdir -p "$(dirname -- "$missing_yaml_entry")"
+cp -R "$REPO_ROOT/node_modules/js-yaml" "$missing_yaml_entry"
+missing_yaml_module="$(node -e \
+    'process.stdout.write(require.resolve(process.argv[1]))' \
+    "$missing_yaml_entry")"
+rm "$missing_yaml_module"
+if node "$YAML_CHECK" "$missing_yaml_entry"; then
+    echo "js-yaml verification must reject a missing declared entry point" >&2
+    exit 1
+fi
+
+invalid_yaml_api="$WORKSPACE/invalid-yaml-api/js-yaml"
+mkdir -p "$invalid_yaml_api"
+cat >"$invalid_yaml_api/package.json" <<'JSON'
+{
+  "name": "js-yaml",
+  "main": "index.cjs"
+}
+JSON
+cat >"$invalid_yaml_api/index.cjs" <<'JS'
+module.exports = {};
+JS
+if node "$YAML_CHECK" "$invalid_yaml_api"; then
+    echo "js-yaml verification must reject a package without yaml.load" >&2
+    exit 1
+fi
 
 if [[ "$(id -u)" -ne 0 ]]; then
     if "$INSTALLER" >"$WORKSPACE/non-root.out" 2>"$WORKSPACE/non-root.err"; then

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -333,6 +333,36 @@ no_overlays_output="$workspace/no-overlays.output"
 assert_passes "$no_overlays_repo" "$no_overlays_output"
 grep -qF 'Skipped (no focused instruction files present)' "$no_overlays_output"
 
+# The pinned js-yaml 5 package exposes its CommonJS entry point through
+# package.json instead of a root index.js. Exercise that installed layout in an
+# isolated validator toolchain so the validator must use Node's package
+# resolution rather than assume a package entry-point filename.
+installed_yaml_root="$workspace/js-yaml-5-toolchain"
+installed_yaml_validator="$installed_yaml_root/scripts/validate-ai-instructions.sh"
+installed_yaml_repo="$installed_yaml_root/repository"
+mkdir -p "$installed_yaml_root/scripts" "$installed_yaml_root/node_modules"
+cp "$VALIDATOR" "$installed_yaml_validator"
+cp -R "$REPO_ROOT/node_modules/js-yaml" "$installed_yaml_root/node_modules/js-yaml"
+cp -R "$REPO_ROOT/node_modules/argparse" "$installed_yaml_root/node_modules/argparse"
+copy_valid_repo "$valid_repo" "$installed_yaml_repo"
+
+if [ -e "$installed_yaml_root/node_modules/js-yaml/index.js" ]; then
+    echo "js-yaml 5 regression fixture must not contain a root index.js" >&2
+    exit 1
+fi
+
+installed_yaml_output="$workspace/js-yaml-5-toolchain.output"
+if ! (
+    cd "$installed_yaml_repo"
+    PATH="$REPO_ROOT/node_modules/.bin:$PATH" \
+        REPO_TYPE=org bash "$installed_yaml_validator"
+) >"$installed_yaml_output" 2>&1; then
+    sed -n '1,240p' "$installed_yaml_output" >&2
+    echo "validator must load the installed js-yaml 5 package layout" >&2
+    exit 1
+fi
+grep -qF 'instruction overlays include valid frontmatter' "$installed_yaml_output"
+
 # Focused frontmatter must fail closed when the repository-pinned YAML parser
 # is unavailable, even if Markdownlint itself is available globally.
 isolated_yaml_root="$workspace/no-frontmatter-yaml-toolchain"


### PR DESCRIPTION
## Problem and evidence

The shared `reusable-ai-instructions.yml` workflow installs the committed governance dependencies, including `js-yaml` 5.2.1. The AI instruction validator then required `node_modules/js-yaml/index.js`, but js-yaml 5 exposes its CommonJS entry point through package metadata at `dist/js-yaml.cjs.js`. As a result, frontend PR #1461 failed the `Validate AI Instructions` job even though its frontend checks passed.

- Failing job: https://github.com/SecPal/frontend/actions/runs/29833780834/job/88644798013
- Tracking issue: #582

The complete pre-push suite also identified two callers of the same pinned dependency that retained js-yaml 4 assumptions: the rollout toolchain check required the removed root `index.js`, and the OpenAPI endpoint validator imported a default export that js-yaml 5 no longer provides.

## Change

- Resolve the repository-pinned `js-yaml` package through Node package resolution before loading it in the AI instruction validator.
- Add an isolated regression fixture for the installed js-yaml 5 layout without a root `index.js`.
- Preserve fail-closed behavior when the pinned YAML parser is missing or cannot be resolved.
- Resolve the pinned package in the rollout installer and validate package metadata in the system-component installer without assuming an entry-point filename.
- Use the js-yaml 5 namespace export in the OpenAPI verified-endpoint validator.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/validate-ai-instructions.sh` failed because the pinned js-yaml 5 package has no `node_modules/js-yaml/index.js`.
- Passing proof after implementation: `bash tests/validate-ai-instructions.sh` passed, including the isolated js-yaml 5 package-layout regression fixture.
- Validate-first exception reference: N/A
- No executable change reason: N/A

The evidence above applies to the signed commit currently proposed by this pull request.

## Validation

- `bash tests/validate-ai-instructions.sh`
- `./scripts/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-system-installer.sh`
- `npm test`
- `shellcheck scripts/install-polyscope-rollout.sh scripts/install-polyscope-system-components.sh scripts/validate-ai-instructions.sh tests/validate-ai-instructions.sh`
- `npx prettier --check scripts/check-openapi-verified-endpoints.mjs`
- `git diff --check`
- Complete repository pre-push hook

## Readiness

No known in-scope dependency or unresolved local check prevents readiness. Hosted pull-request checks remain pending.

Closes #582
