### PR TITLE
docs(review): capture fast-path acceptance lessons

### DIFF
--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -67,6 +67,10 @@ as argument arrays in the target repository, without a shell.
    thread comments and their reactions. PR-level `EYES` activity markers are
    volatile workflow state rather than review feedback. Never infer truth from
    reviewer identity, keywords, or CI.
+   Treat GitHub's empty `COMMENTED` review wrapper for a direct inline comment
+   as structural coverage, not another technical finding; classify the inline
+   comment/thread as specified in the finite contract. A review body containing
+   material text remains separate feedback.
 3. Reproduce every valid finding, add a failing test first, make the smallest
    coherent corrections, and use focused validation while editing.
 4. Perform the one holistic audit across correctness, security, privacy, data
@@ -82,6 +86,9 @@ as argument arrays in the target repository, without a shell.
    `attest-validation --bind-commit` to verify that signed binding and its local
    signature without rerunning validation. Recheck the remote head and push
    once; the later live readiness check enforces required GitHub verification.
+   For initial validation, `--expected-head` is the reviewed parent/head. With
+   `--bind-commit`, it is the new signed commit `HEAD`; the receipt still binds
+   its own recorded parent internally.
 7. Read applicable rules and Required Checks once as one bounded logical read.
    Pending, failed, missing, or unknown required results block; never poll.
 8. Perform one lightweight stable-feedback freshness read. A same-head CI
@@ -100,6 +107,13 @@ as argument arrays in the target repository, without a shell.
 
 Short-circuit immediately to the applicable terminal outcome when a blocker is
 detected. Green CI alone never establishes technical truth or merge readiness.
+
+For setup and fixture preparation, provision the target repository's locked
+dependencies by its documented method before using its committed formatter
+script or local binary. Never use bare `npx prettier` in an unprovisioned
+worktree. Provisioning is setup, not another complete validation run; do not add
+ad hoc production formatting when registered validation already covers it. See
+the workflow guide for the repository-local tooling rationale and scope.
 
 ## Fast-path and forensic-plan discipline
 

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -213,6 +213,17 @@ validation attestation can authorize the expected reviewed-head-to-remediation-
 head transition; the state digest includes the head and base. It contains no
 Required Check, mergeability, worktree, signature, or validation result.
 
+For a direct inline review comment, GitHub emits an empty-body `COMMENTED`
+review wrapper, the inline review comment, and its review thread. Retain all
+three source objects: the wrapper's identity and empty-body digest remain in
+stable-feedback coverage, while the inline comment/thread contains the
+technical finding. The structural wrapper is not an independent finding and is
+not contamination merely because it is the only review. A review body with
+material text remains separate feedback and is classified normally. Reviewer
+identity never determines either classification. The reasoned skill supplies
+the wrapper's structural coverage classification; the deterministic helper only
+preserves and validates source coverage and does not invent a second finding.
+
 Volatile readiness separately contains the current PR head, registered default
 branch and allowed base repository, base SHA, local and remote heads,
 clean-worktree result, Required Checks, mergeability, GitHub merge-state status,
@@ -236,6 +247,11 @@ timestamps do not participate. Any bound-value change invalidates the
 attestation. It contains no environment dump, command output, credential, or
 secret. Manual-gate evidence and every user-controlled batch string are rejected
 when they contain the same secret-like patterns prohibited in forensic plans.
+
+The initial `attest-validation --expected-head` names the reviewed parent/head.
+The `--bind-commit` invocation instead names the newly created signed commit at
+the current local `HEAD`. The receipt continues to bind its own recorded parent;
+the bind invocation's expected head is not the receipt parent.
 
 A batch input validates against `fast-path-batch.schema.json`. It binds one
 repository, PR, expected head, reviewed base branch/SHA, actor, reviewed digests, authorization digest,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## Unreleased
+
+**Changed:**
+
+- clarified GitHub's structural empty `COMMENTED` review wrapper for direct
+  inline feedback, validation `--expected-head` phases, and repository-pinned
+  formatter provisioning without changing fast-path behavior
+- added focused regression coverage for signed commit binding, CLI guidance,
+  and stable-feedback preservation of direct-inline source objects
+
 ## 2026-07-21 - Add Fast PR Feedback Remediation Path
 
 **Changed:**

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -51,6 +51,21 @@ cannot be substituted. Environment-dependent, migration, native-toolchain,
 live-service, and deployment validation is represented by explicit manual gates
 instead of guessed commands.
 
+### Repository-local setup and formatting
+
+During setup or fixture preparation, provision the target repository's locked
+dependencies using that repository's documented method. Then use its committed
+npm script or repository-local formatter binary. Never run bare `npx prettier`
+in an unprovisioned worktree: `npx` can install a Prettier release without the
+repository's declared plugins and produce a false setup failure. This rule is
+limited to setup, fixture preparation, and repository-local tooling; it does not
+mandate `npm ci` for every repository.
+
+Formatting remains registered validation. Dependency provisioning prepares the
+tooling and is not a second complete validation run. Production remediation
+must not add an ad hoc formatting pass when the registered validation already
+covers formatting.
+
 ## Architecture
 
 The workflow has six narrow parts:
@@ -151,6 +166,12 @@ is ready. Likewise, outdated does not mean invalid and resolved does not mean
 fixed. The helper has no keyword classifier; technical truth is established from
 repository evidence while deterministic code validates structure and policy transitions.
 
+GitHub's direct-inline shape is defined canonically in the finite contract. Its
+empty `COMMENTED` review wrapper remains in stable-feedback coverage but does
+not create a second technical finding; the inline comment/thread carries that
+finding. A material review body remains independent feedback, regardless of the
+reviewer's identity.
+
 ## Bounded GitHub actions
 
 The reaction/reply/resolution table is normative in the finite contract. In
@@ -220,6 +241,10 @@ commit and enforces any required GitHub verification from live post-push
 evidence while also verifying local/remote/PR heads, the registered default/
 base-repository boundary, clean worktree, actor, applicable rules/Required
 Checks, strict-base/merge-state policy, and current stable feedback once.
+For the initial invocation, `--expected-head` is the reviewed parent/head. For
+`--bind-commit`, it is the newly created signed commit at local `HEAD`; the
+receipt remains internally bound to its recorded parent, which is not the bind
+invocation's expected head.
 Capture and freshness use the same explicitly selected registry entry as
 attestation and checks. Schema version 1.2 requires the reviewed state to
 originate from an open PR and a classified finding record for every

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -3863,7 +3863,15 @@ def build_parser() -> argparse.ArgumentParser:
             mutation_parser.add_argument("--initial-snapshot", required=True)
     attestation_parser = subparsers.add_parser("attest-validation")
     attestation_parser.add_argument("--repo", required=True)
-    attestation_parser.add_argument("--expected-head", required=True)
+    attestation_parser.add_argument(
+        "--expected-head",
+        required=True,
+        help=(
+            "Expected current local HEAD. For initial validation this is the "
+            "reviewed parent head; with --bind-commit this is the newly created "
+            "signed commit."
+        ),
+    )
     attestation_parser.add_argument("--reviewed-state", required=True)
     attestation_parser.add_argument("--repo-root", default=".")
     attestation_parser.add_argument("--registry")

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -4257,6 +4257,22 @@ class FastPathTests(TestCase):
             gateway,
         )
 
+    def test_attest_validation_expected_head_help_distinguishes_phases(self) -> None:
+        output = io.StringIO()
+        with (
+            mock.patch.object(actions.sys, "stdout", output),
+            self.assertRaises(SystemExit) as exit_status,
+        ):
+            actions.build_parser().parse_args(["attest-validation", "--help"])
+        self.assertEqual(exit_status.exception.code, 0)
+        normalized_help = " ".join(output.getvalue().split())
+        self.assertIn(
+            "Expected current local HEAD. For initial validation this is the "
+            "reviewed parent head; with --bind-commit this is the newly created "
+            "signed commit.",
+            normalized_help,
+        )
+
     def test_thirty_threads_share_one_attestation_checks_and_feedback_read(self) -> None:
         reviewed = fast_feedback(30)
         gateway = FakeFastGateway(reviewed)
@@ -5107,6 +5123,151 @@ class FastPathTests(TestCase):
             ):
                 actions._command_attest_validation(arguments)
 
+    def test_bind_expected_head_is_current_signed_commit_not_receipt_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            repository_root = temporary_root / "repository"
+            repository_root.mkdir()
+            signing_key = temporary_root / "signing-key"
+            allowed_signers = temporary_root / "allowed-signers"
+            reviewed_state_path = temporary_root / "reviewed-state.json"
+            receipt_path = temporary_root / "validation-receipt.json"
+            attestation_path = temporary_root / "validation-attestation.json"
+            environment = p21.uncontrolled_git_test_environment()
+            environment["GIT_CONFIG_GLOBAL"] = actions.os.devnull
+            environment["GIT_CONFIG_NOSYSTEM"] = "1"
+            git = actions.evidence.resolve_trusted_executable("git")
+            ssh_keygen = next(
+                (
+                    directory / "ssh-keygen"
+                    for directory in actions.evidence.TRUSTED_COMMAND_DIRECTORIES
+                    if (directory / "ssh-keygen").is_file()
+                ),
+                None,
+            )
+            self.assertIsNotNone(ssh_keygen)
+
+            def run_git(*arguments: str) -> Any:
+                return actions.subprocess.run(
+                    [git, *arguments],
+                    cwd=repository_root,
+                    env=environment,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+            actions.subprocess.run(
+                [
+                    str(ssh_keygen),
+                    "-q",
+                    "-t",
+                    "ed25519",
+                    "-N",
+                    "",
+                    "-C",
+                    "test@example.com",
+                    "-f",
+                    str(signing_key),
+                ],
+                env=environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            allowed_signers.write_text(
+                f"test@example.com {signing_key.with_suffix('.pub').read_text(encoding='utf-8')}",
+                encoding="utf-8",
+            )
+            run_git("init", "--quiet")
+            run_git("config", "user.name", "SecPal Test")
+            run_git("config", "user.email", "test@example.com")
+            run_git("config", "gpg.format", "ssh")
+            run_git("config", "user.signingkey", str(signing_key))
+            run_git("config", "gpg.ssh.allowedSignersFile", str(allowed_signers))
+            run_git("remote", "add", "origin", "https://github.com/SecPal/.github.git")
+
+            tracked_file = repository_root / "tracked.txt"
+            tracked_file.write_text("reviewed parent\n", encoding="utf-8")
+            run_git("add", "tracked.txt")
+            run_git("commit", "--quiet", "-m", "reviewed parent")
+            parent = run_git("rev-parse", "HEAD").stdout.strip()
+
+            tracked_file.write_text("validated remediation\n", encoding="utf-8")
+            run_git("add", "tracked.txt")
+            validated_tree = run_git("write-tree").stdout.strip()
+            reviewed = fast_feedback(head_sha=parent)
+            entry = actions.select_repository(
+                actions.load_registry(), "SecPal/.github"
+            )
+            binding = actions._fast_registry_binding(entry)
+            manual_gate_evidence = [
+                {
+                    "gate": gate,
+                    "satisfied": True,
+                    "evidence": f"fixture gate {index} satisfied",
+                }
+                for index, gate in enumerate(binding["manual_gates"], start=1)
+            ]
+            receipt = actions._validation_receipt(
+                repository="SecPal/.github",
+                head_sha=parent,
+                tree_sha=validated_tree,
+                binding=binding,
+                reviewed=reviewed,
+                manual_gate_evidence=manual_gate_evidence,
+            )
+            fast_path.atomic_write_json(reviewed_state_path, reviewed.to_dict())
+            fast_path.atomic_write_json(receipt_path, receipt)
+            run_git(
+                "commit",
+                "--quiet",
+                "-S",
+                "-m",
+                "validated remediation",
+                "-m",
+                f"SecPal-Validation-Receipt: {receipt['receipt_digest']}",
+            )
+            commit = run_git("rev-parse", "HEAD").stdout.strip()
+
+            self.assertEqual(
+                run_git("rev-list", "--parents", "-n", "1", commit).stdout.split(),
+                [commit, parent],
+            )
+            self.assertEqual(
+                run_git("rev-parse", "HEAD^{tree}").stdout.strip(), validated_tree
+            )
+            self.assertEqual(
+                actions._commit_validation_receipt_digest(repository_root, commit),
+                receipt["receipt_digest"],
+            )
+            self.assertEqual(run_git("verify-commit", "--raw", commit).returncode, 0)
+
+            arguments = SimpleNamespace(
+                expected_head=parent,
+                repo_root=str(repository_root),
+                repo="SecPal/.github",
+                reviewed_state=str(reviewed_state_path),
+                registry=None,
+                bind_commit=True,
+                receipt=str(receipt_path),
+                output=str(attestation_path),
+                manual_gate_evidence=None,
+            )
+            with mock.patch.object(actions, "_run_registered_validations") as validations:
+                with self.assertRaisesRegex(
+                    fast_path.SecurityBlocker,
+                    rf"^local head mismatch: expected {parent}, observed {commit}$",
+                ):
+                    actions._command_attest_validation(arguments)
+                arguments.expected_head = commit
+                self.assertEqual(actions._command_attest_validation(arguments), 0)
+            validations.assert_not_called()
+            self.assertEqual(
+                json.loads(attestation_path.read_text(encoding="utf-8"))["head_sha"],
+                commit,
+            )
+
     def test_bound_commit_rejects_a_malformed_validation_receipt(self) -> None:
         reviewed = fast_feedback()
         entry = registry_entry("SecPal/.github")
@@ -5466,6 +5627,54 @@ class FastPathTests(TestCase):
         pending = fast_path.StableFeedbackState.from_payload(payload)
         self.assertEqual(successful.state_digest, pending.state_digest)
         self.assertEqual(successful.feedback_digest, pending.feedback_digest)
+
+    def test_stable_feedback_preserves_direct_inline_review_wrapper_shape(self) -> None:
+        payload = fast_feedback(1).to_dict()
+        payload["reviews"] = [
+            {
+                "node_id": "REVIEW_WRAPPER_1",
+                "body_digest": digest(""),
+                "actor": {
+                    "login": "reviewer",
+                    "node_id": "ACTOR_1",
+                    "database_id": 7,
+                },
+                "state": "COMMENTED",
+                "commit_oid": payload["head_sha"],
+                "reactions": [],
+            }
+        ]
+        payload["threads"][0]["comments"][0].update(
+            {
+                "node_id": "INLINE_COMMENT_FOR_REVIEW_WRAPPER_1",
+                "body_digest": digest("inline finding"),
+            }
+        )
+
+        state = fast_path.StableFeedbackState.from_payload(payload)
+        wrapper = state.feedback["reviews"][0]
+        thread = state.feedback["threads"][0]
+        inline_comment = thread["comments"][0]
+        self.assertEqual(
+            (wrapper["node_id"], wrapper["state"], wrapper["body_digest"]),
+            ("REVIEW_WRAPPER_1", "COMMENTED", digest("")),
+        )
+        self.assertEqual(thread["node_id"], "THREAD_1")
+        self.assertEqual(
+            (inline_comment["node_id"], inline_comment["body_digest"]),
+            ("INLINE_COMMENT_FOR_REVIEW_WRAPPER_1", digest("inline finding")),
+        )
+        self.assertEqual(
+            fast_path._classified_feedback_sources(state),
+            {
+                ("REVIEW", "REVIEW_WRAPPER_1"): (digest(""), None),
+                (
+                    "THREAD_COMMENT",
+                    "INLINE_COMMENT_FOR_REVIEW_WRAPPER_1",
+                ): (digest("inline finding"), "THREAD_1"),
+            },
+        )
+        self.assertNotIn("findings", state.to_dict())
 
     def test_stable_feedback_preserves_deleted_source_actor_identity(self) -> None:
         payload = fast_feedback(1).to_dict()


### PR DESCRIPTION
## Summary

- document GitHub's empty `COMMENTED` review wrapper for direct inline comments
- clarify `attest-validation --expected-head` for initial validation versus `--bind-commit`
- document repository-pinned formatter provisioning
- add focused regression coverage for commit binding and CLI guidance

## Acceptance evidence

These clarifications come from the completed Package 2.2 disposable fast-path acceptance. The acceptance passed and all disposable resources were cleaned.

## Validation

- focused PR-review action unit tests
- SecPal PR-review skill integration test, when affected
- `./scripts/preflight.sh --reuse-tracked-only`

## Scope

This PR does not change the fast-path state machine, counters, authorization model, review-request behavior, Ready transitions, merge behavior, or repository settings.