### PR TITLE
Fix preview publication file modes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -504,6 +504,10 @@ sudo -k
 sudo .github/scripts/install-polyscope-system-components.sh
 ```
 
+The host must provide `/usr/bin/setfacl` from its `acl` package before
+activation. The installer checks this prerequisite before writing any system
+component and exits with an actionable error when it is unavailable.
+
 The installer resolves `node` before writing the system drop-in, verifies that
 the `secpal` service account can execute it, and adds its directory to the
 service `PATH`. If root's environment cannot discover a user-managed Node.js

--- a/scripts/install-polyscope-system-components.sh
+++ b/scripts/install-polyscope-system-components.sh
@@ -64,6 +64,13 @@ elif ! SECPAL_UID="$(id -u secpal 2>/dev/null)"; then
     exit 1
 fi
 
+if [[ "$STAGE_ONLY" -eq 0 ]]; then
+    if [[ ! -x /usr/bin/setfacl ]]; then
+        echo "Error: /usr/bin/setfacl is required; install the 'acl' package before activation." >&2
+        exit 1
+    fi
+fi
+
 if [[ -z "$NODE_BIN" ]]; then
     if [[ "$STAGE_ONLY" -eq 1 ]]; then
         NODE_BIN="/usr/bin/node"

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3837,6 +3837,17 @@ def ensure_preview_nginx_access(
 
     executable = resolve_setfacl_bin(setfacl_bin)
 
+    # Clone and repository defaults deliberately keep unknown worktrees closed.
+    # Once this worktree has provisioned successfully, remove the inherited
+    # default denial so later build outputs do not inherit a stale block.  The
+    # worktree's access denial remains effective until traversal is granted
+    # below, after all content ACL reconciliation has succeeded.
+    _run_preview_setfacl(
+        executable,
+        ["-x", "d:u:www-data", "--", str(resolved_worktree_path)],
+        f"unable to remove inherited Nginx preview denial from {resolved_worktree_path}",
+    )
+
     document_roots: list[pathlib.Path] = []
     for document_root_name in ("public", "dist"):
         document_root = resolved_worktree_path / document_root_name
@@ -3906,7 +3917,7 @@ def deny_preview_nginx_access(
         executable,
         [
             "-m",
-            "u:www-data:---,d:u:www-data:---",
+            "u:www-data:---",
             "--",
             str(resolved_worktree_path),
         ],
@@ -3965,6 +3976,9 @@ def deny_preview_nginx_repository_access(
 
 def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
     """Revoke preview traversal before validation and selective regranting."""
+    clone_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if clone_root.is_symlink() or not clone_root.is_dir():
+        raise RuntimeError(f"preview clone root is not a physical directory: {clone_root}")
     resolved_clone_root = clone_root.resolve(strict=True)
     deny_preview_nginx_clone_access(resolved_clone_root)
 
@@ -4515,6 +4529,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $secpal_app_dist $secpal_app_root/dist;
             set $guardguide_de_root /home/secpal/.polyscope/clones/{guardguide_de_id}/$workspace;
             set $guardguide_de_dist $guardguide_de_root/dist;
+            set $preview_worktree /home/secpal/.polyscope/__missing_preview_worktree__;
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
@@ -4523,47 +4538,55 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
             if (-f $api_public/index.php) {{
+                set $preview_worktree $api_root;
                 set $preview_docroot $api_public;
                 set $route_mode api;
             }}
 
             if (-f $frontend_dist/index.html) {{
+                set $preview_worktree $frontend_root;
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if (-f $secpal_app_dist/index.html) {{
+                set $preview_worktree $secpal_app_root;
                 set $preview_docroot $secpal_app_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if (-f $guardguide_de_dist/index.html) {{
+                set $preview_worktree $guardguide_de_root;
                 set $preview_docroot $guardguide_de_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if ($repo = secpal-app) {{
+                set $preview_worktree $secpal_app_root;
                 set $preview_docroot $secpal_app_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if ($repo = guardguide-de) {{
+                set $preview_worktree $guardguide_de_root;
                 set $preview_docroot $guardguide_de_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if ($repo = frontend) {{
+                set $preview_worktree $frontend_root;
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
                 set $secpal_csp $preview_relaxed_csp;
             }}
 
             if ($repo = guardguide) {{
+                set $preview_worktree $guardguide_root;
                 set $preview_docroot $guardguide_public;
                 set $php_root $guardguide_public;
                 set $route_mode api;
@@ -4571,6 +4594,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             if ($repo = api) {{
+                set $preview_worktree $api_root;
                 set $preview_docroot $api_public;
                 set $php_root $api_public;
                 set $route_mode api;
@@ -4578,7 +4602,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             root $preview_docroot;
-            disable_symlinks on from=$preview_docroot;
+            disable_symlinks on from=$preview_worktree;
 
             add_header Content-Security-Policy $secpal_csp always;
             add_header Permissions-Policy $secpal_permissions_policy always;
@@ -5018,7 +5042,7 @@ def main() -> int:
 
     lock_context = (
         provision_worktree_lock(args.provision_lock_path)
-        if args.provision_worktrees
+        if args.provision_worktrees or args.install_nginx
         else contextlib.nullcontext()
     )
     with lock_context:
@@ -5029,7 +5053,7 @@ def run_rollout(args: argparse.Namespace) -> int:
     repo_specs = build_repo_specs(args.workspace_root)
     validated_instruction_roots: set[pathlib.Path] = set()
 
-    if args.provision_worktrees:
+    if args.provision_worktrees or args.install_nginx:
         try:
             revoke_all_preview_nginx_access(args.clone_root)
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
@@ -5060,6 +5084,18 @@ def run_rollout(args: argparse.Namespace) -> int:
 
     args.nginx_output.write_text(render_nginx_config(repo_state, nginx_http2_syntax=nginx_http2_syntax))
 
+    provisioned_worktrees: list[str] = []
+    cleaned_preview_storage_targets: list[str] = []
+    failed_provision_worktrees: list[dict[str, str]] = []
+    if args.provision_worktrees or args.install_nginx:
+        provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
+            repo_state,
+            repo_specs,
+            args.clone_root,
+            db_path=args.db_path,
+            validated_instruction_roots=validated_instruction_roots,
+        )
+
     if args.install_nginx:
         try:
             import polyscope_nginx
@@ -5077,18 +5113,6 @@ def run_rollout(args: argparse.Namespace) -> int:
             writer=polyscope_nginx.write_manifest_atomic,
         )
         install_nginx_config(args.nginx_manifest_output)
-
-    provisioned_worktrees: list[str] = []
-    cleaned_preview_storage_targets: list[str] = []
-    failed_provision_worktrees: list[dict[str, str]] = []
-    if args.provision_worktrees:
-        provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
-            repo_state,
-            repo_specs,
-            args.clone_root,
-            db_path=args.db_path,
-            validated_instruction_roots=validated_instruction_roots,
-        )
 
     summary = build_summary(
         repo_state,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3876,6 +3876,7 @@ def ensure_preview_nginx_access(
         raise RuntimeError("setfacl is required to grant Nginx access to preview worktrees")
 
     for path in (
+        resolved_clone_root.parent.parent,
         resolved_clone_root.parent,
         resolved_clone_root,
         repo_clone_root,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -34,7 +34,6 @@ ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
 
 POLYSCOPE_LOCAL_CONFIG_NAME = "polyscope.local.json"
 PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
-PREVIEW_ACL_POLICY_VERSION = 1
 CANONICAL_AI_INSTRUCTIONS_VALIDATOR = ROLLOUT_SCRIPT_PATH.with_name("validate-ai-instructions.sh")
 DEFAULT_NGINX_MANIFEST_PATH = pathlib.Path("/home/secpal/.local/state/polyscope/nginx-manifest.json")
 DEFAULT_NGINX_HELPER_PATH = pathlib.Path("/usr/local/libexec/secpal-polyscope-nginx-apply")
@@ -3874,14 +3873,30 @@ def resolve_setfacl_bin(explicit_path: str | None = None) -> str:
     return str(override_path)
 
 
+def _run_preview_setfacl(
+    executable: str,
+    arguments: list[str],
+    failure_message: str,
+) -> None:
+    try:
+        subprocess.run(
+            [executable, *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() if error.stderr else "no error output"
+        raise RuntimeError(f"{failure_message}: {detail}") from error
+
+
 def ensure_preview_nginx_access(
     clone_root: pathlib.Path,
     worktree_path: pathlib.Path,
     *,
     setfacl_bin: str | None = None,
-    clean_inherited_acl: bool = True,
 ) -> None:
-    """Allow the nginx worker to traverse exactly one preview worktree path."""
+    """Allow nginx to traverse one worktree and read its preview document roots."""
     resolved_clone_root = clone_root.resolve(strict=True)
     resolved_worktree_path = worktree_path.resolve(strict=True)
     repo_clone_root = resolved_worktree_path.parent
@@ -3892,37 +3907,30 @@ def ensure_preview_nginx_access(
 
     executable = resolve_setfacl_bin(setfacl_bin)
 
-    if clean_inherited_acl:
-        inherited_acl_cleanup = [
-            [executable, "-x", "d:u:www-data", "--", str(resolved_worktree_path)]
-        ]
-        worktree_children = sorted(resolved_worktree_path.iterdir(), key=lambda path: path.name)
-        if worktree_children:
-            inherited_acl_cleanup.append(
-                [
-                    executable,
-                    "-R",
-                    "-P",
-                    "-x",
-                    "u:www-data,d:u:www-data",
-                    "--",
-                    *(str(path) for path in worktree_children),
-                ]
-            )
+    _run_preview_setfacl(
+        executable,
+        ["-x", "d:u:www-data", "--", str(resolved_worktree_path)],
+        f"unable to remove inherited Nginx preview ACL from {resolved_worktree_path}",
+    )
 
-        for arguments in inherited_acl_cleanup:
-            try:
-                subprocess.run(
-                    arguments,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            except subprocess.CalledProcessError as error:
-                detail = error.stderr.strip() if error.stderr else "no error output"
-                raise RuntimeError(
-                    f"unable to grant Nginx preview access to {resolved_worktree_path}: {detail}"
-                ) from error
+    for document_root_name in ("public", "dist"):
+        document_root = resolved_worktree_path / document_root_name
+        if not document_root.exists() and not document_root.is_symlink():
+            continue
+        if document_root.is_symlink() or not document_root.is_dir():
+            raise RuntimeError(f"preview document root is not a physical directory: {document_root}")
+        _run_preview_setfacl(
+            executable,
+            [
+                "-R",
+                "-P",
+                "-m",
+                "u:www-data:rX,d:u:www-data:r-x",
+                "--",
+                str(document_root),
+            ],
+            f"unable to grant Nginx preview content access to {document_root}",
+        )
 
     for path in (
         resolved_clone_root.parent.parent,
@@ -3931,18 +3939,11 @@ def ensure_preview_nginx_access(
         repo_clone_root,
         resolved_worktree_path,
     ):
-        try:
-            subprocess.run(
-                [executable, "-m", "u:www-data:--x", "--", str(path)],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as error:
-            detail = error.stderr.strip() if error.stderr else "no error output"
-            raise RuntimeError(
-                f"unable to grant Nginx preview access to {path}: {detail}"
-            ) from error
+        _run_preview_setfacl(
+            executable,
+            ["-m", "u:www-data:--x", "--", str(path)],
+            f"unable to grant Nginx preview access to {path}",
+        )
 
 
 def deny_preview_nginx_access(
@@ -3960,18 +3961,31 @@ def deny_preview_nginx_access(
         )
 
     executable = resolve_setfacl_bin(setfacl_bin)
-    try:
-        subprocess.run(
-            [executable, "-m", "u:www-data:---", "--", str(resolved_worktree_path)],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as error:
-        detail = error.stderr.strip() if error.stderr else "no error output"
-        raise RuntimeError(
-            f"unable to deny Nginx preview access to {resolved_worktree_path}: {detail}"
-        ) from error
+    _run_preview_setfacl(
+        executable,
+        ["-m", "u:www-data:---", "--", str(resolved_worktree_path)],
+        f"unable to deny Nginx preview access to {resolved_worktree_path}",
+    )
+
+
+def deny_preview_nginx_clone_access(
+    clone_root: pathlib.Path,
+    *,
+    setfacl_bin: str | None = None,
+) -> None:
+    """Block existing and future preview repositories at the clone boundary."""
+    resolved_clone_root = clone_root.resolve(strict=True)
+    executable = resolve_setfacl_bin(setfacl_bin)
+    _run_preview_setfacl(
+        executable,
+        [
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(resolved_clone_root),
+        ],
+        f"unable to deny Nginx preview access at clone root {resolved_clone_root}",
+    )
 
 
 def deny_preview_nginx_repository_access(
@@ -3991,24 +4005,58 @@ def deny_preview_nginx_repository_access(
         )
 
     executable = resolve_setfacl_bin(setfacl_bin)
-    try:
-        subprocess.run(
-            [
-                executable,
-                "-m",
-                "u:www-data:---,d:u:www-data:---",
-                "--",
-                str(resolved_repo_clone_root),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as error:
-        detail = error.stderr.strip() if error.stderr else "no error output"
-        raise RuntimeError(
-            f"unable to deny Nginx preview access to repository {resolved_repo_clone_root}: {detail}"
-        ) from error
+    _run_preview_setfacl(
+        executable,
+        [
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(resolved_repo_clone_root),
+        ],
+        f"unable to deny Nginx preview access to repository {resolved_repo_clone_root}",
+    )
+
+
+def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
+    """Revoke preview traversal before validation and selective regranting."""
+    resolved_clone_root = clone_root.resolve(strict=True)
+    deny_preview_nginx_clone_access(resolved_clone_root)
+
+    for repo_clone_root in sorted(resolved_clone_root.iterdir(), key=lambda path: path.name):
+        if repo_clone_root.is_symlink():
+            raise RuntimeError(
+                f"preview clone root contains a repository symlink: {repo_clone_root}"
+            )
+        if not repo_clone_root.is_dir():
+            continue
+
+        deny_preview_nginx_repository_access(resolved_clone_root, repo_clone_root)
+        children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
+        for child in children:
+            if not child.is_symlink() and child.is_dir():
+                deny_preview_nginx_access(resolved_clone_root, child)
+
+        for child in children:
+            if not child.is_symlink():
+                continue
+            try:
+                resolved_target = child.resolve(strict=True)
+            except FileNotFoundError:
+                link_target = pathlib.Path(os.readlink(child))
+                lexical_target = link_target if link_target.is_absolute() else child.parent / link_target
+                normalized_target = pathlib.Path(os.path.abspath(lexical_target))
+                if normalized_target.parent != repo_clone_root:
+                    raise RuntimeError(
+                        f"preview repository contains an unresolved symlink that escapes its root: "
+                        f"{child} -> {normalized_target}"
+                    )
+                continue
+            except OSError as error:
+                raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
+            if resolved_target.parent != repo_clone_root or not resolved_target.is_dir():
+                raise RuntimeError(
+                    f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
+                )
 
 
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:
@@ -4090,65 +4138,11 @@ def provision_worktrees(
     resolved_db_path = db_path or default_polyscope_db_path()
     failed_provision_worktrees: list[dict[str, str]] = []
 
-    # Revoke the shared repository traversal grant and every physical sibling
-    # before database filtering or validation can exclude a worktree. The
-    # default ACL closes the race for children created during reconciliation.
-    resolved_clone_root = clone_root.resolve()
-    for repo_name, spec in repo_specs.items():
-        preview_prefix = spec.get("preview_prefix")
-        if not isinstance(preview_prefix, str) or not preview_prefix:
-            continue
-        repo_clone_root = resolved_clone_root / str(repo_state[repo_name]["id"])
-        if not repo_clone_root.exists() and not repo_clone_root.is_symlink():
-            continue
-        try:
-            deny_preview_nginx_repository_access(clone_root, repo_clone_root)
-            children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
-            for child in children:
-                if not child.is_symlink() and child.is_dir():
-                    deny_preview_nginx_access(clone_root, child)
-            for child in children:
-                if not child.is_symlink():
-                    continue
-                try:
-                    resolved_target = child.resolve(strict=True)
-                except FileNotFoundError:
-                    continue
-                if resolved_target.parent != repo_clone_root or not resolved_target.is_dir():
-                    raise RuntimeError(
-                        f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
-                    )
-        except (
-            OSError,
-            RuntimeError,
-            subprocess.CalledProcessError,
-            SystemExit,
-        ) as error:
-            error_message = str(error)
-            print(
-                f"Failed to revoke preview access for {repo_name} repository "
-                f"at {repo_clone_root}: {error_message}",
-                file=sys.stderr,
-            )
-            failed_provision_worktrees.append(
-                {
-                    "repo": repo_name,
-                    "workspace": repo_clone_root.name,
-                    "path": str(repo_clone_root),
-                    "error": error_message,
-                }
-            )
-
-    if failed_provision_worktrees:
-        return [], [], failed_provision_worktrees
-
     registered_worktrees = load_registered_worktree_paths(
         resolved_db_path,
         repo_state,
         clone_root,
     )
-
-    validate_repo_instruction_files(repo_specs, validation_cache)
 
     provisionable_worktrees: list[
         tuple[str, dict[str, Any], pathlib.Path, list[str], list[str]]
@@ -4271,22 +4265,10 @@ def provision_worktrees(
 
                 marker_path = locked_worktree_path / PROVISION_MARKER_FILENAME
                 marker = load_provision_marker(marker_path)
-                preview_acl_policy_current = (
-                    preview_enabled
-                    and marker is not None
-                    and marker.get("preview_acl_policy_version") == PREVIEW_ACL_POLICY_VERSION
-                )
                 if marker is not None and marker.get("setup_hash") == setup_hash:
                     if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
                         if preview_enabled:
-                            ensure_preview_nginx_access(
-                                clone_root,
-                                locked_worktree_path,
-                                clean_inherited_acl=not preview_acl_policy_current,
-                            )
-                            if not preview_acl_policy_current:
-                                marker["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
-                                marker_path.write_text(json.dumps(marker, indent=2) + "\n")
+                            ensure_preview_nginx_access(clone_root, locked_worktree_path)
                         continue
 
                 if setup_commands:
@@ -4317,19 +4299,10 @@ def provision_worktrees(
                     marker_payload["preview_storage_target"] = preview_storage_target
                 if linked_setup_context:
                     marker_payload["linked_workspaces"] = linked_setup_context
-                if preview_acl_policy_current:
-                    marker_payload["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
 
                 marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 if preview_enabled:
-                    ensure_preview_nginx_access(
-                        clone_root,
-                        locked_worktree_path,
-                        clean_inherited_acl=not preview_acl_policy_current,
-                    )
-                    if not preview_acl_policy_current:
-                        marker_payload["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
-                        marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
+                    ensure_preview_nginx_access(clone_root, locked_worktree_path)
                 provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)
@@ -5082,8 +5055,25 @@ def main() -> int:
     if direct_mode_result is not None:
         return direct_mode_result
 
+    lock_context = (
+        provision_worktree_lock(args.provision_lock_path)
+        if args.provision_worktrees
+        else contextlib.nullcontext()
+    )
+    with lock_context:
+        return run_rollout(args)
+
+
+def run_rollout(args: argparse.Namespace) -> int:
     repo_specs = build_repo_specs(args.workspace_root)
     validated_instruction_roots: set[pathlib.Path] = set()
+
+    if args.provision_worktrees:
+        try:
+            revoke_all_preview_nginx_access(args.clone_root)
+        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
+            print(f"Failed to revoke preview access: {error}", file=sys.stderr)
+            return 1
 
     try:
         validate_repo_instruction_files(repo_specs, validated_instruction_roots)
@@ -5131,14 +5121,13 @@ def main() -> int:
     cleaned_preview_storage_targets: list[str] = []
     failed_provision_worktrees: list[dict[str, str]] = []
     if args.provision_worktrees:
-        with provision_worktree_lock(args.provision_lock_path):
-            provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
-                repo_state,
-                repo_specs,
-                args.clone_root,
-                db_path=args.db_path,
-                validated_instruction_roots=validated_instruction_roots,
-            )
+        provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
+            repo_state,
+            repo_specs,
+            args.clone_root,
+            db_path=args.db_path,
+            validated_instruction_roots=validated_instruction_roots,
+        )
 
     summary = build_summary(
         repo_state,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -34,6 +34,7 @@ ROLLOUT_SCRIPT_PATH = pathlib.Path(__file__).resolve()
 
 POLYSCOPE_LOCAL_CONFIG_NAME = "polyscope.local.json"
 PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
+PREVIEW_ACL_POLICY_VERSION = 1
 CANONICAL_AI_INSTRUCTIONS_VALIDATOR = ROLLOUT_SCRIPT_PATH.with_name("validate-ai-instructions.sh")
 DEFAULT_NGINX_MANIFEST_PATH = pathlib.Path("/home/secpal/.local/state/polyscope/nginx-manifest.json")
 DEFAULT_NGINX_HELPER_PATH = pathlib.Path("/usr/local/libexec/secpal-polyscope-nginx-apply")
@@ -3878,6 +3879,7 @@ def ensure_preview_nginx_access(
     worktree_path: pathlib.Path,
     *,
     setfacl_bin: str | None = None,
+    clean_inherited_acl: bool = True,
 ) -> None:
     """Allow the nginx worker to traverse exactly one preview worktree path."""
     resolved_clone_root = clone_root.resolve(strict=True)
@@ -3889,6 +3891,38 @@ def ensure_preview_nginx_access(
         )
 
     executable = resolve_setfacl_bin(setfacl_bin)
+
+    if clean_inherited_acl:
+        inherited_acl_cleanup = [
+            [executable, "-x", "d:u:www-data", "--", str(resolved_worktree_path)]
+        ]
+        worktree_children = sorted(resolved_worktree_path.iterdir(), key=lambda path: path.name)
+        if worktree_children:
+            inherited_acl_cleanup.append(
+                [
+                    executable,
+                    "-R",
+                    "-P",
+                    "-x",
+                    "u:www-data,d:u:www-data",
+                    "--",
+                    *(str(path) for path in worktree_children),
+                ]
+            )
+
+        for arguments in inherited_acl_cleanup:
+            try:
+                subprocess.run(
+                    arguments,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as error:
+                detail = error.stderr.strip() if error.stderr else "no error output"
+                raise RuntimeError(
+                    f"unable to grant Nginx preview access to {resolved_worktree_path}: {detail}"
+                ) from error
 
     for path in (
         resolved_clone_root.parent.parent,
@@ -3937,6 +3971,43 @@ def deny_preview_nginx_access(
         detail = error.stderr.strip() if error.stderr else "no error output"
         raise RuntimeError(
             f"unable to deny Nginx preview access to {resolved_worktree_path}: {detail}"
+        ) from error
+
+
+def deny_preview_nginx_repository_access(
+    clone_root: pathlib.Path,
+    repo_clone_root: pathlib.Path,
+    *,
+    setfacl_bin: str | None = None,
+) -> None:
+    """Block existing and newly created children of one preview repository."""
+    resolved_clone_root = clone_root.resolve(strict=True)
+    if repo_clone_root.is_symlink() or not repo_clone_root.is_dir():
+        raise RuntimeError(f"preview repository clone root is not a physical directory: {repo_clone_root}")
+    resolved_repo_clone_root = repo_clone_root.resolve(strict=True)
+    if resolved_repo_clone_root.parent != resolved_clone_root:
+        raise RuntimeError(
+            f"preview repository clone root {resolved_repo_clone_root} is not directly below {resolved_clone_root}"
+        )
+
+    executable = resolve_setfacl_bin(setfacl_bin)
+    try:
+        subprocess.run(
+            [
+                executable,
+                "-m",
+                "u:www-data:---,d:u:www-data:---",
+                "--",
+                str(resolved_repo_clone_root),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() if error.stderr else "no error output"
+        raise RuntimeError(
+            f"unable to deny Nginx preview access to repository {resolved_repo_clone_root}: {detail}"
         ) from error
 
 
@@ -4017,47 +4088,65 @@ def provision_worktrees(
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     validation_cache = validated_instruction_roots if validated_instruction_roots is not None else set()
     resolved_db_path = db_path or default_polyscope_db_path()
+    failed_provision_worktrees: list[dict[str, str]] = []
+
+    # Revoke the shared repository traversal grant and every physical sibling
+    # before database filtering or validation can exclude a worktree. The
+    # default ACL closes the race for children created during reconciliation.
+    resolved_clone_root = clone_root.resolve()
+    for repo_name, spec in repo_specs.items():
+        preview_prefix = spec.get("preview_prefix")
+        if not isinstance(preview_prefix, str) or not preview_prefix:
+            continue
+        repo_clone_root = resolved_clone_root / str(repo_state[repo_name]["id"])
+        if not repo_clone_root.exists() and not repo_clone_root.is_symlink():
+            continue
+        try:
+            deny_preview_nginx_repository_access(clone_root, repo_clone_root)
+            children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
+            for child in children:
+                if not child.is_symlink() and child.is_dir():
+                    deny_preview_nginx_access(clone_root, child)
+            for child in children:
+                if not child.is_symlink():
+                    continue
+                try:
+                    resolved_target = child.resolve(strict=True)
+                except FileNotFoundError:
+                    continue
+                if resolved_target.parent != repo_clone_root or not resolved_target.is_dir():
+                    raise RuntimeError(
+                        f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
+                    )
+        except (
+            OSError,
+            RuntimeError,
+            subprocess.CalledProcessError,
+            SystemExit,
+        ) as error:
+            error_message = str(error)
+            print(
+                f"Failed to revoke preview access for {repo_name} repository "
+                f"at {repo_clone_root}: {error_message}",
+                file=sys.stderr,
+            )
+            failed_provision_worktrees.append(
+                {
+                    "repo": repo_name,
+                    "workspace": repo_clone_root.name,
+                    "path": str(repo_clone_root),
+                    "error": error_message,
+                }
+            )
+
+    if failed_provision_worktrees:
+        return [], [], failed_provision_worktrees
+
     registered_worktrees = load_registered_worktree_paths(
         resolved_db_path,
         repo_state,
         clone_root,
     )
-    failed_provision_worktrees: list[dict[str, str]] = []
-
-    # Revoke every existing preview grant before any validation can exclude a
-    # registered worktree or abort the provisioning batch.
-    for repo_name, spec in repo_specs.items():
-        preview_prefix = spec.get("preview_prefix")
-        if not isinstance(preview_prefix, str) or not preview_prefix:
-            continue
-        for worktree_path in registered_worktrees[repo_name]:
-            if not worktree_path.is_dir() or worktree_path.is_symlink():
-                continue
-            try:
-                deny_preview_nginx_access(clone_root, worktree_path)
-            except (
-                OSError,
-                RuntimeError,
-                subprocess.CalledProcessError,
-                SystemExit,
-            ) as error:
-                error_message = str(error)
-                print(
-                    f"Failed to revoke preview access for {repo_name} worktree "
-                    f"{worktree_path.name} at {worktree_path}: {error_message}",
-                    file=sys.stderr,
-                )
-                failed_provision_worktrees.append(
-                    {
-                        "repo": repo_name,
-                        "workspace": worktree_path.name,
-                        "path": str(worktree_path),
-                        "error": error_message,
-                    }
-                )
-
-    if failed_provision_worktrees:
-        return [], [], failed_provision_worktrees
 
     validate_repo_instruction_files(repo_specs, validation_cache)
 
@@ -4182,10 +4271,22 @@ def provision_worktrees(
 
                 marker_path = locked_worktree_path / PROVISION_MARKER_FILENAME
                 marker = load_provision_marker(marker_path)
+                preview_acl_policy_current = (
+                    preview_enabled
+                    and marker is not None
+                    and marker.get("preview_acl_policy_version") == PREVIEW_ACL_POLICY_VERSION
+                )
                 if marker is not None and marker.get("setup_hash") == setup_hash:
                     if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
                         if preview_enabled:
-                            ensure_preview_nginx_access(clone_root, locked_worktree_path)
+                            ensure_preview_nginx_access(
+                                clone_root,
+                                locked_worktree_path,
+                                clean_inherited_acl=not preview_acl_policy_current,
+                            )
+                            if not preview_acl_policy_current:
+                                marker["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
+                                marker_path.write_text(json.dumps(marker, indent=2) + "\n")
                         continue
 
                 if setup_commands:
@@ -4216,10 +4317,19 @@ def provision_worktrees(
                     marker_payload["preview_storage_target"] = preview_storage_target
                 if linked_setup_context:
                     marker_payload["linked_workspaces"] = linked_setup_context
+                if preview_acl_policy_current:
+                    marker_payload["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
 
                 marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 if preview_enabled:
-                    ensure_preview_nginx_access(clone_root, locked_worktree_path)
+                    ensure_preview_nginx_access(
+                        clone_root,
+                        locked_worktree_path,
+                        clean_inherited_acl=not preview_acl_policy_current,
+                    )
+                    if not preview_acl_policy_current:
+                        marker_payload["preview_acl_policy_version"] = PREVIEW_ACL_POLICY_VERSION
+                        marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1697,6 +1697,7 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
     shutil.copy2(src_file, tmp_path)
+    os.chmod(tmp_path, 0o644)
     if dest_file.is_dir() and not dest_file.is_symlink():
         shutil.rmtree(dest_file)
     os.replace(tmp_path, dest_file)
@@ -1705,6 +1706,7 @@ def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest_dir, 0o755)
     for child in sorted(src_dir.iterdir()):
         dest_child = dest_dir / child.name
         if child.is_dir():
@@ -1742,6 +1744,7 @@ def publish_preview_build(stage_dir: Path) -> None:
     if live_root.is_symlink():
         raise RuntimeError("live preview dist is a symlink")
     live_root.mkdir(parents=True, exist_ok=True)
+    os.chmod(live_root, 0o755)
 
     with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
         tmp_dir = Path(_tmp)
@@ -1909,6 +1912,7 @@ def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
     os.close(fd)
     shutil.copy2(src_file, tmp_path)
+    os.chmod(tmp_path, 0o644)
     if dest_file.is_dir() and not dest_file.is_symlink():
         shutil.rmtree(dest_file)
     os.replace(tmp_path, dest_file)
@@ -1917,6 +1921,7 @@ def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest_dir, 0o755)
     for child in sorted(src_dir.iterdir()):
         dest_child = dest_dir / child.name
         if child.is_dir():
@@ -1954,6 +1959,7 @@ def publish_preview_build(stage_dir: Path) -> None:
     if live_root.is_symlink():
         raise RuntimeError("live preview dist is a symlink")
     live_root.mkdir(parents=True, exist_ok=True)
+    os.chmod(live_root, 0o755)
 
     with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
         tmp_dir = Path(_tmp)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4016,18 +4016,54 @@ def provision_worktrees(
     validated_instruction_roots: set[pathlib.Path] | None = None,
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     validation_cache = validated_instruction_roots if validated_instruction_roots is not None else set()
-    validate_repo_instruction_files(repo_specs, validation_cache)
     resolved_db_path = db_path or default_polyscope_db_path()
     registered_worktrees = load_registered_worktree_paths(
         resolved_db_path,
         repo_state,
         clone_root,
     )
+    failed_provision_worktrees: list[dict[str, str]] = []
+
+    # Revoke every existing preview grant before any validation can exclude a
+    # registered worktree or abort the provisioning batch.
+    for repo_name, spec in repo_specs.items():
+        preview_prefix = spec.get("preview_prefix")
+        if not isinstance(preview_prefix, str) or not preview_prefix:
+            continue
+        for worktree_path in registered_worktrees[repo_name]:
+            if not worktree_path.is_dir() or worktree_path.is_symlink():
+                continue
+            try:
+                deny_preview_nginx_access(clone_root, worktree_path)
+            except (
+                OSError,
+                RuntimeError,
+                subprocess.CalledProcessError,
+                SystemExit,
+            ) as error:
+                error_message = str(error)
+                print(
+                    f"Failed to revoke preview access for {repo_name} worktree "
+                    f"{worktree_path.name} at {worktree_path}: {error_message}",
+                    file=sys.stderr,
+                )
+                failed_provision_worktrees.append(
+                    {
+                        "repo": repo_name,
+                        "workspace": worktree_path.name,
+                        "path": str(worktree_path),
+                        "error": error_message,
+                    }
+                )
+
+    if failed_provision_worktrees:
+        return [], [], failed_provision_worktrees
+
+    validate_repo_instruction_files(repo_specs, validation_cache)
 
     provisionable_worktrees: list[
         tuple[str, dict[str, Any], pathlib.Path, list[str], list[str]]
     ] = []
-    failed_provision_worktrees: list[dict[str, str]] = []
     canonical_validation_failed = False
 
     for repo_name, spec in repo_specs.items():
@@ -4111,8 +4147,6 @@ def provision_worktrees(
         preview_prefix = spec.get("preview_prefix")
         preview_enabled = isinstance(preview_prefix, str) and bool(preview_prefix)
         try:
-            if preview_enabled:
-                deny_preview_nginx_access(clone_root, worktree_path)
             preserve_registered_workspace_physical_path(worktree_path, db_path=db_path)
             config_text = render_worktree_local_config(spec, worktree_path, db_path=db_path)
             sync_worktree_local_config(worktree_path, config_text)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1681,29 +1681,29 @@ exit 1
     ).strip()
 
 
-def build_frontend_preview_build_command() -> str:
-    script = textwrap.dedent(
-        f"""\
-import fcntl
-import os
-import shutil
-import subprocess
-import tempfile
-from pathlib import Path
-
-{build_linked_workspace_resolver_source()}
-
-def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+def build_frontend_preview_publisher_source() -> str:
+    """Render the one canonical atomic preview publication implementation."""
+    return textwrap.dedent(
+        """\
+def replace_file(src_file: Path, dest_file: Path) -> None:
     dest_file.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
+    fd, tmp_name = tempfile.mkstemp(
+        suffix=".tmp",
+        prefix=dest_file.name + "-",
+        dir=dest_file.parent,
+    )
     os.close(fd)
-    shutil.copy2(src_file, tmp_path)
-    os.chmod(tmp_path, 0o644)
-    if dest_file.is_dir() and not dest_file.is_symlink():
-        shutil.rmtree(dest_file)
-    os.replace(tmp_path, dest_file)
+    tmp_path = Path(tmp_name)
+    try:
+        shutil.copyfile(src_file, tmp_path)
+        os.chmod(tmp_path, 0o644)
+        if dest_file.is_dir() and not dest_file.is_symlink():
+            shutil.rmtree(dest_file)
+        os.replace(tmp_path, dest_file)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
-def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
+def merge_tree(src_dir: Path, dest_dir: Path) -> None:
     if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
         dest_dir.unlink()
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -1711,20 +1711,17 @@ def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
     for child in sorted(src_dir.iterdir()):
         dest_child = dest_dir / child.name
         if child.is_dir():
-            merge_tree(child, dest_child, tmp_dir)
+            merge_tree(child, dest_child)
         else:
-            replace_file(child, dest_child, tmp_dir)
+            replace_file(child, dest_child)
 
-def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[Path]]:
-    stage_dirs = {{Path(".")}}
+def collect_stage_paths(stage_dir: Path) -> tuple[set[Path], set[Path]]:
+    stage_dirs = {Path(".")}
     stage_files = set()
     for child in stage_dir.rglob("*"):
-        if child == tmp_dir or tmp_dir in child.parents:
-            continue
-
         relative = child.relative_to(stage_dir)
         if child.is_symlink():
-            raise RuntimeError(f"staged build output contains symlink: {{relative}}")
+            raise RuntimeError(f"staged build output contains symlink: {relative}")
         if child.is_dir():
             stage_dirs.add(relative)
         else:
@@ -1747,33 +1744,46 @@ def publish_preview_build(stage_dir: Path) -> None:
     live_root.mkdir(parents=True, exist_ok=True)
     os.chmod(live_root, 0o755)
 
-    with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
-        tmp_dir = Path(_tmp)
-        stage_dirs, stage_files = collect_stage_paths(stage_dir, tmp_dir)
+    stage_dirs, stage_files = collect_stage_paths(stage_dir)
 
-        stage_assets = stage_dir / "assets"
-        if stage_assets.is_dir():
-            merge_tree(stage_assets, live_root / "assets", tmp_dir)
+    stage_assets = stage_dir / "assets"
+    if stage_assets.is_dir():
+        merge_tree(stage_assets, live_root / "assets")
 
-        deferred_index: Path | None = None
-        for child in sorted(stage_dir.iterdir()):
-            if child.name == "assets":
-                continue
-            if child.name == tmp_dir.name:
-                continue
-            if child.name == "index.html":
-                deferred_index = child
-                continue
-            destination = live_root / child.name
-            if child.is_dir():
-                merge_tree(child, destination, tmp_dir)
-            else:
-                replace_file(child, destination, tmp_dir)
+    deferred_index: Path | None = None
+    for child in sorted(stage_dir.iterdir()):
+        if child.name == "assets":
+            continue
+        if child.name == "index.html":
+            deferred_index = child
+            continue
+        destination = live_root / child.name
+        if child.is_dir():
+            merge_tree(child, destination)
+        else:
+            replace_file(child, destination)
 
-        if deferred_index is not None:
-            replace_file(deferred_index, live_root / "index.html", tmp_dir)
+    if deferred_index is not None:
+        replace_file(deferred_index, live_root / "index.html")
 
-        prune_live_tree(live_root, stage_dirs, stage_files)
+    prune_live_tree(live_root, stage_dirs, stage_files)
+        """
+    ).strip()
+
+
+def build_frontend_preview_build_command() -> str:
+    script = textwrap.dedent(
+        f"""\
+import fcntl
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+{build_linked_workspace_resolver_source()}
+
+{build_frontend_preview_publisher_source()}
 
 workspace = resolve_current_workspace(Path.cwd())
 api_workspace = resolve_linked_workspace("SecPal/api", workspace)
@@ -1908,87 +1918,7 @@ def snapshot() -> str:
 
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
-def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
-    dest_file.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(suffix=".tmp", prefix=dest_file.name + "-", dir=tmp_dir)
-    os.close(fd)
-    shutil.copy2(src_file, tmp_path)
-    os.chmod(tmp_path, 0o644)
-    if dest_file.is_dir() and not dest_file.is_symlink():
-        shutil.rmtree(dest_file)
-    os.replace(tmp_path, dest_file)
-
-def merge_tree(src_dir: Path, dest_dir: Path, tmp_dir: Path) -> None:
-    if dest_dir.is_symlink() or (dest_dir.exists() and not dest_dir.is_dir()):
-        dest_dir.unlink()
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    os.chmod(dest_dir, 0o755)
-    for child in sorted(src_dir.iterdir()):
-        dest_child = dest_dir / child.name
-        if child.is_dir():
-            merge_tree(child, dest_child, tmp_dir)
-        else:
-            replace_file(child, dest_child, tmp_dir)
-
-def collect_stage_paths(stage_dir: Path, tmp_dir: Path) -> tuple[set[Path], set[Path]]:
-    stage_dirs = {{Path(".")}}
-    stage_files = set()
-    for child in stage_dir.rglob("*"):
-        if child == tmp_dir or tmp_dir in child.parents:
-            continue
-
-        relative = child.relative_to(stage_dir)
-        if child.is_symlink():
-            raise RuntimeError(f"staged build output contains symlink: {{relative}}")
-        if child.is_dir():
-            stage_dirs.add(relative)
-        else:
-            stage_files.add(relative)
-    return stage_dirs, stage_files
-
-def prune_live_tree(live_root: Path, stage_dirs: set[Path], stage_files: set[Path]) -> None:
-    for child in sorted(live_root.rglob("*"), key=lambda path: len(path.relative_to(live_root).parts), reverse=True):
-        relative = child.relative_to(live_root)
-        if child.is_dir() and not child.is_symlink():
-            if relative not in stage_dirs:
-                shutil.rmtree(child)
-        elif relative not in stage_files:
-            child.unlink(missing_ok=True)
-
-def publish_preview_build(stage_dir: Path) -> None:
-    live_root = Path("dist")
-    if live_root.is_symlink():
-        raise RuntimeError("live preview dist is a symlink")
-    live_root.mkdir(parents=True, exist_ok=True)
-    os.chmod(live_root, 0o755)
-
-    with tempfile.TemporaryDirectory(prefix="publish-tmp-", dir=stage_dir) as _tmp:
-        tmp_dir = Path(_tmp)
-        stage_dirs, stage_files = collect_stage_paths(stage_dir, tmp_dir)
-
-        stage_assets = stage_dir / "assets"
-        if stage_assets.is_dir():
-            merge_tree(stage_assets, live_root / "assets", tmp_dir)
-
-        deferred_index = None
-        for child in sorted(stage_dir.iterdir()):
-            if child.name == "assets":
-                continue
-            if child.name == tmp_dir.name:
-                continue
-            if child.name == "index.html":
-                deferred_index = child
-                continue
-            destination = live_root / child.name
-            if child.is_dir():
-                merge_tree(child, destination, tmp_dir)
-            else:
-                replace_file(child, destination, tmp_dir)
-
-        if deferred_index is not None:
-            replace_file(deferred_index, live_root / "index.html", tmp_dir)
-
-        prune_live_tree(live_root, stage_dirs, stage_files)
+{build_frontend_preview_publisher_source()}
 
 def run_build() -> int:
     workspace = resolve_current_workspace(Path.cwd())
@@ -4648,6 +4578,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             }}
 
             root $preview_docroot;
+            disable_symlinks on from=$preview_docroot;
 
             add_header Content-Security-Policy $secpal_csp always;
             add_header Permissions-Policy $secpal_permissions_policy always;

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3907,29 +3907,40 @@ def ensure_preview_nginx_access(
 
     executable = resolve_setfacl_bin(setfacl_bin)
 
-    _run_preview_setfacl(
-        executable,
-        ["-x", "d:u:www-data", "--", str(resolved_worktree_path)],
-        f"unable to remove inherited Nginx preview ACL from {resolved_worktree_path}",
-    )
-
+    document_roots: list[pathlib.Path] = []
     for document_root_name in ("public", "dist"):
         document_root = resolved_worktree_path / document_root_name
         if not document_root.exists() and not document_root.is_symlink():
             continue
         if document_root.is_symlink() or not document_root.is_dir():
             raise RuntimeError(f"preview document root is not a physical directory: {document_root}")
+        document_roots.append(document_root)
+
+    for document_root in document_roots:
         _run_preview_setfacl(
             executable,
             [
                 "-R",
                 "-P",
                 "-m",
-                "u:www-data:rX,d:u:www-data:r-x",
+                "u:www-data:rX",
                 "--",
                 str(document_root),
             ],
             f"unable to grant Nginx preview content access to {document_root}",
+        )
+        _run_preview_setfacl(
+            executable,
+            [
+                "-R",
+                "-P",
+                "-d",
+                "-m",
+                "u:www-data:r-x",
+                "--",
+                str(document_root),
+            ],
+            f"unable to grant inherited Nginx preview content access to {document_root}",
         )
 
     for path in (
@@ -3963,7 +3974,12 @@ def deny_preview_nginx_access(
     executable = resolve_setfacl_bin(setfacl_bin)
     _run_preview_setfacl(
         executable,
-        ["-m", "u:www-data:---", "--", str(resolved_worktree_path)],
+        [
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(resolved_worktree_path),
+        ],
         f"unable to deny Nginx preview access to {resolved_worktree_path}",
     )
 
@@ -4031,6 +4047,7 @@ def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
             continue
 
         deny_preview_nginx_repository_access(resolved_clone_root, repo_clone_root)
+        registered_aliases = load_workspace_alias_registry(repo_clone_root)
         children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
         for child in children:
             if not child.is_symlink() and child.is_dir():
@@ -4040,16 +4057,27 @@ def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
             if not child.is_symlink():
                 continue
             try:
+                link_target = os.readlink(child)
+            except OSError as error:
+                raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
+            registered_target = registered_aliases.get(child.name)
+            try:
                 resolved_target = child.resolve(strict=True)
             except FileNotFoundError:
-                link_target = pathlib.Path(os.readlink(child))
-                lexical_target = link_target if link_target.is_absolute() else child.parent / link_target
+                link_target_path = pathlib.Path(link_target)
+                lexical_target = (
+                    link_target_path
+                    if link_target_path.is_absolute()
+                    else child.parent / link_target_path
+                )
                 normalized_target = pathlib.Path(os.path.abspath(lexical_target))
                 if normalized_target.parent != repo_clone_root:
                     raise RuntimeError(
                         f"preview repository contains an unresolved symlink that escapes its root: "
                         f"{child} -> {normalized_target}"
                     )
+                if registered_target != link_target:
+                    raise RuntimeError(f"preview repository contains an unregistered workspace alias: {child}")
                 continue
             except OSError as error:
                 raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
@@ -4057,6 +4085,8 @@ def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
                 raise RuntimeError(
                     f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
                 )
+            if registered_target != link_target or resolved_target.name != registered_target:
+                raise RuntimeError(f"preview repository contains an unregistered workspace alias: {child}")
 
 
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3856,6 +3856,45 @@ def resolve_executable(command: str) -> str | None:
     return None
 
 
+def ensure_preview_nginx_access(
+    clone_root: pathlib.Path,
+    worktree_path: pathlib.Path,
+    *,
+    setfacl_bin: str | None = None,
+) -> None:
+    """Allow the nginx worker to traverse exactly one preview worktree path."""
+    resolved_clone_root = clone_root.resolve(strict=True)
+    resolved_worktree_path = worktree_path.resolve(strict=True)
+    repo_clone_root = resolved_worktree_path.parent
+    if repo_clone_root.parent != resolved_clone_root:
+        raise RuntimeError(
+            f"preview worktree {resolved_worktree_path} is not directly below clone root {resolved_clone_root}"
+        )
+
+    executable = setfacl_bin or resolve_executable("setfacl")
+    if executable is None:
+        raise RuntimeError("setfacl is required to grant Nginx access to preview worktrees")
+
+    for path in (
+        resolved_clone_root.parent,
+        resolved_clone_root,
+        repo_clone_root,
+        resolved_worktree_path,
+    ):
+        try:
+            subprocess.run(
+                [executable, "-m", "u:www-data:--x", "--", str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.strip() if error.stderr else "no error output"
+            raise RuntimeError(
+                f"unable to grant Nginx preview access to {path}: {detail}"
+            ) from error
+
+
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:
     if not (worktree_path / ".pre-commit-config.yaml").exists():
         return
@@ -4029,6 +4068,9 @@ def provision_worktrees(
             config_text = render_worktree_local_config(spec, worktree_path, db_path=db_path)
             sync_worktree_local_config(worktree_path, config_text)
             ensure_workspace_alias(worktree_path, db_path=db_path)
+            preview_prefix = spec.get("preview_prefix")
+            if isinstance(preview_prefix, str) and preview_prefix:
+                ensure_preview_nginx_access(clone_root, worktree_path)
             sync_worktree_auxiliary_files(repo_name, worktree_path)
             ensure_worktree_hooks(worktree_path)
             lock_context = (

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -37,6 +37,7 @@ PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
 CANONICAL_AI_INSTRUCTIONS_VALIDATOR = ROLLOUT_SCRIPT_PATH.with_name("validate-ai-instructions.sh")
 DEFAULT_NGINX_MANIFEST_PATH = pathlib.Path("/home/secpal/.local/state/polyscope/nginx-manifest.json")
 DEFAULT_NGINX_HELPER_PATH = pathlib.Path("/usr/local/libexec/secpal-polyscope-nginx-apply")
+FIXED_SETFACL_BIN = "/usr/bin/setfacl"
 NGINX_MANIFEST_USER = "secpal"
 CANONICAL_VALIDATION_SPEC_KEY = "_canonical_ai_instruction_root"
 NATIVE_SETUP_COMMANDS_KEY = "_native_setup_commands"
@@ -3856,6 +3857,22 @@ def resolve_executable(command: str) -> str | None:
     return None
 
 
+def resolve_setfacl_bin(explicit_path: str | None = None) -> str:
+    if explicit_path is not None:
+        return explicit_path
+
+    test_override = os.environ.get("POLYSCOPE_TEST_SETFACL_BIN")
+    if test_override is None:
+        return FIXED_SETFACL_BIN
+    if os.environ.get("POLYSCOPE_TEST_ALLOW_SETFACL_OVERRIDE") != "1":
+        raise RuntimeError("test setfacl override requires explicit test authorization")
+
+    override_path = pathlib.Path(test_override)
+    if not override_path.is_absolute() or not override_path.is_file() or not os.access(override_path, os.X_OK):
+        raise RuntimeError("test setfacl override must be an absolute executable file")
+    return str(override_path)
+
+
 def ensure_preview_nginx_access(
     clone_root: pathlib.Path,
     worktree_path: pathlib.Path,
@@ -3871,9 +3888,7 @@ def ensure_preview_nginx_access(
             f"preview worktree {resolved_worktree_path} is not directly below clone root {resolved_clone_root}"
         )
 
-    executable = setfacl_bin or resolve_executable("setfacl")
-    if executable is None:
-        raise RuntimeError("setfacl is required to grant Nginx access to preview worktrees")
+    executable = resolve_setfacl_bin(setfacl_bin)
 
     for path in (
         resolved_clone_root.parent.parent,
@@ -3894,6 +3909,35 @@ def ensure_preview_nginx_access(
             raise RuntimeError(
                 f"unable to grant Nginx preview access to {path}: {detail}"
             ) from error
+
+
+def deny_preview_nginx_access(
+    clone_root: pathlib.Path,
+    worktree_path: pathlib.Path,
+    *,
+    setfacl_bin: str | None = None,
+) -> None:
+    """Block the nginx worker at one physical preview worktree."""
+    resolved_clone_root = clone_root.resolve(strict=True)
+    resolved_worktree_path = worktree_path.resolve(strict=True)
+    if resolved_worktree_path.parent.parent != resolved_clone_root:
+        raise RuntimeError(
+            f"preview worktree {resolved_worktree_path} is not directly below clone root {resolved_clone_root}"
+        )
+
+    executable = resolve_setfacl_bin(setfacl_bin)
+    try:
+        subprocess.run(
+            [executable, "-m", "u:www-data:---", "--", str(resolved_worktree_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() if error.stderr else "no error output"
+        raise RuntimeError(
+            f"unable to deny Nginx preview access to {resolved_worktree_path}: {detail}"
+        ) from error
 
 
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:
@@ -4064,14 +4108,15 @@ def provision_worktrees(
     provisioned_worktrees: list[str] = []
 
     for repo_name, spec, worktree_path, _validation_commands, setup_commands in provisionable_worktrees:
+        preview_prefix = spec.get("preview_prefix")
+        preview_enabled = isinstance(preview_prefix, str) and bool(preview_prefix)
         try:
+            if preview_enabled:
+                deny_preview_nginx_access(clone_root, worktree_path)
             preserve_registered_workspace_physical_path(worktree_path, db_path=db_path)
             config_text = render_worktree_local_config(spec, worktree_path, db_path=db_path)
             sync_worktree_local_config(worktree_path, config_text)
             ensure_workspace_alias(worktree_path, db_path=db_path)
-            preview_prefix = spec.get("preview_prefix")
-            if isinstance(preview_prefix, str) and preview_prefix:
-                ensure_preview_nginx_access(clone_root, worktree_path)
             sync_worktree_auxiliary_files(repo_name, worktree_path)
             ensure_worktree_hooks(worktree_path)
             lock_context = (
@@ -4105,6 +4150,8 @@ def provision_worktrees(
                 marker = load_provision_marker(marker_path)
                 if marker is not None and marker.get("setup_hash") == setup_hash:
                     if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
+                        if preview_enabled:
+                            ensure_preview_nginx_access(clone_root, locked_worktree_path)
                         continue
 
                 if setup_commands:
@@ -4137,6 +4184,8 @@ def provision_worktrees(
                     marker_payload["linked_workspaces"] = linked_setup_context
 
                 marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
+                if preview_enabled:
+                    ensure_preview_nginx_access(clone_root, locked_worktree_path)
                 provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6909,6 +6909,7 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         module.subprocess.run = original_run
 
     expected_paths = [
+        clone_root.parent.parent,
         clone_root.parent,
         clone_root,
         worktree.parent,

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6944,8 +6944,8 @@ with tempfile.TemporaryDirectory() as temporary_directory:
             "/usr/bin/setfacl",
             "-R",
             "-P",
-            "-x",
-            "u:www-data,d:u:www-data",
+            "-m",
+            "u:www-data:rX,d:u:www-data:r-x",
             "--",
             str(public_directory),
         ],
@@ -6993,6 +6993,25 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     calls.clear()
     module.subprocess.run = record_run
     try:
+        module.deny_preview_nginx_clone_access(
+            clone_root,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+    finally:
+        module.subprocess.run = original_run
+    assert [arguments for arguments, _kwargs in calls] == [
+        [
+            "/usr/bin/setfacl",
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(clone_root),
+        ]
+    ]
+
+    calls.clear()
+    module.subprocess.run = record_run
+    try:
         module.deny_preview_nginx_repository_access(
             clone_root,
             worktree.parent,
@@ -7026,16 +7045,18 @@ with tempfile.TemporaryDirectory() as temporary_directory:
                 setfacl_bin="/usr/bin/setfacl",
             )
         except RuntimeError as error:
-            assert "unable to grant Nginx preview access" in str(error)
+            assert "unable to" in str(error) and "Nginx preview" in str(error)
         else:
             raise AssertionError("setfacl failure must stop provisioning")
     finally:
         module.subprocess.run = original_run
 PY
 python3 - "$PYTHON_SCRIPT" <<'PY'
+import contextlib
 import importlib.util
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 script_path = Path(__import__("sys").argv[1])
 spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
@@ -7048,14 +7069,9 @@ def run_case(
     *,
     marker_hit: bool,
     setup_fails: bool,
-    marker_acl_current: bool = False,
     provisionable: bool = True,
     canonical_validation_fails: bool = False,
-    deny_fails: bool = False,
-    repository_deny_fails: bool = False,
     registered_worktree_count: int = 1,
-    unregistered_worktree_count: int = 0,
-    escaping_symlink: bool = False,
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     temporary_directory = tempfile.TemporaryDirectory()
     case_root = Path(temporary_directory.name)
@@ -7067,20 +7083,8 @@ def run_case(
         additional_worktree = clone_root / "repository-id" / f"workspace-{index}"
         additional_worktree.mkdir()
         registered_worktrees.append(additional_worktree)
-    for index in range(unregistered_worktree_count):
-        (clone_root / "repository-id" / f"orphan-{index}").mkdir()
-    if escaping_symlink:
-        outside_preview = case_root / "outside-preview"
-        outside_preview.mkdir()
-        (clone_root / "repository-id" / "rogue-alias").symlink_to(
-            outside_preview,
-            target_is_directory=True,
-        )
     order: list[str] = []
 
-    module.validate_repo_instruction_files = lambda *_args, **_kwargs: order.append(
-        "validate-repos"
-    )
     module.load_registered_worktree_paths = lambda *_args, **_kwargs: {
         "api": [],
         "frontend": registered_worktrees,
@@ -7104,26 +7108,10 @@ def run_case(
     module.collect_linked_setup_context = lambda *_args, **_kwargs: {}
     module.resolve_current_workspace_name = lambda *_args, **_kwargs: "workspace"
     module.build_setup_hash = lambda *_args, **_kwargs: "setup-hash"
-    marker_payload = {"setup_hash": "setup-hash"}
-    if marker_acl_current:
-        marker_payload["preview_acl_policy_version"] = module.PREVIEW_ACL_POLICY_VERSION
-    module.load_provision_marker = lambda _path: marker_payload if marker_hit else None
+    module.load_provision_marker = lambda _path: {"setup_hash": "setup-hash"} if marker_hit else None
 
-    def deny_repository_access(*_args, **_kwargs) -> None:
-        order.append("deny-repository")
-        if repository_deny_fails:
-            raise RuntimeError("expected repository ACL denial failure")
-
-    def deny_access(_clone_root, denied_path, **_kwargs) -> None:
-        order.append(f"deny:{denied_path.name}")
-        if deny_fails:
-            raise RuntimeError("expected ACL denial failure")
-
-    module.deny_preview_nginx_repository_access = deny_repository_access
-    module.deny_preview_nginx_access = deny_access
-
-    def grant_access(*_args, clean_inherited_acl: bool = True, **_kwargs) -> None:
-        order.append("grant-clean" if clean_inherited_acl else "grant-current")
+    def grant_access(*_args, **_kwargs) -> None:
+        order.append("grant")
 
     module.ensure_preview_nginx_access = grant_access
 
@@ -7162,9 +7150,6 @@ failure_order, failure_provisioned, failure_details = run_case(
     setup_fails=True,
 )
 assert failure_order == [
-    "deny-repository",
-    "deny:workspace",
-    "validate-repos",
     "validate",
     "setup",
 ], failure_order
@@ -7176,41 +7161,20 @@ marker_order, marker_provisioned, marker_failures = run_case(
     setup_fails=False,
 )
 assert marker_order == [
-    "deny-repository",
-    "deny:workspace",
-    "validate-repos",
     "validate",
-    "grant-clean",
+    "grant",
 ], marker_order
 assert marker_provisioned == []
 assert marker_failures == []
-
-current_marker_order, current_marker_provisioned, current_marker_failures = run_case(
-    marker_hit=True,
-    marker_acl_current=True,
-    setup_fails=False,
-)
-assert current_marker_order == [
-    "deny-repository",
-    "deny:workspace",
-    "validate-repos",
-    "validate",
-    "grant-current",
-], current_marker_order
-assert current_marker_provisioned == []
-assert current_marker_failures == []
 
 success_order, success_provisioned, success_failures = run_case(
     marker_hit=False,
     setup_fails=False,
 )
 assert success_order == [
-    "deny-repository",
-    "deny:workspace",
-    "validate-repos",
     "validate",
     "setup",
-    "grant-clean",
+    "grant",
 ], success_order
 assert success_provisioned == ["frontend:workspace"]
 assert success_failures == []
@@ -7221,9 +7185,6 @@ invalid_order, invalid_provisioned, invalid_failures = run_case(
     provisionable=False,
 )
 assert invalid_order == [
-    "deny-repository",
-    "deny:workspace",
-    "validate-repos",
     "validate",
 ], invalid_order
 assert invalid_provisioned == []
@@ -7236,59 +7197,175 @@ canonical_order, canonical_provisioned, canonical_failures = run_case(
     registered_worktree_count=2,
 )
 assert canonical_order == [
-    "deny-repository",
-    "deny:workspace",
-    "deny:workspace-1",
-    "validate-repos",
     "validate",
     "validate",
 ], canonical_order
 assert canonical_provisioned == []
 assert len(canonical_failures) == 2
 
-deny_failure_order, deny_failure_provisioned, deny_failure_details = run_case(
-    marker_hit=False,
-    setup_fails=False,
-    deny_fails=True,
-)
-assert deny_failure_order == ["deny-repository", "deny:workspace"], deny_failure_order
-assert deny_failure_provisioned == []
-assert len(deny_failure_details) == 1
 
-repository_failure_order, repository_failure_provisioned, repository_failure_details = run_case(
-    marker_hit=False,
-    setup_fails=False,
-    repository_deny_fails=True,
-)
-assert repository_failure_order == ["deny-repository"], repository_failure_order
-assert repository_failure_provisioned == []
-assert len(repository_failure_details) == 1
+def run_revoke_case(
+    *,
+    repository_exists: bool = True,
+    unregistered_worktree_count: int = 0,
+    escaping_symlink: bool = False,
+    broken_symlink: bool = False,
+    broken_internal_symlink: bool = False,
+    clone_deny_fails: bool = False,
+    repository_deny_fails: bool = False,
+    child_deny_fails: bool = False,
+) -> tuple[list[str], str | None]:
+    temporary_directory = tempfile.TemporaryDirectory()
+    case_root = Path(temporary_directory.name)
+    clone_root = case_root / ".polyscope" / "clones"
+    clone_root.mkdir(parents=True)
+    if repository_exists:
+        repo_root = clone_root / "repository-id"
+        worktree = repo_root / "workspace"
+        worktree.mkdir(parents=True)
+        for index in range(unregistered_worktree_count):
+            (repo_root / f"orphan-{index}").mkdir()
+        if escaping_symlink:
+            outside_preview = case_root / "outside-preview"
+            outside_preview.mkdir()
+            (repo_root / "rogue-alias").symlink_to(
+                outside_preview,
+                target_is_directory=True,
+            )
+        if broken_symlink:
+            (repo_root / "broken-alias").symlink_to(
+                case_root / "missing-outside-preview",
+                target_is_directory=True,
+            )
+        if broken_internal_symlink:
+            (repo_root / "broken-internal-alias").symlink_to(
+                "missing-worktree",
+                target_is_directory=True,
+            )
 
-orphan_order, orphan_provisioned, orphan_failures = run_case(
-    marker_hit=False,
-    setup_fails=False,
-    unregistered_worktree_count=1,
-)
+    order: list[str] = []
+
+    def deny_clone(*_args, **_kwargs) -> None:
+        order.append("deny-clone")
+        if clone_deny_fails:
+            raise RuntimeError("expected clone ACL denial failure")
+
+    def deny_repository(_clone_root, denied_path, **_kwargs) -> None:
+        order.append(f"deny-repository:{denied_path.name}")
+        if repository_deny_fails:
+            raise RuntimeError("expected repository ACL denial failure")
+
+    def deny_child(_clone_root, denied_path, **_kwargs) -> None:
+        order.append(f"deny:{denied_path.name}")
+        if child_deny_fails:
+            raise RuntimeError("expected child ACL denial failure")
+
+    module.deny_preview_nginx_clone_access = deny_clone
+    module.deny_preview_nginx_repository_access = deny_repository
+    module.deny_preview_nginx_access = deny_child
+
+    error_message = None
+    try:
+        module.revoke_all_preview_nginx_access(clone_root)
+    except RuntimeError as error:
+        error_message = str(error)
+    temporary_directory.cleanup()
+    return order, error_message
+
+
+empty_order, empty_error = run_revoke_case(repository_exists=False)
+assert empty_order == ["deny-clone"], empty_order
+assert empty_error is None
+
+orphan_order, orphan_error = run_revoke_case(unregistered_worktree_count=1)
 assert orphan_order == [
-    "deny-repository",
+    "deny-clone",
+    "deny-repository:repository-id",
     "deny:orphan-0",
     "deny:workspace",
-    "validate-repos",
-    "validate",
-    "setup",
-    "grant-clean",
 ], orphan_order
-assert orphan_provisioned == ["frontend:workspace"]
-assert orphan_failures == []
+assert orphan_error is None
 
-symlink_order, symlink_provisioned, symlink_failures = run_case(
-    marker_hit=False,
-    setup_fails=False,
-    escaping_symlink=True,
+escaping_order, escaping_error = run_revoke_case(escaping_symlink=True)
+assert escaping_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], escaping_order
+assert escaping_error is not None and "escaping symlink" in escaping_error
+
+broken_order, broken_error = run_revoke_case(broken_symlink=True)
+assert broken_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], broken_order
+assert broken_error is not None and "unresolved symlink" in broken_error
+
+internal_broken_order, internal_broken_error = run_revoke_case(
+    broken_internal_symlink=True,
 )
-assert symlink_order == ["deny-repository", "deny:workspace"], symlink_order
-assert symlink_provisioned == []
-assert len(symlink_failures) == 1
+assert internal_broken_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], internal_broken_order
+assert internal_broken_error is None
+
+clone_failure_order, clone_failure_error = run_revoke_case(clone_deny_fails=True)
+assert clone_failure_order == ["deny-clone"], clone_failure_order
+assert clone_failure_error == "expected clone ACL denial failure"
+
+repository_failure_order, repository_failure_error = run_revoke_case(
+    repository_deny_fails=True,
+)
+assert repository_failure_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+], repository_failure_order
+assert repository_failure_error == "expected repository ACL denial failure"
+
+child_failure_order, child_failure_error = run_revoke_case(child_deny_fails=True)
+assert child_failure_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], child_failure_order
+assert child_failure_error == "expected child ACL denial failure"
+
+main_order: list[str] = []
+
+
+@contextlib.contextmanager
+def observed_provision_lock(_lock_path):
+    main_order.append("lock-enter")
+    try:
+        yield
+    finally:
+        main_order.append("lock-exit")
+
+
+module.parse_args = lambda: SimpleNamespace(
+    clone_root=Path("/tmp/unused-clone-root"),
+    provision_lock_path=Path("/tmp/unused-provision.lock"),
+    provision_worktrees=True,
+    workspace_root=Path("/tmp/unused-workspace-root"),
+)
+module.dispatch_validation_only_direct_mode = lambda _args: None
+module.dispatch_instruction_dependent_direct_api_mode = lambda _args: None
+module.provision_worktree_lock = observed_provision_lock
+module.build_repo_specs = lambda _workspace_root: {}
+module.revoke_all_preview_nginx_access = lambda _clone_root: main_order.append("revoke")
+
+
+def fail_source_validation(*_args, **_kwargs) -> None:
+    main_order.append("validate")
+    raise module.CanonicalInstructionValidationError("expected source validation failure")
+
+
+module.validate_repo_instruction_files = fail_source_validation
+assert module.main() == 1
+assert main_order == ["lock-enter", "revoke", "validate", "lock-exit"], main_order
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6905,6 +6905,9 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     clone_root = temporary_root / ".polyscope" / "clones"
     worktree = clone_root / "repository-id" / "workspace"
     worktree.mkdir(parents=True)
+    public_directory = worktree / "public"
+    public_directory.mkdir()
+    (public_directory / "index.php").write_text("<?php")
 
     calls: list[tuple[list[str], dict[str, object]]] = []
     original_run = module.subprocess.run
@@ -6930,8 +6933,26 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         worktree,
     ]
     assert [arguments for arguments, _kwargs in calls] == [
-        ["/usr/bin/setfacl", "-m", "u:www-data:--x", "--", str(path)]
-        for path in expected_paths
+        [
+            "/usr/bin/setfacl",
+            "-x",
+            "d:u:www-data",
+            "--",
+            str(worktree),
+        ],
+        [
+            "/usr/bin/setfacl",
+            "-R",
+            "-P",
+            "-x",
+            "u:www-data,d:u:www-data",
+            "--",
+            str(public_directory),
+        ],
+        *[
+            ["/usr/bin/setfacl", "-m", "u:www-data:--x", "--", str(path)]
+            for path in expected_paths
+        ],
     ]
     assert all(
         kwargs == {"check": True, "capture_output": True, "text": True}
@@ -6967,6 +6988,26 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         module.subprocess.run = original_run
     assert [arguments for arguments, _kwargs in calls] == [
         ["/usr/bin/setfacl", "-m", "u:www-data:---", "--", str(worktree)]
+    ]
+
+    calls.clear()
+    module.subprocess.run = record_run
+    try:
+        module.deny_preview_nginx_repository_access(
+            clone_root,
+            worktree.parent,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+    finally:
+        module.subprocess.run = original_run
+    assert [arguments for arguments, _kwargs in calls] == [
+        [
+            "/usr/bin/setfacl",
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(worktree.parent),
+        ]
     ]
 
     def fail_run(arguments: list[str], **kwargs: object) -> None:
@@ -7007,10 +7048,14 @@ def run_case(
     *,
     marker_hit: bool,
     setup_fails: bool,
+    marker_acl_current: bool = False,
     provisionable: bool = True,
     canonical_validation_fails: bool = False,
     deny_fails: bool = False,
+    repository_deny_fails: bool = False,
     registered_worktree_count: int = 1,
+    unregistered_worktree_count: int = 0,
+    escaping_symlink: bool = False,
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     temporary_directory = tempfile.TemporaryDirectory()
     case_root = Path(temporary_directory.name)
@@ -7022,6 +7067,15 @@ def run_case(
         additional_worktree = clone_root / "repository-id" / f"workspace-{index}"
         additional_worktree.mkdir()
         registered_worktrees.append(additional_worktree)
+    for index in range(unregistered_worktree_count):
+        (clone_root / "repository-id" / f"orphan-{index}").mkdir()
+    if escaping_symlink:
+        outside_preview = case_root / "outside-preview"
+        outside_preview.mkdir()
+        (clone_root / "repository-id" / "rogue-alias").symlink_to(
+            outside_preview,
+            target_is_directory=True,
+        )
     order: list[str] = []
 
     module.validate_repo_instruction_files = lambda *_args, **_kwargs: order.append(
@@ -7050,17 +7104,28 @@ def run_case(
     module.collect_linked_setup_context = lambda *_args, **_kwargs: {}
     module.resolve_current_workspace_name = lambda *_args, **_kwargs: "workspace"
     module.build_setup_hash = lambda *_args, **_kwargs: "setup-hash"
-    module.load_provision_marker = lambda _path: (
-        {"setup_hash": "setup-hash"} if marker_hit else None
-    )
+    marker_payload = {"setup_hash": "setup-hash"}
+    if marker_acl_current:
+        marker_payload["preview_acl_policy_version"] = module.PREVIEW_ACL_POLICY_VERSION
+    module.load_provision_marker = lambda _path: marker_payload if marker_hit else None
 
-    def deny_access(*_args, **_kwargs) -> None:
-        order.append("deny")
+    def deny_repository_access(*_args, **_kwargs) -> None:
+        order.append("deny-repository")
+        if repository_deny_fails:
+            raise RuntimeError("expected repository ACL denial failure")
+
+    def deny_access(_clone_root, denied_path, **_kwargs) -> None:
+        order.append(f"deny:{denied_path.name}")
         if deny_fails:
             raise RuntimeError("expected ACL denial failure")
 
+    module.deny_preview_nginx_repository_access = deny_repository_access
     module.deny_preview_nginx_access = deny_access
-    module.ensure_preview_nginx_access = lambda *_args, **_kwargs: order.append("grant")
+
+    def grant_access(*_args, clean_inherited_acl: bool = True, **_kwargs) -> None:
+        order.append("grant-clean" if clean_inherited_acl else "grant-current")
+
+    module.ensure_preview_nginx_access = grant_access
 
     def run_setup(*_args, **_kwargs) -> None:
         order.append("setup")
@@ -7096,7 +7161,13 @@ failure_order, failure_provisioned, failure_details = run_case(
     marker_hit=False,
     setup_fails=True,
 )
-assert failure_order == ["deny", "validate-repos", "validate", "setup"], failure_order
+assert failure_order == [
+    "deny-repository",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+    "setup",
+], failure_order
 assert failure_provisioned == []
 assert len(failure_details) == 1
 
@@ -7104,15 +7175,43 @@ marker_order, marker_provisioned, marker_failures = run_case(
     marker_hit=True,
     setup_fails=False,
 )
-assert marker_order == ["deny", "validate-repos", "validate", "grant"], marker_order
+assert marker_order == [
+    "deny-repository",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+    "grant-clean",
+], marker_order
 assert marker_provisioned == []
 assert marker_failures == []
+
+current_marker_order, current_marker_provisioned, current_marker_failures = run_case(
+    marker_hit=True,
+    marker_acl_current=True,
+    setup_fails=False,
+)
+assert current_marker_order == [
+    "deny-repository",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+    "grant-current",
+], current_marker_order
+assert current_marker_provisioned == []
+assert current_marker_failures == []
 
 success_order, success_provisioned, success_failures = run_case(
     marker_hit=False,
     setup_fails=False,
 )
-assert success_order == ["deny", "validate-repos", "validate", "setup", "grant"], success_order
+assert success_order == [
+    "deny-repository",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+    "setup",
+    "grant-clean",
+], success_order
 assert success_provisioned == ["frontend:workspace"]
 assert success_failures == []
 
@@ -7121,7 +7220,12 @@ invalid_order, invalid_provisioned, invalid_failures = run_case(
     setup_fails=False,
     provisionable=False,
 )
-assert invalid_order == ["deny", "validate-repos", "validate"], invalid_order
+assert invalid_order == [
+    "deny-repository",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+], invalid_order
 assert invalid_provisioned == []
 assert invalid_failures == []
 
@@ -7132,8 +7236,9 @@ canonical_order, canonical_provisioned, canonical_failures = run_case(
     registered_worktree_count=2,
 )
 assert canonical_order == [
-    "deny",
-    "deny",
+    "deny-repository",
+    "deny:workspace",
+    "deny:workspace-1",
     "validate-repos",
     "validate",
     "validate",
@@ -7146,9 +7251,44 @@ deny_failure_order, deny_failure_provisioned, deny_failure_details = run_case(
     setup_fails=False,
     deny_fails=True,
 )
-assert deny_failure_order == ["deny"], deny_failure_order
+assert deny_failure_order == ["deny-repository", "deny:workspace"], deny_failure_order
 assert deny_failure_provisioned == []
 assert len(deny_failure_details) == 1
+
+repository_failure_order, repository_failure_provisioned, repository_failure_details = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    repository_deny_fails=True,
+)
+assert repository_failure_order == ["deny-repository"], repository_failure_order
+assert repository_failure_provisioned == []
+assert len(repository_failure_details) == 1
+
+orphan_order, orphan_provisioned, orphan_failures = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    unregistered_worktree_count=1,
+)
+assert orphan_order == [
+    "deny-repository",
+    "deny:orphan-0",
+    "deny:workspace",
+    "validate-repos",
+    "validate",
+    "setup",
+    "grant-clean",
+], orphan_order
+assert orphan_provisioned == ["frontend:workspace"]
+assert orphan_failures == []
+
+symlink_order, symlink_provisioned, symlink_failures = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    escaping_symlink=True,
+)
+assert symlink_order == ["deny-repository", "deny:workspace"], symlink_order
+assert symlink_provisioned == []
+assert len(symlink_failures) == 1
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4621,7 +4621,12 @@ grep -qF "set \$php_root \$guardguide_public;" "$nginx_output"
 grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
-grep -qF "disable_symlinks on from=\$preview_docroot;" "$nginx_output"
+grep -qF "set \$preview_worktree /home/secpal/.polyscope/__missing_preview_worktree__;" "$nginx_output"
+grep -qF "disable_symlinks on from=\$preview_worktree;" "$nginx_output"
+if grep -qF "disable_symlinks on from=\$preview_docroot;" "$nginx_output"; then
+    echo "preview nginx config must check the document-root symlink itself" >&2
+    exit 1
+fi
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
 grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
@@ -6959,6 +6964,13 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     assert [arguments for arguments, _kwargs in calls] == [
         [
             "/usr/bin/setfacl",
+            "-x",
+            "d:u:www-data",
+            "--",
+            str(worktree),
+        ],
+        [
+            "/usr/bin/setfacl",
             "-R",
             "-P",
             "-m",
@@ -7007,7 +7019,14 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         [
             "/usr/bin/setfacl",
             "-m",
-            "u:www-data:---,d:u:www-data:---",
+            "u:www-data:---",
+            "--",
+            str(missing_document_root_worktree),
+        ],
+        [
+            "/usr/bin/setfacl",
+            "-x",
+            "d:u:www-data",
             "--",
             str(missing_document_root_worktree),
         ],
@@ -7054,7 +7073,7 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         [
             "/usr/bin/setfacl",
             "-m",
-            "u:www-data:---,d:u:www-data:---",
+            "u:www-data:---",
             "--",
             str(worktree),
         ]
@@ -7124,6 +7143,7 @@ PY
 python3 - "$PYTHON_SCRIPT" <<'PY'
 import contextlib
 import importlib.util
+import sys
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -7276,6 +7296,7 @@ assert len(canonical_failures) == 2
 
 def run_revoke_case(
     *,
+    clone_exists: bool = True,
     repository_exists: bool = True,
     unregistered_worktree_count: int = 0,
     escaping_symlink: bool = False,
@@ -7290,7 +7311,8 @@ def run_revoke_case(
     temporary_directory = tempfile.TemporaryDirectory()
     case_root = Path(temporary_directory.name)
     clone_root = case_root / ".polyscope" / "clones"
-    clone_root.mkdir(parents=True)
+    if clone_exists:
+        clone_root.mkdir(parents=True)
     if repository_exists:
         repo_root = clone_root / "repository-id"
         worktree = repo_root / "workspace"
@@ -7359,6 +7381,13 @@ def run_revoke_case(
 empty_order, empty_error = run_revoke_case(repository_exists=False)
 assert empty_order == ["deny-clone"], empty_order
 assert empty_error is None
+
+missing_clone_order, missing_clone_error = run_revoke_case(
+    clone_exists=False,
+    repository_exists=False,
+)
+assert missing_clone_order == ["deny-clone"], missing_clone_order
+assert missing_clone_error is None
 
 orphan_order, orphan_error = run_revoke_case(unregistered_worktree_count=1)
 assert orphan_order == [
@@ -7448,6 +7477,7 @@ def observed_provision_lock(_lock_path):
 
 module.parse_args = lambda: SimpleNamespace(
     clone_root=Path("/tmp/unused-clone-root"),
+    install_nginx=False,
     provision_lock_path=Path("/tmp/unused-provision.lock"),
     provision_worktrees=True,
     workspace_root=Path("/tmp/unused-workspace-root"),
@@ -7467,6 +7497,64 @@ def fail_source_validation(*_args, **_kwargs) -> None:
 module.validate_repo_instruction_files = fail_source_validation
 assert module.main() == 1
 assert main_order == ["lock-enter", "revoke", "validate", "lock-exit"], main_order
+
+main_order.clear()
+module.parse_args = lambda: SimpleNamespace(
+    clone_root=Path("/tmp/unused-clone-root"),
+    install_nginx=True,
+    provision_lock_path=Path("/tmp/unused-provision.lock"),
+    provision_worktrees=False,
+    workspace_root=Path("/tmp/unused-workspace-root"),
+)
+assert module.main() == 1
+assert main_order == ["lock-enter", "revoke", "validate", "lock-exit"], main_order
+
+rollout_order: list[str] = []
+with tempfile.TemporaryDirectory() as temporary_directory:
+    temporary_root = Path(temporary_directory)
+    args = SimpleNamespace(
+        clone_root=temporary_root / "clones",
+        db_path=temporary_root / "polyscope.db",
+        install_nginx=True,
+        nginx_http2_syntax="modern",
+        nginx_manifest_output=temporary_root / "nginx-manifest.json",
+        nginx_output=temporary_root / "preview.nginx.conf",
+        polyscope_api_base="http://127.0.0.1:4321/api",
+        provision_worktrees=False,
+        repo_state_file=temporary_root / "repo-state.json",
+        skip_db_sync=True,
+        skip_local_configs=True,
+        summary_output=None,
+        workspace_root=temporary_root / "workspace",
+    )
+    args.clone_root.mkdir()
+
+    module.build_repo_specs = lambda _workspace_root: {}
+    module.revoke_all_preview_nginx_access = lambda _clone_root: rollout_order.append("revoke")
+    module.validate_repo_instruction_files = lambda *_args: rollout_order.append("validate")
+    module.validate_repo_local_configs = lambda _repo_specs: None
+    module.load_repo_state = lambda _path: {}
+    module.detect_nginx_http2_syntax = lambda: "modern"
+    module.render_nginx_config = lambda *_args, **_kwargs: "rendered\n"
+    module.provision_worktrees = lambda *_args, **_kwargs: (
+        rollout_order.append("provision") or ([], [], [])
+    )
+    module.write_nginx_manifest = lambda *_args, **_kwargs: rollout_order.append("manifest")
+    module.install_nginx_config = lambda _path: rollout_order.append("install")
+    module.build_summary = lambda *_args: {}
+    sys.modules["polyscope_nginx"] = SimpleNamespace(
+        build_manifest=lambda *_args, **_kwargs: {},
+        write_manifest_atomic=lambda *_args, **_kwargs: None,
+    )
+
+    assert module.run_rollout(args) == 0
+    assert rollout_order == [
+        "revoke",
+        "validate",
+        "provision",
+        "manifest",
+        "install",
+    ], rollout_order
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6908,11 +6908,24 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     public_directory = worktree / "public"
     public_directory.mkdir()
     (public_directory / "index.php").write_text("<?php")
+    assets_directory = public_directory / "assets"
+    assets_directory.mkdir()
+    (assets_directory / "app.js").write_text("console.log('preview')")
 
     calls: list[tuple[list[str], dict[str, object]]] = []
     original_run = module.subprocess.run
 
     def record_run(arguments: list[str], **kwargs: object) -> None:
+        if (
+            "-R" in arguments
+            and "-d" not in arguments
+            and any("d:u:www-data" in argument for argument in arguments)
+        ):
+            raise subprocess.CalledProcessError(
+                1,
+                arguments,
+                stderr="Only directories can have default ACLs",
+            )
         calls.append((arguments, kwargs))
 
     module.subprocess.run = record_run
@@ -6935,17 +6948,20 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     assert [arguments for arguments, _kwargs in calls] == [
         [
             "/usr/bin/setfacl",
-            "-x",
-            "d:u:www-data",
+            "-R",
+            "-P",
+            "-m",
+            "u:www-data:rX",
             "--",
-            str(worktree),
+            str(public_directory),
         ],
         [
             "/usr/bin/setfacl",
             "-R",
             "-P",
+            "-d",
             "-m",
-            "u:www-data:rX,d:u:www-data:r-x",
+            "u:www-data:r-x",
             "--",
             str(public_directory),
         ],
@@ -6958,6 +6974,43 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         kwargs == {"check": True, "capture_output": True, "text": True}
         for _arguments, kwargs in calls
     )
+
+    calls.clear()
+    missing_document_root_worktree = clone_root / "repository-id" / "missing-document-root"
+    missing_document_root_worktree.mkdir()
+    module.subprocess.run = record_run
+    try:
+        module.deny_preview_nginx_access(
+            clone_root,
+            missing_document_root_worktree,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+        module.ensure_preview_nginx_access(
+            clone_root,
+            missing_document_root_worktree,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+    finally:
+        module.subprocess.run = original_run
+    assert [arguments for arguments, _kwargs in calls] == [
+        [
+            "/usr/bin/setfacl",
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(missing_document_root_worktree),
+        ],
+        *[
+            ["/usr/bin/setfacl", "-m", "u:www-data:--x", "--", str(path)]
+            for path in [
+                clone_root.parent.parent,
+                clone_root.parent,
+                clone_root,
+                missing_document_root_worktree.parent,
+                missing_document_root_worktree,
+            ]
+        ],
+    ]
 
     calls.clear()
     original_resolve_executable = module.resolve_executable
@@ -6987,7 +7040,13 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     finally:
         module.subprocess.run = original_run
     assert [arguments for arguments, _kwargs in calls] == [
-        ["/usr/bin/setfacl", "-m", "u:www-data:---", "--", str(worktree)]
+        [
+            "/usr/bin/setfacl",
+            "-m",
+            "u:www-data:---,d:u:www-data:---",
+            "--",
+            str(worktree),
+        ]
     ]
 
     calls.clear()
@@ -7211,6 +7270,8 @@ def run_revoke_case(
     escaping_symlink: bool = False,
     broken_symlink: bool = False,
     broken_internal_symlink: bool = False,
+    internal_symlink: bool = False,
+    registered_internal_symlink: bool = False,
     clone_deny_fails: bool = False,
     repository_deny_fails: bool = False,
     child_deny_fails: bool = False,
@@ -7242,6 +7303,17 @@ def run_revoke_case(
                 "missing-worktree",
                 target_is_directory=True,
             )
+        if internal_symlink or registered_internal_symlink:
+            alias_name = "managed-alias" if registered_internal_symlink else "rogue-alias"
+            (repo_root / alias_name).symlink_to(
+                worktree.name,
+                target_is_directory=True,
+            )
+            if registered_internal_symlink:
+                module.write_workspace_alias_registry(
+                    repo_root,
+                    {alias_name: worktree.name},
+                )
 
     order: list[str] = []
 
@@ -7310,7 +7382,25 @@ assert internal_broken_order == [
     "deny-repository:repository-id",
     "deny:workspace",
 ], internal_broken_order
-assert internal_broken_error is None
+assert internal_broken_error is not None and "unregistered workspace alias" in internal_broken_error
+
+internal_order, internal_error = run_revoke_case(internal_symlink=True)
+assert internal_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], internal_order
+assert internal_error is not None and "unregistered workspace alias" in internal_error
+
+managed_alias_order, managed_alias_error = run_revoke_case(
+    registered_internal_symlink=True,
+)
+assert managed_alias_order == [
+    "deny-clone",
+    "deny-repository:repository-id",
+    "deny:workspace",
+], managed_alias_order
+assert managed_alias_error is None
 
 clone_failure_order, clone_failure_error = run_revoke_case(clone_deny_fails=True)
 assert clone_failure_order == ["deny-clone"], clone_failure_order

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -7003,20 +7003,42 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 
-def run_case(*, marker_hit: bool, setup_fails: bool) -> tuple[list[str], list[str], list[dict[str, str]]]:
+def run_case(
+    *,
+    marker_hit: bool,
+    setup_fails: bool,
+    provisionable: bool = True,
+    canonical_validation_fails: bool = False,
+    deny_fails: bool = False,
+    registered_worktree_count: int = 1,
+) -> tuple[list[str], list[str], list[dict[str, str]]]:
     temporary_directory = tempfile.TemporaryDirectory()
     case_root = Path(temporary_directory.name)
     clone_root = case_root / ".polyscope" / "clones"
     worktree = clone_root / "repository-id" / "workspace"
     worktree.mkdir(parents=True)
+    registered_worktrees = [worktree]
+    for index in range(1, registered_worktree_count):
+        additional_worktree = clone_root / "repository-id" / f"workspace-{index}"
+        additional_worktree.mkdir()
+        registered_worktrees.append(additional_worktree)
     order: list[str] = []
 
-    module.validate_repo_instruction_files = lambda *_args, **_kwargs: None
+    module.validate_repo_instruction_files = lambda *_args, **_kwargs: order.append(
+        "validate-repos"
+    )
     module.load_registered_worktree_paths = lambda *_args, **_kwargs: {
         "api": [],
-        "frontend": [worktree],
+        "frontend": registered_worktrees,
     }
-    module.is_provisionable_worktree = lambda *_args, **_kwargs: True
+
+    def is_provisionable(*_args, **_kwargs) -> bool:
+        order.append("validate")
+        if canonical_validation_fails:
+            raise module.CanonicalInstructionValidationError("expected validation failure")
+        return provisionable
+
+    module.is_provisionable_worktree = is_provisionable
     module.cleanup_removed_workspace_aliases = lambda *_args, **_kwargs: []
     module.cleanup_removed_api_preview_databases = lambda *_args, **_kwargs: []
     module.preserve_registered_workspace_physical_path = lambda *_args, **_kwargs: None
@@ -7031,7 +7053,13 @@ def run_case(*, marker_hit: bool, setup_fails: bool) -> tuple[list[str], list[st
     module.load_provision_marker = lambda _path: (
         {"setup_hash": "setup-hash"} if marker_hit else None
     )
-    module.deny_preview_nginx_access = lambda *_args, **_kwargs: order.append("deny")
+
+    def deny_access(*_args, **_kwargs) -> None:
+        order.append("deny")
+        if deny_fails:
+            raise RuntimeError("expected ACL denial failure")
+
+    module.deny_preview_nginx_access = deny_access
     module.ensure_preview_nginx_access = lambda *_args, **_kwargs: order.append("grant")
 
     def run_setup(*_args, **_kwargs) -> None:
@@ -7068,7 +7096,7 @@ failure_order, failure_provisioned, failure_details = run_case(
     marker_hit=False,
     setup_fails=True,
 )
-assert failure_order == ["deny", "setup"], failure_order
+assert failure_order == ["deny", "validate-repos", "validate", "setup"], failure_order
 assert failure_provisioned == []
 assert len(failure_details) == 1
 
@@ -7076,7 +7104,7 @@ marker_order, marker_provisioned, marker_failures = run_case(
     marker_hit=True,
     setup_fails=False,
 )
-assert marker_order == ["deny", "grant"], marker_order
+assert marker_order == ["deny", "validate-repos", "validate", "grant"], marker_order
 assert marker_provisioned == []
 assert marker_failures == []
 
@@ -7084,9 +7112,43 @@ success_order, success_provisioned, success_failures = run_case(
     marker_hit=False,
     setup_fails=False,
 )
-assert success_order == ["deny", "setup", "grant"], success_order
+assert success_order == ["deny", "validate-repos", "validate", "setup", "grant"], success_order
 assert success_provisioned == ["frontend:workspace"]
 assert success_failures == []
+
+invalid_order, invalid_provisioned, invalid_failures = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    provisionable=False,
+)
+assert invalid_order == ["deny", "validate-repos", "validate"], invalid_order
+assert invalid_provisioned == []
+assert invalid_failures == []
+
+canonical_order, canonical_provisioned, canonical_failures = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    canonical_validation_fails=True,
+    registered_worktree_count=2,
+)
+assert canonical_order == [
+    "deny",
+    "deny",
+    "validate-repos",
+    "validate",
+    "validate",
+], canonical_order
+assert canonical_provisioned == []
+assert len(canonical_failures) == 2
+
+deny_failure_order, deny_failure_provisioned, deny_failure_details = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    deny_fails=True,
+)
+assert deny_failure_order == ["deny"], deny_failure_order
+assert deny_failure_provisioned == []
+assert len(deny_failure_details) == 1
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6813,6 +6813,66 @@ fi
 grep -qF 'fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)' "$workspace_root/frontend/polyscope.local.json"
 grep -qF '.polyscope-preview-stage' "$workspace_root/frontend/polyscope.local.json"
 grep -qF 'build.lock' "$workspace_root/frontend/polyscope.local.json"
+python3 - "$PYTHON_SCRIPT" <<'PY'
+import importlib.util
+import os
+import shlex
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+def generated_namespace(command: str, terminator: str) -> dict[str, object]:
+    argv = shlex.split(command)
+    assert argv[:2] == ["python3", "-c"], argv
+    source = argv[2].split(terminator, 1)[0]
+    namespace: dict[str, object] = {}
+    exec(source, namespace)
+    return namespace
+
+
+for command, terminator in (
+    (module.build_frontend_preview_build_command(), "\nworkspace = resolve_current_workspace"),
+    (module.build_frontend_preview_build_watch_command(), "\ndef run_build"),
+):
+    namespace = generated_namespace(command, terminator)
+    publish_preview_build = namespace["publish_preview_build"]
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        worktree = Path(temporary_directory)
+        stage_dir = worktree / "stage"
+        assets_dir = stage_dir / "assets"
+        assets_dir.mkdir(parents=True)
+        os.chmod(assets_dir, 0o700)
+
+        index_file = stage_dir / "index.html"
+        index_file.write_text("<!doctype html>")
+        os.chmod(index_file, 0o600)
+
+        asset_file = assets_dir / "app.js"
+        asset_file.write_text("console.log('preview')")
+        os.chmod(asset_file, 0o600)
+
+        previous_directory = Path.cwd()
+        try:
+            os.chdir(worktree)
+            publish_preview_build(stage_dir)
+        finally:
+            os.chdir(previous_directory)
+
+        dist_dir = worktree / "dist"
+        assert stat.S_IMODE(dist_dir.stat().st_mode) == 0o755
+        assert stat.S_IMODE((dist_dir / "assets").stat().st_mode) == 0o755
+        assert stat.S_IMODE((dist_dir / "index.html").stat().st_mode) == 0o644
+        assert stat.S_IMODE((dist_dir / "assets" / "app.js").stat().st_mode) == 0o644
+PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6873,6 +6873,78 @@ for command, terminator in (
         assert stat.S_IMODE((dist_dir / "index.html").stat().st_mode) == 0o644
         assert stat.S_IMODE((dist_dir / "assets" / "app.js").stat().st_mode) == 0o644
 PY
+python3 - "$PYTHON_SCRIPT" <<'PY'
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+with tempfile.TemporaryDirectory() as temporary_directory:
+    temporary_root = Path(temporary_directory)
+    clone_root = temporary_root / ".polyscope" / "clones"
+    worktree = clone_root / "repository-id" / "workspace"
+    worktree.mkdir(parents=True)
+
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    original_run = module.subprocess.run
+
+    def record_run(arguments: list[str], **kwargs: object) -> None:
+        calls.append((arguments, kwargs))
+
+    module.subprocess.run = record_run
+    try:
+        module.ensure_preview_nginx_access(
+            clone_root,
+            worktree,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+    finally:
+        module.subprocess.run = original_run
+
+    expected_paths = [
+        clone_root.parent,
+        clone_root,
+        worktree.parent,
+        worktree,
+    ]
+    assert [arguments for arguments, _kwargs in calls] == [
+        ["/usr/bin/setfacl", "-m", "u:www-data:--x", "--", str(path)]
+        for path in expected_paths
+    ]
+    assert all(
+        kwargs == {"check": True, "capture_output": True, "text": True}
+        for _arguments, kwargs in calls
+    )
+
+    def fail_run(arguments: list[str], **kwargs: object) -> None:
+        raise subprocess.CalledProcessError(
+            1,
+            arguments,
+            stderr="Operation not supported",
+        )
+
+    module.subprocess.run = fail_run
+    try:
+        try:
+            module.ensure_preview_nginx_access(
+                clone_root,
+                worktree,
+                setfacl_bin="/usr/bin/setfacl",
+            )
+        except RuntimeError as error:
+            assert "unable to grant Nginx preview access" in str(error)
+        else:
+            raise AssertionError("setfacl failure must stop provisioning")
+    finally:
+        module.subprocess.run = original_run
+PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"
 grep -q 'restart polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2159,7 +2159,7 @@ build_script = shlex.split(build_command)[2]
 build_publish_source = build_script[
     build_script.index("def publish_preview_build(stage_dir: Path) -> None:") : build_script.index("workspace = resolve_current_workspace(Path.cwd())")
 ]
-assert build_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < build_publish_source.index(
+assert build_publish_source.index('replace_file(deferred_index, live_root / "index.html")') < build_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), build_publish_source
 assert "child.is_symlink()" in build_script, build_script
@@ -2177,8 +2177,8 @@ assert frontend_worktree.joinpath("dist", "assets", "removed.js").is_file()
 assert frontend_worktree.joinpath("dist", "assets", "shape").is_dir()
 
 failing_build_script = build_script.replace(
-    "def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:\n",
-    """def replace_file(src_file: Path, dest_file: Path, tmp_dir: Path) -> None:
+    "def replace_file(src_file: Path, dest_file: Path) -> None:\n",
+    """def replace_file(src_file: Path, dest_file: Path) -> None:
     if src_file.name == "index.html" and dest_file.name == "index.html" and os.environ.get("FAIL_INDEX_SWAP") == "1":
         raise RuntimeError("simulated index replace failure")
 """,
@@ -2291,7 +2291,7 @@ assert 'Path("dist")' in watch_script, watch_script
 assert 'Path("node_modules/.package-lock.json")' in watch_script, watch_script
 assert 'Path("node_modules/.bin/cross-env")' not in watch_script, watch_script
 assert 'Path("node_modules/.bin/vite")' not in watch_script, watch_script
-assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html", tmp_dir)') < watch_publish_source.index(
+assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html")') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
@@ -4621,6 +4621,7 @@ grep -qF "set \$php_root \$guardguide_public;" "$nginx_output"
 grep -qF "try_files \$uri @preview_router;" "$nginx_output"
 grep -qF "try_files \$uri/index.html /index.html =404;" "$nginx_output"
 grep -qF "set \$preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;" "$nginx_output"
+grep -qF "disable_symlinks on from=\$preview_docroot;" "$nginx_output"
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
 grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
@@ -6873,6 +6874,13 @@ for command, terminator in (
         asset_file.write_text("console.log('preview')")
         os.chmod(asset_file, 0o600)
 
+        copied_xattr = "user.secpal-preview-source-metadata"
+        try:
+            os.setxattr(index_file, copied_xattr, b"must-not-be-published")
+            os.setxattr(asset_file, copied_xattr, b"must-not-be-published")
+        except OSError:
+            copied_xattr = ""
+
         previous_directory = Path.cwd()
         try:
             os.chdir(worktree)
@@ -6885,6 +6893,9 @@ for command, terminator in (
         assert stat.S_IMODE((dist_dir / "assets").stat().st_mode) == 0o755
         assert stat.S_IMODE((dist_dir / "index.html").stat().st_mode) == 0o644
         assert stat.S_IMODE((dist_dir / "assets" / "app.js").stat().st_mode) == 0o644
+        if copied_xattr:
+            assert copied_xattr not in os.listxattr(dist_dir / "index.html")
+            assert copied_xattr not in os.listxattr(dist_dir / "assets" / "app.js")
 PY
 python3 - "$PYTHON_SCRIPT" <<'PY'
 import importlib.util

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PYTHON_SCRIPT="$REPO_ROOT/scripts/polyscope-rollout.py"
+PYTHON_SOURCE="$REPO_ROOT/scripts/polyscope-rollout.py"
 INSTALL_SCRIPT="$REPO_ROOT/scripts/install-polyscope-rollout.sh"
 PRETTIER_BIN="$REPO_ROOT/node_modules/.bin/prettier"
 
@@ -34,6 +34,19 @@ PY
 
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-rollout.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
+
+fake_setfacl="$workspace/fake-tools/setfacl"
+mkdir -p "$(dirname "$fake_setfacl")"
+cat >"$fake_setfacl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$fake_setfacl"
+
+grep -qF 'FIXED_SETFACL_BIN = "/usr/bin/setfacl"' "$PYTHON_SOURCE"
+PYTHON_SCRIPT="$PYTHON_SOURCE"
+export POLYSCOPE_TEST_ALLOW_SETFACL_OVERRIDE=1
+export POLYSCOPE_TEST_SETFACL_BIN="$fake_setfacl"
 
 workspace_root="$workspace/SecPal"
 home_dir="$workspace/home"
@@ -6875,6 +6888,7 @@ for command, terminator in (
 PY
 python3 - "$PYTHON_SCRIPT" <<'PY'
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -6924,6 +6938,37 @@ with tempfile.TemporaryDirectory() as temporary_directory:
         for _arguments, kwargs in calls
     )
 
+    calls.clear()
+    original_resolve_executable = module.resolve_executable
+    test_setfacl_bin = os.environ.pop("POLYSCOPE_TEST_SETFACL_BIN")
+    test_allow_override = os.environ.pop("POLYSCOPE_TEST_ALLOW_SETFACL_OVERRIDE")
+    module.resolve_executable = lambda _command: "/tmp/shadowed-setfacl"
+    module.subprocess.run = record_run
+    try:
+        module.ensure_preview_nginx_access(clone_root, worktree)
+    finally:
+        os.environ["POLYSCOPE_TEST_SETFACL_BIN"] = test_setfacl_bin
+        os.environ["POLYSCOPE_TEST_ALLOW_SETFACL_OVERRIDE"] = test_allow_override
+        module.resolve_executable = original_resolve_executable
+        module.subprocess.run = original_run
+
+    assert calls
+    assert all(arguments[0] == module.FIXED_SETFACL_BIN for arguments, _kwargs in calls)
+
+    calls.clear()
+    module.subprocess.run = record_run
+    try:
+        module.deny_preview_nginx_access(
+            clone_root,
+            worktree,
+            setfacl_bin="/usr/bin/setfacl",
+        )
+    finally:
+        module.subprocess.run = original_run
+    assert [arguments for arguments, _kwargs in calls] == [
+        ["/usr/bin/setfacl", "-m", "u:www-data:---", "--", str(worktree)]
+    ]
+
     def fail_run(arguments: list[str], **kwargs: object) -> None:
         raise subprocess.CalledProcessError(
             1,
@@ -6945,6 +6990,103 @@ with tempfile.TemporaryDirectory() as temporary_directory:
             raise AssertionError("setfacl failure must stop provisioning")
     finally:
         module.subprocess.run = original_run
+PY
+python3 - "$PYTHON_SCRIPT" <<'PY'
+import importlib.util
+import tempfile
+from pathlib import Path
+
+script_path = Path(__import__("sys").argv[1])
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+def run_case(*, marker_hit: bool, setup_fails: bool) -> tuple[list[str], list[str], list[dict[str, str]]]:
+    temporary_directory = tempfile.TemporaryDirectory()
+    case_root = Path(temporary_directory.name)
+    clone_root = case_root / ".polyscope" / "clones"
+    worktree = clone_root / "repository-id" / "workspace"
+    worktree.mkdir(parents=True)
+    order: list[str] = []
+
+    module.validate_repo_instruction_files = lambda *_args, **_kwargs: None
+    module.load_registered_worktree_paths = lambda *_args, **_kwargs: {
+        "api": [],
+        "frontend": [worktree],
+    }
+    module.is_provisionable_worktree = lambda *_args, **_kwargs: True
+    module.cleanup_removed_workspace_aliases = lambda *_args, **_kwargs: []
+    module.cleanup_removed_api_preview_databases = lambda *_args, **_kwargs: []
+    module.preserve_registered_workspace_physical_path = lambda *_args, **_kwargs: None
+    module.render_worktree_local_config = lambda *_args, **_kwargs: "{}\n"
+    module.sync_worktree_local_config = lambda *_args, **_kwargs: None
+    module.ensure_workspace_alias = lambda *_args, **_kwargs: None
+    module.sync_worktree_auxiliary_files = lambda *_args, **_kwargs: None
+    module.ensure_worktree_hooks = lambda *_args, **_kwargs: None
+    module.collect_linked_setup_context = lambda *_args, **_kwargs: {}
+    module.resolve_current_workspace_name = lambda *_args, **_kwargs: "workspace"
+    module.build_setup_hash = lambda *_args, **_kwargs: "setup-hash"
+    module.load_provision_marker = lambda _path: (
+        {"setup_hash": "setup-hash"} if marker_hit else None
+    )
+    module.deny_preview_nginx_access = lambda *_args, **_kwargs: order.append("deny")
+    module.ensure_preview_nginx_access = lambda *_args, **_kwargs: order.append("grant")
+
+    def run_setup(*_args, **_kwargs) -> None:
+        order.append("setup")
+        if setup_fails:
+            raise RuntimeError("expected setup failure")
+
+    module.run_setup_commands = run_setup
+    repo_state = {
+        "frontend": {
+            "id": "repository-id",
+            "name": "SecPal/frontend",
+            "path": str(case_root / "source-frontend"),
+        }
+    }
+    repo_specs = {
+        "frontend": {
+            module.NATIVE_SETUP_COMMANDS_KEY: ["npm run build"],
+            "path": str(case_root / "source-frontend"),
+            "preview_prefix": "frontend",
+        }
+    }
+    provisioned, _cleaned, failures = module.provision_worktrees(
+        repo_state,
+        repo_specs,
+        clone_root,
+        db_path=case_root / "polyscope.db",
+    )
+    temporary_directory.cleanup()
+    return order, provisioned, failures
+
+
+failure_order, failure_provisioned, failure_details = run_case(
+    marker_hit=False,
+    setup_fails=True,
+)
+assert failure_order == ["deny", "setup"], failure_order
+assert failure_provisioned == []
+assert len(failure_details) == 1
+
+marker_order, marker_provisioned, marker_failures = run_case(
+    marker_hit=True,
+    setup_fails=False,
+)
+assert marker_order == ["deny", "grant"], marker_order
+assert marker_provisioned == []
+assert marker_failures == []
+
+success_order, success_provisioned, success_failures = run_case(
+    marker_hit=False,
+    setup_fails=False,
+)
+assert success_order == ["deny", "setup", "grant"], success_order
+assert success_provisioned == ["frontend:workspace"]
+assert success_failures == []
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"

--- a/tests/polyscope-system-installer.sh
+++ b/tests/polyscope-system-installer.sh
@@ -11,6 +11,9 @@ YAML_CHECK="$REPO_ROOT/scripts/verify-js-yaml-package.cjs"
 WORKSPACE="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-system-installer.XXXXXX")"
 trap 'rm -rf "$WORKSPACE"' EXIT
 
+grep -qF 'if [[ ! -x /usr/bin/setfacl ]]; then' "$INSTALLER"
+grep -qF "Error: /usr/bin/setfacl is required; install the 'acl' package before activation." "$INSTALLER"
+
 node "$YAML_CHECK" "$REPO_ROOT/node_modules/js-yaml"
 
 missing_yaml_entry="$WORKSPACE/missing-yaml-entry/js-yaml"


### PR DESCRIPTION
## Problem and evidence

Preview publication preserved modes from staged assets. Restrictive source modes, such as directories at `0700` and files at `0600`, can leave deployed preview assets unreadable by the web server. Preview worktrees also require traversal permission for the nginx worker.

The regression coverage stages restrictive modes, verifies the published `dist` tree is web-readable for both generated frontend preview commands, and verifies nginx ACL provisioning.

## Change

Normalize published preview directories to `0755` and files to `0644`. Grant the nginx worker traversal-only ACLs on the preview worktree path during provisioning.

## Validation

- `bash tests/polyscope-rollout.sh`
- Full mandatory pre-push validation suite, including REUSE, formatting, domain policy, workflow, instruction, rollout, and package checks
- `git diff --check`

## TDD / Validate-First Evidence

- Failing proof before implementation: The added rollout regression assertions fail against the prior behavior: published assets retain restrictive modes, and nginx ACL provisioning is absent.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` passes with the new mode and ACL assertions.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Dependencies and unresolved checks

No in-scope dependency or unresolved local check prevents readiness.