### PR TITLE
fix(deps): update brace-expansion to 5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Updates the transitive development dependency `brace-expansion` from 5.0.8 to 5.0.9.

## Problem and evidence

`npm audit` reported a high-severity denial-of-service advisory for `brace-expansion` 4.0.0–5.0.8. The affected path was `markdownlint-cli@0.49.1 → minimatch@10.2.5 → brace-expansion@5.0.8`.

## Change

Updates the resolved package version, registry URL, and integrity hash in `package-lock.json`. No production dependency or source code changes are included.

## Validation

- `npm ci --ignore-scripts`
- `npm audit --json` (0 vulnerabilities)
- `npm audit --omit=dev --json` (0 vulnerabilities)
- `npm test`
- `npm run lint:markdown`
- `git diff --check`

## TDD / Validate-First Evidence

- Failing proof before implementation: `npm audit --json` reported GHSA-rgw5-rvv9-x895 as one high-severity vulnerability in `brace-expansion@5.0.8`.
- Passing proof after implementation: `npm audit --json` completed successfully with 0 vulnerabilities after resolving `brace-expansion@5.0.9`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Readiness

No in-scope dependencies or unresolved checks prevent readiness.
