### PR TITLE
Preserve previews on provision failure

### DIFF
--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3534,6 +3534,30 @@ def load_provision_marker(marker_path: pathlib.Path) -> dict[str, Any] | None:
     return marker
 
 
+def write_provision_marker(marker_path: pathlib.Path, marker_payload: dict[str, Any]) -> None:
+    if marker_path.is_symlink() or (marker_path.exists() and not marker_path.is_file()):
+        raise RuntimeError(f"provision marker is not a regular file: {marker_path}")
+
+    payload = json.dumps(marker_payload, indent=2) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{PROVISION_MARKER_FILENAME}.",
+        dir=marker_path.parent,
+    )
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, marker_path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
 def run_setup_commands(worktree_path: pathlib.Path, commands: list[str], *, db_path: pathlib.Path | None = None) -> None:
     env = os.environ.copy()
     if db_path is not None:
@@ -3997,40 +4021,82 @@ def revoke_all_preview_nginx_access(clone_root: pathlib.Path) -> None:
             if not child.is_symlink() and child.is_dir():
                 deny_preview_nginx_access(resolved_clone_root, child)
 
-        for child in children:
-            if not child.is_symlink():
-                continue
-            try:
-                link_target = os.readlink(child)
-            except OSError as error:
-                raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
-            registered_target = registered_aliases.get(child.name)
-            try:
-                resolved_target = child.resolve(strict=True)
-            except FileNotFoundError:
-                link_target_path = pathlib.Path(link_target)
-                lexical_target = (
-                    link_target_path
-                    if link_target_path.is_absolute()
-                    else child.parent / link_target_path
-                )
-                normalized_target = pathlib.Path(os.path.abspath(lexical_target))
-                if normalized_target.parent != repo_clone_root:
-                    raise RuntimeError(
-                        f"preview repository contains an unresolved symlink that escapes its root: "
-                        f"{child} -> {normalized_target}"
-                    )
-                if registered_target != link_target:
-                    raise RuntimeError(f"preview repository contains an unregistered workspace alias: {child}")
-                continue
-            except OSError as error:
-                raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
-            if resolved_target.parent != repo_clone_root or not resolved_target.is_dir():
+        validate_preview_nginx_workspace_aliases(repo_clone_root, registered_aliases, children)
+
+
+def validate_preview_nginx_workspace_aliases(
+    repo_clone_root: pathlib.Path,
+    registered_aliases: dict[str, str],
+    children: list[pathlib.Path],
+) -> None:
+    for child in children:
+        if not child.is_symlink():
+            continue
+        try:
+            link_target = os.readlink(child)
+        except OSError as error:
+            raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
+        registered_target = registered_aliases.get(child.name)
+        try:
+            resolved_target = child.resolve(strict=True)
+        except FileNotFoundError:
+            link_target_path = pathlib.Path(link_target)
+            lexical_target = (
+                link_target_path
+                if link_target_path.is_absolute()
+                else child.parent / link_target_path
+            )
+            normalized_target = pathlib.Path(os.path.abspath(lexical_target))
+            if normalized_target.parent != repo_clone_root:
                 raise RuntimeError(
-                    f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
+                    f"preview repository contains an unresolved symlink that escapes its root: "
+                    f"{child} -> {normalized_target}"
                 )
-            if registered_target != link_target or resolved_target.name != registered_target:
+            if registered_target != link_target:
                 raise RuntimeError(f"preview repository contains an unregistered workspace alias: {child}")
+            continue
+        except OSError as error:
+            raise RuntimeError(f"preview repository contains an unreadable symlink: {child}") from error
+        if resolved_target.parent != repo_clone_root or not resolved_target.is_dir():
+            raise RuntimeError(
+                f"preview repository contains an escaping symlink: {child} -> {resolved_target}"
+            )
+        if registered_target != link_target or resolved_target.name != registered_target:
+            raise RuntimeError(f"preview repository contains an unregistered workspace alias: {child}")
+
+
+def revoke_unregistered_preview_nginx_access(
+    clone_root: pathlib.Path,
+    registered_worktrees: dict[str, list[pathlib.Path]],
+) -> None:
+    """Deny stale preview worktrees without disrupting active registrations."""
+    clone_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if clone_root.is_symlink() or not clone_root.is_dir():
+        raise RuntimeError(f"preview clone root is not a physical directory: {clone_root}")
+    resolved_clone_root = clone_root.resolve(strict=True)
+    registered_paths = {
+        worktree_path.resolve()
+        for repo_worktrees in registered_worktrees.values()
+        for worktree_path in repo_worktrees
+    }
+
+    for repo_clone_root in sorted(resolved_clone_root.iterdir(), key=lambda path: path.name):
+        if repo_clone_root.is_symlink():
+            raise RuntimeError(
+                f"preview clone root contains a repository symlink: {repo_clone_root}"
+            )
+        if not repo_clone_root.is_dir():
+            continue
+
+        registered_aliases = load_workspace_alias_registry(repo_clone_root)
+        children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
+        for child in children:
+            if child.is_symlink() or not child.is_dir():
+                continue
+            if child.resolve(strict=True) not in registered_paths:
+                deny_preview_nginx_access(resolved_clone_root, child)
+
+        validate_preview_nginx_workspace_aliases(repo_clone_root, registered_aliases, children)
 
 
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:
@@ -4117,6 +4183,7 @@ def provision_worktrees(
         repo_state,
         clone_root,
     )
+    revoke_unregistered_preview_nginx_access(clone_root, registered_worktrees)
 
     provisionable_worktrees: list[
         tuple[str, dict[str, Any], pathlib.Path, list[str], list[str]]
@@ -4275,8 +4342,19 @@ def provision_worktrees(
                     marker_payload["linked_workspaces"] = linked_setup_context
 
                 if preview_enabled:
-                    ensure_preview_nginx_access(clone_root, locked_worktree_path)
-                marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
+                    try:
+                        ensure_preview_nginx_access(clone_root, locked_worktree_path)
+                        write_provision_marker(marker_path, marker_payload)
+                    except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
+                        try:
+                            deny_preview_nginx_access(clone_root, locked_worktree_path)
+                        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as rollback_error:
+                            raise RuntimeError(
+                                f"{error}; additionally failed to revoke preview access: {rollback_error}"
+                            ) from rollback_error
+                        raise
+                else:
+                    write_provision_marker(marker_path, marker_payload)
                 provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4274,9 +4274,9 @@ def provision_worktrees(
                 if linked_setup_context:
                     marker_payload["linked_workspaces"] = linked_setup_context
 
-                marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 if preview_enabled:
                     ensure_preview_nginx_access(clone_root, locked_worktree_path)
+                marker_path.write_text(json.dumps(marker_payload, indent=2) + "\n")
                 provisioned_worktrees.append(f"{repo_name}:{workspace}")
         except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
             error_message = str(error)
@@ -5053,13 +5053,6 @@ def run_rollout(args: argparse.Namespace) -> int:
     repo_specs = build_repo_specs(args.workspace_root)
     validated_instruction_roots: set[pathlib.Path] = set()
 
-    if args.provision_worktrees or args.install_nginx:
-        try:
-            revoke_all_preview_nginx_access(args.clone_root)
-        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
-            print(f"Failed to revoke preview access: {error}", file=sys.stderr)
-            return 1
-
     try:
         validate_repo_instruction_files(repo_specs, validated_instruction_roots)
     except CanonicalInstructionValidationError as error:
@@ -5087,6 +5080,17 @@ def run_rollout(args: argparse.Namespace) -> int:
     provisioned_worktrees: list[str] = []
     cleaned_preview_storage_targets: list[str] = []
     failed_provision_worktrees: list[dict[str, str]] = []
+    if args.install_nginx:
+        # The routine worktree provisioner must preserve established previews:
+        # new worktrees inherit a deny-by-default ACL, while a global revoke
+        # would let one failed bootstrap take every preview offline. A full
+        # Nginx rollout reconciles that broader boundary only after all its
+        # prerequisites have completed.
+        try:
+            revoke_all_preview_nginx_access(args.clone_root)
+        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
+            print(f"Failed to revoke preview access: {error}", file=sys.stderr)
+            return 1
     if args.provision_worktrees or args.install_nginx:
         provisioned_worktrees, cleaned_preview_storage_targets, failed_provision_worktrees = provision_worktrees(
             repo_state,

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -545,6 +545,7 @@ assert unrelated_alias.is_symlink(), (
 assert module.load_workspace_alias_registry(github_clone_root) == {
     "registered-valid": valid_candidate.name,
 }
+unrelated_alias.unlink()
 
 # Registration aliases may be migrated back to their verified physical target,
 # but symlink chains and paths outside the expected repository clone root are
@@ -569,6 +570,9 @@ else:
 with sqlite3.connect(db_path) as connection:
     assert connection.execute("select path from worktrees where id = 'chain'").fetchone()[0] == str(chain_alias)
     connection.execute("delete from worktrees where id = 'chain'")
+chain_alias.unlink()
+chain_middle.unlink()
+chain_target.rmdir()
 
 # Registry records cannot escape the repository clone root or turn another
 # user-owned path into an alias-cleanup target.
@@ -590,6 +594,7 @@ except RuntimeError as error:
 else:
     raise AssertionError("workspace alias registry traversal must fail closed")
 assert outside_sentinel.read_text() == "unchanged"
+module.workspace_alias_registry_path(unsafe_registry_root).unlink()
 
 # SQLite URI mode must quote legal filename characters instead of treating
 # them as URI query, fragment, or percent-escape syntax and selecting or

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1234,6 +1234,14 @@ for repository_root in (source_api, physical_worktree):
 fake_bin.mkdir(parents=True)
 race_state.mkdir()
 alias_worktree.symlink_to(physical_worktree.name)
+physical_worktree.parent.joinpath(".polyscope-secpal-workspace-aliases.json").write_text(
+    '{\n'
+    '  "version": 1,\n'
+    '  "aliases": {\n'
+    f'    "{alias_worktree.name}": "{physical_worktree.name}"\n'
+    '  }\n'
+    '}\n'
+)
 os.mkfifo(release_first)
 
 source_api.joinpath(".env.example").write_text(
@@ -7160,6 +7168,7 @@ def run_case(
     marker_hit: bool,
     setup_fails: bool,
     grant_fails: bool = False,
+    marker_write_fails: bool = False,
     provisionable: bool = True,
     canonical_validation_fails: bool = False,
     registered_worktree_count: int = 1,
@@ -7207,6 +7216,15 @@ def run_case(
             raise RuntimeError("expected preview ACL failure")
 
     module.ensure_preview_nginx_access = grant_access
+    module.deny_preview_nginx_access = lambda *_args, **_kwargs: order.append("deny")
+
+    def write_marker(marker_path: Path, marker_payload: dict[str, object]) -> None:
+        if marker_write_fails:
+            order.append("marker")
+            raise OSError("expected provision marker failure")
+        marker_path.write_text(__import__("json").dumps(marker_payload, indent=2) + "\n")
+
+    module.write_provision_marker = write_marker
 
     def run_setup(*_args, **_kwargs) -> None:
         order.append("setup")
@@ -7285,10 +7303,27 @@ assert acl_failure_order == [
     "validate",
     "setup",
     "grant",
+    "deny",
 ], acl_failure_order
 assert acl_failure_provisioned == []
 assert len(acl_failure_details) == 1
 assert not acl_failure_marker_exists
+
+marker_write_failure_order, marker_write_failure_provisioned, marker_write_failure_details, marker_write_failure_exists = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    marker_write_fails=True,
+)
+assert marker_write_failure_order == [
+    "validate",
+    "setup",
+    "grant",
+    "marker",
+    "deny",
+], marker_write_failure_order
+assert marker_write_failure_provisioned == []
+assert len(marker_write_failure_details) == 1
+assert not marker_write_failure_exists
 
 invalid_order, invalid_provisioned, invalid_failures, invalid_marker_exists = run_case(
     marker_hit=False,
@@ -7464,6 +7499,45 @@ assert managed_alias_order == [
     "deny:workspace",
 ], managed_alias_order
 assert managed_alias_error is None
+
+with tempfile.TemporaryDirectory() as temporary_directory:
+    case_root = Path(temporary_directory)
+    clone_root = case_root / ".polyscope" / "clones"
+    repo_root = clone_root / "repository-id"
+    registered_worktree = repo_root / "registered"
+    orphan_worktree = repo_root / "orphan"
+    registered_worktree.mkdir(parents=True)
+    orphan_worktree.mkdir()
+    reconcile_order: list[str] = []
+
+    module.deny_preview_nginx_access = (
+        lambda _clone_root, denied_path, **_kwargs: reconcile_order.append(f"deny:{denied_path.name}")
+    )
+    module.revoke_unregistered_preview_nginx_access(
+        clone_root,
+        {"frontend": [registered_worktree]},
+    )
+    assert reconcile_order == ["deny:orphan"], reconcile_order
+
+with tempfile.TemporaryDirectory() as temporary_directory:
+    case_root = Path(temporary_directory)
+    clone_root = case_root / ".polyscope" / "clones"
+    repo_root = clone_root / "repository-id"
+    worktree = repo_root / "workspace"
+    outside_preview = case_root / "outside-preview"
+    worktree.mkdir(parents=True)
+    outside_preview.mkdir()
+    (repo_root / "rogue-alias").symlink_to(outside_preview, target_is_directory=True)
+
+    try:
+        module.revoke_unregistered_preview_nginx_access(
+            clone_root,
+            {"frontend": [worktree]},
+        )
+    except RuntimeError as error:
+        assert "escaping symlink" in str(error)
+    else:
+        raise AssertionError("routine ACL reconciliation must reject escaping workspace aliases")
 
 clone_failure_order, clone_failure_error = run_revoke_case(clone_deny_fails=True)
 assert clone_failure_order == ["deny-clone"], clone_failure_order

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -7159,10 +7159,11 @@ def run_case(
     *,
     marker_hit: bool,
     setup_fails: bool,
+    grant_fails: bool = False,
     provisionable: bool = True,
     canonical_validation_fails: bool = False,
     registered_worktree_count: int = 1,
-) -> tuple[list[str], list[str], list[dict[str, str]]]:
+) -> tuple[list[str], list[str], list[dict[str, str]], bool]:
     temporary_directory = tempfile.TemporaryDirectory()
     case_root = Path(temporary_directory.name)
     clone_root = case_root / ".polyscope" / "clones"
@@ -7202,6 +7203,8 @@ def run_case(
 
     def grant_access(*_args, **_kwargs) -> None:
         order.append("grant")
+        if grant_fails:
+            raise RuntimeError("expected preview ACL failure")
 
     module.ensure_preview_nginx_access = grant_access
 
@@ -7231,11 +7234,12 @@ def run_case(
         clone_root,
         db_path=case_root / "polyscope.db",
     )
+    marker_exists = (worktree / module.PROVISION_MARKER_FILENAME).exists()
     temporary_directory.cleanup()
-    return order, provisioned, failures
+    return order, provisioned, failures, marker_exists
 
 
-failure_order, failure_provisioned, failure_details = run_case(
+failure_order, failure_provisioned, failure_details, failure_marker_exists = run_case(
     marker_hit=False,
     setup_fails=True,
 )
@@ -7245,8 +7249,9 @@ assert failure_order == [
 ], failure_order
 assert failure_provisioned == []
 assert len(failure_details) == 1
+assert not failure_marker_exists
 
-marker_order, marker_provisioned, marker_failures = run_case(
+marker_order, marker_provisioned, marker_failures, marker_marker_exists = run_case(
     marker_hit=True,
     setup_fails=False,
 )
@@ -7256,8 +7261,9 @@ assert marker_order == [
 ], marker_order
 assert marker_provisioned == []
 assert marker_failures == []
+assert not marker_marker_exists
 
-success_order, success_provisioned, success_failures = run_case(
+success_order, success_provisioned, success_failures, success_marker_exists = run_case(
     marker_hit=False,
     setup_fails=False,
 )
@@ -7268,8 +7274,23 @@ assert success_order == [
 ], success_order
 assert success_provisioned == ["frontend:workspace"]
 assert success_failures == []
+assert success_marker_exists
 
-invalid_order, invalid_provisioned, invalid_failures = run_case(
+acl_failure_order, acl_failure_provisioned, acl_failure_details, acl_failure_marker_exists = run_case(
+    marker_hit=False,
+    setup_fails=False,
+    grant_fails=True,
+)
+assert acl_failure_order == [
+    "validate",
+    "setup",
+    "grant",
+], acl_failure_order
+assert acl_failure_provisioned == []
+assert len(acl_failure_details) == 1
+assert not acl_failure_marker_exists
+
+invalid_order, invalid_provisioned, invalid_failures, invalid_marker_exists = run_case(
     marker_hit=False,
     setup_fails=False,
     provisionable=False,
@@ -7279,8 +7300,9 @@ assert invalid_order == [
 ], invalid_order
 assert invalid_provisioned == []
 assert invalid_failures == []
+assert not invalid_marker_exists
 
-canonical_order, canonical_provisioned, canonical_failures = run_case(
+canonical_order, canonical_provisioned, canonical_failures, canonical_marker_exists = run_case(
     marker_hit=False,
     setup_fails=False,
     canonical_validation_fails=True,
@@ -7292,6 +7314,7 @@ assert canonical_order == [
 ], canonical_order
 assert canonical_provisioned == []
 assert len(canonical_failures) == 2
+assert not canonical_marker_exists
 
 
 def run_revoke_case(
@@ -7496,7 +7519,7 @@ def fail_source_validation(*_args, **_kwargs) -> None:
 
 module.validate_repo_instruction_files = fail_source_validation
 assert module.main() == 1
-assert main_order == ["lock-enter", "revoke", "validate", "lock-exit"], main_order
+assert main_order == ["lock-enter", "validate", "lock-exit"], main_order
 
 main_order.clear()
 module.parse_args = lambda: SimpleNamespace(
@@ -7507,7 +7530,7 @@ module.parse_args = lambda: SimpleNamespace(
     workspace_root=Path("/tmp/unused-workspace-root"),
 )
 assert module.main() == 1
-assert main_order == ["lock-enter", "revoke", "validate", "lock-exit"], main_order
+assert main_order == ["lock-enter", "validate", "lock-exit"], main_order
 
 rollout_order: list[str] = []
 with tempfile.TemporaryDirectory() as temporary_directory:
@@ -7549,12 +7572,45 @@ with tempfile.TemporaryDirectory() as temporary_directory:
 
     assert module.run_rollout(args) == 0
     assert rollout_order == [
-        "revoke",
         "validate",
+        "revoke",
         "provision",
         "manifest",
         "install",
     ], rollout_order
+
+provision_order: list[str] = []
+with tempfile.TemporaryDirectory() as temporary_directory:
+    temporary_root = Path(temporary_directory)
+    args = SimpleNamespace(
+        clone_root=temporary_root / "clones",
+        db_path=temporary_root / "polyscope.db",
+        install_nginx=False,
+        nginx_http2_syntax="modern",
+        nginx_output=temporary_root / "preview.nginx.conf",
+        polyscope_api_base="http://127.0.0.1:4321/api",
+        provision_worktrees=True,
+        repo_state_file=temporary_root / "repo-state.json",
+        skip_db_sync=True,
+        skip_local_configs=True,
+        summary_output=None,
+        workspace_root=temporary_root / "workspace",
+    )
+    args.clone_root.mkdir()
+
+    module.build_repo_specs = lambda _workspace_root: {}
+    module.revoke_all_preview_nginx_access = lambda _clone_root: provision_order.append("revoke")
+    module.validate_repo_instruction_files = lambda *_args: provision_order.append("validate")
+    module.validate_repo_local_configs = lambda _repo_specs: None
+    module.load_repo_state = lambda _path: {}
+    module.render_nginx_config = lambda *_args, **_kwargs: "rendered\n"
+    module.provision_worktrees = lambda *_args, **_kwargs: (
+        provision_order.append("provision") or ([], [], [])
+    )
+    module.build_summary = lambda *_args: {}
+
+    assert module.run_rollout(args) == 0
+    assert provision_order == ["validate", "provision"], provision_order
 PY
 grep -q 'daemon-reload' "$fake_systemctl_log"
 grep -q 'enable --now polyscope-server.service' "$fake_systemctl_log"


### PR DESCRIPTION
## Problem and evidence

Routine worktree provisioning revoked preview Nginx access before validation and bootstrap. If any later provision step failed, that global revocation took established previews offline. The provision marker was also written before preview access was granted, allowing a failed ACL update to leave a stale marker.

## Change

- Limit the global preview-access revocation to full Nginx rollout requests.
- Grant preview access before writing the provision marker.
- Add regression coverage for ACL failures, marker ordering, and routine provisioning without a global revoke.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` exits non-zero when run with `scripts/polyscope-rollout.py` from `origin/main` and the new regression suite.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/polyscope-rollout.sh`
- `python3 -m py_compile scripts/polyscope-rollout.py`
- `git diff --check`
- Full local pre-push suite

## Dependencies and readiness

No in-scope dependency or unresolved check prevents review. This remains a draft PR as requested.