### PR TITLE
Prevent preview provisioning failures

### DIFF
--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1633,8 +1633,8 @@ if package_json.is_file():
         if isinstance(section, dict):
             optional_packages.update(name for name in section if isinstance(name, str))
 
-required_packages.difference_update(optional_packages)
 required_packages.update(development_packages)
+required_packages.difference_update(optional_packages)
 
 required_paths = []
 if declared_packages:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1858,6 +1858,8 @@ watch_files = [
             Path(".env.preview.local"),
             Path(".env.production.local"),
             Path("node_modules/.package-lock.json"),
+]
+build_binary_paths = [
             Path("node_modules/.bin/cross-env"),
             Path("node_modules/.bin/vite"),
 ]
@@ -1879,7 +1881,11 @@ watch_suffixes = {
 def iter_watch_paths():
     seen = set()
 
-    for path in watch_files:
+    # npm may create command shims one at a time. Treat them as one readiness
+    # signal so a partially completed install cannot trigger a premature build.
+    ready_build_binary_paths = build_binary_paths if all(path.is_file() for path in build_binary_paths) else []
+
+    for path in [*watch_files, *ready_build_binary_paths]:
         if not path.exists():
             continue
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1607,6 +1607,7 @@ from pathlib import Path
 
 package_json = Path("package.json")
 declared_packages = set()
+required_packages = set()
 if package_json.is_file():
     try:
         package_data = json.loads(package_json.read_text())
@@ -1617,10 +1618,15 @@ if package_json.is_file():
             section = package_data.get(key, {})
             if isinstance(section, dict):
                 declared_packages.update(name for name in section if isinstance(name, str))
+        for key in ("dependencies", "devDependencies"):
+            section = package_data.get(key, {})
+            if isinstance(section, dict):
+                required_packages.update(name for name in section if isinstance(name, str))
 
 required_paths = []
 if declared_packages:
     required_paths.append(Path("node_modules/.package-lock.json"))
+required_paths.extend(Path("node_modules") / package / "package.json" for package in sorted(required_packages))
 if "typescript" in declared_packages:
     required_paths.extend(
         [
@@ -1852,6 +1858,8 @@ watch_files = [
             Path(".env.preview.local"),
             Path(".env.production.local"),
             Path("node_modules/.package-lock.json"),
+            Path("node_modules/.bin/cross-env"),
+            Path("node_modules/.bin/vite"),
 ]
 watch_suffixes = {
             ".css",
@@ -4588,6 +4596,11 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
 
             access_log /var/log/nginx/preview.secpal.dev.access.log;
             error_log /var/log/nginx/preview.secpal.dev.error.log;
+
+            # Worktrees are built and published after their preview hostname is
+            # reachable. Do not retain a missing-file or permission result from
+            # that short provisioning window.
+            open_file_cache off;
 
             client_max_body_size 25m;
             index index.html index.php;

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -75,6 +75,7 @@ MODERN_NGINX_HTTP2_VERSION = (1, 25, 1)
 NGINX_HTTP2_SYNTAX_CHOICES = ("modern", "legacy", "auto")
 API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_BOOTSTRAP_SETUP__"
 API_REFRESH_COMMAND_PLACEHOLDER = "__POLYSCOPE_API_REFRESH__"
+FRONTEND_PREVIEW_BUILD_BINARIES = ("cross-env", "vite")
 API_QUEUE_WORKER_COMMAND = (
     "php artisan queue:work --queue=activity-hash-chain,merkle,opentimestamp,default "
     "--sleep=3 --tries=3"
@@ -1562,7 +1563,7 @@ for env_name in (".env.local", ".env.preview.local", ".env.production.local"):
     return f"python3 -c {shlex.quote(script)}"
 
 
-def build_verified_npm_ci_command() -> str:
+def build_verified_npm_ci_command(*, required_binaries: tuple[str, ...] = ()) -> str:
     remove_node_modules_script = textwrap.dedent(
         """\
 import os
@@ -1600,9 +1601,11 @@ if last_error is not None:
         """
     ).strip()
 
-    validate_install_script = textwrap.dedent(
-        """\
+    validate_install_script = (
+        textwrap.dedent(
+            """\
 import json
+import os
 from pathlib import Path
 
 package_json = Path("package.json")
@@ -1627,6 +1630,9 @@ required_paths = []
 if declared_packages:
     required_paths.append(Path("node_modules/.package-lock.json"))
 required_paths.extend(Path("node_modules") / package / "package.json" for package in sorted(required_packages))
+required_binary_paths = [
+    Path("node_modules/.bin") / binary for binary in __REQUIRED_BINARIES__
+]
 if "typescript" in declared_packages:
     required_paths.extend(
         [
@@ -1638,10 +1644,16 @@ if "@types/node" in declared_packages:
     required_paths.append(Path("node_modules/@types/node/package.json"))
 
 missing = [str(path) for path in required_paths if not path.is_file()]
-if missing:
+unusable_binaries = [
+    str(path) for path in required_binary_paths if not path.is_file() or not os.access(path, os.X_OK)
+]
+if missing or unusable_binaries:
     raise SystemExit(1)
-        """
-    ).strip()
+            """
+        )
+        .strip()
+        .replace("__REQUIRED_BINARIES__", repr(required_binaries))
+    )
 
     return textwrap.dedent(
         f"""\
@@ -1831,6 +1843,10 @@ with lock_path.open("w") as lock_file:
 
 
 def build_frontend_preview_build_watch_command() -> str:
+    build_binary_paths_source = "\n".join(
+        f'            Path({json.dumps(f"node_modules/.bin/{binary}")}),'
+        for binary in FRONTEND_PREVIEW_BUILD_BINARIES
+    )
     script = textwrap.dedent(
         f"""\
 import hashlib
@@ -1860,8 +1876,7 @@ watch_files = [
             Path("node_modules/.package-lock.json"),
 ]
 build_binary_paths = [
-            Path("node_modules/.bin/cross-env"),
-            Path("node_modules/.bin/vite"),
+{build_binary_paths_source}
 ]
 watch_suffixes = {
             ".css",
@@ -1881,9 +1896,13 @@ watch_suffixes = {
 def iter_watch_paths():
     seen = set()
 
-    # npm may create command shims one at a time. Treat them as one readiness
-    # signal so a partially completed install cannot trigger a premature build.
-    ready_build_binary_paths = build_binary_paths if all(path.is_file() for path in build_binary_paths) else []
+    # npm may create and chmod command shims one at a time. Treat executable
+    # shims as one readiness signal so a partial install cannot trigger a build.
+    ready_build_binary_paths = (
+        build_binary_paths
+        if all(path.is_file() and os.access(path, os.X_OK) for path in build_binary_paths)
+        else []
+    )
 
     for path in [*watch_files, *ready_build_binary_paths]:
         if not path.exists():
@@ -1924,11 +1943,13 @@ def snapshot() -> str:
 
     for path in iter_watch_paths():
         try:
-            stat = path.stat()
+            path_stat = path.stat()
         except OSError:
             continue
 
-        state.append(f"{{path.as_posix()}}:{{stat.st_mtime_ns}}:{{stat.st_size}}")
+        state.append(
+            f"{{path.as_posix()}}:{{path_stat.st_mtime_ns}}:{{path_stat.st_size}}:{{path_stat.st_mode}}"
+        )
 
     return hashlib.sha256("\\n".join(state).encode("utf-8")).hexdigest()
 
@@ -2443,7 +2464,7 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
             "scripts": {
                 "setup": [
                     build_frontend_preview_env_setup_command(),
-                    build_verified_npm_ci_command(),
+                    build_verified_npm_ci_command(required_binaries=FRONTEND_PREVIEW_BUILD_BINARIES),
                     build_frontend_preview_build_command(),
                 ],
                 "run": [

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1611,6 +1611,7 @@ from pathlib import Path
 package_json = Path("package.json")
 declared_packages = set()
 required_packages = set()
+optional_packages = set()
 if package_json.is_file():
     try:
         package_data = json.loads(package_json.read_text())
@@ -1625,6 +1626,11 @@ if package_json.is_file():
             section = package_data.get(key, {})
             if isinstance(section, dict):
                 required_packages.update(name for name in section if isinstance(name, str))
+        section = package_data.get("optionalDependencies", {})
+        if isinstance(section, dict):
+            optional_packages.update(name for name in section if isinstance(name, str))
+
+required_packages.difference_update(optional_packages)
 
 required_paths = []
 if declared_packages:
@@ -1633,14 +1639,14 @@ required_paths.extend(Path("node_modules") / package / "package.json" for packag
 required_binary_paths = [
     Path("node_modules/.bin") / binary for binary in __REQUIRED_BINARIES__
 ]
-if "typescript" in declared_packages:
+if "typescript" in required_packages:
     required_paths.extend(
         [
             Path("node_modules/typescript/lib/lib.es2020.d.ts"),
             Path("node_modules/typescript/lib/lib.dom.d.ts"),
         ]
     )
-if "@types/node" in declared_packages:
+if "@types/node" in required_packages:
     required_paths.append(Path("node_modules/@types/node/package.json"))
 
 missing = [str(path) for path in required_paths if not path.is_file()]

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -1612,6 +1612,7 @@ package_json = Path("package.json")
 declared_packages = set()
 required_packages = set()
 optional_packages = set()
+development_packages = set()
 if package_json.is_file():
     try:
         package_data = json.loads(package_json.read_text())
@@ -1622,15 +1623,18 @@ if package_json.is_file():
             section = package_data.get(key, {})
             if isinstance(section, dict):
                 declared_packages.update(name for name in section if isinstance(name, str))
-        for key in ("dependencies", "devDependencies"):
-            section = package_data.get(key, {})
-            if isinstance(section, dict):
-                required_packages.update(name for name in section if isinstance(name, str))
+        section = package_data.get("dependencies", {})
+        if isinstance(section, dict):
+            required_packages.update(name for name in section if isinstance(name, str))
+        section = package_data.get("devDependencies", {})
+        if isinstance(section, dict):
+            development_packages.update(name for name in section if isinstance(name, str))
         section = package_data.get("optionalDependencies", {})
         if isinstance(section, dict):
             optional_packages.update(name for name in section if isinstance(name, str))
 
 required_packages.difference_update(optional_packages)
+required_packages.update(development_packages)
 
 required_paths = []
 if declared_packages:

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -120,6 +120,7 @@ rendered = library.render_nginx_config(loaded)
 assert "preview\\.secpal\\.dev" in rendered
 assert "d35c0cdc" in rendered
 assert "fastcgi_pass unix:/run/php/php8.4-fpm-secpal-preview.sock;" in rendered
+assert "open_file_cache off;" in rendered
 
 invalid_payloads = []
 for key, value in (

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -105,8 +105,12 @@ for executable in ("composer", "npm", "php"):
         f"printf '{executable}:%s\\n' \"$*\" >>\"$NATIVE_SETUP_LOG\"\n"
         f"touch .native-{executable}-invoked\n"
         + (
-            "mkdir -p node_modules\n"
+            "mkdir -p node_modules/.bin\n"
             "printf '{}\\n' >node_modules/.package-lock.json\n"
+            "for binary in cross-env vite; do\n"
+            "    printf '#!/usr/bin/env bash\\nexit 0\\n' >\"node_modules/.bin/$binary\"\n"
+            "    chmod +x \"node_modules/.bin/$binary\"\n"
+            "done\n"
             "if [[ \"${1:-}\" == run && \"${2:-}\" == build && -n \"${VITE_POLYSCOPE_OUTPUT_DIR:-}\" ]]; then\n"
             "    mkdir -p \"$VITE_POLYSCOPE_OUTPUT_DIR\"\n"
             "    printf '<html></html>\\n' >\"$VITE_POLYSCOPE_OUTPUT_DIR/index.html\"\n"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4102,6 +4102,62 @@ assert result.returncode == 0, result.stderr
 assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "1"
 PY
 
+# npm permits a package to be declared as both a development and optional
+# dependency. The development edge takes precedence, so a missing package must
+# still make rollout validation reject the install.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "dev-optional-overlap-fixture"
+fake_bin = fixture / "fake-bin"
+fixture.mkdir()
+fake_bin.mkdir()
+fixture.joinpath("package.json").write_text(
+    '{"name":"dev-optional-overlap","version":"1.0.0",'
+    '"devDependencies":{"required-dev-package":"file:./missing-package"},'
+    '"optionalDependencies":{"required-dev-package":"file:./missing-package"}}\n'
+)
+fixture.joinpath("package-lock.json").write_text(
+    '{"name":"dev-optional-overlap","version":"1.0.0","lockfileVersion":3,'
+    '"packages":{"":{"name":"dev-optional-overlap","version":"1.0.0"}}}\n'
+)
+fake_bin.joinpath("npm").write_text(
+    """#!/usr/bin/env python3
+from pathlib import Path
+
+counter_path = Path("npm-ci-attempts.txt")
+attempt = int(counter_path.read_text()) + 1 if counter_path.exists() else 1
+counter_path.write_text(str(attempt))
+Path("node_modules").mkdir(exist_ok=True)
+Path("node_modules/.package-lock.json").write_text("{}\\n")
+"""
+)
+fake_bin.joinpath("npm").chmod(0o755)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+env = os.environ.copy()
+env["PATH"] = str(fake_bin) + os.pathsep + env["PATH"]
+result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_verified_npm_ci_command()],
+    cwd=fixture,
+    env=env,
+    capture_output=True,
+    text=True,
+)
+assert result.returncode == 1, result.stderr
+assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "3"
+PY
+
 # GuardGuide preview env setup must write APP_URL for the normalized preview
 # workspace host, not the physical worktree directory basename.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1952,6 +1952,7 @@ fi
 
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace" "$REPO_ROOT"
 import importlib.util
+import hashlib
 import os
 import pathlib
 import shutil
@@ -2304,9 +2305,27 @@ assert watch_publish_source.index('replace_file(deferred_index, live_root / "ind
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
 
-# The watcher can race setup-time npm ci. Dependency installation completes
-# independently after the initial missing-command failure and must trigger one
-# retry via npm's stable hidden lockfile, without a source edit.
+# A single build binary is not enough to retry the build. The watcher must wait
+# until both commands needed by the frontend build are available.
+snapshot_source = watch_script[watch_script.index("watch_directories =") : watch_script.index("def replace_file")]
+snapshot_scope = {"hashlib": hashlib}
+exec("from pathlib import Path\n" + snapshot_source, snapshot_scope)
+original_cwd = pathlib.Path.cwd()
+try:
+    os.chdir(frontend_worktree)
+    shutil.rmtree(frontend_worktree / "node_modules", ignore_errors=True)
+    initial_snapshot = snapshot_scope["snapshot"]()
+    frontend_worktree.joinpath("node_modules/.bin").mkdir(parents=True, exist_ok=True)
+    frontend_worktree.joinpath("node_modules/.bin/cross-env").write_text("ready\\n")
+    assert snapshot_scope["snapshot"]() == initial_snapshot
+    frontend_worktree.joinpath("node_modules/.bin/vite").write_text("ready\\n")
+    assert snapshot_scope["snapshot"]() != initial_snapshot
+finally:
+    os.chdir(original_cwd)
+
+# The watcher can race setup-time npm ci. When the required build binaries
+# become available after an initial missing-command failure, it must retry once
+# without a source edit.
 frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
 frontend_worktree.joinpath("dist").unlink()
 shutil.rmtree(frontend_worktree / "node_modules", ignore_errors=True)
@@ -2335,9 +2354,13 @@ frontend_worktree.joinpath("node_modules").mkdir(exist_ok=True)
 frontend_worktree.joinpath("node_modules/.bin").mkdir(exist_ok=True)
 frontend_worktree.joinpath("node_modules/.bin/cross-env").write_text("ready\\n")
 frontend_worktree.joinpath("node_modules/.bin/vite").write_text("ready\\n")
-time.sleep(0.2)
-assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "1"
-frontend_worktree.joinpath("node_modules/.package-lock.json").write_text("{}\\n")
+for _ in range(20):
+    if frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2":
+        break
+    time.sleep(0.05)
+else:
+    watch_retry_process.kill()
+    raise AssertionError("watcher did not retry after the build binaries became available")
 _watch_retry_stdout, watch_retry_stderr = watch_retry_process.communicate(timeout=5)
 assert watch_retry_process.returncode == 0, watch_retry_stderr
 assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2", watch_retry_stderr
@@ -2348,7 +2371,7 @@ assert "waiting for dependency installation or a source change" in watch_retry_s
 # Permanently unavailable dependencies must wait for a subsequent change, not
 # spin through repeated exit-127 builds.
 frontend_worktree.joinpath(".fake-npm-build-count").write_text("0")
-frontend_worktree.joinpath("node_modules/.package-lock.json").unlink()
+frontend_worktree.joinpath("node_modules/.package-lock.json").unlink(missing_ok=True)
 watch_no_retry_result = subprocess.run(
     ["python3", "-c", bounded_watch_script],
     cwd=frontend_worktree,

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4046,6 +4046,62 @@ result = subprocess.run(
 assert result.returncode == 0, result.stderr
 PY
 
+# An optional dependency overrides a dependency with the same name. npm may
+# therefore complete successfully without installing that package, and the
+# rollout validator must not reject the resulting valid install.
+python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2])
+fixture = workspace / "optional-npm-override-fixture"
+fake_bin = fixture / "fake-bin"
+fixture.mkdir()
+fake_bin.mkdir()
+fixture.joinpath("package.json").write_text(
+    '{"name":"optional-override","version":"1.0.0",'
+    '"dependencies":{"optional-package":"file:./missing-package"},'
+    '"optionalDependencies":{"optional-package":"file:./missing-package"}}\n'
+)
+fixture.joinpath("package-lock.json").write_text(
+    '{"name":"optional-override","version":"1.0.0","lockfileVersion":3,'
+    '"packages":{"":{"name":"optional-override","version":"1.0.0"}}}\n'
+)
+fake_bin.joinpath("npm").write_text(
+    """#!/usr/bin/env python3
+from pathlib import Path
+
+counter_path = Path("npm-ci-attempts.txt")
+attempt = int(counter_path.read_text()) + 1 if counter_path.exists() else 1
+counter_path.write_text(str(attempt))
+Path("node_modules").mkdir(exist_ok=True)
+Path("node_modules/.package-lock.json").write_text("{}\\n")
+"""
+)
+fake_bin.joinpath("npm").chmod(0o755)
+
+spec = importlib.util.spec_from_file_location("polyscope_rollout", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+env = os.environ.copy()
+env["PATH"] = str(fake_bin) + os.pathsep + env["PATH"]
+result = subprocess.run(
+    ["bash", "-c", "set -euo pipefail; " + module.build_verified_npm_ci_command()],
+    cwd=fixture,
+    env=env,
+    capture_output=True,
+    text=True,
+)
+assert result.returncode == 0, result.stderr
+assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "1"
+PY
+
 # GuardGuide preview env setup must write APP_URL for the normalized preview
 # workspace host, not the physical worktree directory basename.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4103,8 +4103,8 @@ assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "1"
 PY
 
 # npm permits a package to be declared as both a development and optional
-# dependency. The development edge takes precedence, so a missing package must
-# still make rollout validation reject the install.
+# dependency. The optional edge permits npm ci to succeed without installing
+# that package, so rollout validation must accept the resulting install.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import os
@@ -4154,8 +4154,8 @@ result = subprocess.run(
     capture_output=True,
     text=True,
 )
-assert result.returncode == 1, result.stderr
-assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "3"
+assert result.returncode == 0, result.stderr
+assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "1"
 PY
 
 # GuardGuide preview env setup must write APP_URL for the normalized preview

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2297,8 +2297,8 @@ assert '--outDir' in run_build_source, run_build_source
 assert 'publish_preview_build(stage_dir)' in run_build_source, run_build_source
 assert 'Path("dist")' in watch_script, watch_script
 assert 'Path("node_modules/.package-lock.json")' in watch_script, watch_script
-assert 'Path("node_modules/.bin/cross-env")' not in watch_script, watch_script
-assert 'Path("node_modules/.bin/vite")' not in watch_script, watch_script
+assert 'Path("node_modules/.bin/cross-env")' in watch_script, watch_script
+assert 'Path("node_modules/.bin/vite")' in watch_script, watch_script
 assert watch_publish_source.index('replace_file(deferred_index, live_root / "index.html")') < watch_publish_source.index(
     "prune_live_tree(live_root, stage_dirs, stage_files)"
 ), watch_publish_source
@@ -4047,8 +4047,9 @@ assert "APP_URL=https://guardguide-steady-otter.preview.secpal.dev" in env_text,
 assert "APP_URL=https://guardguide-Steady Otter.preview.secpal.dev" not in env_text, env_text
 PY
 
-# build_verified_npm_ci_command must retry failed npm ci attempts even though
-# provisioning runs the generated shell under `set -euo pipefail`.
+# build_verified_npm_ci_command must retry a zero-exit npm ci attempt that
+# leaves a declared development dependency incomplete, even though provisioning
+# runs the generated shell under `set -euo pipefail`.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace"
 import importlib.util
 import os
@@ -4062,7 +4063,10 @@ fixture = workspace / "npm-ci-retry-fixture"
 fake_bin = fixture / "fake-bin"
 fixture.mkdir()
 fake_bin.mkdir()
-fixture.joinpath("package.json").write_text('{"name":"retry","version":"1.0.0","dependencies":{"left-pad":"1.3.0"}}\n')
+fixture.joinpath("package.json").write_text(
+    '{"name":"retry","version":"1.0.0","dependencies":{"left-pad":"1.3.0"},'
+    '"devDependencies":{"vite":"8.1.5"}}\n'
+)
 fixture.joinpath("package-lock.json").write_text(
     '{"name":"retry","version":"1.0.0","lockfileVersion":3,"packages":{"":{"name":"retry","version":"1.0.0"},"node_modules/left-pad":{"version":"1.3.0"}}}\n'
 )
@@ -4074,10 +4078,13 @@ import sys
 counter_path = Path("npm-ci-attempts.txt")
 attempt = int(counter_path.read_text()) + 1 if counter_path.exists() else 1
 counter_path.write_text(str(attempt))
-if attempt == 1:
-    sys.exit(42)
 Path("node_modules").mkdir(exist_ok=True)
 Path("node_modules/.package-lock.json").write_text("{}\\n")
+Path("node_modules/left-pad").mkdir(exist_ok=True)
+Path("node_modules/left-pad/package.json").write_text("{}\\n")
+if attempt > 1:
+    Path("node_modules/vite").mkdir(exist_ok=True)
+    Path("node_modules/vite/package.json").write_text("{}\\n")
 sys.exit(0)
 """
 )

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -2132,7 +2132,7 @@ if "run" in args and "build" in args:
     if os.environ.get("FAKE_NPM_FAIL_ALWAYS_BUILD_127") == "1" or (
         os.environ.get("FAKE_NPM_FAIL_WITHOUT_BUILD_BINARIES") == "1"
         and not all(
-            Path(f"node_modules/.bin/{binary}").exists()
+            (path := Path(f"node_modules/.bin/{binary}")).is_file() and os.access(path, os.X_OK)
             for binary in ("cross-env", "vite")
         )
     ):
@@ -2305,10 +2305,10 @@ assert watch_publish_source.index('replace_file(deferred_index, live_root / "ind
 ), watch_publish_source
 assert "child.is_symlink()" in watch_script, watch_script
 
-# A single build binary is not enough to retry the build. The watcher must wait
-# until both commands needed by the frontend build are available.
+# A single executable build binary is not enough to retry the build. The
+# watcher must wait until both commands needed by the frontend build are ready.
 snapshot_source = watch_script[watch_script.index("watch_directories =") : watch_script.index("def replace_file")]
-snapshot_scope = {"hashlib": hashlib}
+snapshot_scope = {"hashlib": hashlib, "os": os}
 exec("from pathlib import Path\n" + snapshot_source, snapshot_scope)
 original_cwd = pathlib.Path.cwd()
 try:
@@ -2319,6 +2319,10 @@ try:
     frontend_worktree.joinpath("node_modules/.bin/cross-env").write_text("ready\\n")
     assert snapshot_scope["snapshot"]() == initial_snapshot
     frontend_worktree.joinpath("node_modules/.bin/vite").write_text("ready\\n")
+    assert snapshot_scope["snapshot"]() == initial_snapshot
+    frontend_worktree.joinpath("node_modules/.bin/cross-env").chmod(0o755)
+    assert snapshot_scope["snapshot"]() == initial_snapshot
+    frontend_worktree.joinpath("node_modules/.bin/vite").chmod(0o755)
     assert snapshot_scope["snapshot"]() != initial_snapshot
 finally:
     os.chdir(original_cwd)
@@ -2354,6 +2358,10 @@ frontend_worktree.joinpath("node_modules").mkdir(exist_ok=True)
 frontend_worktree.joinpath("node_modules/.bin").mkdir(exist_ok=True)
 frontend_worktree.joinpath("node_modules/.bin/cross-env").write_text("ready\\n")
 frontend_worktree.joinpath("node_modules/.bin/vite").write_text("ready\\n")
+time.sleep(0.2)
+assert frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "1"
+frontend_worktree.joinpath("node_modules/.bin/cross-env").chmod(0o755)
+frontend_worktree.joinpath("node_modules/.bin/vite").chmod(0o755)
 for _ in range(20):
     if frontend_worktree.joinpath(".fake-npm-build-count").read_text() == "2":
         break
@@ -4088,7 +4096,7 @@ fixture.mkdir()
 fake_bin.mkdir()
 fixture.joinpath("package.json").write_text(
     '{"name":"retry","version":"1.0.0","dependencies":{"left-pad":"1.3.0"},'
-    '"devDependencies":{"vite":"8.1.5"}}\n'
+    '"devDependencies":{"cross-env":"10.1.0","vite":"8.1.5"}}\n'
 )
 fixture.joinpath("package-lock.json").write_text(
     '{"name":"retry","version":"1.0.0","lockfileVersion":3,"packages":{"":{"name":"retry","version":"1.0.0"},"node_modules/left-pad":{"version":"1.3.0"}}}\n'
@@ -4105,9 +4113,16 @@ Path("node_modules").mkdir(exist_ok=True)
 Path("node_modules/.package-lock.json").write_text("{}\\n")
 Path("node_modules/left-pad").mkdir(exist_ok=True)
 Path("node_modules/left-pad/package.json").write_text("{}\\n")
+for package in ("cross-env", "vite"):
+    package_path = Path("node_modules") / package
+    package_path.mkdir(exist_ok=True)
+    package_path.joinpath("package.json").write_text("{}\\n")
 if attempt > 1:
-    Path("node_modules/vite").mkdir(exist_ok=True)
-    Path("node_modules/vite/package.json").write_text("{}\\n")
+    Path("node_modules/.bin").mkdir(exist_ok=True)
+    for binary in ("cross-env", "vite"):
+        binary_path = Path("node_modules/.bin") / binary
+        binary_path.write_text("#!/bin/sh\\nexit 0\\n")
+        binary_path.chmod(0o755)
 sys.exit(0)
 """
 )
@@ -4121,7 +4136,12 @@ spec.loader.exec_module(module)
 env = os.environ.copy()
 env["PATH"] = str(fake_bin) + os.pathsep + env["PATH"]
 result = subprocess.run(
-    ["bash", "-c", "set -euo pipefail; " + module.build_verified_npm_ci_command()],
+    [
+        "bash",
+        "-c",
+        "set -euo pipefail; "
+        + module.build_verified_npm_ci_command(required_binaries=module.FRONTEND_PREVIEW_BUILD_BINARIES),
+    ],
     cwd=fixture,
     env=env,
     capture_output=True,
@@ -4129,6 +4149,10 @@ result = subprocess.run(
 )
 assert result.returncode == 0, result.stderr
 assert fixture.joinpath("npm-ci-attempts.txt").read_text() == "2"
+for binary in module.FRONTEND_PREVIEW_BUILD_BINARIES:
+    binary_path = fixture / "node_modules/.bin" / binary
+    assert binary_path.is_file()
+    assert os.access(binary_path, os.X_OK)
 PY
 
 # --prepare-api-worktree CLI path: assert --db-path is threaded into ensure_api_worktree_ready
@@ -4982,11 +5006,15 @@ cat >"$fake_exec_dir/npm" <<'STUB'
 #!/usr/bin/env bash
 printf 'npm:%s:%s\n' "$PWD" "$*" >> "$PROVISION_LOG"
 if [[ "$*" == *" ci"* || "$1" == "ci" ]]; then
-    mkdir -p node_modules/typescript/lib node_modules/@types/node
+    mkdir -p node_modules/typescript/lib node_modules/@types/node node_modules/.bin
     printf '{}\n' > node_modules/.package-lock.json
     printf '// fake lib\n' > node_modules/typescript/lib/lib.es2020.d.ts
     printf '// fake lib\n' > node_modules/typescript/lib/lib.dom.d.ts
     printf '{ "name": "@types/node" }\n' > node_modules/@types/node/package.json
+    for binary in cross-env vite; do
+        printf '#!/usr/bin/env bash\nexit 0\n' > "node_modules/.bin/$binary"
+        chmod +x "node_modules/.bin/$binary"
+    done
 fi
 if [[ "$*" == *"run build"* ]]; then
     out_dir="dist"


### PR DESCRIPTION
## Summary

- disable Nginx file caching for dynamically provisioned preview worktrees
- reject incomplete `npm ci` installs before a frontend preview build starts
- trigger the frontend preview watcher when its required build binaries become available

## Root cause

Nginx could cache a transient missing-file or permission result while a worktree preview was being provisioned. Separately, `npm ci` could return successfully with an incomplete `node_modules` tree, allowing the later Vite build to fail with a missing executable.

## Impact

Preview provisioning recovers reliably instead of serving a cached 404 or treating a damaged dependency installation as ready.

## Validation

- `bash tests/polyscope-rollout.sh`
- `bash tests/polyscope-nginx-helper.sh`

## TDD / Validate-First Evidence

- Failing proof before implementation: the new grouped-readiness regression failed against the watcher that tracked `cross-env` and `vite` independently; adding only `cross-env` changed the snapshot and could trigger a premature rebuild.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `bash tests/polyscope-nginx-helper.sh` pass with the watcher exposing the binary pair only after both shims are available.
