### PR TITLE
fix(polyscope): retire changelog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Log of notable changes to SecPal organization defaults (newest first).
   and systemd path watchers
 - retained only an inert `changelog` manifest tombstone so the unprivileged
   rollout remains compatible with the already installed privileged helper
+- required that tombstone to match its exact fixed value and fail closed when
+  its legacy clone-root path exists, preventing an older installed renderer
+  from serving content through its retained compatibility route
+- documented that rerunning the privileged system-component installer removes
+  the legacy changelog matcher itself after a repository-set change
 - kept stale Polyscope database rows unmanaged so an existing retired entry
   cannot make the system server's post-start rollout fail and restart-loop
 - added regression coverage for workspaces and manifests without the retired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - required that tombstone to match its exact fixed value and fail closed when
   its legacy clone-root path exists, preventing an older installed renderer
   from serving content through its retained compatibility route
+- kept the retired `changelog-` hostname prefix reserved as an explicit `404`
+  boundary so it cannot fall through to generic active-workspace routing
 - documented that rerunning the privileged system-component installer removes
-  the legacy changelog matcher itself after a repository-set change
+  the legacy changelog content mapping after a repository-set change while
+  retaining that fail-closed hostname boundary
 - kept stale Polyscope database rows unmanaged so an existing retired entry
   cannot make the system server's post-start rollout fail and restart-loop
 - added regression coverage for workspaces and manifests without the retired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-28 - Retire Changelog Polyscope Integration
+
+**Changed:**
+
+- removed the retired `SecPal/changelog` repository from managed Polyscope
+  validation, metadata links, generated local configuration, preview routing,
+  and systemd path watchers
+- retained only an inert `changelog` manifest tombstone so the unprivileged
+  rollout remains compatible with the already installed privileged helper
+- kept stale Polyscope database rows unmanaged so an existing retired entry
+  cannot make the system server's post-start rollout fail and restart-loop
+- added regression coverage for workspaces and manifests without the retired
+  repository
+
+---
+
 ## 2026-07-26 - Make Pull Request Size Reporting Advisory
 
 **Changed:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -553,8 +553,9 @@ During a staged upgrade, an older installed renderer can retain a syntactic
 route for a retired repository. The live rollout supplies only the exact fixed
 tombstone required by that older contract and fails closed if the tombstone's
 clone-root path exists, so the compatibility route cannot serve content. The
-privileged reinstall removes the obsolete route from generated nginx
-configuration entirely.
+privileged reinstall removes the obsolete content mapping from generated nginx
+configuration. The retired hostname prefix remains reserved solely as an
+explicit `404` boundary so it cannot be reinterpreted as a generic workspace.
 
 After both installation steps, verify the steady state:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -547,6 +547,15 @@ atomic; `nginx -t` precedes reload, and validation or reload failure restores
 the prior configuration. Root may invoke the helper directly; invocations
 carrying sudo identity are accepted only from `secpal` with its exact UID.
 
+When the managed repository set changes, rerun this privileged installer before
+the unprivileged rollout installer to replace the root-owned renderer contract.
+During a staged upgrade, an older installed renderer can retain a syntactic
+route for a retired repository. The live rollout supplies only the exact fixed
+tombstone required by that older contract and fails closed if the tombstone's
+clone-root path exists, so the compatibility route cannot serve content. The
+privileged reinstall removes the obsolete route from generated nginx
+configuration entirely.
+
 After both installation steps, verify the steady state:
 
 ```bash

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -463,9 +463,6 @@ PathChanged=$WORKSPACE_ROOT/guardguide.de/.github/instructions
 PathChanged=$WORKSPACE_ROOT/GuardGuide/AGENTS.md
 PathChanged=$WORKSPACE_ROOT/GuardGuide/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/GuardGuide/.github/instructions
-PathChanged=$WORKSPACE_ROOT/changelog/AGENTS.md
-PathChanged=$WORKSPACE_ROOT/changelog/.github/copilot-instructions.md
-PathChanged=$WORKSPACE_ROOT/changelog/.github/instructions
 PathChanged=$WORKSPACE_ROOT/.github/AGENTS.md
 PathChanged=$WORKSPACE_ROOT/.github/.github/copilot-instructions.md
 PathChanged=$WORKSPACE_ROOT/.github/.github/instructions
@@ -519,7 +516,6 @@ PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/android/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/secpal.app/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/guardguide.de/polyscope.local.json
-PathChanged=$WORKSPACE_ROOT/changelog/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/.github/polyscope.local.json
 
 [Install]

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4878,6 +4878,7 @@ def main() -> int:
             repo_state,
             nginx_http2_syntax=nginx_http2_syntax,
         )
+        polyscope_nginx.ensure_retired_repository_roots_absent(nginx_manifest)
         write_nginx_manifest(
             args.nginx_manifest_output,
             nginx_manifest,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4295,17 +4295,19 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
     guardguide_de_id = repo_state["guardguide.de"]["id"]
     http2_listen_suffix = "" if nginx_http2_syntax == "modern" else " http2"
     http2_directive = "\n            http2 on;" if nginx_http2_syntax == "modern" else ""
-    # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-, or secpal-app- are
-    # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
-    # Generic workspaces must not use those prefixes; the regex will treat them as legacy
-    # hosts and route them to the wrong backend.
+    # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-,
+    # secpal-app-, or changelog- are reserved for legacy per-repo routing (e.g.
+    # api-WORKSPACE.preview.secpal.dev). The retired changelog prefix remains reserved
+    # solely so those hostnames can fail closed instead of becoming generic workspaces.
+    # Generic workspaces must not use the active prefixes because the regex will route
+    # them to a repository-specific backend; the retired prefix always returns 404.
     # `http2 on;` requires nginx >= 1.25.1, so install mode version-gates this render option.
     return textwrap.dedent(
         f"""
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -4317,7 +4319,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
         server {{
             listen 443 ssl{http2_listen_suffix};
             listen [::]:443 ssl{http2_listen_suffix};{http2_directive}
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -4346,6 +4348,10 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+
+            if ($repo = changelog) {{
+                return 404;
+            }}
 
             if (-f $api_public/index.php) {{
                 set $preview_docroot $api_public;

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2368,7 +2368,6 @@ def build_repo_all_checks_command(repo_name: str) -> str | None:
         "contracts": "npm run validate && npm run lint && npm run format:check",
         "android": "npm run lint && npm run typecheck && npm run test:run && npm run native:verify",
         "secpal.app": "npm run check && npm run lint && npm run test && npm run build",
-        "changelog": "npm run check && npm run lint && npm run csp:check && npm run build",
         "guardguide.de": "npm run check && npm run lint && npm run test && npm run build",
         ".github": "./scripts/preflight.sh",
     }
@@ -2671,7 +2670,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
         ],
         "preview_prefix": "secpal-app",
         "review_focus": "Astro static rendering, minimal client-side JavaScript, semantic HTML, accessible landmarks, and strict TypeScript on the public site.",
-        "link_names": ["changelog"],
+        "link_names": [],
         "local_config": {
             "copyGitignored": True,
             "runMode": "replace",
@@ -2757,50 +2756,6 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                 {
                     "label": "Triage failing Astro",
                     "prompt": "Reproduce the failing static-site behavior or Astro check, add or update the smallest relevant validation first, then implement the minimal fix and rerun the touched commands. Keep the change scoped to one issue.",
-                },
-            ],
-        },
-    },
-    "changelog": {
-        "display_name": "SecPal/changelog",
-        "base_branch": "main",
-        "copilot_instructions": ".github/copilot-instructions.md",
-        "focus_instruction_paths": [
-            ".github/instructions/org-shared.instructions.md",
-            ".github/instructions/nextjs-changelog.instructions.md",
-        ],
-        "preview_prefix": "changelog",
-        "review_focus": "Next.js static-style changelog output, MDX content rules, Commit template conventions, CSP/feed safety, and no server-side runtime dependencies.",
-        "link_names": ["secpal.app"],
-        "local_config": {
-            "copyGitignored": True,
-            "runMode": "replace",
-            "preview": {"url": build_preview_url_template("changelog")},
-            "scripts": {
-                "setup": [build_verified_npm_ci_command(), "npm run build"],
-                "run": [
-                    {
-                        "label": "Build Watch",
-                        "command": build_static_preview_build_watch_command(
-                            "changelog",
-                            ["changelog", "mdx", "public", "scripts", "src"],
-                        ),
-                        "autostart": True,
-                        "runMode": "replace",
-                    },
-                    {"label": "Typecheck", "command": "npm run check", "runMode": "preserve"},
-                    {"label": "Lint", "command": "npm run lint", "runMode": "preserve"},
-                    {"label": "CSP Check", "command": "npm run csp:check", "runMode": "preserve"},
-                ],
-            },
-            "tasks": [
-                {
-                    "label": "Review changelog export",
-                    "prompt": "Review the changelog-site change for static export regressions, feed or CSP drift, MDX rendering issues, and missing lint or typecheck coverage. Keep the work scoped to the touched entry or component.",
-                },
-                {
-                    "label": "Triage failing Next build",
-                    "prompt": "Reproduce the failing changelog build or typecheck, update the smallest relevant input first, then implement the minimal fix and rerun the touched validation. Keep the change scoped to one issue.",
                 },
             ],
         },
@@ -4338,10 +4293,9 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
     guardguide_id = repo_state["GuardGuide"]["id"]
     secpal_app_id = repo_state["secpal.app"]["id"]
     guardguide_de_id = repo_state["guardguide.de"]["id"]
-    changelog_id = repo_state["changelog"]["id"]
     http2_listen_suffix = "" if nginx_http2_syntax == "modern" else " http2"
     http2_directive = "\n            http2 on;" if nginx_http2_syntax == "modern" else ""
-    # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-, secpal-app-, or changelog- are
+    # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-, or secpal-app- are
     # reserved for legacy per-repo routing (e.g. api-WORKSPACE.preview.secpal.dev).
     # Generic workspaces must not use those prefixes; the regex will treat them as legacy
     # hosts and route them to the wrong backend.
@@ -4351,7 +4305,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -4363,7 +4317,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
         server {{
             listen 443 ssl{http2_listen_suffix};
             listen [::]:443 ssl{http2_listen_suffix};{http2_directive}
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -4386,8 +4340,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $secpal_app_dist $secpal_app_root/dist;
             set $guardguide_de_root /home/secpal/.polyscope/clones/{guardguide_de_id}/$workspace;
             set $guardguide_de_dist $guardguide_de_root/dist;
-            set $changelog_root /home/secpal/.polyscope/clones/{changelog_id}/$workspace;
-            set $changelog_out $changelog_root/out;
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
@@ -4414,18 +4366,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
 
             if (-f $guardguide_de_dist/index.html) {{
                 set $preview_docroot $guardguide_de_dist;
-                set $route_mode static;
-                set $secpal_csp $preview_relaxed_csp;
-            }}
-
-            if (-f $changelog_out/index.html) {{
-                set $preview_docroot $changelog_out;
-                set $route_mode static;
-                set $secpal_csp $preview_relaxed_csp;
-            }}
-
-            if ($repo = changelog) {{
-                set $preview_docroot $changelog_out;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}

--- a/scripts/polyscope_nginx.py
+++ b/scripts/polyscope_nginx.py
@@ -27,6 +27,7 @@ EXPECTED_REPOSITORIES = (
     "guardguide.de",
     "changelog",
 )
+RETIRED_REPOSITORY_IDS = {"changelog": "retired"}
 EXPECTED_UNIX_UPSTREAM = "/run/php/php8.4-fpm-secpal-preview.sock"
 TOP_LEVEL_KEYS = {
     "version",
@@ -139,7 +140,11 @@ def build_manifest(
         "preview_domain": EXPECTED_PREVIEW_DOMAIN,
         "clone_root": EXPECTED_CLONE_ROOT,
         "repositories": {
-            repo_name: str(repo_state[repo_name]["id"])
+            repo_name: (
+                RETIRED_REPOSITORY_IDS[repo_name]
+                if repo_name in RETIRED_REPOSITORY_IDS
+                else str(repo_state[repo_name]["id"])
+            )
             for repo_name in EXPECTED_REPOSITORIES
         },
         "php_upstream": {

--- a/scripts/polyscope_nginx.py
+++ b/scripts/polyscope_nginx.py
@@ -27,7 +27,7 @@ EXPECTED_REPOSITORIES = (
     "guardguide.de",
     "changelog",
 )
-RETIRED_REPOSITORY_IDS = {"changelog": "retired"}
+RETIRED_REPOSITORY_IDS = {"changelog": "__retired_changelog__"}
 EXPECTED_UNIX_UPSTREAM = "/run/php/php8.4-fpm-secpal-preview.sock"
 TOP_LEVEL_KEYS = {
     "version",
@@ -74,6 +74,11 @@ def validate_manifest_data(payload: Any) -> dict[str, Any]:
     for repo_name, repo_id in repositories.items():
         if not isinstance(repo_id, str) or REPOSITORY_ID_PATTERN.fullmatch(repo_id) is None:
             raise ValueError(f"repository id for {repo_name} is unsafe")
+    for repo_name, retired_id in RETIRED_REPOSITORY_IDS.items():
+        if repositories[repo_name] != retired_id:
+            raise ValueError(
+                f"repository id for retired {repo_name} must be exactly {retired_id}"
+            )
 
     upstream = payload["php_upstream"]
     if not isinstance(upstream, dict):
@@ -94,6 +99,31 @@ def validate_manifest_data(payload: Any) -> dict[str, Any]:
         raise ValueError("php_upstream kind must be unix or tcp")
 
     return payload
+
+
+def ensure_retired_repository_roots_absent(
+    payload: dict[str, Any],
+    *,
+    filesystem_clone_root: pathlib.Path | None = None,
+) -> None:
+    """Keep compatibility tombstones inert for an older installed renderer."""
+    manifest = validate_manifest_data(payload)
+    clone_root = filesystem_clone_root or pathlib.Path(manifest["clone_root"])
+    for repo_name, retired_id in RETIRED_REPOSITORY_IDS.items():
+        retired_root = clone_root / retired_id
+        try:
+            retired_root.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            raise ValueError(
+                f"unable to verify retired repository tombstone path for {repo_name}: "
+                f"{retired_root}: {error}"
+            ) from error
+        raise ValueError(
+            f"retired repository tombstone path must stay absent for {repo_name}: "
+            f"{retired_root}"
+        )
 
 
 def load_manifest(path: pathlib.Path, *, expected_uid: int) -> dict[str, Any]:

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -90,7 +90,7 @@ manifest = {
         "GuardGuide": "8fadd2fb",
         "secpal.app": "c46a8454",
         "guardguide.de": "3d0fcf01",
-        "changelog": "retired",
+        "changelog": "__retired_changelog__",
     },
     "php_upstream": {
         "kind": "unix",
@@ -108,7 +108,38 @@ built_manifest = library.build_manifest(
     active_repo_state,
     nginx_http2_syntax="modern",
 )
-assert built_manifest["repositories"]["changelog"] == "retired"
+assert built_manifest["repositories"]["changelog"] == "__retired_changelog__"
+library.ensure_retired_repository_roots_absent(
+    built_manifest,
+    filesystem_clone_root=workspace / "absent-retired-clone-root",
+)
+
+occupied_clone_root = workspace / "occupied-retired-clone-root"
+(occupied_clone_root / "__retired_changelog__").mkdir(parents=True)
+try:
+    library.ensure_retired_repository_roots_absent(
+        built_manifest,
+        filesystem_clone_root=occupied_clone_root,
+    )
+except ValueError as error:
+    assert "retired repository tombstone path must stay absent" in str(error), error
+else:
+    raise AssertionError("occupied retired repository tombstone path was accepted")
+
+linked_clone_root = workspace / "linked-retired-clone-root"
+linked_clone_root.mkdir()
+(linked_clone_root / "__retired_changelog__").symlink_to(
+    workspace / "missing-retired-target"
+)
+try:
+    library.ensure_retired_repository_roots_absent(
+        built_manifest,
+        filesystem_clone_root=linked_clone_root,
+    )
+except ValueError as error:
+    assert "retired repository tombstone path must stay absent" in str(error), error
+else:
+    raise AssertionError("linked retired repository tombstone path was accepted")
 
 
 def write_manifest(path: pathlib.Path, payload: object, mode: int = 0o600) -> None:
@@ -145,6 +176,9 @@ for port in (0, 65536, "9000"):
     invalid_payloads.append(payload)
 payload = copy.deepcopy(manifest)
 payload["repositories"]["api"] = "../../etc"
+invalid_payloads.append(payload)
+payload = copy.deepcopy(manifest)
+payload["repositories"]["changelog"] = "active123"
 invalid_payloads.append(payload)
 
 for index, payload in enumerate(invalid_payloads):

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -90,7 +90,7 @@ manifest = {
         "GuardGuide": "8fadd2fb",
         "secpal.app": "c46a8454",
         "guardguide.de": "3d0fcf01",
-        "changelog": "0a40ecd7",
+        "changelog": "retired",
     },
     "php_upstream": {
         "kind": "unix",
@@ -98,6 +98,17 @@ manifest = {
     },
     "nginx_http2_syntax": "modern",
 }
+
+active_repo_state = {
+    repo_name: {"id": repo_id}
+    for repo_name, repo_id in manifest["repositories"].items()
+    if repo_name != "changelog"
+}
+built_manifest = library.build_manifest(
+    active_repo_state,
+    nginx_http2_syntax="modern",
+)
+assert built_manifest["repositories"]["changelog"] == "retired"
 
 
 def write_manifest(path: pathlib.Path, payload: object, mode: int = 0o600) -> None:

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -177,13 +177,6 @@ package_scripts = {
         "lint": "eslint .",
         "test": "node --test tests/**/*.mjs",
     },
-    "changelog": {
-        "build": "next build",
-        "check": "tsc --noEmit",
-        "lint": "eslint .",
-        "csp:check": "node scripts/generate-csp.mjs --check",
-        "preflight": "./scripts/preflight.sh",
-    },
     ".github": {
         "copilot:review:scan": "./scripts/copilot-review-tool.sh scan",
         "test": "npm run test:openapi-verified-presence",
@@ -718,42 +711,6 @@ applyTo: 'src/**/*.astro'
 - Run formatting, lint, typecheck, and build.
 "
 
-create_repo "changelog" "$common_header
-
-# Changelog Instructions
-
-## Always-On Rules
-
-- Run git status --short --branch before any write action.
-- Validate-first.
-
-## Issue And PR Discipline
-
-- The first PR state must be draft.
-
-## Required Validation
-
-- the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
-- CHANGELOG.md was updated for real changes
-- no bypass was used
-
-## AI Findings Triage
-
-- Treat AI findings and AI-generated fix PRs as hints, not proof.
-- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant.
-- Green CI alone is not enough for AI-generated changes.
-" "nextjs-changelog.instructions.md" "---
-name: Next.js Changelog Rules
-applyTo: 'src/**/*.tsx'
----
-
-# Next.js Changelog Rules
-
-- Keep client-side JavaScript minimal.
-- Do not introduce server actions.
-- Run npm run build as the primary validation after source changes.
-"
-
 create_repo ".github" "$common_header
 
 # Org Instructions
@@ -862,6 +819,8 @@ repo_state = {
     'android': {'id': 'an123456', 'name': 'SecPal/android', 'path': str(workspace_root / 'android')},
     'secpal.app': {'id': 'sa123456', 'name': 'SecPal/secpal.app', 'path': str(workspace_root / 'secpal.app')},
     'guardguide.de': {'id': 'gd123456', 'name': 'SecPal/guardguide.de', 'path': str(workspace_root / 'guardguide.de')},
+    # Preserve a retired database row to prove rollout ignores repositories
+    # that are no longer part of the managed workspace.
     'changelog': {'id': 'ch123456', 'name': 'SecPal/changelog', 'path': str(workspace_root / 'changelog')},
     'GuardGuide': {'id': 'gg123456', 'name': 'SecPal/GuardGuide', 'path': str(workspace_root / 'GuardGuide')},
     '.github': {'id': 'gh123456', 'name': 'SecPal/.github', 'path': str(workspace_root / '.github')},
@@ -1930,7 +1889,6 @@ grep -q '## Always-On Rules' "$workspace_root/frontend/.github/copilot-instructi
 grep -q 'https://guardguide-{{worktree}}.preview.secpal.dev' "$workspace_root/GuardGuide/polyscope.local.json"
 grep -q 'https://secpal-app-{{worktree}}.preview.secpal.dev' "$workspace_root/secpal.app/polyscope.local.json"
 grep -q 'https://guardguide-de-{{worktree}}.preview.secpal.dev' "$workspace_root/guardguide.de/polyscope.local.json"
-grep -q 'https://changelog-{{worktree}}.preview.secpal.dev' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '.env.local' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'VITE_API_URL' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'resolve_linked_workspace(\"SecPal/api\", workspace)' "$workspace_root/frontend/polyscope.local.json"
@@ -4182,11 +4140,6 @@ grep -qF '"label": "Build Watch"' "$workspace_root/guardguide.de/polyscope.local
 grep -qF 'Watching guardguide.de preview sources for changes...' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF 'public/og-default.svg' "$workspace_root/guardguide.de/polyscope.local.json"
 grep -qF 'public/og-de.png' "$workspace_root/guardguide.de/polyscope.local.json"
-grep -qF '"command": "npm run check && npm run lint && npm run csp:check && npm run build"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF '"label": "Fix current findings"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF '"label": "Build Watch"' "$workspace_root/changelog/polyscope.local.json"
-grep -qF 'Watching changelog preview sources for changes...' "$workspace_root/changelog/polyscope.local.json"
 grep -qF '"command": "./scripts/preflight.sh"' "$workspace_root/.github/polyscope.local.json"
 grep -qF '"label": "Fix current findings"' "$workspace_root/.github/polyscope.local.json"
 
@@ -4339,7 +4292,7 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 command = module.build_static_preview_build_watch_command(
-    "changelog",
+    "static-site",
     ["public", "src"],
     ignored_paths=["public/generated.svg"],
 )
@@ -4432,7 +4385,11 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output"
+grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>' "$nginx_output"
+if grep -qF 'changelog' "$nginx_output"; then
+    echo "preview nginx config must not retain routing for the retired changelog repository" >&2
+    exit 1
+fi
 grep -qF "listen 443 ssl;" "$nginx_output"
 grep -qF "listen [::]:443 ssl;" "$nginx_output"
 grep -qF "http2 on;" "$nginx_output"
@@ -4763,16 +4720,14 @@ api_if_line="$(grep -nF "if (-f \$api_public/index.php) {" "$nginx_output" | hea
 frontend_if_line="$(grep -nF "if (-f \$frontend_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 secpal_app_if_line="$(grep -nF "if (-f \$secpal_app_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 guardguide_de_if_line="$(grep -nF "if (-f \$guardguide_de_dist/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
-changelog_if_line="$(grep -nF "if (-f \$changelog_out/index.html) {" "$nginx_output" | head -n 1 | cut -d: -f1)"
 
 test -n "$api_if_line"
 test -n "$frontend_if_line"
 test -n "$secpal_app_if_line"
 test -n "$guardguide_de_if_line"
-test -n "$changelog_if_line"
 
-if (( api_if_line >= frontend_if_line || frontend_if_line >= secpal_app_if_line || secpal_app_if_line >= guardguide_de_if_line || guardguide_de_if_line >= changelog_if_line )); then
-    echo "generic preview precedence must prefer changelog > guardguide.de > secpal.app > frontend > api" >&2
+if (( api_if_line >= frontend_if_line || frontend_if_line >= secpal_app_if_line || secpal_app_if_line >= guardguide_de_if_line )); then
+    echo "generic preview precedence must prefer guardguide.de > secpal.app > frontend > api" >&2
     exit 1
 fi
 
@@ -4784,7 +4739,6 @@ fi
     "$workspace_root/GuardGuide/polyscope.local.json" \
     "$workspace_root/secpal.app/polyscope.local.json" \
     "$workspace_root/guardguide.de/polyscope.local.json" \
-    "$workspace_root/changelog/polyscope.local.json" \
     "$workspace_root/.github/polyscope.local.json" \
     >/dev/null
 
@@ -4807,8 +4761,12 @@ org_prompts = cur.execute(
     ('gh123456',),
 ).fetchone()
 prompt_rows = cur.execute(
-    'select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories order by id'
+    "select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id != 'ch123456' order by id"
 ).fetchall()
+retired_prompts = cur.execute(
+    'select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id = ?',
+    ('ch123456',),
+).fetchone()
 links = cur.execute('select repo_id, linked_repo_id from repository_links order by repo_id, linked_repo_id').fetchall()
 
 assert 'api/AGENTS.md' in api_prompt
@@ -4840,7 +4798,9 @@ assert ('gg123456', 'an123456') in links
 assert ('gg123456', 'api12345') in links
 assert ('gg123456', 'co123456') in links
 assert ('gg123456', 'fe123456') in links
-assert ('sa123456', 'ch123456') in links
+assert ('sa123456', 'ch123456') not in links
+assert retired_prompts is not None
+assert all(prompt is None for prompt in retired_prompts)
 
 summary = json.loads(summary_path.read_text())
 assert summary['db_backup'] is not None
@@ -4849,7 +4809,7 @@ assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
 assert summary['repositories']['GuardGuide']['preview_prefix'] == 'guardguide'
 assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
 assert summary['repositories']['guardguide.de']['preview_prefix'] == 'guardguide-de'
-assert summary['repositories']['changelog']['preview_prefix'] == 'changelog'
+assert 'changelog' not in summary['repositories']
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['agent_instructions'].endswith('/api/AGENTS.md')
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
@@ -6780,6 +6740,10 @@ grep -q 'Environment=POLYSCOPE_NGINX_HELPER=/usr/local/libexec/secpal-polyscope-
 grep -q -- '--nginx-manifest-output .*nginx-manifest.json --install-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
+if grep -q '/changelog/' "$fake_unit_dir/polyscope-rollout-sync.path"; then
+    echo "rollout sync watcher must not retain the retired changelog repository" >&2
+    exit 1
+fi
 grep -q '/templates/polyscope-codex-AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/polyscope-rollout\.py$' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -qE '^PathChanged=.*/scripts/validate-ai-instructions\.sh$' "$fake_unit_dir/polyscope-rollout-sync.path"
@@ -6802,6 +6766,10 @@ if grep -qE '^(Restart=|SuccessExitStatus=|ExecStart=-)' "$fake_unit_dir/polysco
 fi
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --provision-lock-path .*worktree-provision.lock --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.path"
+if grep -q '/changelog/' "$fake_unit_dir/polyscope-worktree-provision.path"; then
+    echo "worktree provision watcher must not retain the retired changelog repository" >&2
+    exit 1
+fi
 grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnStartupSec=30s$' "$fake_unit_dir/polyscope-worktree-provision.timer"
 grep -q '^OnUnitActiveSec=3min$' "$fake_unit_dir/polyscope-worktree-provision.timer"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4385,11 +4385,29 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-grep -q 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>' "$nginx_output"
-if grep -qF 'changelog' "$nginx_output"; then
-    echo "preview nginx config must not retain routing for the retired changelog repository" >&2
+if [ "$(grep -cF 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output")" -ne 2 ]; then
+    echo "preview nginx config must reserve the retired changelog hostname prefix in both servers" >&2
     exit 1
 fi
+python3 -B - <<'PY' "$nginx_output"
+import pathlib
+import re
+import sys
+
+config = pathlib.Path(sys.argv[1]).read_text()
+retired_route = re.search(
+    r"if \(\$repo = changelog\) \{\s*(?P<body>.*?)\s*\}",
+    config,
+    re.DOTALL,
+)
+if retired_route is None or "return 404;" not in retired_route.group("body"):
+    raise SystemExit("retired changelog hostnames must fail closed with an explicit 404")
+tls_server = config.index("listen 443 ssl;")
+retired_guard = config.index("if ($repo = changelog)")
+first_docroot_probe = config.index("if (-f $api_public/index.php)")
+if not tls_server < retired_guard < first_docroot_probe:
+    raise SystemExit("retired changelog hostnames must fail closed before docroot probes")
+PY
 grep -qF "listen 443 ssl;" "$nginx_output"
 grep -qF "listen [::]:443 ssl;" "$nginx_output"
 grep -qF "http2 on;" "$nginx_output"

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -106,8 +106,9 @@ grep -Fq 'Push and PR creation never imply CI-observation authorization.' <<<"$t
   || fail 'push and PR creation authorization boundary is missing'
 assert_polyscope_template_baseline "$POLYSCOPE_TEMPLATE"
 if (
-  mutated_template="$(mktemp)"
-  trap 'rm -f "$mutated_template"' EXIT
+  mutation_workspace="$(mktemp -d "${TMPDIR:-/tmp}/secpal-pr-review-skill-policy.XXXXXX")"
+  mutated_template="$mutation_workspace/polyscope-codex-AGENTS.md"
+  trap 'rm -rf -- "$mutation_workspace"' EXIT
   sed \
     's/Preserve a branch or worktree already provisioned by Polyscope/Discard the branch or worktree already provisioned by Polyscope/' \
     "$POLYSCOPE_TEMPLATE" >"$mutated_template"


### PR DESCRIPTION
## Description

Retire the removed `SecPal/changelog` repository from Polyscope workspace coordination while preserving a bounded manifest tombstone for rollout compatibility.

The change removes changelog-specific repository settings, linked-workspace metadata, local configuration, preview routing, and systemd path watchers. Stale Polyscope database rows are intentionally left unmanaged so they cannot break server startup. It also fixes the `mktemp` portability violation uncovered by the full repository preflight.

## Root cause and impact

The Polyscope server post-start rollout still treated `SecPal/changelog` as a required managed repository after that repository had been removed. The missing checkout made `ExecStartPost` fail, and the service restart policy repeatedly cycled Polyscope between connected and disconnected states.

After this change, a stale changelog row no longer participates in managed rollout, and generated Nginx configuration no longer exposes changelog preview routing. Existing privileged helper compatibility is maintained through an inert `changelog: retired` manifest value.

## Related Issues

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring

## Testing

- [x] Tested locally
- [x] Added/updated regression tests
- [x] Manual installation and runtime verification performed

Validated with:

- `./scripts/preflight.sh`
- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-nginx-helper.sh`
- `bash tests/polyscope-system-installer.sh`
- `bash tests/mktemp-portability.sh`
- `bash tests/secpal-pr-review-skill-policy.sh`
- `git diff --check`

Runtime verification confirmed that `polyscope-server.service` remained active with zero restarts, the rollout post-start hook succeeded, and the local health endpoint returned `{"status":"ok"}`.

## TDD / Validate-First Evidence

- Failing proof before implementation: the rollout regression fixture failed when the managed repository set still required the absent changelog checkout; the full preflight also identified the non-portable temporary-file usage.
- Passing proof after implementation: the focused rollout, Nginx helper, system installer, temporary-directory portability, policy, and complete preflight validations all pass.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] The changelog entry was checked against the implementation and regression tests
- [x] Comments are limited to compatibility and stale-state invariants
- [x] Documentation updated where needed
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] No related issue exists to link