### PR TITLE
Remove retired changelog integration

### DIFF
--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -364,56 +364,6 @@
       "maximum_reactions": 50
     },
     {
-      "repository": "SecPal/changelog",
-      "default_branch": "main",
-      "allowed_base_repositories": ["SecPal/changelog"],
-      "reviewer_identities": [],
-      "focused_validation": [
-        {
-          "argv": ["npm", "run", "csp:test"],
-          "working_directory": ".",
-          "purpose": "Run deterministic CSP unit tests"
-        }
-      ],
-      "required_local_validation": [
-        {
-          "argv": ["npm", "run", "preflight"],
-          "working_directory": ".",
-          "purpose": "Run the repository's documented preflight validation"
-        }
-      ],
-      "signature_policy": {
-        "require_github_verified": true,
-        "require_local_verified": true,
-        "accepted_formats": ["ssh", "openpgp"]
-      },
-      "check_policy": {
-        "require_ruleset_evidence": true,
-        "require_branch_protection_evidence": true,
-        "expected_skipped": "block"
-      },
-      "manual_gates": [
-        "Do not restart services, deploy, or use environment-connected preview validation."
-      ],
-      "unsupported_operations": [
-        "REVIEW_REQUEST",
-        "READY_TRANSITION",
-        "LABEL",
-        "ISSUE",
-        "REVIEW_SUBMISSION",
-        "MERGE",
-        "AUTO_MERGE",
-        "COMMENT_DELETE",
-        "REVIEW_DISMISSAL",
-        "BRANCH_WRITE"
-      ],
-      "maximum_api_calls": 200,
-      "maximum_items": 10000,
-      "maximum_threads": 500,
-      "maximum_comments": 200,
-      "maximum_reactions": 50
-    },
-    {
       "repository": "SecPal/GuardGuide",
       "default_branch": "main",
       "allowed_base_repositories": ["SecPal/GuardGuide"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-01 - Remove Retired Changelog Integration
+
+**Changed:**
+
+- removed the final retired standalone changelog repository from Polyscope
+  manifests, preview routing, repository registries, required-check policy,
+  workspace hook setup, domain policy, and active documentation
+- removed the compatibility tombstone now that the privileged Nginx helper and
+  rollout runtime are deployed together
+
+---
+
 ## 2026-08-01 - Register Frontend Container Validation
 
 **Changed:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ Create a dedicated directory for all SecPal repositories. This mirrors the GitHu
 ├── .github/          # Organization-wide settings and documentation
 ├── api/              # Laravel backend API
 ├── android/          # React/TypeScript Android app via Capacitor
-├── changelog/        # Next.js public changelog site
 ├── contracts/        # OpenAPI 3.1 specifications
 ├── frontend/         # React/TypeScript frontend
 └── secpal.app/       # Astro public website

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ SecPal is the operations software for German private security services. Everythi
 - [`.github`](https://github.com/SecPal/.github): Organization-wide settings and documentation
 - [`api`](https://github.com/SecPal/api): Laravel backend API
 - [`android`](https://github.com/SecPal/android): React/TypeScript Android app via Capacitor
-- [`changelog`](https://github.com/SecPal/changelog): Public changelog site for SecPal releases
 - [`contracts`](https://github.com/SecPal/contracts): OpenAPI 3.1 API specifications
 - [`frontend`](https://github.com/SecPal/frontend): React/TypeScript frontend application
 - [`GuardGuide`](https://github.com/SecPal/GuardGuide): Laravel/React operations platform for GuardGuide

--- a/WORKSPACE_SETUP.md
+++ b/WORKSPACE_SETUP.md
@@ -15,7 +15,6 @@ SecPal/
 │   └── setup-hooks.sh  # Master script to setup hooks in all repos
 ├── api/           # Laravel backend API
 ├── android/       # React/TypeScript Android app via Capacitor
-├── changelog/     # Next.js public changelog site
 ├── contracts/     # OpenAPI 3.1 API specifications
 ├── frontend/      # React/TypeScript frontend application
 └── secpal.app/    # Astro public website

--- a/docs/adr/BRAND-0004-footer-wording.md
+++ b/docs/adr/BRAND-0004-footer-wording.md
@@ -41,7 +41,6 @@ SecPal and GuardGuide use a fixed two-line footer on every AGPL-licensed public 
 - The Source Code label is linked **per surface** to the canonical public source repository that backs the surface rendering the footer:
   - SecPal platform/suite (org-level page): `https://github.com/SecPal` (the SecPal organization is used because no single repository backs the platform as a whole).
   - SecPal landing page (`secpal.app`): `https://github.com/SecPal/secpal.app`.
-  - SecPal changelog site (`changelog.secpal.app`): `https://github.com/SecPal/changelog`.
   - GuardGuide product app: `https://github.com/SecPal/GuardGuide`.
   - GuardGuide marketing site (`guardguide.de`): `https://github.com/SecPal/guardguide.de`.
   - Surfaces added in the future follow the same per-surface rule.

--- a/docs/brand/footer-wording.md
+++ b/docs/brand/footer-wording.md
@@ -69,13 +69,12 @@ The Source Code link target is **per-surface**, not per-brand. It points to the 
 
 ### Source Code Link Targets Per Managed Surface
 
-| Surface                                        | Source Code link target                   |
-| ---------------------------------------------- | ----------------------------------------- |
-| SecPal platform/suite footer (org-level page)  | `https://github.com/SecPal`               |
-| SecPal landing page (`secpal.app`)             | `https://github.com/SecPal/secpal.app`    |
-| SecPal changelog site (`changelog.secpal.app`) | `https://github.com/SecPal/changelog`     |
-| GuardGuide product app                         | `https://github.com/SecPal/GuardGuide`    |
-| GuardGuide marketing site (`guardguide.de`)    | `https://github.com/SecPal/guardguide.de` |
+| Surface                                       | Source Code link target                   |
+| --------------------------------------------- | ----------------------------------------- |
+| SecPal platform/suite footer (org-level page) | `https://github.com/SecPal`               |
+| SecPal landing page (`secpal.app`)            | `https://github.com/SecPal/secpal.app`    |
+| GuardGuide product app                        | `https://github.com/SecPal/GuardGuide`    |
+| GuardGuide marketing site (`guardguide.de`)   | `https://github.com/SecPal/guardguide.de` |
 
 The SecPal platform/suite entry points at the SecPal GitHub organization because no single repository backs the platform as a whole. Every per-surface entry points at that surface's own repository because every managed SecPal/GuardGuide deployment is published from its own dedicated public AGPL repository. Surfaces added in the future follow the same per-surface rule.
 

--- a/docs/design/page-titles.md
+++ b/docs/design/page-titles.md
@@ -20,7 +20,6 @@ Use the product-name-only fallback when the current route, document, or preview 
 ## Examples
 
 - `Dashboard – SecPal`
-- `Changelog – SecPal`
 - `Security Briefings – GuardGuide by SecPal`
 - `Acme Security GmbH – Customers – SecPal`
 - `Work Instruction 42 – Instructions – GuardGuide by SecPal`

--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # Typography
 
-Inter is the primary and only default typeface for SecPal, GuardGuide, changelog, promotional sites, generated documents, and shared contributor-facing materials.
+Inter is the primary and only default typeface for SecPal, GuardGuide, promotional sites, generated documents, and shared contributor-facing materials.
 
 Use Inter for body text, headings, navigation, controls, data tables, labels, and generated PDF or document text. Product repositories should self-host Inter where the surface ships fonts directly, subject to license and platform constraints. Do not rely on remote font CDNs for production product interfaces when self-hosting is practical.
 

--- a/docs/development-principles.md
+++ b/docs/development-principles.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 > `AGENTS.md`, an independent `.github/copilot-instructions.md` review profile,
 > and focused `.github/instructions/*.instructions.md` overlays.
 
-This document explains the design principles and best practices that guide all actively maintained SecPal repositories, including `api`, `frontend`, `contracts`, `android`, `secpal.app`, `changelog`, `GuardGuide`, and `guardguide.de`.
+This document explains the design principles and best practices that guide all actively maintained SecPal repositories, including `api`, `frontend`, `contracts`, `android`, `secpal.app`, `GuardGuide`, and `guardguide.de`.
 
 ## Quick Navigation
 

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -37,7 +37,6 @@ The production registry explicitly supports:
 - `SecPal/frontend`
 - `SecPal/contracts`
 - `SecPal/android`
-- `SecPal/changelog`
 - `SecPal/GuardGuide`
 - `SecPal/guardguide.de`
 - `SecPal/secpal.app`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,7 +94,7 @@ Enforces the SecPal `secpal.*` namespace split. The script greps text files
 in the working tree (via `grep -r --include=...`, so untracked files matching
 the include patterns are inspected too) for any `secpal.<something>`
 substring and flags entries that fall outside the approved set
-(`secpal.app`, `changelog.secpal.app`, `apk.secpal.app`, `secpal.dev`,
+(`secpal.app`, `apk.secpal.app`, `secpal.dev`,
 `api.secpal.dev`, `app.secpal.dev`, plus arbitrary `*.preview.secpal.dev`
 previews). It also surfaces `api.secpal.app`, the deprecated `.app` web
 host, so callers cannot reintroduce it as an active host.
@@ -320,7 +320,6 @@ The script automatically detects repository type:
 - **org**: `.github` repository (org-wide instructions)
 - **api**: Laravel API (has `artisan`, `composer.json`)
 - **frontend**: React frontend or Android wrapper (has `package.json` with `vite`)
-- **changelog**: Next.js changelog site (has `next.config.mjs`)
 - **website**: Astro landing page (has `astro.config.mjs`)
 - **contracts**: OpenAPI contracts (has `package.json` with `openapi` or `docs/openapi.yaml`)
 
@@ -346,7 +345,6 @@ bash scripts/sync-required-checks.sh --apply
 
 - `.github`
 - `api`
-- `changelog`
 - `frontend`
 - `contracts`
 - `android`

--- a/scripts/audit-closed-epics.sh
+++ b/scripts/audit-closed-epics.sh
@@ -28,7 +28,7 @@ Options:
   --repo REPO  Repository name to inspect. Repeat to scope the audit.
 
 If no repositories are provided, the script audits the active SecPal workspace
-repositories: api, changelog, frontend, contracts, android, secpal.app, guardguide.de, .github.
+repositories: api, frontend, contracts, android, secpal.app, guardguide.de, .github.
 EOF
       exit 0
       ;;
@@ -40,7 +40,7 @@ EOF
 done
 
 if [ ${#repos[@]} -eq 0 ]; then
-  repos=(api changelog frontend contracts android secpal.app guardguide.de .github)
+  repos=(api frontend contracts android secpal.app guardguide.de .github)
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -22,8 +22,7 @@ echo -e "${BLUE}=== Domain Policy Check ===${NC}"
 echo "Scope: enforces the secpal.* namespace split only (match regex: secpal\\.[A-Za-z0-9.-]+)."
 echo "Out of scope: non-secpal SecPal-owned hosts such as guardguide.de are governed by"
 echo "their own repository policy guards and are intentionally not inspected here."
-echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
-echo "Public changelog site: changelog.secpal.app"
+echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Human-facing Android landing page: secpal.app/android"
@@ -94,7 +93,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api.secpal.app is temporarily tolerated (deprecated web host, flagged separately).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -149,7 +148,6 @@ else
     fi
     echo -e "${YELLOW}Policy (scope: secpal.* namespace split only):${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
-    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact/download host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"

--- a/scripts/polyscope-expose-wrapper.sh
+++ b/scripts/polyscope-expose-wrapper.sh
@@ -64,11 +64,10 @@ repo_prefixes = {
     "GuardGuide": "guardguide",
     "guardguide.de": "guardguide-de",
     "secpal.app": "secpal-app",
-    "changelog": "changelog",
 }
 url = urlsplit(direct_url)
 host_match = re.fullmatch(
-    r"(api|frontend|guardguide-de|guardguide|secpal-app|changelog)-([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev",
+    r"(api|frontend|guardguide-de|guardguide|secpal-app)-([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.preview\.secpal\.dev",
     url.hostname or "",
 )
 if host_match is None:
@@ -182,7 +181,7 @@ if [[ $# -ge 2 && "$1" == "share" ]]; then
 		canonical_preview_url=""
 		if canonical_preview_url="$(canonicalize_preview_url_from_marker "$direct_preview_url")"; then
 			direct_preview_url="$canonical_preview_url"
-		elif [[ "$direct_preview_url" =~ ^https://(api|frontend|guardguide-de|guardguide|secpal-app|changelog)-[A-Za-z0-9-]+-[0-9a-fA-F]{8}\.preview\.secpal\.dev(/|$) ]]; then
+		elif [[ "$direct_preview_url" =~ ^https://(api|frontend|guardguide-de|guardguide|secpal-app)-[A-Za-z0-9-]+-[0-9a-fA-F]{8}\.preview\.secpal\.dev(/|$) ]]; then
 			echo "Error: refusing to announce physical hash-suffixed preview URL without a canonical workspace host: $direct_preview_url" >&2
 			exit 1
 		fi

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4296,18 +4296,16 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
     http2_listen_suffix = "" if nginx_http2_syntax == "modern" else " http2"
     http2_directive = "\n            http2 on;" if nginx_http2_syntax == "modern" else ""
     # NOTE: workspace names starting with api-, frontend-, guardguide-, guardguide-de-,
-    # secpal-app-, or changelog- are reserved for legacy per-repo routing (e.g.
-    # api-WORKSPACE.preview.secpal.dev). The retired changelog prefix remains reserved
-    # solely so those hostnames can fail closed instead of becoming generic workspaces.
-    # Generic workspaces must not use the active prefixes because the regex will route
-    # them to a repository-specific backend; the retired prefix always returns 404.
+    # or secpal-app- are reserved for per-repository routing (for example,
+    # api-WORKSPACE.preview.secpal.dev). Generic workspaces must not use these prefixes
+    # because the regex routes them to a repository-specific backend.
     # `http2 on;` requires nginx >= 1.25.1, so install mode version-gates this render option.
     return textwrap.dedent(
         f"""
         server {{
             listen 80;
             listen [::]:80;
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;
 
             location /.well-known/acme-challenge/ {{
                 root /var/www/certbot;
@@ -4319,7 +4317,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
         server {{
             listen 443 ssl{http2_listen_suffix};
             listen [::]:443 ssl{http2_listen_suffix};{http2_directive}
-            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
+            server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>[a-z0-9][a-z0-9-]*)\\.preview\\.secpal\\.dev$;  # same reserved-prefix rule
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
@@ -4348,10 +4346,6 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
-
-            if ($repo = changelog) {{
-                return 404;
-            }}
 
             if (-f $api_public/index.php) {{
                 set $preview_docroot $api_public;
@@ -4884,7 +4878,6 @@ def main() -> int:
             repo_state,
             nginx_http2_syntax=nginx_http2_syntax,
         )
-        polyscope_nginx.ensure_retired_repository_roots_absent(nginx_manifest)
         write_nginx_manifest(
             args.nginx_manifest_output,
             nginx_manifest,

--- a/scripts/polyscope_nginx.py
+++ b/scripts/polyscope_nginx.py
@@ -25,9 +25,7 @@ EXPECTED_REPOSITORIES = (
     "GuardGuide",
     "secpal.app",
     "guardguide.de",
-    "changelog",
 )
-RETIRED_REPOSITORY_IDS = {"changelog": "__retired_changelog__"}
 EXPECTED_UNIX_UPSTREAM = "/run/php/php8.4-fpm-secpal-preview.sock"
 TOP_LEVEL_KEYS = {
     "version",
@@ -74,12 +72,6 @@ def validate_manifest_data(payload: Any) -> dict[str, Any]:
     for repo_name, repo_id in repositories.items():
         if not isinstance(repo_id, str) or REPOSITORY_ID_PATTERN.fullmatch(repo_id) is None:
             raise ValueError(f"repository id for {repo_name} is unsafe")
-    for repo_name, retired_id in RETIRED_REPOSITORY_IDS.items():
-        if repositories[repo_name] != retired_id:
-            raise ValueError(
-                f"repository id for retired {repo_name} must be exactly {retired_id}"
-            )
-
     upstream = payload["php_upstream"]
     if not isinstance(upstream, dict):
         raise ValueError("php_upstream must be a JSON object")
@@ -99,31 +91,6 @@ def validate_manifest_data(payload: Any) -> dict[str, Any]:
         raise ValueError("php_upstream kind must be unix or tcp")
 
     return payload
-
-
-def ensure_retired_repository_roots_absent(
-    payload: dict[str, Any],
-    *,
-    filesystem_clone_root: pathlib.Path | None = None,
-) -> None:
-    """Keep compatibility tombstones inert for an older installed renderer."""
-    manifest = validate_manifest_data(payload)
-    clone_root = filesystem_clone_root or pathlib.Path(manifest["clone_root"])
-    for repo_name, retired_id in RETIRED_REPOSITORY_IDS.items():
-        retired_root = clone_root / retired_id
-        try:
-            retired_root.lstat()
-        except FileNotFoundError:
-            continue
-        except OSError as error:
-            raise ValueError(
-                f"unable to verify retired repository tombstone path for {repo_name}: "
-                f"{retired_root}: {error}"
-            ) from error
-        raise ValueError(
-            f"retired repository tombstone path must stay absent for {repo_name}: "
-            f"{retired_root}"
-        )
 
 
 def load_manifest(path: pathlib.Path, *, expected_uid: int) -> dict[str, Any]:
@@ -170,11 +137,7 @@ def build_manifest(
         "preview_domain": EXPECTED_PREVIEW_DOMAIN,
         "clone_root": EXPECTED_CLONE_ROOT,
         "repositories": {
-            repo_name: (
-                RETIRED_REPOSITORY_IDS[repo_name]
-                if repo_name in RETIRED_REPOSITORY_IDS
-                else str(repo_state[repo_name]["id"])
-            )
+            repo_name: str(repo_state[repo_name]["id"])
             for repo_name in EXPECTED_REPOSITORIES
         },
         "php_upstream": {

--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -64,19 +64,6 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "check-conflicts / Detect Git Conflict Markers",
     "AI Instructions / Validate AI Instructions"
   ],
-  "changelog": [
-    "Check REUSE Compliance / Check REUSE Compliance",
-    "Check License Compatibility / Check License Compatibility",
-    "Formatting Check / Check Code Formatting",
-    "Markdown Lint / Lint Markdown Files",
-    "ESLint / Run Linter",
-    "Next.js Build / Build Project",
-    "Check PR Size / Check PR Size",
-    "check-conflicts / Detect Git Conflict Markers",
-    "TypeScript Check / Build Project",
-    "Analyze Code (javascript-typescript)",
-    "AI Instructions / Validate AI Instructions"
-  ],
   "guardguide.de": [
     "Check REUSE Compliance / Check REUSE Compliance",
     "Check License Compatibility / Check License Compatibility",

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -46,8 +46,6 @@ detect_repo_type() {
         printf '%s\n' guardguide
     elif [ -f artisan ] || [ -f composer.json ]; then
         printf '%s\n' api
-    elif [ -f next.config.mjs ]; then
-        printf '%s\n' changelog
     elif [ -f capacitor.config.ts ] || [ -d android/app/src ]; then
         printf '%s\n' android
     elif [ -f astro.config.mjs ]; then

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$WORKSPACE_ROOT"
 
-REPOS=("api" "frontend" "contracts" "android" "secpal.app" "guardguide.de" "changelog" ".github")
+REPOS=("api" "frontend" "contracts" "android" "secpal.app" "guardguide.de" ".github")
 ROLLOUT_HINT="Run .github/scripts/install-polyscope-rollout.sh (or sync via Polyscope) to provision missing SecPal repositories."
 SUCCESS_COUNT=0
 FAILED_REPOS=()

--- a/tests/check-domains.sh
+++ b/tests/check-domains.sh
@@ -167,7 +167,6 @@ Marketing redirect: https://www.guardguide.de
 
 Approved SecPal hosts used in examples:
 - https://secpal.app
-- https://changelog.secpal.app
 - https://apk.secpal.app
 - https://api.secpal.dev
 - https://app.secpal.dev

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -90,7 +90,6 @@ manifest = {
         "GuardGuide": "8fadd2fb",
         "secpal.app": "c46a8454",
         "guardguide.de": "3d0fcf01",
-        "changelog": "__retired_changelog__",
     },
     "php_upstream": {
         "kind": "unix",
@@ -102,44 +101,11 @@ manifest = {
 active_repo_state = {
     repo_name: {"id": repo_id}
     for repo_name, repo_id in manifest["repositories"].items()
-    if repo_name != "changelog"
 }
 built_manifest = library.build_manifest(
     active_repo_state,
     nginx_http2_syntax="modern",
 )
-assert built_manifest["repositories"]["changelog"] == "__retired_changelog__"
-library.ensure_retired_repository_roots_absent(
-    built_manifest,
-    filesystem_clone_root=workspace / "absent-retired-clone-root",
-)
-
-occupied_clone_root = workspace / "occupied-retired-clone-root"
-(occupied_clone_root / "__retired_changelog__").mkdir(parents=True)
-try:
-    library.ensure_retired_repository_roots_absent(
-        built_manifest,
-        filesystem_clone_root=occupied_clone_root,
-    )
-except ValueError as error:
-    assert "retired repository tombstone path must stay absent" in str(error), error
-else:
-    raise AssertionError("occupied retired repository tombstone path was accepted")
-
-linked_clone_root = workspace / "linked-retired-clone-root"
-linked_clone_root.mkdir()
-(linked_clone_root / "__retired_changelog__").symlink_to(
-    workspace / "missing-retired-target"
-)
-try:
-    library.ensure_retired_repository_roots_absent(
-        built_manifest,
-        filesystem_clone_root=linked_clone_root,
-    )
-except ValueError as error:
-    assert "retired repository tombstone path must stay absent" in str(error), error
-else:
-    raise AssertionError("linked retired repository tombstone path was accepted")
 
 
 def write_manifest(path: pathlib.Path, payload: object, mode: int = 0o600) -> None:
@@ -177,10 +143,6 @@ for port in (0, 65536, "9000"):
 payload = copy.deepcopy(manifest)
 payload["repositories"]["api"] = "../../etc"
 invalid_payloads.append(payload)
-payload = copy.deepcopy(manifest)
-payload["repositories"]["changelog"] = "active123"
-invalid_payloads.append(payload)
-
 for index, payload in enumerate(invalid_payloads):
     candidate = workspace / f"invalid-{index}.json"
     write_manifest(candidate, payload)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -821,7 +821,7 @@ repo_state = {
     'guardguide.de': {'id': 'gd123456', 'name': 'SecPal/guardguide.de', 'path': str(workspace_root / 'guardguide.de')},
     # Preserve a retired database row to prove rollout ignores repositories
     # that are no longer part of the managed workspace.
-    'changelog': {'id': 'ch123456', 'name': 'SecPal/changelog', 'path': str(workspace_root / 'changelog')},
+    'retired-docs': {'id': 'rd123456', 'name': 'SecPal/retired-docs', 'path': str(workspace_root / 'retired-docs')},
     'GuardGuide': {'id': 'gg123456', 'name': 'SecPal/GuardGuide', 'path': str(workspace_root / 'GuardGuide')},
     '.github': {'id': 'gh123456', 'name': 'SecPal/.github', 'path': str(workspace_root / '.github')},
 }
@@ -4385,29 +4385,10 @@ if grep -q 'node_modules' "$workspace_root/api/polyscope.local.json"; then
     exit 1
 fi
 
-if [ "$(grep -cF 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app|changelog)-)?(?<workspace>' "$nginx_output")" -ne 2 ]; then
-    echo "preview nginx config must reserve the retired changelog hostname prefix in both servers" >&2
+if [ "$(grep -cF 'server_name ~^(?:(?<repo>api|frontend|guardguide-de|guardguide|secpal-app)-)?(?<workspace>' "$nginx_output")" -ne 2 ]; then
+    echo "preview nginx config must reserve every active repository hostname prefix in both servers" >&2
     exit 1
 fi
-python3 -B - <<'PY' "$nginx_output"
-import pathlib
-import re
-import sys
-
-config = pathlib.Path(sys.argv[1]).read_text()
-retired_route = re.search(
-    r"if \(\$repo = changelog\) \{\s*(?P<body>.*?)\s*\}",
-    config,
-    re.DOTALL,
-)
-if retired_route is None or "return 404;" not in retired_route.group("body"):
-    raise SystemExit("retired changelog hostnames must fail closed with an explicit 404")
-tls_server = config.index("listen 443 ssl;")
-retired_guard = config.index("if ($repo = changelog)")
-first_docroot_probe = config.index("if (-f $api_public/index.php)")
-if not tls_server < retired_guard < first_docroot_probe:
-    raise SystemExit("retired changelog hostnames must fail closed before docroot probes")
-PY
 grep -qF "listen 443 ssl;" "$nginx_output"
 grep -qF "listen [::]:443 ssl;" "$nginx_output"
 grep -qF "http2 on;" "$nginx_output"
@@ -4779,11 +4760,11 @@ org_prompts = cur.execute(
     ('gh123456',),
 ).fetchone()
 prompt_rows = cur.execute(
-    "select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id != 'ch123456' order by id"
+    "select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id != 'rd123456' order by id"
 ).fetchall()
 retired_prompts = cur.execute(
     'select review_prompt, pr_prompt, draft_pr_prompt, merge_prompt, merge_and_push_prompt from repositories where id = ?',
-    ('ch123456',),
+    ('rd123456',),
 ).fetchone()
 links = cur.execute('select repo_id, linked_repo_id from repository_links order by repo_id, linked_repo_id').fetchall()
 
@@ -4816,7 +4797,7 @@ assert ('gg123456', 'an123456') in links
 assert ('gg123456', 'api12345') in links
 assert ('gg123456', 'co123456') in links
 assert ('gg123456', 'fe123456') in links
-assert ('sa123456', 'ch123456') not in links
+assert ('sa123456', 'rd123456') not in links
 assert retired_prompts is not None
 assert all(prompt is None for prompt in retired_prompts)
 
@@ -4827,7 +4808,7 @@ assert summary['repositories']['frontend']['preview_prefix'] == 'frontend'
 assert summary['repositories']['GuardGuide']['preview_prefix'] == 'guardguide'
 assert summary['repositories']['secpal.app']['preview_prefix'] == 'secpal-app'
 assert summary['repositories']['guardguide.de']['preview_prefix'] == 'guardguide-de'
-assert 'changelog' not in summary['repositories']
+assert 'retired-docs' not in summary['repositories']
 assert summary['repositories']['contracts']['preview_prefix'] is None
 assert summary['repositories']['api']['agent_instructions'].endswith('/api/AGENTS.md')
 assert summary['repositories']['api']['focus_instruction_paths'][0].endswith('org-shared.instructions.md')
@@ -6758,8 +6739,8 @@ grep -q 'Environment=POLYSCOPE_NGINX_HELPER=/usr/local/libexec/secpal-polyscope-
 grep -q -- '--nginx-manifest-output .*nginx-manifest.json --install-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
-if grep -q '/changelog/' "$fake_unit_dir/polyscope-rollout-sync.path"; then
-    echo "rollout sync watcher must not retain the retired changelog repository" >&2
+if grep -q '/retired-docs/' "$fake_unit_dir/polyscope-rollout-sync.path"; then
+    echo "rollout sync watcher must not retain an unmanaged repository" >&2
     exit 1
 fi
 grep -q '/templates/polyscope-codex-AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
@@ -6784,8 +6765,8 @@ if grep -qE '^(Restart=|SuccessExitStatus=|ExecStart=-)' "$fake_unit_dir/polysco
 fi
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --provision-lock-path .*worktree-provision.lock --skip-local-configs --skip-db-sync --provision-worktrees' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.path"
-if grep -q '/changelog/' "$fake_unit_dir/polyscope-worktree-provision.path"; then
-    echo "worktree provision watcher must not retain the retired changelog repository" >&2
+if grep -q '/retired-docs/' "$fake_unit_dir/polyscope-worktree-provision.path"; then
+    echo "worktree provision watcher must not retain an unmanaged repository" >&2
     exit 1
 fi
 grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.timer"

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3703,7 +3703,7 @@ class MutationTests(TestCase):
 class RegistryTests(TestCase):
     repositories = [
         "SecPal/.github", "SecPal/api", "SecPal/frontend", "SecPal/contracts", "SecPal/android",
-        "SecPal/changelog", "SecPal/GuardGuide", "SecPal/guardguide.de", "SecPal/secpal.app",
+        "SecPal/GuardGuide", "SecPal/guardguide.de", "SecPal/secpal.app",
     ]
 
     def test_registry_caps_match_unpaginated_nested_live_connections(self) -> None:

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -296,7 +296,7 @@ assert fast_schema["$defs"]["operation"]["properties"]["kind"] == {
 
 expected = [
     "SecPal/.github", "SecPal/api", "SecPal/frontend", "SecPal/contracts",
-    "SecPal/android", "SecPal/changelog", "SecPal/GuardGuide",
+    "SecPal/android", "SecPal/GuardGuide",
     "SecPal/guardguide.de", "SecPal/secpal.app",
 ]
 assert [item["repository"] for item in registry["repositories"]] == expected

--- a/tests/setup-hooks.sh
+++ b/tests/setup-hooks.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-ALL_REPOS=(api frontend contracts android secpal.app guardguide.de changelog .github)
+ALL_REPOS=(api frontend contracts android secpal.app guardguide.de .github)
 
 # Single portable mktemp invocation (matches the regression guard in
 # tests/mktemp-portability.sh); each scenario gets its own subdirectory below.
@@ -105,7 +105,7 @@ fi
 # must surface as a warning so workspaces that have not synced the latest REPOS
 # list (for example after a fresh repo is added) still install hooks for the
 # repos they do have, instead of failing the whole script.
-warning_present_repos=(api frontend contracts android secpal.app changelog .github)
+warning_present_repos=(api frontend contracts android secpal.app .github)
 setup_workspace "$warning_workspace" "${warning_present_repos[@]}"
 
 warning_output="$warning_workspace/output.txt"
@@ -132,7 +132,7 @@ fi
 # ─── Corrupt path: managed repo path exists but is not a directory ───────────
 # Only a truly missing repo should soft-warn. If the path exists as a regular
 # file, the workspace is corrupted and setup-hooks.sh must fail loudly.
-corrupt_present_repos=(api frontend contracts android secpal.app changelog .github)
+corrupt_present_repos=(api frontend contracts android secpal.app .github)
 setup_workspace "$corrupt_workspace" "${corrupt_present_repos[@]}"
 printf 'not a directory\n' >"$corrupt_workspace/guardguide.de"
 

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -68,10 +68,6 @@ secpal_app_payload="$(bash "$SYNC_SCRIPT" --repo secpal.app --print-payload)"
 assert_payload_has_context "$secpal_app_payload" "Node Tests / Run Tests"
 assert_payload_has_context "$secpal_app_payload" "Analyze Code (javascript-typescript)"
 
-changelog_payload="$(bash "$SYNC_SCRIPT" --repo changelog --print-payload)"
-assert_payload_has_context "$changelog_payload" "Analyze Code (javascript-typescript)"
-assert_payload_has_context "$changelog_payload" "Next.js Build / Build Project"
-
 guardguide_de_payload="$(bash "$SYNC_SCRIPT" --repo guardguide.de --print-payload)"
 assert_payload_has_context "$guardguide_de_payload" "Node Tests / Run Tests"
 assert_payload_has_context "$guardguide_de_payload" "Astro Build / Build Project"
@@ -88,7 +84,7 @@ assert_payload_has_context "$contracts_payload" "AI Instructions / Validate AI I
 # Guardrail workflow names its job exactly 'CodeQL'). For every other repo the
 # CodeQL workflow names a different job (e.g. 'Analyze with CodeQL' / 'Analyze
 # Code'), so requiring bare 'CodeQL' there would block PRs forever.
-for non_github_payload in "$api_payload" "$android_payload" "$guardguide_payload" "$secpal_app_payload" "$changelog_payload" "$guardguide_de_payload" "$frontend_payload" "$contracts_payload"; do
+for non_github_payload in "$api_payload" "$android_payload" "$guardguide_payload" "$secpal_app_payload" "$guardguide_de_payload" "$frontend_payload" "$contracts_payload"; do
   if jq -e '.checks | any(.context == "CodeQL")' >/dev/null <<<"$non_github_payload"; then
     echo "Only the '.github' manifest entry may require the bare 'CodeQL' context; other repos must require their actual CodeQL job context (e.g. 'Analyze with CodeQL (<language>)' or 'Analyze Code (<language>)')." >&2
     echo "$non_github_payload" >&2


### PR DESCRIPTION
## Summary

- remove the retired standalone changelog repository from managed repository registries, required-check policy, and hook setup
- remove its Polyscope manifest tombstone, preview routing, expose-wrapper support, and active documentation
- replace changelog-specific fixtures with generic unmanaged-repository coverage

## Why

The standalone changelog repository and site have been permanently retired. Keeping compatibility paths and policy entries left stale integration state in the organization tooling.

## Impact

Polyscope and Nginx now manage only active repositories. No retired changelog host prefix, repository registration, or compatibility tombstone remains.

## TDD / Validate-First Evidence

- Failing proof before implementation: Updated `tests/polyscope-rollout.sh` expectations for an unmanaged retired repository and active preview prefixes failed while the retired changelog integrations were still present.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `bash tests/polyscope-nginx-helper.sh` pass after removing the retired changelog integrations.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-nginx-helper.sh`
- `bash tests/sync-required-checks.sh`
- `bash tests/setup-hooks.sh`
- `bash tests/secpal-pr-review-skill-policy.sh`
- `python3 tests/secpal-pr-review-actions-unit.py`
- `bash tests/check-domains.sh`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/audit-closed-epics.sh`
- `reuse lint`
- repository pre-commit hooks