### PR TITLE
Fix PR-size exclusions for file paths

### DIFF
--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -44,24 +44,13 @@ jobs:
           # Calculate merge base
           MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
 
-          # Get raw diff output
-          RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD)
-          DIFF_OUTPUT="$RAW_DIFF_OUTPUT"
-
-          # --numstat records contain insertion count, deletion count, and path.
-          # Exclusions describe paths, not their tab-separated accounting records.
-          filter_numstat_by_path() {
-            local records="$1"
-            local exclude_regex="$2"
-            local insertions deletions path
-
-            while IFS=$'\t' read -r insertions deletions path; do
-              [ -n "$insertions$deletions$path" ] || continue
-              if ! printf '%s\n' "$path" | grep -qE -- "$exclude_regex"; then
-                printf '%s\t%s\t%s\n' "$insertions" "$deletions" "$path"
-              fi
-            done <<< "$records"
-          }
+          # Keep raw path bytes and separate rename/copy source and destination paths.
+          # Bash variables cannot store NUL bytes, so retain the diff in a temporary file.
+          NUMSTAT_FILE=$(mktemp "${TMPDIR:-/tmp}/secpal-pr-size.XXXXXX")
+          trap 'rm -f -- "$NUMSTAT_FILE"' EXIT
+          git diff --numstat -z "$MERGE_BASE"..HEAD >"$NUMSTAT_FILE"
+          EXCLUDE_REGEX=""
+          CUSTOM_REGEX=""
 
           # Load exclude patterns from .preflight-exclude if it exists
           if [ -f ".preflight-exclude" ]; then
@@ -84,8 +73,10 @@ jobs:
               set +e  # Temporarily disable exit-on-error to capture grep's exit code
               echo "" | grep -qE -- "$EXCLUDE_REGEX" 2>/dev/null
               GREP_EXIT=$?
+              [[ "" =~ $EXCLUDE_REGEX ]]
+              BASH_REGEX_EXIT=$?
               set -e  # Re-enable exit-on-error
-              if [ $GREP_EXIT -ne 2 ]; then
+              if [ $GREP_EXIT -ne 2 ] && [ $BASH_REGEX_EXIT -ne 2 ]; then
                 # Pattern is valid (exit 0 or 1), check if it matches everything
                 # Test against diverse filenames to detect overly broad patterns
                 # Include various cases: lowercase, uppercase, numbers, special chars, hidden files
@@ -101,9 +92,9 @@ jobs:
                   echo "::warning::This will exclude all files from PR size calculation!"
                 fi
 
-                DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$EXCLUDE_REGEX")
               else
                 # Invalid regex - grep failed even on empty input
+                EXCLUDE_REGEX=""
                 echo "::warning::⚠️  .preflight-exclude contains invalid regex pattern(s)"
                 echo "::warning::The pattern will be ignored. Please check your .preflight-exclude file."
                 echo "::warning::Common issues: unbalanced brackets [, unmatched (, trailing backslash \\"
@@ -134,26 +125,59 @@ jobs:
               set +e
               echo "" | grep -qE -- "$CUSTOM_REGEX" 2>/dev/null
               CUSTOM_GREP_EXIT=$?
+              [[ "" =~ $CUSTOM_REGEX ]]
+              CUSTOM_BASH_REGEX_EXIT=$?
               set -e
 
-              if [ $CUSTOM_GREP_EXIT -eq 2 ]; then
+              if [ $CUSTOM_GREP_EXIT -eq 2 ] || [ $CUSTOM_BASH_REGEX_EXIT -eq 2 ]; then
+                CUSTOM_REGEX=""
                 echo "::warning::⚠️  Custom exclude patterns contain invalid regex"
                 echo "::warning::Invalid patterns will be ignored. Check workflow input exclude-patterns."
-              else
-                # Use validated patterns
-                DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$CUSTOM_REGEX")
               fi
             fi
           fi
 
+          # With --numstat -z, a rename or copy has an empty path field followed
+          # by separate source and destination paths. Match only the destination.
+          RAW_RECORD_COUNT=0
+          INCLUDED_RECORD_COUNT=0
+          INSERTIONS=0
+          DELETIONS=0
+          while IFS= read -r -d '' record; do
+            insertions=${record%%$'\t'*}
+            remainder=${record#*$'\t'}
+            deletions=${remainder%%$'\t'*}
+            path=${remainder#*$'\t'}
+
+            if [ -z "$path" ]; then
+              if ! IFS= read -r -d '' _source_path || ! IFS= read -r -d '' path; then
+                echo "::error::Malformed rename or copy record in git diff --numstat output"
+                exit 1
+              fi
+            fi
+
+            RAW_RECORD_COUNT=$((RAW_RECORD_COUNT + 1))
+            if { [ -n "$EXCLUDE_REGEX" ] && [[ $path =~ $EXCLUDE_REGEX ]]; } || \
+               { [ -n "$CUSTOM_REGEX" ] && [[ $path =~ $CUSTOM_REGEX ]]; }; then
+              continue
+            fi
+
+            INCLUDED_RECORD_COUNT=$((INCLUDED_RECORD_COUNT + 1))
+            if [[ $insertions =~ ^[0-9]+$ ]] && [[ $deletions =~ ^[0-9]+$ ]]; then
+              INSERTIONS=$((INSERTIONS + insertions))
+              DELETIONS=$((DELETIONS + deletions))
+            elif [ "$insertions" != "-" ] || [ "$deletions" != "-" ]; then
+              echo "::error::Malformed counts in git diff --numstat output"
+              exit 1
+            fi
+          done <"$NUMSTAT_FILE"
+
           # Report when all files were filtered out, then continue with zero counts.
-          if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
+          if [ "$RAW_RECORD_COUNT" -gt 0 ] && [ "$INCLUDED_RECORD_COUNT" -eq 0 ]; then
             echo "⚠️  Warning: All changed files were excluded by filters"
             echo "This PR contains only lock files, license texts, or other excluded patterns"
           fi
 
-          INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
-          DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
           CHANGED=$((INSERTIONS + DELETIONS))
           SIZE_REPORT="PR size: $CHANGED changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $ADVISORY_THRESHOLD)"
 

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -48,6 +48,21 @@ jobs:
           RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD)
           DIFF_OUTPUT="$RAW_DIFF_OUTPUT"
 
+          # --numstat records contain insertion count, deletion count, and path.
+          # Exclusions describe paths, not their tab-separated accounting records.
+          filter_numstat_by_path() {
+            local records="$1"
+            local exclude_regex="$2"
+            local insertions deletions path
+
+            while IFS=$'\t' read -r insertions deletions path; do
+              [ -n "$insertions$deletions$path" ] || continue
+              if ! printf '%s\n' "$path" | grep -qE -- "$exclude_regex"; then
+                printf '%s\t%s\t%s\n' "$insertions" "$deletions" "$path"
+              fi
+            done <<< "$records"
+          }
+
           # Load exclude patterns from .preflight-exclude if it exists
           if [ -f ".preflight-exclude" ]; then
             # Extract non-comment, non-empty lines as grep-compatible regex patterns
@@ -86,7 +101,7 @@ jobs:
                   echo "::warning::This will exclude all files from PR size calculation!"
                 fi
 
-                DIFF_OUTPUT=$(echo "$DIFF_OUTPUT" | grep -vE -- "$EXCLUDE_REGEX" 2>/dev/null || true)
+                DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$EXCLUDE_REGEX")
               else
                 # Invalid regex - grep failed even on empty input
                 echo "::warning::⚠️  .preflight-exclude contains invalid regex pattern(s)"
@@ -126,7 +141,7 @@ jobs:
                 echo "::warning::Invalid patterns will be ignored. Check workflow input exclude-patterns."
               else
                 # Use validated patterns
-                DIFF_OUTPUT=$(echo "$DIFF_OUTPUT" | grep -vE -- "$CUSTOM_REGEX" 2>/dev/null || true)
+                DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$CUSTOM_REGEX")
               fi
             fi
           fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -479,24 +479,12 @@ else
   if [ -z "$MERGE_BASE" ]; then
     echo "Warning: Cannot determine merge base with origin/$BASE. Skipping PR size check." >&2
   else
-    # Get raw diff output
-    RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null)
-    DIFF_OUTPUT="$RAW_DIFF_OUTPUT"
-
-    # --numstat records contain insertion count, deletion count, and path.
-    # Exclusions describe paths, not their tab-separated accounting records.
-    filter_numstat_by_path() {
-      local records="$1"
-      local exclude_regex="$2"
-      local insertions deletions path
-
-      while IFS=$'\t' read -r insertions deletions path; do
-        [ -n "$insertions$deletions$path" ] || continue
-        if ! printf '%s\n' "$path" | grep -qE -- "$exclude_regex"; then
-          printf '%s\t%s\t%s\n' "$insertions" "$deletions" "$path"
-        fi
-      done <<< "$records"
-    }
+    # Keep raw path bytes and separate rename/copy source and destination paths.
+    # Bash variables cannot store NUL bytes, so retain the diff in a temporary file.
+    NUMSTAT_FILE=$(mktemp "${TMPDIR:-/tmp}/secpal-pr-size.XXXXXX")
+    trap 'rm -f -- "$NUMSTAT_FILE"' EXIT
+    git diff --numstat -z "$MERGE_BASE"..HEAD >"$NUMSTAT_FILE" 2>/dev/null
+    EXCLUDE_REGEX=""
 
     # Load exclude patterns from .preflight-exclude if it exists
     if [ -f "$ROOT_DIR/.preflight-exclude" ]; then
@@ -513,8 +501,10 @@ else
         set +e  # Temporarily disable exit-on-error to capture grep's exit code
         echo "" | grep -qE -- "$EXCLUDE_REGEX" 2>/dev/null
         GREP_EXIT=$?
+        [[ "" =~ $EXCLUDE_REGEX ]]
+        BASH_REGEX_EXIT=$?
         set -e  # Re-enable exit-on-error
-        if [ $GREP_EXIT -ne 2 ]; then
+        if [ $GREP_EXIT -ne 2 ] && [ $BASH_REGEX_EXIT -ne 2 ]; then
           # Pattern is valid (exit 0 or 1), check if it matches everything
           # Test against diverse filenames to detect overly broad patterns
           # Include various cases: lowercase, uppercase, numbers, special chars, hidden files
@@ -530,9 +520,9 @@ else
             echo "This will exclude all files from PR size calculation!" >&2
           fi
 
-          DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$EXCLUDE_REGEX")
         else
           # Invalid regex - grep failed even on empty input
+          EXCLUDE_REGEX=""
           echo "⚠️  WARNING: .preflight-exclude contains invalid regex pattern(s)" >&2
           echo "The pattern will be ignored. Please check your .preflight-exclude file." >&2
           echo "Common issues: unbalanced brackets [, unmatched (, trailing backslash \\" >&2
@@ -541,16 +531,47 @@ else
       fi
     fi
 
+    # With --numstat -z, a rename or copy has an empty path field followed
+    # by separate source and destination paths. Match only the destination.
+    RAW_RECORD_COUNT=0
+    INCLUDED_RECORD_COUNT=0
+    INSERTIONS=0
+    DELETIONS=0
+    while IFS= read -r -d '' record; do
+      insertions=${record%%$'\t'*}
+      remainder=${record#*$'\t'}
+      deletions=${remainder%%$'\t'*}
+      path=${remainder#*$'\t'}
+
+      if [ -z "$path" ]; then
+        if ! IFS= read -r -d '' _source_path || ! IFS= read -r -d '' path; then
+          echo "Error: Malformed rename or copy record in git diff --numstat output" >&2
+          exit 1
+        fi
+      fi
+
+      RAW_RECORD_COUNT=$((RAW_RECORD_COUNT + 1))
+      if [ -n "$EXCLUDE_REGEX" ] && [[ $path =~ $EXCLUDE_REGEX ]]; then
+        continue
+      fi
+
+      INCLUDED_RECORD_COUNT=$((INCLUDED_RECORD_COUNT + 1))
+      if [[ $insertions =~ ^[0-9]+$ ]] && [[ $deletions =~ ^[0-9]+$ ]]; then
+        INSERTIONS=$((INSERTIONS + insertions))
+        DELETIONS=$((DELETIONS + deletions))
+      elif [ "$insertions" != "-" ] || [ "$deletions" != "-" ]; then
+        echo "Error: Malformed counts in git diff --numstat output" >&2
+        exit 1
+      fi
+    done <"$NUMSTAT_FILE"
+
     PR_SIZE_ADVISORY_THRESHOLD=600
 
     # Report when all files were excluded, then continue with zero counts.
-    if [ -n "$RAW_DIFF_OUTPUT" ] && [ -z "$DIFF_OUTPUT" ]; then
+    if [ "$RAW_RECORD_COUNT" -gt 0 ] && [ "$INCLUDED_RECORD_COUNT" -eq 0 ]; then
       echo "⚠️  All changed files are excluded (lock files, license files, etc.)" >&2
     fi
 
-    # Use --numstat for locale-independent parsing.
-    INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
-    DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
     CHANGED=$((INSERTIONS + DELETIONS))
     SIZE_REPORT="PR size: $CHANGED changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $PR_SIZE_ADVISORY_THRESHOLD)"
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -483,6 +483,21 @@ else
     RAW_DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null)
     DIFF_OUTPUT="$RAW_DIFF_OUTPUT"
 
+    # --numstat records contain insertion count, deletion count, and path.
+    # Exclusions describe paths, not their tab-separated accounting records.
+    filter_numstat_by_path() {
+      local records="$1"
+      local exclude_regex="$2"
+      local insertions deletions path
+
+      while IFS=$'\t' read -r insertions deletions path; do
+        [ -n "$insertions$deletions$path" ] || continue
+        if ! printf '%s\n' "$path" | grep -qE -- "$exclude_regex"; then
+          printf '%s\t%s\t%s\n' "$insertions" "$deletions" "$path"
+        fi
+      done <<< "$records"
+    }
+
     # Load exclude patterns from .preflight-exclude if it exists
     if [ -f "$ROOT_DIR/.preflight-exclude" ]; then
       # Extract non-comment, non-empty lines as grep-compatible regex patterns
@@ -515,7 +530,7 @@ else
             echo "This will exclude all files from PR size calculation!" >&2
           fi
 
-          DIFF_OUTPUT=$(echo "$DIFF_OUTPUT" | grep -vE -- "$EXCLUDE_REGEX" 2>/dev/null || true)
+          DIFF_OUTPUT=$(filter_numstat_by_path "$DIFF_OUTPUT" "$EXCLUDE_REGEX")
         else
           # Invalid regex - grep failed even on empty input
           echo "⚠️  WARNING: .preflight-exclude contains invalid regex pattern(s)" >&2

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -49,12 +49,17 @@ make_lines() {
 
 create_git_fixture() {
   local repository="$1"
+  local exclude_patterns="${2-}"
 
   mkdir -p "$repository/source" "$repository/generated" "$repository/vendor"
-  cat >"$repository/.preflight-exclude" <<'EOF'
+  if [ -n "$exclude_patterns" ]; then
+    printf '%s\n' "$exclude_patterns" >"$repository/.preflight-exclude"
+  else
+    cat >"$repository/.preflight-exclude" <<'EOF'
 # Keep generated changes out of the reviewability report.
 generated/
 EOF
+  fi
   make_lines 4 "$repository/source/existing.txt"
 
   (
@@ -74,8 +79,9 @@ EOF
 
 create_preflight_fixture() {
   local repository="$1"
+  local exclude_patterns="${2-}"
 
-  create_git_fixture "$repository"
+  create_git_fixture "$repository" "$exclude_patterns"
   mkdir -p "$repository/scripts" "$repository/bin"
   cp "$PREFLIGHT_SCRIPT" "$repository/scripts/preflight.sh"
 
@@ -177,6 +183,50 @@ assert_not_contains \
   "$excluded_local_stderr" \
   "WARNING: PR size advisory threshold exceeded" \
   "excluded changes must not trigger the advisory warning"
+
+path_exclusion_local_repo="$workspace/local-path-exclusions"
+path_exclusion_local_stdout="$workspace/local-path-exclusions.stdout"
+path_exclusion_local_stderr="$workspace/local-path-exclusions.stderr"
+create_preflight_fixture \
+  "$path_exclusion_local_repo" \
+  $'^LICENSES/.*\\.txt$\npackage-lock.json'
+mkdir -p \
+  "$path_exclusion_local_repo/LICENSES" \
+  "$path_exclusion_local_repo/docs/LICENSES" \
+  "$path_exclusion_local_repo/assets" \
+  "$path_exclusion_local_repo/custom" \
+  "$path_exclusion_local_repo/lockfiles" \
+  "$path_exclusion_local_repo/prefix LICENSES"
+make_lines 601 "$path_exclusion_local_repo/LICENSES/license.txt"
+make_lines 5 "$path_exclusion_local_repo/docs/LICENSES/license.txt"
+make_lines 6 "$path_exclusion_local_repo/prefix LICENSES/notes.txt"
+make_lines 700 "$path_exclusion_local_repo/lockfiles/package-lock.json"
+make_lines 500 "$path_exclusion_local_repo/custom/ignored.txt"
+printf 'binary\0content\n' >"$path_exclusion_local_repo/assets/image.bin"
+(
+  cd "$path_exclusion_local_repo"
+  git add LICENSES/license.txt docs/LICENSES/license.txt 'prefix LICENSES/notes.txt' \
+    lockfiles/package-lock.json custom/ignored.txt assets/image.bin
+  git commit --quiet -m "test: cover path-based exclusions"
+)
+if ! git -C "$path_exclusion_local_repo" diff --numstat origin/main..HEAD | grep -Fqx -- $'-\t-\tassets/image.bin'; then
+  record_failure "path-exclusion fixture must contain a binary --numstat record"
+fi
+run_preflight_fixture \
+  "$path_exclusion_local_repo" \
+  "$path_exclusion_local_stdout" \
+  "$path_exclusion_local_stderr"
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "local preflight must support anchored path exclusions (status $fixture_status)"
+fi
+assert_contains \
+  "$path_exclusion_local_stdout" \
+  "Preflight OK · PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" \
+  "local preflight must exclude root licenses and lock files without excluding nested or spaced paths"
+assert_not_contains \
+  "$path_exclusion_local_stderr" \
+  "WARNING: PR size advisory threshold exceeded" \
+  "path exclusions must prevent the local advisory warning"
 
 all_excluded_local_repo="$workspace/local-all-excluded"
 all_excluded_local_stdout="$workspace/local-all-excluded.stdout"
@@ -355,6 +405,45 @@ assert_not_contains \
   "$excluded_workflow_output" \
   "::warning::PR size advisory threshold exceeded" \
   "hosted excluded changes must not trigger the advisory warning"
+
+path_exclusion_workflow_output="$workspace/workflow-path-exclusions.out"
+run_workflow_fixture \
+  "$path_exclusion_local_repo" \
+  "$path_exclusion_workflow_output" \
+  ""
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "reusable workflow shell must match local path exclusions (status $fixture_status)"
+fi
+assert_contains \
+  "$path_exclusion_workflow_output" \
+  "PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" \
+  "local and hosted fixtures must report identical counts after repository exclusions"
+
+path_exclusion_custom_workflow_output="$workspace/workflow-path-custom-exclusions.out"
+run_workflow_fixture \
+  "$path_exclusion_local_repo" \
+  "$path_exclusion_custom_workflow_output" \
+  '^custom/.*\.txt$'
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "reusable workflow shell must support anchored path exclusions (status $fixture_status)"
+fi
+assert_contains \
+  "$path_exclusion_custom_workflow_output" \
+  "PR size: 11 changed lines (11 insertions, 0 deletions; advisory threshold: 600)" \
+  "reusable workflow must apply repository and custom exclusions to paths only"
+assert_not_contains \
+  "$path_exclusion_custom_workflow_output" \
+  "::warning::PR size advisory threshold exceeded" \
+  "path exclusions must prevent the hosted advisory warning"
+
+local_path_counts=$(sed -n 's/.*\(PR size: [0-9][0-9]* changed lines.*\)/\1/p' "$path_exclusion_local_stdout")
+hosted_path_counts=$(sed -n 's/.*\(PR size: [0-9][0-9]* changed lines.*\)/\1/p' "$path_exclusion_workflow_output")
+if [ "$local_path_counts" != "PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" ]; then
+  record_failure "local path-exclusion fixture must retain nested and spaced paths"
+fi
+if [ "$hosted_path_counts" != "$local_path_counts" ]; then
+  record_failure "hosted path-exclusion fixture must retain nested and spaced paths"
+fi
 
 invalid_workflow_repo="$workspace/workflow-invalid-exclusion"
 invalid_workflow_output="$workspace/workflow-invalid-exclusion.out"

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -47,9 +47,26 @@ make_lines() {
   awk -v count="$count" 'BEGIN { for (line = 1; line <= count; line++) print "line " line }' >"$target"
 }
 
+append_lines() {
+  local count="$1"
+  local target="$2"
+
+  awk -v count="$count" 'BEGIN { for (line = 1; line <= count; line++) print "appended " line }' >>"$target"
+}
+
+make_prefixed_lines() {
+  local count="$1"
+  local prefix="$2"
+  local target="$3"
+
+  awk -v count="$count" -v prefix="$prefix" \
+    'BEGIN { for (line = 1; line <= count; line++) print prefix " " line }' >"$target"
+}
+
 create_git_fixture() {
   local repository="$1"
   local exclude_patterns="${2-}"
+  local seed_renames="${3-false}"
 
   mkdir -p "$repository/source" "$repository/generated" "$repository/vendor"
   if [ -n "$exclude_patterns" ]; then
@@ -61,6 +78,10 @@ generated/
 EOF
   fi
   make_lines 4 "$repository/source/existing.txt"
+  if [ "$seed_renames" = "true" ]; then
+    make_prefixed_lines 700 "generated source" "$repository/generated/old-name.txt"
+    make_prefixed_lines 700 "included source" "$repository/source/to-generated.txt"
+  fi
 
   (
     cd "$repository"
@@ -69,6 +90,9 @@ EOF
     git config user.email "test@secpal.dev"
     git config commit.gpgSign false
     git add .preflight-exclude source/existing.txt
+    if [ "$seed_renames" = "true" ]; then
+      git add generated/old-name.txt source/to-generated.txt
+    fi
     git commit --quiet -m "test: seed size fixture"
     git remote add origin "$repository"
     git update-ref refs/remotes/origin/main HEAD
@@ -80,8 +104,9 @@ EOF
 create_preflight_fixture() {
   local repository="$1"
   local exclude_patterns="${2-}"
+  local seed_renames="${3-false}"
 
-  create_git_fixture "$repository" "$exclude_patterns"
+  create_git_fixture "$repository" "$exclude_patterns" "$seed_renames"
   mkdir -p "$repository/scripts" "$repository/bin"
   cp "$PREFLIGHT_SCRIPT" "$repository/scripts/preflight.sh"
 
@@ -189,7 +214,8 @@ path_exclusion_local_stdout="$workspace/local-path-exclusions.stdout"
 path_exclusion_local_stderr="$workspace/local-path-exclusions.stderr"
 create_preflight_fixture \
   "$path_exclusion_local_repo" \
-  $'^LICENSES/.*\\.txt$\npackage-lock.json'
+  $'^LICENSES/.*\\.txt$\npackage-lock.json\n^generated/' \
+  true
 mkdir -p \
   "$path_exclusion_local_repo/LICENSES" \
   "$path_exclusion_local_repo/docs/LICENSES" \
@@ -198,6 +224,9 @@ mkdir -p \
   "$path_exclusion_local_repo/lockfiles" \
   "$path_exclusion_local_repo/prefix LICENSES"
 make_lines 601 "$path_exclusion_local_repo/LICENSES/license.txt"
+make_lines 602 "$path_exclusion_local_repo/LICENSES/über.txt"
+make_lines 603 "$path_exclusion_local_repo/"$'LICENSES/tab\tname.txt'
+make_lines 604 "$path_exclusion_local_repo/"$'LICENSES/line\nname.txt'
 make_lines 5 "$path_exclusion_local_repo/docs/LICENSES/license.txt"
 make_lines 6 "$path_exclusion_local_repo/prefix LICENSES/notes.txt"
 make_lines 700 "$path_exclusion_local_repo/lockfiles/package-lock.json"
@@ -205,12 +234,25 @@ make_lines 500 "$path_exclusion_local_repo/custom/ignored.txt"
 printf 'binary\0content\n' >"$path_exclusion_local_repo/assets/image.bin"
 (
   cd "$path_exclusion_local_repo"
-  git add LICENSES/license.txt docs/LICENSES/license.txt 'prefix LICENSES/notes.txt' \
-    lockfiles/package-lock.json custom/ignored.txt assets/image.bin
+  mv generated/old-name.txt source/from-generated.txt
+  append_lines 20 source/from-generated.txt
+  mv source/to-generated.txt generated/from-source.txt
+  append_lines 21 generated/from-source.txt
+  git add -- LICENSES/license.txt 'LICENSES/über.txt' $'LICENSES/tab\tname.txt' \
+    $'LICENSES/line\nname.txt' docs/LICENSES/license.txt 'prefix LICENSES/notes.txt' \
+    lockfiles/package-lock.json custom/ignored.txt assets/image.bin \
+    generated/old-name.txt source/from-generated.txt \
+    source/to-generated.txt generated/from-source.txt
   git commit --quiet -m "test: cover path-based exclusions"
 )
 if ! git -C "$path_exclusion_local_repo" diff --numstat origin/main..HEAD | grep -Fqx -- $'-\t-\tassets/image.bin'; then
   record_failure "path-exclusion fixture must contain a binary --numstat record"
+fi
+if ! git -C "$path_exclusion_local_repo" diff --numstat origin/main..HEAD | grep -Fqx -- $'20\t0\tgenerated/old-name.txt => source/from-generated.txt'; then
+  record_failure "path-exclusion fixture must contain a detected rename from excluded to included"
+fi
+if ! git -C "$path_exclusion_local_repo" diff --numstat origin/main..HEAD | grep -Fqx -- $'21\t0\tsource/to-generated.txt => generated/from-source.txt'; then
+  record_failure "path-exclusion fixture must contain a detected rename from included to excluded"
 fi
 run_preflight_fixture \
   "$path_exclusion_local_repo" \
@@ -221,8 +263,8 @@ if [ "$fixture_status" -ne 0 ]; then
 fi
 assert_contains \
   "$path_exclusion_local_stdout" \
-  "Preflight OK · PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" \
-  "local preflight must exclude root licenses and lock files without excluding nested or spaced paths"
+  "Preflight OK · PR size: 531 changed lines (531 insertions, 0 deletions; advisory threshold: 600)" \
+  "local preflight must filter raw paths and apply rename exclusions to destination paths"
 assert_not_contains \
   "$path_exclusion_local_stderr" \
   "WARNING: PR size advisory threshold exceeded" \
@@ -416,7 +458,7 @@ if [ "$fixture_status" -ne 0 ]; then
 fi
 assert_contains \
   "$path_exclusion_workflow_output" \
-  "PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" \
+  "PR size: 531 changed lines (531 insertions, 0 deletions; advisory threshold: 600)" \
   "local and hosted fixtures must report identical counts after repository exclusions"
 
 path_exclusion_custom_workflow_output="$workspace/workflow-path-custom-exclusions.out"
@@ -429,7 +471,7 @@ if [ "$fixture_status" -ne 0 ]; then
 fi
 assert_contains \
   "$path_exclusion_custom_workflow_output" \
-  "PR size: 11 changed lines (11 insertions, 0 deletions; advisory threshold: 600)" \
+  "PR size: 31 changed lines (31 insertions, 0 deletions; advisory threshold: 600)" \
   "reusable workflow must apply repository and custom exclusions to paths only"
 assert_not_contains \
   "$path_exclusion_custom_workflow_output" \
@@ -438,8 +480,8 @@ assert_not_contains \
 
 local_path_counts=$(sed -n 's/.*\(PR size: [0-9][0-9]* changed lines.*\)/\1/p' "$path_exclusion_local_stdout")
 hosted_path_counts=$(sed -n 's/.*\(PR size: [0-9][0-9]* changed lines.*\)/\1/p' "$path_exclusion_workflow_output")
-if [ "$local_path_counts" != "PR size: 511 changed lines (511 insertions, 0 deletions; advisory threshold: 600)" ]; then
-  record_failure "local path-exclusion fixture must retain nested and spaced paths"
+if [ "$local_path_counts" != "PR size: 531 changed lines (531 insertions, 0 deletions; advisory threshold: 600)" ]; then
+  record_failure "local path-exclusion fixture must retain included paths and rename destinations"
 fi
 if [ "$hosted_path_counts" != "$local_path_counts" ]; then
   record_failure "hosted path-exclusion fixture must retain nested and spaced paths"
@@ -484,6 +526,20 @@ assert_contains \
   "$invalid_workflow_output" \
   "PR size: 604 changed lines" \
   "an invalid exclusion must not hide a large hosted-workflow diff"
+
+invalid_custom_workflow_output="$workspace/workflow-invalid-custom-exclusion.out"
+run_workflow_fixture "$large_workflow_repo" "$invalid_custom_workflow_output" "["
+if [ "$fixture_status" -ne 0 ]; then
+  record_failure "reusable workflow shell must safely ignore invalid custom exclusions (status $fixture_status)"
+fi
+assert_contains \
+  "$invalid_custom_workflow_output" \
+  "Custom exclude patterns contain invalid regex" \
+  "reusable workflow must report an invalid custom exclusion"
+assert_contains \
+  "$invalid_custom_workflow_output" \
+  "PR size: 601 changed lines" \
+  "an invalid custom exclusion must not hide a large hosted-workflow diff"
 
 policy_files=(
   "$REPO_ROOT/README.md"


### PR DESCRIPTION
## Summary

Fixes #598.

### Problem and evidence

The reusable PR-size workflow applied exclusion expressions to complete `git diff --numstat` records rather than to their path field. A row such as `601\t0\tLICENSES/license.txt` therefore could not match the anchored expression `^LICENSES/.*\\.txt$`.

### Change

- Parse each numstat record into insertions, deletions, and path before filtering.
- Apply repository and custom exclusion expressions to the path only.
- Keep the existing invalid-expression warnings, empty-diff handling, binary-record accounting, and all-excluded reporting.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/pr-size-advisory.sh` failed with the anchored root-license regression before path-only filtering was implemented.
- Passing proof after implementation: `bash tests/pr-size-advisory.sh` passes with root-license, nested-path, spaced-path, lock-file, binary-record, custom-pattern, invalid-expression, and local/hosted parity coverage.
- Validate-first exception reference: N/A
- No executable change reason: N/A

### Validation

- `bash -n scripts/preflight.sh tests/pr-size-advisory.sh`
- `actionlint .github/workflows/reusable-pr-size.yml`
- YAML parsing and `git diff --check`
- Full local pre-push suite, including REUSE, formatting, workflow linting, shellcheck, governance regression tests, and the PR-size advisory test

### Dependency / unresolved check

Managed callers in `SecPal/contracts`, `SecPal/api`, and `SecPal/frontend` must update their immutable reusable-workflow pins only after this shared change merges and provides a new commit SHA. That downstream rollout is outside this repository and cannot be completed before merge.