### PR TITLE
fix(ci): make PR size reporting advisory

### DIFF
--- a/.github/ISSUE_TEMPLATE/sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/sub-issue.yml
@@ -69,7 +69,7 @@ body:
         - [ ] Code follows project style guidelines (Pint, PHPStan, etc.)
         - [ ] Test coverage maintained or improved
         - [ ] No breaking changes (or documented if necessary)
-        - [ ] LOC count ≤ 600 (excluding tests, or marked with `large-pr-approved` label)
+        - [ ] PR addresses one logical topic and remains reviewable; line-count warnings are advisory
     validations:
       required: true
 

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
+    uses: ./.github/workflows/reusable-pr-size.yml
     with:
       max-lines: 600

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   pr-size:

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       max-lines:
-        description: "Maximum number of lines allowed in a PR"
+        description: "Advisory changed-line threshold for reviewability"
         required: false
         type: number
         default: 600
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   pr-size:
@@ -35,20 +34,10 @@ jobs:
 
       - name: Check PR size
         env:
-          GH_TOKEN: ${{ github.token }}
-          MAX_LINES: ${{ inputs.max-lines }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ADVISORY_THRESHOLD: ${{ inputs.max-lines }}
+          CUSTOM_EXCLUDE_PATTERNS: ${{ inputs.exclude-patterns }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          # Check if PR has 'large-pr-approved' label
-          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
-
-          if echo "$LABELS" | grep -q "large-pr-approved"; then
-            echo "✅ PR has 'large-pr-approved' label - skipping size check"
-            echo "Reason: Legitimate large PR (e.g., boilerplate templates, auto-generated code)"
-            exit 0
-          fi
-
           # Fetch base branch
           git fetch origin "$BASE_REF"
 
@@ -110,8 +99,8 @@ jobs:
           fi
 
           # Add custom exclude patterns if provided via input
-          if [ -n "${{ inputs.exclude-patterns }}" ]; then
-            IFS=',' read -ra CUSTOM_PATTERNS <<< "${{ inputs.exclude-patterns }}"
+          if [ -n "$CUSTOM_EXCLUDE_PATTERNS" ]; then
+            IFS=',' read -ra CUSTOM_PATTERNS <<< "$CUSTOM_EXCLUDE_PATTERNS"
 
             # Validate and sanitize custom patterns: remove empty/comment patterns, trim whitespace, strip CR
             VALID_CUSTOM_PATTERNS=()
@@ -144,25 +133,21 @@ jobs:
             fi
           fi
 
-          # Validate that not all files were filtered out
+          # Report when all files were filtered out, then continue with zero counts.
           if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
             echo "⚠️  Warning: All changed files were excluded by filters"
             echo "This PR contains only lock files, license texts, or other excluded patterns"
-            echo "✅ PR size check passed (all changes are auto-generated/excluded)"
-            exit 0
           fi
 
-          CHANGED=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
+          INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
+          DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
+          CHANGED=$((INSERTIONS + DELETIONS))
+          SIZE_REPORT="PR size: $CHANGED changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $ADVISORY_THRESHOLD)"
 
-          echo "Changed lines (after exclusions from .preflight-exclude): $CHANGED"
-          echo "Maximum allowed: $MAX_LINES"
+          echo "$SIZE_REPORT"
 
-          if [ "$CHANGED" -gt "$MAX_LINES" ]; then
-            echo "::error::PR too large ($CHANGED > $MAX_LINES lines). Please split into smaller changes."
-            echo "Tip: Lock files and license files are excluded via .preflight-exclude"
-            echo "For legitimate large PRs (e.g., boilerplate templates),"
-            echo "request the 'large-pr-approved' label from a maintainer."
-            exit 1
+          if [ "$CHANGED" -gt "$ADVISORY_THRESHOLD" ]; then
+            echo "::warning::PR size advisory threshold exceeded ($CHANGED > $ADVISORY_THRESHOLD). Keep this pull request focused on one logical topic and make the review plan explicit."
+          else
+            echo "✅ PR size is within the advisory threshold ($CHANGED <= $ADVISORY_THRESHOLD lines)"
           fi
-
-          echo "✅ PR size is acceptable ($CHANGED <= $MAX_LINES lines)"

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,4 @@ yarn-error.log*
 *.temp
 .cache/
 
-# Preflight overrides (local only)
-.preflight-allow-large-pr
-
 .context/

--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -6,7 +6,7 @@
 
 # ==========================================
 
-# Files matching these patterns are excluded from the 600-line PR size check.
+# Files matching these patterns are excluded from the 600-line advisory threshold.
 
 # Each line is a grep-compatible regex pattern.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-26 - Make Pull Request Size Reporting Advisory
+
+**Changed:**
+
+- replaced the local and reusable-workflow 600-line hard failure with
+  insertion, deletion, and total reporting plus a visible advisory warning
+- removed the local override file, hosted approval-label lookup, and the
+  pull-request token permissions used only for those bypasses
+- retained repository and caller-provided exclusion patterns, stable required
+  check identities, and the strict one-PR-one-topic rule without weakening any
+  formatting, test, security, signature, domain, REUSE, or conflict gate
+- added temporary-repository regression coverage for above-threshold,
+  at-threshold, excluded, caller-exclusion, permission, and policy behavior
+
+---
+
 ## 2026-07-23 - Supersede Retired Android Provisioning Documentation
 
 **Changed:**
@@ -1832,7 +1848,9 @@ The key insight: `require_ci_to_pass: false` allows Dependabot PRs to proceed wh
 - **Critical Rule #6: Issue Management Protocol** - ZERO TOLERANCE enforcement for immediate issue creation
 
   - MANDATORY: Create GitHub issue immediately when bug/issue found in old code that cannot be fixed now
-  - MANDATORY: EPIC + sub-issues structure for ALL features requiring >1 PR (>600 lines, multi-module, >1 day work)
+  - HISTORICAL: EPIC + sub-issues were mandatory for features requiring >1 PR
+    (>600 lines, multi-module, >1 day work); the fixed line-count trigger was
+    superseded by the 2026-07-26 advisory reporting policy
   - Top-level `issue_management` section in `copilot-config.yaml` (200+ lines) with complete protocol, workflows, examples
   - Pre-commit checklist item: "Issue Creation Protocol" validates all findings documented as GitHub issues
   - AI Execution Protocol updated with prominent reminder: "Found bug → CREATE GITHUB ISSUE NOW"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,37 +95,18 @@ This script runs automatically before every `git push` via the pre-push hook.
 - PHP linting and tests (if applicable)
 - Node.js linting and tests (if applicable)
 - OpenAPI validation (if applicable)
-- PR size (< 600 lines recommended, excluding lock files and license files)
+- PR size reporting (600 changed lines recommended, excluding lock files and license files)
 
 If you want a manual local workflow lint pass, prefer `pre-commit run actionlint --all-files` — this avoids the environment-specific hangs that can occur with a direct `actionlint` invocation. If you must run `actionlint` directly, wrap it with a timeout (e.g. `timeout 30 actionlint`). The local preflight script intentionally does not invoke `actionlint` directly.
 
 **Excluded from PR size calculation:**
 
-The following files are automatically excluded from the 600-line limit because they are auto-generated or boilerplate:
+The following files are automatically excluded from the changed-line report because they are auto-generated or boilerplate:
 
 - `package-lock.json`, `composer.lock`, `yarn.lock`, `pnpm-lock.yaml` (dependency lock files)
 - `LICENSES/*.txt` (license boilerplate files)
 
 These exclusions are configured in `.preflight-exclude` and match the GitHub CI workflow. You can add project-specific patterns by editing this file.
-
-**Bypassing the PR size check locally:**
-
-If you need to work on a large PR that is justified (see exceptions below), you can temporarily bypass the 600-line limit:
-
-```bash
-# Create override file to allow large PR
-touch .preflight-allow-large-pr
-
-# Work on your changes
-git add .
-git commit -m "Your changes"
-git push
-
-# Clean up after merge
-rm .preflight-allow-large-pr
-```
-
-⚠️ **Important:** The override file is automatically ignored by git and should only be used for exceptional cases that match the criteria below.
 
 ## How to Contribute
 
@@ -173,25 +154,18 @@ All pull requests will be reviewed by a maintainer and by GitHub Copilot.
 
 **If tempted to add "just one more thing":** Stop, create a separate branch and PR.
 
-### PR Size Limit
+### PR Size Recommendation
 
-Keep PRs **≤ 600 changed lines** for maintainability. If larger, split into sequential PRs:
+600 changed lines is a reviewability recommendation, not a correctness boundary
+or hard maximum. Local preflight and hosted CI report insertions, deletions, and
+the total after exclusions. They emit an advisory warning above the configured
+threshold but do not fail solely because of the line count.
 
-1. Infrastructure/types/interfaces
-2. Core implementation
-3. Tests and documentation
-
-**Exceptions:**
-
-Large PRs (> 600 lines) are acceptable for:
-
-- **Dependency updates** (e.g., `package-lock.json`, `Cargo.lock`)
-- **Generated code** (e.g., OpenAPI clients, database migrations)
-- **Boilerplate/templates** that cannot be reasonably split
-
-**On GitHub:** Add the `large-pr-approved` label to bypass the size check. See [Organization Label Standards](https://github.com/SecPal/.github/blob/main/docs/labels.md) for details.
-
-**Locally:** Create a `.preflight-allow-large-pr` file in the repository root to bypass the preflight check (see "Bypassing the PR size check locally" above).
+Split work when it contains independently reviewable topics. Keep a coherent
+implementation together with its tests and documentation when separating them
+would make review or validation less reliable. Regardless of size, the strict
+one-PR-one-topic rule, reviewability expectations, validation, and testing
+requirements remain in force.
 
 ## Branch Naming Convention
 
@@ -388,7 +362,7 @@ gpg --armor --export <YOUR_KEY_ID>
 
 ## Pull Request Guidelines
 
-- **Keep PRs small:** Aim for < 600 lines of changes. Large PRs are harder to review.
+- **Keep PRs reviewable:** Aim for about 600 changed lines or fewer where a coherent change can be split without separating its implementation, tests, or documentation.
 - **Write clear descriptions:** Use the PR template and fill out all relevant sections.
 - **Link related issues:** Reference issues with `Closes #123` or `Fixes #456`.
 - **Ensure CI passes:** All checks must pass before merging.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The hooks are installed as symlinks in `.git/hooks/`, ensuring they automaticall
   - **PHP/Laravel**: Pint, PHPStan, tests
   - **Node.js**: ESLint, TypeScript, tests, npm audit
   - **OpenAPI**: Spectral/Redocly linting
-- PR size limit (600 lines, configurable with `.preflight-allow-large-pr`)
+- PR size reporting with a 600-line advisory threshold and repository exclusions
 
 **Manual Usage:**
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -64,11 +64,10 @@ Labels that describe the **current state** of an issue or PR.
 
 Labels used by automated tools and workflows.
 
-| Label               | Color   | Description                                                    | Usage      |
-| ------------------- | ------- | -------------------------------------------------------------- | ---------- |
-| `dependabot`        | #0366d6 | Pull requests created by Dependabot                            | PRs (auto) |
-| `github-actions`    | #0366d6 | Pull requests that update GitHub Actions workflows             | PRs (auto) |
-| `large-pr-approved` | #FFA500 | Approved large PR (boilerplate/templates that cannot be split) | PRs        |
+| Label            | Color   | Description                                        | Usage      |
+| ---------------- | ------- | -------------------------------------------------- | ---------- |
+| `dependabot`     | #0366d6 | Pull requests created by Dependabot                | PRs (auto) |
+| `github-actions` | #0366d6 | Pull requests that update GitHub Actions workflows | PRs (auto) |
 
 ## Label Usage Guidelines
 
@@ -99,7 +98,6 @@ Labels: bug, security, priority: high
 **Optional:**
 
 - `breaking-change` if backward incompatible
-- `large-pr-approved` if > 600 lines and legitimate (see [CONTRIBUTING.md](../CONTRIBUTING.md#pr-size-limit))
 - `dependencies` (usually auto-added by Dependabot)
 - `github-actions` for GitHub Actions dependency updates
 
@@ -151,7 +149,6 @@ We follow a consistent color scheme:
 - **Blue (#0075ca, #0366d6)**: Documentation/Dependencies
 - **Green (#008672)**: Help/Community
 - **Purple (#7057ff, #d876e3)**: Newcomers/Questions
-- **Orange (#FFA500)**: Special approvals
 - **Gray (#ededed, #cfd3d7)**: Neutral/Infrastructure
 - **Yellow (#e4e669)**: Invalid/Warning
 - **White (#ffffff)**: Won't fix
@@ -183,7 +180,6 @@ Common label combinations:
 - `breaking-change` + `documentation`
 - `enhancement` (new endpoints)
 - `bug` (spec errors)
-- `large-pr-approved` (template updates)
 
 ## FAQ
 
@@ -211,6 +207,10 @@ Choose the **primary** type. If a PR is both `enhancement` and `documentation`, 
 
 ## Change Log
 
+### 2026-07-26
+
+- Removed the obsolete PR-size override label from the managed baseline
+
 ### 2026-03-22
 
 - Added `github-actions` to the automation label baseline
@@ -219,7 +219,6 @@ Choose the **primary** type. If a PR is both `enhancement` and `documentation`, 
 
 - Initial label standards documentation
 - Defined the standard label baseline across 4 categories
-- Created `large-pr-approved` for legitimate large PRs
 - Added label sync script
 
 ---

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -279,6 +279,15 @@ if [ -f tests/preflight-check-system-requirements.sh ]; then
   }
 fi
 
+if [ -f tests/pr-size-advisory.sh ]; then
+  bash tests/pr-size-advisory.sh || {
+    echo "" >&2
+    echo "❌ Advisory PR-size reporting regression test failed!" >&2
+    echo "Keep local and hosted changed-line reporting advisory while preserving exclusions and stable check names." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/markdownlint-precommit-config.sh ]; then
   bash tests/markdownlint-precommit-config.sh || {
     echo "" >&2
@@ -518,48 +527,25 @@ else
       fi
     fi
 
-    # Check if all files were excluded
+    PR_SIZE_ADVISORY_THRESHOLD=600
+
+    # Report when all files were excluded, then continue with zero counts.
     if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
       echo "⚠️  All changed files are excluded (lock files, license files, etc.)"
-      echo "Preflight OK · Changed lines: 0 (after exclusions)"
-      exit 0
-    else
-      # Use --numstat for locale-independent parsing
-      INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
-      DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
-      CHANGED=$((INSERTIONS + DELETIONS))
+    fi
 
-      if [ "$CHANGED" -gt 600 ]; then
-        # Check for override file (similar to GitHub label for exceptional cases)
-        if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
-          echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
-        else
-          echo "" >&2
-          echo "═══════════════════════════════════════════════════════════════" >&2
-          echo "❌ PRE-PUSH CHECK FAILED: PR TOO LARGE" >&2
-          echo "═══════════════════════════════════════════════════════════════" >&2
-          echo "" >&2
-          echo "Your changes: $CHANGED lines ($INSERTIONS insertions, $DELETIONS deletions)" >&2
-          echo "Maximum allowed: 600 lines per PR" >&2
-          echo "" >&2
-          echo "Action required: Split changes into smaller, focused PRs" >&2
-          echo "" >&2
-          echo "💡 Available options:" >&2
-          echo "  1. Split PR: Recommended approach" >&2
-          echo "  2. Override check: touch .preflight-allow-large-pr" >&2
-          echo "" >&2
-          echo "Note: Lock files and license files are already excluded" >&2
-          echo "      See .preflight-exclude for custom exclusion patterns" >&2
-          echo "" >&2
-          echo "═══════════════════════════════════════════════════════════════" >&2
-          echo "Push aborted. Fix the issue above and try again." >&2
-          echo "═══════════════════════════════════════════════════════════════" >&2
-          echo "" >&2
-          exit 2
-        fi
-      else
-        echo "Preflight OK · Changed lines: $CHANGED"
-      fi
+    # Use --numstat for locale-independent parsing.
+    INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
+    DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
+    CHANGED=$((INSERTIONS + DELETIONS))
+    SIZE_REPORT="PR size: $CHANGED changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $PR_SIZE_ADVISORY_THRESHOLD)"
+
+    if [ "$CHANGED" -gt "$PR_SIZE_ADVISORY_THRESHOLD" ]; then
+      echo "$SIZE_REPORT" >&2
+      echo "⚠️  WARNING: PR size advisory threshold exceeded ($CHANGED > $PR_SIZE_ADVISORY_THRESHOLD)." >&2
+      echo "Keep this pull request focused on one logical topic and make the review plan explicit." >&2
+    else
+      echo "Preflight OK · $SIZE_REPORT"
     fi
   fi
 fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -531,7 +531,7 @@ else
 
     # Report when all files were excluded, then continue with zero counts.
     if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
-      echo "⚠️  All changed files are excluded (lock files, license files, etc.)"
+      echo "⚠️  All changed files are excluded (lock files, license files, etc.)" >&2
     fi
 
     # Use --numstat for locale-independent parsing.

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -55,7 +55,6 @@ declare -a LABELS=(
   # Automation labels
   "dependabot|0366d6|Pull requests created by Dependabot"
   "github-actions|0366d6|Pull requests that update GitHub Actions workflows"
-  "large-pr-approved|FFA500|Approved large PR (boilerplate/templates that cannot be split)"
 )
 
 # Check if gh CLI is installed

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -198,6 +198,14 @@ assert_not_contains \
   "$CALLER_WORKFLOW" \
   "pull-requests: read" \
   "the caller must not retain pull-request permission solely for a size override"
+assert_contains \
+  "$CALLER_WORKFLOW" \
+  "uses: ./.github/workflows/reusable-pr-size.yml" \
+  "the same-repository caller must resolve the changed reusable workflow from the same revision"
+assert_not_contains \
+  "$CALLER_WORKFLOW" \
+  "uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main" \
+  "the same-repository caller must not combine branch permissions with the reusable workflow from main"
 assert_not_contains \
   "$REUSABLE_WORKFLOW" \
   "GH_TOKEN" \

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT_SCRIPT="$REPO_ROOT/scripts/preflight.sh"
+CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/pr-size.yml"
+REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-pr-size.yml"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/pr-size-advisory.XXXXXX")"
+trap 'rm -rf -- "$workspace"' EXIT
+
+failures=0
+
+record_failure() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local message="$3"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    record_failure "$message"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local forbidden="$2"
+  local message="$3"
+
+  if grep -Fq -- "$forbidden" "$file"; then
+    record_failure "$message"
+  fi
+}
+
+make_lines() {
+  local count="$1"
+  local target="$2"
+
+  awk -v count="$count" 'BEGIN { for (line = 1; line <= count; line++) print "line " line }' >"$target"
+}
+
+create_git_fixture() {
+  local repository="$1"
+
+  mkdir -p "$repository/source" "$repository/generated" "$repository/vendor"
+  cat >"$repository/.preflight-exclude" <<'EOF'
+# Keep generated changes out of the reviewability report.
+generated/
+EOF
+  make_lines 4 "$repository/source/existing.txt"
+
+  (
+    cd "$repository"
+    git init --quiet --initial-branch=main
+    git config user.name "SecPal Test"
+    git config user.email "test@secpal.dev"
+    git config commit.gpgSign false
+    git add .preflight-exclude source/existing.txt
+    git commit --quiet -m "test: seed size fixture"
+    git remote add origin "$repository"
+    git update-ref refs/remotes/origin/main HEAD
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+    git checkout --quiet -b test-branch
+  )
+}
+
+create_preflight_fixture() {
+  local repository="$1"
+
+  create_git_fixture "$repository"
+  mkdir -p "$repository/scripts" "$repository/bin"
+  cp "$PREFLIGHT_SCRIPT" "$repository/scripts/preflight.sh"
+
+  cat >"$repository/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  cat >"$repository/bin/reuse" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$repository/bin/npx" "$repository/bin/reuse"
+}
+
+run_preflight_fixture() {
+  local repository="$1"
+  local output="$2"
+
+  set +e
+  (
+    cd "$repository"
+    PATH="$repository/bin:/usr/bin:/bin" bash scripts/preflight.sh
+  ) >"$output" 2>&1
+  fixture_status=$?
+  set -e
+}
+
+large_local_repo="$workspace/local-large"
+large_local_output="$workspace/local-large.out"
+create_preflight_fixture "$large_local_repo"
+make_lines 597 "$large_local_repo/source/large.txt"
+(
+  cd "$large_local_repo"
+  git rm --quiet source/existing.txt
+  git add source/large.txt
+  git commit --quiet -m "test: create 601-line change"
+)
+run_preflight_fixture "$large_local_repo" "$large_local_output"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "local preflight must succeed when the advisory threshold is exceeded (status $fixture_status)"
+fi
+assert_contains \
+  "$large_local_output" \
+  "PR size: 601 changed lines (597 insertions, 4 deletions; advisory threshold: 600)" \
+  "local preflight must report insertion, deletion, total, and advisory-threshold counts above the threshold"
+assert_contains \
+  "$large_local_output" \
+  "WARNING: PR size advisory threshold exceeded" \
+  "local preflight must emit a visible advisory warning above the threshold"
+if [ -e "$large_local_repo/.preflight-allow-large-pr" ]; then
+  record_failure "local advisory reporting must not require an override file"
+fi
+
+threshold_local_repo="$workspace/local-threshold"
+threshold_local_output="$workspace/local-threshold.out"
+create_preflight_fixture "$threshold_local_repo"
+make_lines 600 "$threshold_local_repo/source/threshold.txt"
+(
+  cd "$threshold_local_repo"
+  git add source/threshold.txt
+  git commit --quiet -m "test: create threshold-sized change"
+)
+run_preflight_fixture "$threshold_local_repo" "$threshold_local_output"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "local preflight must succeed at the advisory threshold (status $fixture_status)"
+fi
+assert_contains \
+  "$threshold_local_output" \
+  "Preflight OK · PR size: 600 changed lines (600 insertions, 0 deletions; advisory threshold: 600)" \
+  "local preflight must report normal success and complete counts at the threshold"
+assert_not_contains \
+  "$threshold_local_output" \
+  "WARNING: PR size advisory threshold exceeded" \
+  "local preflight must not warn at the advisory threshold"
+
+excluded_local_repo="$workspace/local-excluded"
+excluded_local_output="$workspace/local-excluded.out"
+create_preflight_fixture "$excluded_local_repo"
+make_lines 700 "$excluded_local_repo/generated/client.txt"
+make_lines 5 "$excluded_local_repo/source/included.txt"
+(
+  cd "$excluded_local_repo"
+  git add generated/client.txt source/included.txt
+  git commit --quiet -m "test: create excluded change"
+)
+run_preflight_fixture "$excluded_local_repo" "$excluded_local_output"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "local preflight must succeed when exclusions reduce the report below the threshold (status $fixture_status)"
+fi
+assert_contains \
+  "$excluded_local_output" \
+  "Preflight OK · PR size: 5 changed lines (5 insertions, 0 deletions; advisory threshold: 600)" \
+  "local preflight must preserve .preflight-exclude behavior"
+assert_not_contains \
+  "$excluded_local_output" \
+  "WARNING: PR size advisory threshold exceeded" \
+  "excluded changes must not trigger the advisory warning"
+
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  'description: "Advisory changed-line threshold for reviewability"' \
+  "the reusable max-lines input must describe an advisory threshold"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "default: 600" \
+  "the reusable advisory threshold must remain configurable with a 600-line default"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "ADVISORY_THRESHOLD: \${{ inputs.max-lines }}" \
+  "the reusable workflow must pass the configured advisory threshold to its shell"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "CUSTOM_EXCLUDE_PATTERNS: \${{ inputs.exclude-patterns }}" \
+  "custom exclusions must remain supported without interpolating them into shell source"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "pull-requests: read" \
+  "the reusable workflow must not retain pull-request permission solely for a size override"
+assert_not_contains \
+  "$CALLER_WORKFLOW" \
+  "pull-requests: read" \
+  "the caller must not retain pull-request permission solely for a size override"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "GH_TOKEN" \
+  "the reusable workflow must not require GH_TOKEN for advisory size reporting"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "PR_NUMBER" \
+  "the reusable workflow must not require PR_NUMBER for advisory size reporting"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "gh pr view" \
+  "the reusable workflow must not query pull-request labels"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "large-pr-approved" \
+  "the reusable workflow must not implement a label override"
+assert_not_contains \
+  "$REUSABLE_WORKFLOW" \
+  "exit 1" \
+  "the reusable workflow must not fail solely because the advisory threshold was exceeded"
+assert_contains \
+  "$CALLER_WORKFLOW" \
+  "name: PR Size Check" \
+  "the caller workflow name must remain stable"
+assert_contains \
+  "$CALLER_WORKFLOW" \
+  "  pr-size:" \
+  "the caller job identifier must remain stable"
+assert_contains \
+  "$CALLER_WORKFLOW" \
+  "name: Check PR Size" \
+  "the caller job name must remain stable"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "name: Reusable PR Size Check" \
+  "the reusable workflow name must remain stable"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "  pr-size:" \
+  "the reusable job identifier must remain stable"
+assert_contains \
+  "$REUSABLE_WORKFLOW" \
+  "name: Check PR Size" \
+  "the reusable job name must remain stable"
+
+workflow_script="$workspace/reusable-pr-size-step.sh"
+awk '
+  /^      - name: Check PR size$/ { in_step = 1; next }
+  in_step && /^        run: \|$/ { capture = 1; next }
+  capture && /^      - name:/ { exit }
+  capture && /^          / { print substr($0, 11) }
+' "$REUSABLE_WORKFLOW" >"$workflow_script"
+
+run_workflow_fixture() {
+  local repository="$1"
+  local output="$2"
+  local custom_patterns="$3"
+
+  set +e
+  (
+    cd "$repository"
+    BASE_REF=main \
+      ADVISORY_THRESHOLD=600 \
+      CUSTOM_EXCLUDE_PATTERNS="$custom_patterns" \
+      bash -euo pipefail "$workflow_script"
+  ) >"$output" 2>&1
+  fixture_status=$?
+  set -e
+}
+
+large_workflow_repo="$workspace/workflow-large"
+large_workflow_output="$workspace/workflow-large.out"
+create_git_fixture "$large_workflow_repo"
+make_lines 601 "$large_workflow_repo/source/large.txt"
+(
+  cd "$large_workflow_repo"
+  git add source/large.txt
+  git commit --quiet -m "test: create hosted advisory change"
+)
+run_workflow_fixture "$large_workflow_repo" "$large_workflow_output" ""
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "reusable workflow shell must succeed above the advisory threshold (status $fixture_status)"
+fi
+assert_contains \
+  "$large_workflow_output" \
+  "PR size: 601 changed lines (601 insertions, 0 deletions; advisory threshold: 600)" \
+  "reusable workflow must report insertion, deletion, total, and threshold counts"
+assert_contains \
+  "$large_workflow_output" \
+  "::warning::PR size advisory threshold exceeded" \
+  "reusable workflow must emit a GitHub warning above the threshold"
+
+excluded_workflow_repo="$workspace/workflow-excluded"
+excluded_workflow_output="$workspace/workflow-excluded.out"
+create_git_fixture "$excluded_workflow_repo"
+make_lines 700 "$excluded_workflow_repo/generated/client.txt"
+make_lines 800 "$excluded_workflow_repo/vendor/bundle.txt"
+make_lines 5 "$excluded_workflow_repo/source/included.txt"
+(
+  cd "$excluded_workflow_repo"
+  git add generated/client.txt vendor/bundle.txt source/included.txt
+  git commit --quiet -m "test: create hosted excluded change"
+)
+run_workflow_fixture "$excluded_workflow_repo" "$excluded_workflow_output" "vendor/"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "reusable workflow shell must preserve repository and custom exclusions (status $fixture_status)"
+fi
+assert_contains \
+  "$excluded_workflow_output" \
+  "PR size: 5 changed lines (5 insertions, 0 deletions; advisory threshold: 600)" \
+  "reusable workflow must apply .preflight-exclude and custom exclusions"
+assert_not_contains \
+  "$excluded_workflow_output" \
+  "::warning::PR size advisory threshold exceeded" \
+  "hosted excluded changes must not trigger the advisory warning"
+
+policy_files=(
+  "$REPO_ROOT/README.md"
+  "$REPO_ROOT/CONTRIBUTING.md"
+  "$REPO_ROOT/docs/labels.md"
+  "$REPO_ROOT/.github/ISSUE_TEMPLATE/sub-issue.yml"
+  "$REPO_ROOT/.preflight-exclude"
+)
+
+for policy_file in "${policy_files[@]}"; do
+  assert_not_contains \
+    "$policy_file" \
+    ".preflight-allow-large-pr" \
+    "policy documentation must not instruct contributors to use a local size override: ${policy_file#"$REPO_ROOT"/}"
+  assert_not_contains \
+    "$policy_file" \
+    "large-pr-approved" \
+    "policy documentation must not instruct contributors to use a label size override: ${policy_file#"$REPO_ROOT"/}"
+done
+
+if grep -Eni 'PR Size Limit|Maximum allowed: 600|600-line limit|≤ 600 changed lines' \
+  "${policy_files[@]}" >/dev/null; then
+  record_failure "policy documentation must not describe 600 lines as a hard maximum"
+fi
+assert_contains \
+  "$REPO_ROOT/CONTRIBUTING.md" \
+  "600 changed lines is a reviewability recommendation" \
+  "the contribution guide must describe 600 lines as a reviewability recommendation"
+assert_contains \
+  "$REPO_ROOT/CONTRIBUTING.md" \
+  "Every PR must address exactly ONE logical topic." \
+  "the strict one-PR-one-topic rule must remain in force"
+assert_contains \
+  "$REPO_ROOT/README.md" \
+  "600-line advisory threshold" \
+  "the repository README must describe advisory PR-size reporting"
+assert_not_contains \
+  "$REPO_ROOT/scripts/sync-labels.sh" \
+  "large-pr-approved" \
+  "the obsolete size-override label must be removed from managed label definitions"
+assert_contains \
+  "$REPO_ROOT/CHANGELOG.md" \
+  "Make Pull Request Size Reporting Advisory" \
+  "the governance changelog must record the advisory reporting change"
+
+if [ "$failures" -ne 0 ]; then
+  echo "tests/pr-size-advisory.sh: $failures regression assertion(s) failed." >&2
+  exit 1
+fi
+
+echo "tests/pr-size-advisory.sh: advisory PR-size reporting verified."

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -92,19 +92,21 @@ EOF
 
 run_preflight_fixture() {
   local repository="$1"
-  local output="$2"
+  local stdout="$2"
+  local stderr="$3"
 
   set +e
   (
     cd "$repository"
     PATH="$repository/bin:/usr/bin:/bin" bash scripts/preflight.sh
-  ) >"$output" 2>&1
+  ) >"$stdout" 2>"$stderr"
   fixture_status=$?
   set -e
 }
 
 large_local_repo="$workspace/local-large"
-large_local_output="$workspace/local-large.out"
+large_local_stdout="$workspace/local-large.stdout"
+large_local_stderr="$workspace/local-large.stderr"
 create_preflight_fixture "$large_local_repo"
 make_lines 597 "$large_local_repo/source/large.txt"
 (
@@ -113,16 +115,16 @@ make_lines 597 "$large_local_repo/source/large.txt"
   git add source/large.txt
   git commit --quiet -m "test: create 601-line change"
 )
-run_preflight_fixture "$large_local_repo" "$large_local_output"
+run_preflight_fixture "$large_local_repo" "$large_local_stdout" "$large_local_stderr"
 if [ "$fixture_status" -ne 0 ]; then
   record_failure "local preflight must succeed when the advisory threshold is exceeded (status $fixture_status)"
 fi
 assert_contains \
-  "$large_local_output" \
+  "$large_local_stderr" \
   "PR size: 601 changed lines (597 insertions, 4 deletions; advisory threshold: 600)" \
   "local preflight must report insertion, deletion, total, and advisory-threshold counts above the threshold"
 assert_contains \
-  "$large_local_output" \
+  "$large_local_stderr" \
   "WARNING: PR size advisory threshold exceeded" \
   "local preflight must emit a visible advisory warning above the threshold"
 if [ -e "$large_local_repo/.preflight-allow-large-pr" ]; then
@@ -130,7 +132,8 @@ if [ -e "$large_local_repo/.preflight-allow-large-pr" ]; then
 fi
 
 threshold_local_repo="$workspace/local-threshold"
-threshold_local_output="$workspace/local-threshold.out"
+threshold_local_stdout="$workspace/local-threshold.stdout"
+threshold_local_stderr="$workspace/local-threshold.stderr"
 create_preflight_fixture "$threshold_local_repo"
 make_lines 600 "$threshold_local_repo/source/threshold.txt"
 (
@@ -138,21 +141,22 @@ make_lines 600 "$threshold_local_repo/source/threshold.txt"
   git add source/threshold.txt
   git commit --quiet -m "test: create threshold-sized change"
 )
-run_preflight_fixture "$threshold_local_repo" "$threshold_local_output"
+run_preflight_fixture "$threshold_local_repo" "$threshold_local_stdout" "$threshold_local_stderr"
 if [ "$fixture_status" -ne 0 ]; then
   record_failure "local preflight must succeed at the advisory threshold (status $fixture_status)"
 fi
 assert_contains \
-  "$threshold_local_output" \
+  "$threshold_local_stdout" \
   "Preflight OK · PR size: 600 changed lines (600 insertions, 0 deletions; advisory threshold: 600)" \
   "local preflight must report normal success and complete counts at the threshold"
 assert_not_contains \
-  "$threshold_local_output" \
+  "$threshold_local_stderr" \
   "WARNING: PR size advisory threshold exceeded" \
   "local preflight must not warn at the advisory threshold"
 
 excluded_local_repo="$workspace/local-excluded"
-excluded_local_output="$workspace/local-excluded.out"
+excluded_local_stdout="$workspace/local-excluded.stdout"
+excluded_local_stderr="$workspace/local-excluded.stderr"
 create_preflight_fixture "$excluded_local_repo"
 make_lines 700 "$excluded_local_repo/generated/client.txt"
 make_lines 5 "$excluded_local_repo/source/included.txt"
@@ -161,18 +165,48 @@ make_lines 5 "$excluded_local_repo/source/included.txt"
   git add generated/client.txt source/included.txt
   git commit --quiet -m "test: create excluded change"
 )
-run_preflight_fixture "$excluded_local_repo" "$excluded_local_output"
+run_preflight_fixture "$excluded_local_repo" "$excluded_local_stdout" "$excluded_local_stderr"
 if [ "$fixture_status" -ne 0 ]; then
   record_failure "local preflight must succeed when exclusions reduce the report below the threshold (status $fixture_status)"
 fi
 assert_contains \
-  "$excluded_local_output" \
+  "$excluded_local_stdout" \
   "Preflight OK · PR size: 5 changed lines (5 insertions, 0 deletions; advisory threshold: 600)" \
   "local preflight must preserve .preflight-exclude behavior"
 assert_not_contains \
-  "$excluded_local_output" \
+  "$excluded_local_stderr" \
   "WARNING: PR size advisory threshold exceeded" \
   "excluded changes must not trigger the advisory warning"
+
+all_excluded_local_repo="$workspace/local-all-excluded"
+all_excluded_local_stdout="$workspace/local-all-excluded.stdout"
+all_excluded_local_stderr="$workspace/local-all-excluded.stderr"
+create_preflight_fixture "$all_excluded_local_repo"
+make_lines 700 "$all_excluded_local_repo/generated/client.txt"
+(
+  cd "$all_excluded_local_repo"
+  git add generated/client.txt
+  git commit --quiet -m "test: create fully excluded change"
+)
+run_preflight_fixture \
+  "$all_excluded_local_repo" \
+  "$all_excluded_local_stdout" \
+  "$all_excluded_local_stderr"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "local preflight must succeed when every changed file is excluded (status $fixture_status)"
+fi
+assert_contains \
+  "$all_excluded_local_stderr" \
+  "All changed files are excluded" \
+  "local preflight must emit the all-excluded advisory on stderr"
+assert_not_contains \
+  "$all_excluded_local_stdout" \
+  "All changed files are excluded" \
+  "local preflight must keep the all-excluded advisory out of stdout"
+assert_contains \
+  "$all_excluded_local_stdout" \
+  "Preflight OK · PR size: 0 changed lines (0 insertions, 0 deletions; advisory threshold: 600)" \
+  "local preflight must report zero counts normally when every changed file is excluded"
 
 assert_contains \
   "$REUSABLE_WORKFLOW" \
@@ -224,8 +258,8 @@ assert_not_contains \
   "the reusable workflow must not implement a label override"
 assert_not_contains \
   "$REUSABLE_WORKFLOW" \
-  "exit 1" \
-  "the reusable workflow must not fail solely because the advisory threshold was exceeded"
+  "::error::PR too large" \
+  "the reusable workflow must not emit the removed hard-failure error"
 assert_contains \
   "$CALLER_WORKFLOW" \
   "name: PR Size Check" \


### PR DESCRIPTION
## Operational problem

The local pre-push preflight and hosted PR-size workflow treated more than 600 changed lines as a hard failure. Legitimate coherent changes therefore needed either a local override file or an approval label before they could pass, even when implementation, regression tests, and documentation belonged to one reviewable topic.

A fixed line count is an imprecise reviewability heuristic, not a correctness boundary. This change keeps 600 as the default advisory threshold while retaining the strict one-PR-one-topic rule.

## Changes

- Local preflight still calculates changed lines from the merge base with `.preflight-exclude`, but now reports insertions, deletions, and total lines, emits a visible advisory warning above 600, and succeeds with respect to size.
- The reusable workflow retains the compatible `max-lines` and custom exclusion inputs, reports the same counts, emits a GitHub `::warning::` above the configured threshold, and finishes successfully with respect to size.
- The hosted label lookup, `GH_TOKEN`, PR number, pull-request read permission, local override branch, ignored override file, and managed size-approval label definition are removed.
- Contributor documentation describes 600 lines as a reviewability recommendation and explains that coherent implementation, tests, and documentation need not be split solely to satisfy a line count.
- Workflow, job, and Required Check identities remain stable. The strict one-topic, reviewability, validation, and testing requirements remain in force.

No override file or approval label is required.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/pr-size-advisory.sh` exited 1 with 31 regression assertion failures, including local exit status 2 above 600 and the hosted label and failure paths.
- Passing proof after implementation: `bash tests/pr-size-advisory.sh` exited 0 and verified local and hosted advisory reporting, threshold behavior, exclusions, permissions, stable check names, and policy documentation.
- Validate-first exception reference: N/A
- No executable change reason: N/A

The regression creates temporary Git histories and proves:

- local 601-line reporting with 597 insertions and 4 deletions warns and exits successfully without an override file;
- local 600-line reporting succeeds normally;
- `.preflight-exclude` remains effective;
- the reusable workflow shell warns and succeeds at 601 lines;
- repository and caller-provided workflow exclusions remain effective;
- obsolete token, PR-number, permission, label, and failure paths are absent;
- stable check names and the documentation policy invariants are retained.

## Validation

- `actionlint .github/workflows/reusable-pr-size.yml .github/workflows/pr-size.yml` — **passed**
- `pre-commit run check-yaml --files .github/workflows/reusable-pr-size.yml .github/workflows/pr-size.yml` — **passed**
- `bash tests/reusable-workflow-timeouts.sh` — **passed**
- `bash tests/reusable-workflow-policy.sh` — **passed**
- `bash tests/sync-required-checks.sh` — **passed**
- `bash tests/preflight-markdownlint-scope.sh` — **passed**
- focused ShellCheck, Prettier, Markdownlint, and yamllint hooks — **passed**
- `./scripts/preflight.sh` — **passed** (single complete final run)
- `git diff --check` — **passed**
- `test ! -e .preflight-allow-large-pr` — **passed**
- signed commit verification — **passed** with the configured ED25519 signing key

The branch changes 575 lines against `main` (449 insertions and 126 deletions), so this PR itself is below the advisory threshold. The 601-line local and hosted regression fixtures prove the warning-and-success behavior above the threshold.

No formatting, test, security, commit-signature, domain-policy, REUSE, conflict-detection, or other quality gate was weakened.

## Readiness

No in-scope dependency or unresolved check prevents review. The initial PR-evidence check failed because equivalent evidence used a non-canonical heading; the body now provides the exact checked-in evidence section, and the corrected check passed. The pull request remains Draft and no reviewers are requested.