### PR TITLE
Update vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,16 +76,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/character-entities": {
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Updates the locked npm dependencies that were reported as high-severity vulnerabilities.

## Problem and evidence

`npm audit --json` reported two high-severity findings:

- `js-yaml@5.2.1` was affected by exponential parsing time in flow collections.
- Transitive `brace-expansion@5.0.7` was affected by unbounded expansion denial of service.

## Change

Updates `package-lock.json` to resolve `js-yaml@5.2.2` and `brace-expansion@5.0.8`. No production dependency declarations or runtime code changed.

## TDD / Validate-First Evidence

- Failing proof before implementation: `npm audit --json` reported 2 high-severity vulnerabilities.
- Passing proof after implementation: `npm audit --json` reported 0 vulnerabilities.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `npm ci`
- `npm audit --omit=dev --json` — 0 vulnerabilities
- `npm audit --json` — 0 vulnerabilities
- `npm test`
- `npm run lint:markdown`
- `git diff --check`

## Readiness

No in-scope dependency or unresolved check prevents readiness.