### PR TITLE
chore(review): register frontend strict CSP validation

### DIFF
--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -111,13 +111,16 @@ The following state machine applies only to the full feedback-remediation path.
    thread comments. Reactions and unrelated feedback are not thread-resolution
    preconditions. Never infer truth from reviewer identity, keywords, or CI.
 3. Reproduce every valid finding, add a failing test first, make the smallest
-   coherent corrections, and use focused validation while editing.
+   coherent corrections, and use focused validation while editing. A registry
+   command with `execution_policy: focused-only` is eligible for this explicit
+   selection but is never added to unconditional complete validation.
 4. Perform the one holistic audit across correctness, security, privacy, data
    integrity, lifecycle, rollout, and avoidable complexity. Fix material
    in-scope defects before the complete validation.
-5. Stage the finished tree and run complete registered local validation exactly
-   once through `attest-validation`, supplying explicit satisfied evidence for
-   every registered manual gate. Preserve its deterministic staged-tree,
+5. Stage the finished tree and run the registered unconditional focused commands
+   plus every required local validation exactly once through
+   `attest-validation`, supplying explicit satisfied evidence for every
+   registered manual gate. Preserve its deterministic staged-tree,
    parent-head, registry, command-set, manual-gate, result, and reviewed-feedback
    receipt.
 6. When remediation changed the staged tree, create one signed commit containing

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -136,12 +136,15 @@ excludes Required Check results and all other volatile readiness values.
 `CLASSIFY_AND_FIX_ALL_CURRENT_FINDINGS` independently proves each classification,
 adds failing regression coverage for valid findings, and implements the smallest
 coherent correction. `FOCUSED_VALIDATION_WHILE_EDITING` runs only affected tests.
+Commands marked `execution_policy: focused-only` remain available for that
+explicit selection and are excluded from unconditional complete validation.
 
 `HOLISTIC_AUDIT` runs once and covers correctness, security, privacy, data
 integrity, lifecycle, rollout, user control, and avoidable complexity.
 
-`COMPLETE_LOCAL_VALIDATION_ONCE` runs the registered complete command
-set once and returns a deterministic receipt binding repository, parent head,
+`COMPLETE_LOCAL_VALIDATION_ONCE` runs the registry's unconditional focused
+commands and every required local command once and returns a deterministic
+receipt binding repository, parent head,
 staged-tree SHA, registry digest, command-set digest, successful result, and
 reviewed-feedback digests plus explicit satisfied evidence for every registered
 manual gate. Time is informational only and cannot determine validity.
@@ -414,7 +417,7 @@ independently prove all of the following:
 
 - expected head unchanged and local, upstream remote, and PR heads equal;
 - clean worktree and every relevant commit validly signed;
-- focused and complete required local validation successful;
+- selected focused and complete required local validation successful;
 - all required checks successful, with no missing, pending, failed, or unknown
   required evidence;
 - complete snapshot evidence and an unchanged expected target thread belonging
@@ -435,8 +438,9 @@ signed commit and fast-forward push, with the chain starting at the immutable
 initial head and ending at the expected final head. Reusing the final snapshot
 as the initial anchor therefore fails closed.
 
-Immediately before each resolution write, the helper runs the repository's
-registered focused and required local validation commands without a shell and
+Immediately before each forensic resolution write, the helper runs the
+repository's unconditional focused and required local validation commands
+without a shell and
 performs one bounded live PR-wide feedback read. It compares the canonical
 reviews, conversation comments, review threads, inline comments, and reactions
 with the final snapshot, allowing only individually recorded earlier thread

--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -153,6 +153,16 @@
           "argv": ["npm", "run", "test:migration-boundary"],
           "working_directory": ".",
           "purpose": "Run documented frontend migration-boundary tests"
+        },
+        {
+          "argv": ["npm", "run", "test:ui-csp"],
+          "working_directory": ".",
+          "purpose": "Run the focused shadcn/Base UI and strict CSP architecture and artifact contracts"
+        },
+        {
+          "argv": ["npm", "run", "test:e2e:csp"],
+          "working_directory": ".",
+          "purpose": "Exercise the local production frontend under the strict CSP in Chromium"
         }
       ],
       "required_local_validation": [
@@ -177,9 +187,14 @@
           "purpose": "Run deterministic Vitest suite"
         },
         {
-          "argv": ["npm", "run", "build"],
+          "argv": ["npm", "run", "build:web"],
           "working_directory": ".",
-          "purpose": "Build the web surface"
+          "purpose": "Build the Web production surface"
+        },
+        {
+          "argv": ["npm", "run", "build:android"],
+          "working_directory": ".",
+          "purpose": "Build the Capacitor Android frontend surface"
         }
       ],
       "signature_policy": {
@@ -194,7 +209,7 @@
       },
       "manual_gates": [
         "Select additional focused Vitest paths from the changed behavior using documented test entry points.",
-        "Live, workspace, Lighthouse, Playwright, and environment-connected targets require separate user authorization."
+        "The deterministic local `npm run test:e2e:csp` target may be selected when UI or CSP behavior is affected. Live, workspace, Lighthouse, and other environment-connected targets require separate user authorization."
       ],
       "unsupported_operations": [
         "REVIEW_REQUEST",

--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -162,7 +162,8 @@
         {
           "argv": ["npm", "run", "test:e2e:csp"],
           "working_directory": ".",
-          "purpose": "Exercise the local production frontend under the strict CSP in Chromium"
+          "purpose": "Exercise the local production frontend under the strict CSP in Chromium",
+          "execution_policy": "focused-only"
         }
       ],
       "required_local_validation": [

--- a/.agents/skills/secpal-pr-review/references/repositories.schema.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.schema.json
@@ -92,7 +92,8 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "working_directory": { "type": "string", "minLength": 1 },
-        "purpose": { "type": "string", "minLength": 1 }
+        "purpose": { "type": "string", "minLength": 1 },
+        "execution_policy": { "enum": ["always", "focused-only"] }
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 - registered the local production Chromium CSP test as an allowed focused
   target while keeping live, workspace, Lighthouse, and other
   environment-connected targets subject to separate user authorization
+- preserved the isolated validation environment while making the canonical
+  local Playwright browser installation available to the CSP test
 - continued to derive Required Checks from live rulesets and branch protection
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-07-31 - Register Frontend Strict CSP Validation
+
+**Changed:**
+
+- updated the frontend review registry to use explicit Web and Android surface
+  builds
+- registered focused shadcn/Base UI architecture and strict-CSP validation
+- registered the local production Chromium CSP test as an allowed focused
+  target while keeping live, workspace, Lighthouse, and other
+  environment-connected targets subject to separate user authorization
+- continued to derive Required Checks from live rulesets and branch protection
+
+---
+
 ## 2026-07-28 - Retire Changelog Polyscope Integration
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   builds
 - registered focused shadcn/Base UI architecture and strict-CSP validation
 - registered the local production Chromium CSP test as an allowed focused
-  target while keeping live, workspace, Lighthouse, and other
-  environment-connected targets subject to separate user authorization
+  target that is excluded from unconditional complete validation, while keeping
+  live, workspace, Lighthouse, and other environment-connected targets subject
+  to separate user authorization
 - preserved the isolated validation environment while making the canonical
   local Playwright browser installation available to the CSP test
 - continued to derive Required Checks from live rulesets and branch protection

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -280,8 +280,9 @@ requires `--apply`. `reply` has the same anchors. `resolve` also requires
 `--initial-snapshot` and refuses the write until final evidence proves clean and
 matching heads, accepted signatures, complete validation, successful required
 checks, no late feedback, and complete dispositions for all unresolved initial
-threads and material top-level findings. Each resolution invocation also runs
-the checked-in focused and required local validation commands and compares the
+threads and material top-level findings. Each forensic resolution invocation
+also runs the checked-in unconditional focused and required local validation
+commands and compares the
 complete live target-thread comment set with the final snapshot. It then
 re-reads applicable required-check rules, branch protection, the current base,
 the effective check target, and current required-check outcomes; any drift or

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -1034,6 +1034,13 @@ def validate_registry(registry: dict[str, Any]) -> dict[str, Any]:
             raise RegistryError(f"invalid Package 2.1 configuration for {repository}: {exc}") from exc
         for command in (*entry["focused_validation"], *entry["required_local_validation"]):
             _validate_command(command)
+        if any(
+            command.get("execution_policy") == "focused-only"
+            for command in entry["required_local_validation"]
+        ):
+            raise RegistryError(
+                "required local validation cannot use focused-only execution"
+            )
         if not entry["required_local_validation"] and not entry["manual_gates"]:
             raise RegistryError("incomplete validation requires an explicit manual gate")
         if set(entry["unsupported_operations"]) != set(PROHIBITED_OPERATION_KINDS):
@@ -1087,15 +1094,26 @@ def _validation_executable(
     raise RegistryError("registered validation executable is unavailable")
 
 
+def _complete_validation_commands(
+    repository: dict[str, Any],
+) -> tuple[dict[str, Any], ...]:
+    focused = tuple(
+        command
+        for command in repository["focused_validation"]
+        if command.get("execution_policy", "always") == "always"
+    )
+    return (*focused, *repository["required_local_validation"])
+
+
 def _run_registered_validations(
     repository: dict[str, Any], repository_root: Path
 ) -> bool:
-    """Run every checked-in validation command once, without a shell or diagnostic output."""
+    """Run unconditional validation once, without a shell or diagnostic output."""
 
     repository_root = repository_root.resolve()
     if not repository_root.is_dir():
         return False
-    commands = (*repository["focused_validation"], *repository["required_local_validation"])
+    commands = _complete_validation_commands(repository)
     try:
         validation_home = tempfile.TemporaryDirectory(
             prefix="secpal-pr-review-validation-"
@@ -4008,8 +4026,13 @@ def _fast_registry_binding(entry: dict[str, Any]) -> dict[str, Any]:
             key: entry[key]
             for key in ("maximum_api_calls", "maximum_items")
         },
-        "validation": copy.deepcopy(
-            [*entry["focused_validation"], *entry["required_local_validation"]]
+        "validation": copy.deepcopy(list(_complete_validation_commands(entry))),
+        "focused_only_validation": copy.deepcopy(
+            [
+                command
+                for command in entry["focused_validation"]
+                if command.get("execution_policy") == "focused-only"
+            ]
         ),
     }
 

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -86,9 +86,23 @@ def _load_fast_path_helper() -> Any:
 
 
 fast_path = _load_fast_path_helper()
+
+
+def _playwright_browsers_path(account_home: Path) -> Path:
+    candidates = (
+        account_home / ".cache/ms-playwright",
+        account_home / "Library/Caches/ms-playwright",
+    )
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[0]
+
+
 ACCOUNT_HOME = Path(pwd.getpwuid(os.getuid()).pw_dir)
 ACCOUNT_NAME = pwd.getpwuid(os.getuid()).pw_name
 USER_SITE_PACKAGES = site.getusersitepackages()
+PLAYWRIGHT_BROWSERS_PATH = _playwright_browsers_path(ACCOUNT_HOME)
 LOCAL_VALIDATION_COMMAND_DIRECTORIES = (
     *evidence.TRUSTED_COMMAND_DIRECTORIES,
     ACCOUNT_HOME / ".local/bin",
@@ -1110,6 +1124,7 @@ def _run_registered_validations(
             "PATH": os.pathsep.join(
                 str(directory) for directory in LOCAL_VALIDATION_COMMAND_DIRECTORIES
             ),
+            "PLAYWRIGHT_BROWSERS_PATH": str(PLAYWRIGHT_BROWSERS_PATH),
             "PYTHONPATH": os.pathsep.join(
                 USER_SITE_PACKAGES
                 if isinstance(USER_SITE_PACKAGES, list)

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -89,14 +89,9 @@ fast_path = _load_fast_path_helper()
 
 
 def _playwright_browsers_path(account_home: Path) -> Path:
-    candidates = (
-        account_home / ".cache/ms-playwright",
-        account_home / "Library/Caches/ms-playwright",
-    )
-    for candidate in candidates:
-        if candidate.is_dir():
-            return candidate
-    return candidates[0]
+    if sys.platform == "darwin":
+        return account_home / "Library/Caches/ms-playwright"
+    return account_home / ".cache/ms-playwright"
 
 
 ACCOUNT_HOME = Path(pwd.getpwuid(os.getuid()).pw_dir)

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3756,6 +3756,28 @@ class RegistryTests(TestCase):
                     str(executable),
                 )
 
+    def test_playwright_browser_cache_supports_linux_and_macos_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            account_home = Path(directory)
+            self.assertEqual(
+                actions._playwright_browsers_path(account_home),
+                account_home / ".cache/ms-playwright",
+            )
+
+            macos_cache = account_home / "Library/Caches/ms-playwright"
+            macos_cache.mkdir(parents=True)
+            self.assertEqual(
+                actions._playwright_browsers_path(account_home),
+                macos_cache,
+            )
+
+            linux_cache = account_home / ".cache/ms-playwright"
+            linux_cache.mkdir(parents=True)
+            self.assertEqual(
+                actions._playwright_browsers_path(account_home),
+                linux_cache,
+            )
+
     def test_registered_validations_receive_a_minimal_secret_free_environment(self) -> None:
         repository = registry_entry("SecPal/.github")
         completed = SimpleNamespace(returncode=0)
@@ -3765,6 +3787,7 @@ class RegistryTests(TestCase):
                 {
                     "GH_TOKEN": "parent-token-placeholder",
                     "AWS_SECRET_ACCESS_KEY": "parent-secret",
+                    "PLAYWRIGHT_BROWSERS_PATH": "/tmp/parent-controlled-browser-cache",
                     "PYTHONPATH": "/tmp/parent-controlled-pythonpath",
                     "UNRELATED_PARENT_VALUE": "must-not-leak",
                 },
@@ -3793,6 +3816,14 @@ class RegistryTests(TestCase):
             self.assertNotEqual(
                 environment["PYTHONPATH"], "/tmp/parent-controlled-pythonpath"
             )
+            self.assertEqual(
+                environment.get("PLAYWRIGHT_BROWSERS_PATH"),
+                str(actions.PLAYWRIGHT_BROWSERS_PATH),
+            )
+            self.assertNotEqual(
+                environment.get("PLAYWRIGHT_BROWSERS_PATH"),
+                "/tmp/parent-controlled-browser-cache",
+            )
             self.assertNotEqual(environment.get("HOME"), str(actions.ACCOUNT_HOME))
             self.assertEqual(
                 set(environment),
@@ -3809,6 +3840,7 @@ class RegistryTests(TestCase):
                     "NO_COLOR",
                     "PAGER",
                     "PATH",
+                    "PLAYWRIGHT_BROWSERS_PATH",
                     "PYTHONPATH",
                     "TMPDIR",
                     "USER",

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -280,6 +280,41 @@ def registry_entry(repository: str) -> dict[str, Any]:
     }
 
 
+def frontend_registry_entry() -> dict[str, Any]:
+    value = registry_entry("SecPal/frontend")
+    value["focused_validation"] = [
+        {
+            "argv": ["npm", "run", "test:migration-boundary"],
+            "working_directory": ".",
+            "purpose": "Run migration tests",
+        },
+        {
+            "argv": ["npm", "run", "test:ui-csp"],
+            "working_directory": ".",
+            "purpose": "Run UI and CSP tests",
+        },
+        {
+            "argv": ["npm", "run", "test:e2e:csp"],
+            "working_directory": ".",
+            "purpose": "Run local CSP browser tests",
+            "execution_policy": "focused-only",
+        },
+    ]
+    value["required_local_validation"] = [
+        {
+            "argv": ["npm", "run", "build:web"],
+            "working_directory": ".",
+            "purpose": "Build Web",
+        },
+        {
+            "argv": ["npm", "run", "build:android"],
+            "working_directory": ".",
+            "purpose": "Build Android",
+        },
+    ]
+    return value
+
+
 class FakeGitHub:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
@@ -3852,6 +3887,62 @@ class RegistryTests(TestCase):
                     "XDG_DATA_HOME",
                 },
             )
+
+    def test_complete_validation_excludes_focused_only_commands(self) -> None:
+        repository = frontend_registry_entry()
+
+        with (
+            mock.patch.object(
+                actions,
+                "_validation_executable",
+                return_value="/usr/bin/true",
+            ),
+            mock.patch.object(
+                actions.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=0),
+            ) as run,
+        ):
+            self.assertTrue(
+                actions._run_registered_validations(repository, REPO_ROOT)
+            )
+
+        executed_scripts = [call.args[0][-1] for call in run.call_args_list]
+        self.assertIn("test:migration-boundary", executed_scripts)
+        self.assertIn("test:ui-csp", executed_scripts)
+        self.assertNotIn("test:e2e:csp", executed_scripts)
+        self.assertIn("build:web", executed_scripts)
+        self.assertIn("build:android", executed_scripts)
+
+    def test_complete_validation_binding_excludes_focused_only_commands(self) -> None:
+        repository = frontend_registry_entry()
+
+        binding = actions._fast_registry_binding(repository)
+
+        self.assertNotIn(
+            ["npm", "run", "test:e2e:csp"],
+            [command["argv"] for command in binding["validation"]],
+        )
+        self.assertIn(
+            ["npm", "run", "test:ui-csp"],
+            [command["argv"] for command in binding["validation"]],
+        )
+        self.assertEqual(
+            [command["argv"] for command in binding["focused_only_validation"]],
+            [["npm", "run", "test:e2e:csp"]],
+        )
+
+    def test_required_validation_rejects_focused_only_execution(self) -> None:
+        registry = {"schema_version": "1.0", "repositories": [frontend_registry_entry()]}
+        registry["repositories"][0]["required_local_validation"][0][
+            "execution_policy"
+        ] = "focused-only"
+
+        with self.assertRaisesRegex(
+            actions.RegistryError,
+            "required local validation cannot use focused-only execution",
+        ):
+            actions.validate_registry(registry)
 
 
 class AuditModeTests(TestCase):

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3756,27 +3756,30 @@ class RegistryTests(TestCase):
                     str(executable),
                 )
 
-    def test_playwright_browser_cache_supports_linux_and_macos_defaults(self) -> None:
+    def test_playwright_browser_cache_uses_the_host_platform_default(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             account_home = Path(directory)
-            self.assertEqual(
-                actions._playwright_browsers_path(account_home),
-                account_home / ".cache/ms-playwright",
-            )
+            expected_by_platform = {
+                "linux": account_home / ".cache/ms-playwright",
+                "darwin": account_home / "Library/Caches/ms-playwright",
+            }
 
-            macos_cache = account_home / "Library/Caches/ms-playwright"
-            macos_cache.mkdir(parents=True)
-            self.assertEqual(
-                actions._playwright_browsers_path(account_home),
-                macos_cache,
-            )
-
-            linux_cache = account_home / ".cache/ms-playwright"
-            linux_cache.mkdir(parents=True)
-            self.assertEqual(
-                actions._playwright_browsers_path(account_home),
-                linux_cache,
-            )
+            for caches_exist in (False, True):
+                if caches_exist:
+                    for cache in expected_by_platform.values():
+                        cache.mkdir(parents=True)
+                for host_platform, expected in expected_by_platform.items():
+                    with (
+                        self.subTest(
+                            host_platform=host_platform,
+                            caches_exist=caches_exist,
+                        ),
+                        mock.patch.object(actions.sys, "platform", host_platform),
+                    ):
+                        self.assertEqual(
+                            actions._playwright_browsers_path(account_home),
+                            expected,
+                        )
 
     def test_registered_validations_receive_a_minimal_secret_free_environment(self) -> None:
         repository = registry_entry("SecPal/.github")

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -11,6 +11,7 @@ CONTRACT="$REPO_ROOT/.agents/skills/secpal-pr-review/references/contract.md"
 EVIDENCE="$REPO_ROOT/scripts/secpal-pr-review.py"
 ACTIONS="$REPO_ROOT/scripts/secpal-pr-review-actions.py"
 REGISTRY="$REPO_ROOT/.agents/skills/secpal-pr-review/references/repositories.json"
+REGISTRY_SCHEMA="$REPO_ROOT/.agents/skills/secpal-pr-review/references/repositories.schema.json"
 PLAN_SCHEMA="$REPO_ROOT/.agents/skills/secpal-pr-review/references/mutation-plan.schema.json"
 FAST_SCHEMA="$REPO_ROOT/.agents/skills/secpal-pr-review/references/fast-path-batch.schema.json"
 FAST_PATH="$REPO_ROOT/scripts/secpal_pr_review/fast_path.py"
@@ -61,6 +62,7 @@ for required in \
   "$SCRIPT_README" \
   "$POLYSCOPE_INSTALLER" \
   "$REGISTRY" \
+  "$REGISTRY_SCHEMA" \
   "$PLAN_SCHEMA" \
   "$FAST_SCHEMA"; do
   test -f "$required" || fail "missing ${required#"$REPO_ROOT"/}"
@@ -269,13 +271,14 @@ done
 test "$(git -C "$REPO_ROOT" diff --name-only "$P21_BASELINE" -- "${relative_paths[@]}" | wc -l)" -eq 0 \
   || fail 'existing review governance or instruction routing changed'
 
-python3 - "$PLAN_SCHEMA" "$FAST_SCHEMA" "$REGISTRY" <<'PY'
+python3 - "$PLAN_SCHEMA" "$FAST_SCHEMA" "$REGISTRY" "$REGISTRY_SCHEMA" <<'PY'
 import json
 import sys
 
 plan_schema = json.load(open(sys.argv[1], encoding="utf-8"))
 fast_schema = json.load(open(sys.argv[2], encoding="utf-8"))
 registry = json.load(open(sys.argv[3], encoding="utf-8"))
+schema = json.load(open(sys.argv[4], encoding="utf-8"))
 
 allowed = {"REACTION", "EVIDENCE_REPLY", "THREAD_RESOLUTION"}
 operation_kind = plan_schema["$defs"]["operation"]["properties"]["kind"]["enum"]
@@ -326,6 +329,7 @@ expected_focused_validation = [
             "Exercise the local production frontend under the strict CSP "
             "in Chromium"
         ),
+        "execution_policy": "focused-only",
     },
 ]
 assert frontend["focused_validation"] == expected_focused_validation, (
@@ -384,6 +388,19 @@ expected_manual_gates = [
 assert frontend["manual_gates"] == expected_manual_gates, (
     "SecPal/frontend must distinguish the deterministic local CSP browser test "
     "from separately authorized environment-connected targets"
+)
+assert [
+    command["argv"]
+    for command in frontend["focused_validation"]
+    if command.get("execution_policy") == "focused-only"
+] == [["npm", "run", "test:e2e:csp"]], (
+    "SecPal/frontend must keep only the local Chromium CSP target out of "
+    "unconditional complete validation"
+)
+command_policy = schema["$defs"]["command"]["properties"]["execution_policy"]
+assert command_policy == {"enum": ["always", "focused-only"]}, (
+    "registry command execution policy must remain closed to always and "
+    "focused-only"
 )
 
 all_validation_argv = [

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -297,6 +297,143 @@ expected = [
     "SecPal/guardguide.de", "SecPal/secpal.app",
 ]
 assert [item["repository"] for item in registry["repositories"]] == expected
+
+frontend_entries = [
+    item for item in registry["repositories"]
+    if item["repository"] == "SecPal/frontend"
+]
+assert len(frontend_entries) == 1, "SecPal/frontend must have exactly one registry entry"
+frontend = frontend_entries[0]
+
+expected_focused_validation = [
+    {
+        "argv": ["npm", "run", "test:migration-boundary"],
+        "working_directory": ".",
+        "purpose": "Run documented frontend migration-boundary tests",
+    },
+    {
+        "argv": ["npm", "run", "test:ui-csp"],
+        "working_directory": ".",
+        "purpose": (
+            "Run the focused shadcn/Base UI and strict CSP architecture "
+            "and artifact contracts"
+        ),
+    },
+    {
+        "argv": ["npm", "run", "test:e2e:csp"],
+        "working_directory": ".",
+        "purpose": (
+            "Exercise the local production frontend under the strict CSP "
+            "in Chromium"
+        ),
+    },
+]
+assert frontend["focused_validation"] == expected_focused_validation, (
+    "SecPal/frontend focused validation must register the migration, UI/CSP, "
+    "and local Chromium CSP contracts exactly once and in order"
+)
+
+expected_required_local_validation = [
+    {
+        "argv": ["npm", "run", "format:check"],
+        "working_directory": ".",
+        "purpose": "Check formatting",
+    },
+    {
+        "argv": ["npm", "run", "lint"],
+        "working_directory": ".",
+        "purpose": "Run ESLint",
+    },
+    {
+        "argv": ["npm", "run", "typecheck"],
+        "working_directory": ".",
+        "purpose": "Run TypeScript checks",
+    },
+    {
+        "argv": ["npm", "run", "test:ci"],
+        "working_directory": ".",
+        "purpose": "Run deterministic Vitest suite",
+    },
+    {
+        "argv": ["npm", "run", "build:web"],
+        "working_directory": ".",
+        "purpose": "Build the Web production surface",
+    },
+    {
+        "argv": ["npm", "run", "build:android"],
+        "working_directory": ".",
+        "purpose": "Build the Capacitor Android frontend surface",
+    },
+]
+assert frontend["required_local_validation"] == expected_required_local_validation, (
+    "SecPal/frontend required local validation must preserve static checks and "
+    "use the explicit Web and Android builds exactly once and in order"
+)
+
+expected_manual_gates = [
+    (
+        "Select additional focused Vitest paths from the changed behavior using "
+        "documented test entry points."
+    ),
+    (
+        "The deterministic local `npm run test:e2e:csp` target may be selected "
+        "when UI or CSP behavior is affected. Live, workspace, Lighthouse, and "
+        "other environment-connected targets require separate user authorization."
+    ),
+]
+assert frontend["manual_gates"] == expected_manual_gates, (
+    "SecPal/frontend must distinguish the deterministic local CSP browser test "
+    "from separately authorized environment-connected targets"
+)
+
+all_validation_argv = [
+    tuple(command["argv"])
+    for command_group in ("focused_validation", "required_local_validation")
+    for command in frontend[command_group]
+]
+assert len(all_validation_argv) == len(set(all_validation_argv)), (
+    "SecPal/frontend validation commands must not be duplicated"
+)
+assert ("npm", "run", "build") not in all_validation_argv, (
+    "SecPal/frontend must not use the generic build command"
+)
+prohibited_target_fragments = ("test:e2e:live:", "workspace", "lighthouse")
+assert not any(
+    fragment in argument.lower()
+    for argv in all_validation_argv
+    for argument in argv
+    for fragment in prohibited_target_fragments
+), "SecPal/frontend must not register live, workspace, or Lighthouse targets"
+
+assert frontend["signature_policy"] == {
+    "require_github_verified": True,
+    "require_local_verified": True,
+    "accepted_formats": ["ssh", "openpgp"],
+}, "SecPal/frontend signature policy must remain strict"
+assert frontend["check_policy"] == {
+    "require_ruleset_evidence": True,
+    "require_branch_protection_evidence": True,
+    "expected_skipped": "block",
+}, "SecPal/frontend check policy must remain strict"
+assert frontend["unsupported_operations"] == [
+    "REVIEW_REQUEST", "READY_TRANSITION", "LABEL", "ISSUE",
+    "REVIEW_SUBMISSION", "MERGE", "AUTO_MERGE", "COMMENT_DELETE",
+    "REVIEW_DISMISSAL", "BRANCH_WRITE",
+], "SecPal/frontend unsupported operations must remain unchanged"
+assert {
+    key: frontend[key]
+    for key in (
+        "maximum_api_calls", "maximum_items", "maximum_threads",
+        "maximum_comments", "maximum_reactions",
+    )
+} == {
+    "maximum_api_calls": 200,
+    "maximum_items": 10000,
+    "maximum_threads": 500,
+    "maximum_comments": 200,
+    "maximum_reactions": 50,
+}, "SecPal/frontend capture limits must remain unchanged"
+
 for item in registry["repositories"]:
     for command_group in ("focused_validation", "required_local_validation"):
         for command in item[command_group]:

--- a/tests/secpal-pr-review-static-policy.py
+++ b/tests/secpal-pr-review-static-policy.py
@@ -330,7 +330,7 @@ DIRECT_MODULE_ATTRIBUTES = {
         "importlib": {"util"},
         "pwd": {"getpwuid"},
         "site": {"getusersitepackages"},
-        "sys": {"modules", "stderr", "stdout", "version_info"},
+        "sys": {"modules", "platform", "stderr", "stdout", "version_info"},
         "tempfile": {"TemporaryDirectory"},
     },
     "fast_path.py": {


### PR DESCRIPTION
## Problem and evidence

The central `SecPal/frontend` entry in `.agents/skills/secpal-pr-review/references/repositories.json` still registered only `npm run test:migration-boundary`, used the generic `npm run build` command, and treated every Playwright target as separately authorized.

The permanent frontend contract on `main` defines:

- shadcn/ui over Base UI with a static strict CSP;
- `npm run test:ui-csp` for architecture and artifact validation;
- `npm run test:e2e:csp` for the deterministic local production Chromium contract;
- explicit `npm run build:web` and `npm run build:android` surface builds; and
- the required-check identity `UI and CSP Architecture / Strict CSP`.

The action helper runs registered validation in an isolated environment. The local CSP browser target also needs the canonical Playwright browser cache path to remain available without inheriting a caller-controlled environment value.

## Change

- Register `test:ui-csp` and `test:e2e:csp` as focused frontend validation.
- Preserve `test:migration-boundary`.
- Replace the generic build with explicit Web and Android builds.
- Allow only the deterministic local CSP browser target without additional authorization.
- Keep live, workspace, Lighthouse, and other environment-connected targets separately authorized.
- Expose the canonical Linux or macOS Playwright browser cache path through the sanitized registered-validation environment.
- Add structural regression coverage for command order, duplicates, prohibited targets, signature policy, check policy, unsupported operations, capture limits, and browser-cache isolation.
- Record the governance contract change in this repository's changelog.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/secpal-pr-review-skill-policy.sh` failed with the expected missing frontend focused-validation assertion.
- Passing proof after implementation: `bash tests/secpal-pr-review-skill-policy.sh` passed after the registry update.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `python3 -m json.tool .agents/skills/secpal-pr-review/references/repositories.json >/dev/null` — passed
- `python3 -m unittest tests/secpal-pr-review-actions-unit.py` — passed (174 tests)
- `python3 -m unittest tests/secpal-resolve-fixed-threads-unit.py` — passed (47 tests)
- `python3 -m unittest tests/secpal-pr-review-unit.py` — passed (177 tests)
- `bash tests/secpal-pr-review-skill-policy.sh` — passed
- `bash tests/secpal-pr-review-integration.sh` — passed
- `bash tests/secpal-pr-review-skill-integration.sh` — passed
- `bash tests/review-governance-suite.sh` — passed
- `bash tests/reusable-workflow-policy.sh` — passed
- `bash tests/pr-size-advisory.sh` — passed
- `npm run lint:markdown` — passed
- `./scripts/preflight.sh --reuse-tracked-only` — passed
- `pre-commit run --files .github/workflows/reusable-pr-size.yml CHANGELOG.md scripts/preflight.sh tests/pr-size-advisory.sh` — passed
- `git diff --check origin/main...HEAD` — passed
- Local pre-push validation from `git push origin chore/frontend-strict-csp` — passed

## Readiness dependency

The expected context `UI and CSP Architecture / Strict CSP` is not currently present in the live `SecPal/frontend` main-branch required status checks. It must be added manually to the frontend ruleset or branch protection before this governance contract is relied on as a required check. This PR does not mutate GitHub settings.

## Scope

- No frontend source changes.
- No GitHub settings, ruleset, or branch-protection mutation.
- No rollout or deployment.
- No review request, merge, or auto-merge.
