### PR TITLE
chore: register deployment repository

### DIFF
--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -604,6 +604,44 @@
       "maximum_threads": 500,
       "maximum_comments": 200,
       "maximum_reactions": 50
+    },
+    {
+      "repository": "SecPal/deployment",
+      "default_branch": "main",
+      "allowed_base_repositories": ["SecPal/deployment"],
+      "reviewer_identities": [],
+      "focused_validation": [],
+      "required_local_validation": [],
+      "signature_policy": {
+        "require_github_verified": true,
+        "require_local_verified": true,
+        "accepted_formats": ["ssh", "openpgp"]
+      },
+      "check_policy": {
+        "require_ruleset_evidence": true,
+        "require_branch_protection_evidence": true,
+        "expected_skipped": "block"
+      },
+      "manual_gates": [
+        "Do not deploy, access deployment infrastructure, or use environment-connected validation; this repository currently contains only a governance bootstrap."
+      ],
+      "unsupported_operations": [
+        "REVIEW_REQUEST",
+        "READY_TRANSITION",
+        "LABEL",
+        "ISSUE",
+        "REVIEW_SUBMISSION",
+        "MERGE",
+        "AUTO_MERGE",
+        "COMMENT_DELETE",
+        "REVIEW_DISMISSAL",
+        "BRANCH_WRITE"
+      ],
+      "maximum_api_calls": 200,
+      "maximum_items": 10000,
+      "maximum_threads": 500,
+      "maximum_comments": 200,
+      "maximum_reactions": 50
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Create a dedicated directory for all SecPal repositories. This mirrors the GitHu
 ├── android/          # React/TypeScript Android app via Capacitor
 ├── changelog/        # Next.js public changelog site
 ├── contracts/        # OpenAPI 3.1 specifications
+├── deployment/       # Public governance and future deployment repository
 ├── frontend/         # React/TypeScript frontend
 └── secpal.app/       # Astro public website
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SecPal is the operations software for German private security services. Everythi
 - [`android`](https://github.com/SecPal/android): React/TypeScript Android app via Capacitor
 - [`changelog`](https://github.com/SecPal/changelog): Public changelog site for SecPal releases
 - [`contracts`](https://github.com/SecPal/contracts): OpenAPI 3.1 API specifications
+- [`deployment`](https://github.com/SecPal/deployment): Public governance and future deployment repository
 - [`frontend`](https://github.com/SecPal/frontend): React/TypeScript frontend application
 - [`GuardGuide`](https://github.com/SecPal/GuardGuide): Laravel/React operations platform for GuardGuide
 - [`guardguide.de`](https://github.com/SecPal/guardguide.de): Public website for GuardGuide

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -41,6 +41,7 @@ The production registry explicitly supports:
 - `SecPal/GuardGuide`
 - `SecPal/guardguide.de`
 - `SecPal/secpal.app`
+- `SecPal/deployment`
 
 Repository-local `AGENTS.md` and focused instructions remain authoritative.
 Commands in the central registry are argument arrays, never shell strings. Bare

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3704,7 +3704,61 @@ class RegistryTests(TestCase):
     repositories = [
         "SecPal/.github", "SecPal/api", "SecPal/frontend", "SecPal/contracts", "SecPal/android",
         "SecPal/changelog", "SecPal/GuardGuide", "SecPal/guardguide.de", "SecPal/secpal.app",
+        "SecPal/deployment",
     ]
+
+    def test_deployment_repository_registration_matches_the_supported_schema(self) -> None:
+        registry = actions.load_registry()
+        self.assertEqual([item["repository"] for item in registry["repositories"]], self.repositories)
+        deployment = actions.select_repository(registry, "SecPal/deployment")
+
+        self.assertEqual(deployment["repository"], "SecPal/deployment")
+        self.assertEqual(
+            f"https://github.com/{deployment['repository']}",
+            "https://github.com/SecPal/deployment",
+        )
+        self.assertEqual(deployment["default_branch"], "main")
+        self.assertEqual(deployment["allowed_base_repositories"], ["SecPal/deployment"])
+        self.assertEqual(deployment["reviewer_identities"], [])
+        self.assertEqual(deployment["focused_validation"], [])
+        self.assertEqual(deployment["required_local_validation"], [])
+        self.assertEqual(
+            deployment["signature_policy"],
+            {
+                "require_github_verified": True,
+                "require_local_verified": True,
+                "accepted_formats": ["ssh", "openpgp"],
+            },
+        )
+        self.assertEqual(
+            deployment["check_policy"],
+            {
+                "require_ruleset_evidence": True,
+                "require_branch_protection_evidence": True,
+                "expected_skipped": "block",
+            },
+        )
+        self.assertIn("BRANCH_WRITE", deployment["unsupported_operations"])
+        self.assertEqual(
+            set(deployment),
+            {
+                "repository",
+                "default_branch",
+                "allowed_base_repositories",
+                "reviewer_identities",
+                "focused_validation",
+                "required_local_validation",
+                "signature_policy",
+                "check_policy",
+                "manual_gates",
+                "unsupported_operations",
+                "maximum_api_calls",
+                "maximum_items",
+                "maximum_threads",
+                "maximum_comments",
+                "maximum_reactions",
+            },
+        )
 
     def test_registry_caps_match_unpaginated_nested_live_connections(self) -> None:
         registry = actions.load_registry()

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -297,7 +297,7 @@ assert fast_schema["$defs"]["operation"]["properties"]["kind"] == {
 expected = [
     "SecPal/.github", "SecPal/api", "SecPal/frontend", "SecPal/contracts",
     "SecPal/android", "SecPal/changelog", "SecPal/GuardGuide",
-    "SecPal/guardguide.de", "SecPal/secpal.app",
+    "SecPal/guardguide.de", "SecPal/secpal.app", "SecPal/deployment",
 ]
 assert [item["repository"] for item in registry["repositories"]] == expected
 


### PR DESCRIPTION
## Problem and evidence

`SecPal/deployment` has been initialized as a public governance bootstrap, but the central pull-request review registry did not contain it. The registry order is explicitly asserted by the policy test, and the targeted registration test initially failed because the entry was absent.

## Change

- register `SecPal/deployment` in the canonical central repository/review registry
- apply the existing governance-bootstrap review policy without introducing unsupported registry fields
- document the repository in the affected repository and review-workflow lists
- add structured assertions for the identifier, derived GitHub URL, default branch, supported fields, registration order, and review policy

## Repository

- repository: `SecPal/deployment`
- visibility: public
- default branch: `main`
- bootstrap baseline: `bbbea131a8ab32b3a33483857249e13a94494954`

The registry schema has no fields for visibility, category, bootstrap revision, or exact required-check names, so none were added.

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py RegistryTests.test_deployment_repository_registration_matches_the_supported_schema` failed because the registry omitted `SecPal/deployment`.
- Passing proof after implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py` and `bash tests/secpal-pr-review-skill-policy.sh`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

Passed:

- `python3 -m unittest tests/secpal-pr-review-actions-unit.py`
- `bash tests/secpal-pr-review-skill-policy.sh`
- `bash -n scripts/*.sh tests/*.sh`
- `reuse lint`
- `npm run lint:markdown`
- `./scripts/preflight.sh --reuse-tracked-only`
- complete local pre-push validation, including `tests/polyscope-rollout.sh`
- `pre-commit validate-config`
- changed-file pre-commit hooks
- `git diff --check`

## Readiness

The branch is conflict-free and the complete local pre-push validation passed after merging the current `main`. The pull request remains a draft pending review and completion of GitHub checks.

## Scope

This change only registers the repository. It does not modify `SecPal/deployment`, organization settings, branch protection, secrets, GitHub Apps, webhooks, or deployment infrastructure.