### PR TITLE
chore(review): register deployment phase B validation

### DIFF
--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -560,8 +560,21 @@
       "default_branch": "main",
       "allowed_base_repositories": ["SecPal/deployment"],
       "reviewer_identities": [],
-      "focused_validation": [],
-      "required_local_validation": [],
+      "focused_validation": [
+        {
+          "argv": ["./scripts/local-integration.sh"],
+          "working_directory": ".",
+          "purpose": "Build and exercise the complete local API/frontend integration stack",
+          "execution_policy": "focused-only"
+        }
+      ],
+      "required_local_validation": [
+        {
+          "argv": ["./scripts/preflight.sh"],
+          "working_directory": ".",
+          "purpose": "Run the deterministic deployment repository preflight"
+        }
+      ],
       "signature_policy": {
         "require_github_verified": true,
         "require_local_verified": true,
@@ -573,7 +586,7 @@
         "expected_skipped": "block"
       },
       "manual_gates": [
-        "Do not deploy, access deployment infrastructure, or use environment-connected validation; this repository currently contains only a governance bootstrap."
+        "The deterministic `./scripts/preflight.sh` target is required. The Docker-backed `./scripts/local-integration.sh` target may be selected when Compose, container roles, runtime secrets, PostgreSQL, Valkey, queue, cache, shared storage, gateway, CORS, Sanctum, browser integration, or lifecycle or cleanup behavior is affected, but requires explicit current authorization for Docker daemon access and outbound GitHub, container-registry, and package-registry network access. Authorization from an earlier task does not carry over. Registry login, image publishing, image push, prune, production infrastructure, public exposure, deployment, live systems, and real secrets remain prohibited."
       ],
       "unsupported_operations": [
         "REVIEW_REQUEST",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-01 - Register Deployment Phase B Validation
+
+**Changed:**
+
+- registered the deterministic deployment preflight as required local validation
+- registered the Docker-backed complete local integration target as focused-only
+  and required explicit current authorization for Docker daemon and outbound
+  GitHub, container-registry, and package-registry network access
+- kept registry login, image publishing and push, prune, production
+  infrastructure, public exposure, deployment, live systems, and real secrets
+  prohibited
+- continued to derive Required Checks from live rulesets and branch protection
+
+---
+
 ## 2026-08-01 - Remove Retired Changelog Integration
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Log of notable changes to SecPal organization defaults (newest first).
 - registered the Docker-backed complete local integration target as focused-only
   and required explicit current authorization for Docker daemon and outbound
   GitHub, container-registry, and package-registry network access
-- kept registry login, image publishing and push, prune, production
+- kept registry login, image publishing, image push, prune, production
   infrastructure, public exposure, deployment, live systems, and real secrets
   prohibited
 - continued to derive Required Checks from live rulesets and branch protection

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3720,8 +3720,30 @@ class RegistryTests(TestCase):
         self.assertEqual(deployment["default_branch"], "main")
         self.assertEqual(deployment["allowed_base_repositories"], ["SecPal/deployment"])
         self.assertEqual(deployment["reviewer_identities"], [])
-        self.assertEqual(deployment["focused_validation"], [])
-        self.assertEqual(deployment["required_local_validation"], [])
+        self.assertEqual(
+            deployment["focused_validation"],
+            [
+                {
+                    "argv": ["./scripts/local-integration.sh"],
+                    "working_directory": ".",
+                    "purpose": (
+                        "Build and exercise the complete local API/frontend "
+                        "integration stack"
+                    ),
+                    "execution_policy": "focused-only",
+                }
+            ],
+        )
+        self.assertEqual(
+            deployment["required_local_validation"],
+            [
+                {
+                    "argv": ["./scripts/preflight.sh"],
+                    "working_directory": ".",
+                    "purpose": "Run the deterministic deployment repository preflight",
+                }
+            ],
+        )
         self.assertEqual(
             deployment["signature_policy"],
             {
@@ -4008,6 +4030,27 @@ class RegistryTests(TestCase):
                 ["npm", "run", "test:container"],
                 ["npm", "run", "test:e2e:container"],
             ],
+        )
+
+    def test_deployment_validation_binding_separates_preflight_from_integration(
+        self,
+    ) -> None:
+        repository = actions.select_repository(
+            actions.load_registry(), "SecPal/deployment"
+        )
+
+        self.assertEqual(
+            [command["argv"] for command in actions._complete_validation_commands(repository)],
+            [["./scripts/preflight.sh"]],
+        )
+        binding = actions._fast_registry_binding(repository)
+        self.assertEqual(
+            [command["argv"] for command in binding["validation"]],
+            [["./scripts/preflight.sh"]],
+        )
+        self.assertEqual(
+            [command["argv"] for command in binding["focused_only_validation"]],
+            [["./scripts/local-integration.sh"]],
         )
 
     def test_required_validation_rejects_focused_only_execution(self) -> None:

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -6247,6 +6247,18 @@ class FastPathTests(TestCase):
 
 
 class PolicyScriptTests(TestCase):
+    def test_deployment_manual_gate_count_assertion_has_diagnostic(self) -> None:
+        policy = (REPO_ROOT / "tests/secpal-pr-review-skill-policy.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            'assert len(deployment["manual_gates"]) == 1, (\n'
+            '    "SecPal/deployment must define exactly one manual gate"\n'
+            ")",
+            policy,
+        )
+
     def test_reuse_precommit_hook_provisions_the_pinned_tool(self) -> None:
         pre_commit = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
         reuse_hook = pre_commit.split("  # Code formatting", 1)[0]

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -552,7 +552,9 @@ assert not any(
     "deployment, production, or live targets"
 )
 
-assert len(deployment["manual_gates"]) == 1
+assert len(deployment["manual_gates"]) == 1, (
+    "SecPal/deployment must define exactly one manual gate"
+)
 deployment_gate = deployment["manual_gates"][0]
 for required_text in (
     "The deterministic `./scripts/preflight.sh` target is required.",

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -503,6 +503,102 @@ assert {
     "maximum_reactions": 50,
 }, "SecPal/frontend capture limits must remain unchanged"
 
+deployment_entries = [
+    item for item in registry["repositories"]
+    if item["repository"] == "SecPal/deployment"
+]
+assert len(deployment_entries) == 1, (
+    "SecPal/deployment must have exactly one registry entry"
+)
+deployment = deployment_entries[0]
+assert deployment["required_local_validation"] == [
+    {
+        "argv": ["./scripts/preflight.sh"],
+        "working_directory": ".",
+        "purpose": "Run the deterministic deployment repository preflight",
+    },
+], "SecPal/deployment must require the deterministic preflight exactly once"
+assert deployment["focused_validation"] == [
+    {
+        "argv": ["./scripts/local-integration.sh"],
+        "working_directory": ".",
+        "purpose": "Build and exercise the complete local API/frontend integration stack",
+        "execution_policy": "focused-only",
+    },
+], "SecPal/deployment must register local integration as focused-only exactly once"
+
+deployment_validation_argv = [
+    tuple(command["argv"])
+    for command_group in ("focused_validation", "required_local_validation")
+    for command in deployment[command_group]
+]
+assert len(deployment_validation_argv) == len(set(deployment_validation_argv)), (
+    "SecPal/deployment validation commands must not be duplicated"
+)
+assert ("./scripts/local-integration.sh",) not in {
+    tuple(command["argv"])
+    for command in deployment["required_local_validation"]
+}, "SecPal/deployment local integration must not become required validation"
+deployment_prohibited_fragments = (
+    "docker login", "docker push", "docker system prune", "docker image prune",
+    "ghcr", "publish", "deploy", "production", "live",
+)
+assert not any(
+    fragment in " ".join(argv).lower()
+    for argv in deployment_validation_argv
+    for fragment in deployment_prohibited_fragments
+), (
+    "SecPal/deployment must not register login, publishing, push, prune, "
+    "deployment, production, or live targets"
+)
+
+assert len(deployment["manual_gates"]) == 1
+deployment_gate = deployment["manual_gates"][0]
+for required_text in (
+    "The deterministic `./scripts/preflight.sh` target is required.",
+    "Docker-backed `./scripts/local-integration.sh`",
+    "Compose", "container roles", "runtime secrets", "PostgreSQL", "Valkey",
+    "queue", "cache", "shared storage", "gateway", "CORS", "Sanctum",
+    "browser integration", "lifecycle", "cleanup",
+    "explicit current authorization for Docker daemon access",
+    "outbound GitHub, container-registry, and package-registry network access",
+    "Authorization from an earlier task does not carry over.",
+    "Registry login", "publishing", "push", "prune", "production infrastructure",
+    "public exposure", "deployment", "live systems", "real secrets",
+):
+    assert required_text in deployment_gate, (
+        f"SecPal/deployment manual gate must retain: {required_text}"
+    )
+
+assert deployment["signature_policy"] == {
+    "require_github_verified": True,
+    "require_local_verified": True,
+    "accepted_formats": ["ssh", "openpgp"],
+}, "SecPal/deployment signature policy must remain strict"
+assert deployment["check_policy"] == {
+    "require_ruleset_evidence": True,
+    "require_branch_protection_evidence": True,
+    "expected_skipped": "block",
+}, "SecPal/deployment check policy must remain strict"
+assert deployment["unsupported_operations"] == [
+    "REVIEW_REQUEST", "READY_TRANSITION", "LABEL", "ISSUE",
+    "REVIEW_SUBMISSION", "MERGE", "AUTO_MERGE", "COMMENT_DELETE",
+    "REVIEW_DISMISSAL", "BRANCH_WRITE",
+], "SecPal/deployment unsupported operations must remain unchanged"
+assert {
+    key: deployment[key]
+    for key in (
+        "maximum_api_calls", "maximum_items", "maximum_threads",
+        "maximum_comments", "maximum_reactions",
+    )
+} == {
+    "maximum_api_calls": 200,
+    "maximum_items": 10000,
+    "maximum_threads": 500,
+    "maximum_comments": 200,
+    "maximum_reactions": 50,
+}, "SecPal/deployment capture limits must remain unchanged"
+
 for item in registry["repositories"]:
     for command_group in ("focused_validation", "required_local_validation"):
         for command in item[command_group]:


### PR DESCRIPTION
## Problem and evidence

The central deployment registry still represented the governance-only bootstrap: it had no required or focused validation and retained the obsolete bootstrap manual gate. Phase B now provides a deterministic preflight and a Docker-backed integration contract. The deployment entry and authorization boundary are visible in [`repositories.json`](https://github.com/SecPal/.github/blob/f9c62dccea887a7fc9735a2b69c719f4b69a6b19/.agents/skills/secpal-pr-review/references/repositories.json#L559-L589).

Docker daemon access and transitive GitHub, container-registry, and package-registry access require explicit current authorization. Authorization from an earlier task must not carry over.

## Change

- register `./scripts/preflight.sh` as required local validation;
- register `./scripts/local-integration.sh` as focused-only validation;
- keep Docker-backed integration out of unconditional complete validation;
- preserve signature, Required Check, unsupported-operation, and capture-limit policies;
- add exact registry and binding regression coverage in [`secpal-pr-review-actions-unit.py`](https://github.com/SecPal/.github/blob/f9c62dccea887a7fc9735a2b69c719f4b69a6b19/tests/secpal-pr-review-actions-unit.py#L3710-L3760) and [`secpal-pr-review-skill-policy.sh`](https://github.com/SecPal/.github/blob/f9c62dccea887a7fc9735a2b69c719f4b69a6b19/tests/secpal-pr-review-skill-policy.sh#L506-L600);
- record the governance contract in [`CHANGELOG.md`](https://github.com/SecPal/.github/blob/f9c62dccea887a7fc9735a2b69c719f4b69a6b19/CHANGELOG.md#L12-L23).

## Security

- no Docker access;
- no image build;
- no publishing;
- no deployment;
- no GitHub settings mutation.

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py` failed because deployment Complete Validation returned no commands instead of `./scripts/preflight.sh`; `bash tests/secpal-pr-review-skill-policy.sh` failed because the deployment preflight was not registered.
- Passing proof after implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py` passed all 179 tests; `bash tests/secpal-pr-review-skill-policy.sh` passed the finite review-skill policy checks.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Readiness dependency

`Local Integration / Compose Contract`

Manual GitHub administration remains required: add `Local Integration / Compose Contract` to the strict required-status-check policy for `SecPal/deployment` `main`. During the single read-only inspection, no repository ruleset required it, classic branch protection required three other checks, and the current `SecPal/deployment#1` head had no matching check run. This PR does not mutate GitHub settings.

## Validation

Passed:

- `python3 -m json.tool .agents/skills/secpal-pr-review/references/repositories.json >/dev/null`
- `python3 -m unittest tests/secpal-pr-review-actions-unit.py`
- `python3 -m unittest tests/secpal-resolve-fixed-threads-unit.py`
- `python3 -m unittest tests/secpal-pr-review-unit.py`
- `bash tests/secpal-pr-review-skill-policy.sh`
- `bash tests/secpal-pr-review-integration.sh`
- `bash tests/secpal-pr-review-skill-integration.sh`
- `bash tests/review-governance-suite.sh`
- `bash tests/reusable-workflow-policy.sh`
- `bash tests/pr-size-advisory.sh`
- `npm run lint:markdown`
- `./scripts/preflight.sh --reuse-tracked-only`
- `git diff --check`
- signed commit hooks
- pre-push hook
