### PR TITLE
Align preview CSP style attributes

### DIFF
--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4611,7 +4611,8 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'self'; upgrade-insecure-requests";
+            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            set $preview_frontend_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
@@ -4625,7 +4626,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $preview_worktree $frontend_root;
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
-                set $secpal_csp $preview_relaxed_csp;
+                set $secpal_csp $preview_frontend_csp;
             }}
 
             if (-f $secpal_app_dist/index.html) {{
@@ -4660,7 +4661,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
                 set $preview_worktree $frontend_root;
                 set $preview_docroot $frontend_dist;
                 set $route_mode static;
-                set $secpal_csp $preview_relaxed_csp;
+                set $secpal_csp $preview_frontend_csp;
             }}
 
             if ($repo = guardguide) {{

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4611,7 +4611,7 @@ def render_nginx_config(repo_state: dict[str, dict[str, Any]], nginx_http2_synta
             set $preview_docroot /home/secpal/.polyscope/__missing_preview_docroot__;
             set $php_root $api_public;
             set $route_mode static;
-            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; worker-src 'self'; upgrade-insecure-requests";
+            set $preview_relaxed_csp "default-src 'self'; base-uri 'self'; connect-src 'self' https:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'self'; upgrade-insecure-requests";
             set $secpal_csp $preview_relaxed_csp;
             set $secpal_permissions_policy "accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4636,9 +4636,15 @@ if grep -qF "disable_symlinks on from=\$preview_docroot;" "$nginx_output"; then
     exit 1
 fi
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
+grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline';" "$nginx_output"
+grep -qF "set \$preview_frontend_csp " "$nginx_output"
 grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'none';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
-if grep -qF "preview_frontend_csp" "$nginx_output" || grep -qF "csp_nonce" "$nginx_output" || grep -qF "nonce-\$csp_nonce" "$nginx_output"; then
+if [[ "$(grep -cF "set \$secpal_csp \$preview_frontend_csp;" "$nginx_output")" -ne 2 ]]; then
+    echo "preview nginx config must select the strict CSP for both frontend routes" >&2
+    exit 1
+fi
+if grep -qF "csp_nonce" "$nginx_output" || grep -qF "nonce-\$csp_nonce" "$nginx_output"; then
     echo "preview nginx config must not advertise nonce-based frontend CSP after SSI removal" >&2
     exit 1
 fi

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4636,7 +4636,7 @@ if grep -qF "disable_symlinks on from=\$preview_docroot;" "$nginx_output"; then
     exit 1
 fi
 grep -qF "set \$preview_relaxed_csp " "$nginx_output"
-grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline';" "$nginx_output"
+grep -qF "script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'none';" "$nginx_output"
 grep -qF "set \$secpal_csp \$preview_relaxed_csp;" "$nginx_output"
 if grep -qF "preview_frontend_csp" "$nginx_output" || grep -qF "csp_nonce" "$nginx_output" || grep -qF "nonce-\$csp_nonce" "$nginx_output"; then
     echo "preview nginx config must not advertise nonce-based frontend CSP after SSI removal" >&2


### PR DESCRIPTION
Fixes #603

## Problem and evidence

The preview PWA header smoke test requires `style-src-attr 'none'`. The generated preview nginx policy instead emitted `style-src-attr 'unsafe-inline'`, causing the live preview header check to fail.

## Change

- Set `style-src-attr 'none'` in the generated preview CSP.
- Extend the rollout regression to require that directive in rendered nginx output.

## Validation

- `bash tests/polyscope-rollout.sh`
- `git diff --check`
- Signed commit hooks: REUSE, shellcheck, and repository integrity checks

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` exited 1 after the rendered-CSP regression required `style-src-attr 'none'` while the generator still emitted `style-src-attr 'unsafe-inline'`.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` exited 0 after the generated preview CSP was aligned with the PWA header policy.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Deployment dependency

The normal Polyscope rollout must regenerate and apply `/etc/nginx/sites-available/preview.secpal.dev` before the existing live preview endpoint reflects this change. No source-level checks remain unresolved.