### PR TITLE
Bound review and publish validation

### DIFF
--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -112,11 +112,12 @@ The following state machine applies only to the full feedback-remediation path.
    preconditions. Never infer truth from reviewer identity, keywords, or CI.
 3. Reproduce every valid finding, add a failing test first, make the smallest
    coherent corrections, and use focused validation while editing.
-   Never use a complete, repository-wide, or aggregate suite as focused validation. If the
-   relevant regression is available only through such a suite, isolate the
-   smallest direct test, filter, or fixture before running it. A registry command
-   with `execution_policy: focused-only` is eligible for this explicit selection
-   but is never added to unconditional complete validation.
+   Never use a complete, repository-wide, or aggregate suite as focused
+   validation by default. If the relevant regression is available only through
+   such a suite, isolate the smallest direct test, filter, or fixture before
+   running it. A registered focused-only command explicitly authorized by its
+   matching manual gate is the bounded exception. It remains excluded from
+   unconditional complete validation.
 4. Perform the one holistic audit across correctness, security, privacy, data
    integrity, lifecycle, rollout, and avoidable complexity. Complete all source,
    provenance, edge-case, and diff inspection here, and fix material in-scope

--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -111,18 +111,25 @@ The following state machine applies only to the full feedback-remediation path.
    thread comments. Reactions and unrelated feedback are not thread-resolution
    preconditions. Never infer truth from reviewer identity, keywords, or CI.
 3. Reproduce every valid finding, add a failing test first, make the smallest
-   coherent corrections, and use focused validation while editing. A registry
-   command with `execution_policy: focused-only` is eligible for this explicit
-   selection but is never added to unconditional complete validation.
+   coherent corrections, and use focused validation while editing.
+   Never use a complete, repository-wide, or aggregate suite as focused validation. If the
+   relevant regression is available only through such a suite, isolate the
+   smallest direct test, filter, or fixture before running it. A registry command
+   with `execution_policy: focused-only` is eligible for this explicit selection
+   but is never added to unconditional complete validation.
 4. Perform the one holistic audit across correctness, security, privacy, data
-   integrity, lifecycle, rollout, and avoidable complexity. Fix material
-   in-scope defects before the complete validation.
+   integrity, lifecycle, rollout, and avoidable complexity. Complete all source,
+   provenance, edge-case, and diff inspection here, and fix material in-scope
+   defects before the complete validation.
 5. Stage the finished tree and run the registered unconditional focused commands
    plus every required local validation exactly once through
    `attest-validation`, supplying explicit satisfied evidence for every
    registered manual gate. Preserve its deterministic staged-tree,
    parent-head, registry, command-set, manual-gate, result, and reviewed-feedback
-   receipt.
+   receipt. Do not continue discovery or change the tree after this step begins.
+   A failed command produces no receipt; correct only that proven failure with
+   the smallest focused check before starting one new complete attempt. Never
+   repeat a successful complete validation.
 6. When remediation changed the staged tree, create one signed commit containing
    exactly that tree, use the receipt digest as its single
    `SecPal-Validation-Receipt` trailer, and use `attest-validation --bind-commit`

--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -127,9 +127,11 @@ The following state machine applies only to the full feedback-remediation path.
    registered manual gate. Preserve its deterministic staged-tree,
    parent-head, registry, command-set, manual-gate, result, and reviewed-feedback
    receipt. Do not continue discovery or change the tree after this step begins.
-   A failed command produces no receipt; correct only that proven failure with
-   the smallest focused check before starting one new complete attempt. Never
-   repeat a successful complete validation.
+   A failed command produces no receipt and is a terminal security blocker for
+   this invocation. Do not change the tree or retry any complete command.
+   Require a new explicit remediation invocation so any correction receives
+   focused validation and a fresh holistic audit before its single complete
+   validation. Never repeat a successful complete validation.
 6. When remediation changed the staged tree, create one signed commit containing
    exactly that tree, use the receipt digest as its single
    `SecPal-Validation-Receipt` trailer, and use `attest-validation --bind-commit`

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -136,18 +136,27 @@ excludes Required Check results and all other volatile readiness values.
 `CLASSIFY_AND_FIX_ALL_CURRENT_FINDINGS` independently proves each classification,
 adds failing regression coverage for valid findings, and implements the smallest
 coherent correction. `FOCUSED_VALIDATION_WHILE_EDITING` runs only affected tests.
+Focused validation must not invoke a complete, repository-wide, or aggregate suite,
+directly or through a wrapper. When the relevant regression is available only
+through such a suite, isolate the smallest direct test, filter, or fixture first.
 Commands marked `execution_policy: focused-only` remain available for that
 explicit selection and are excluded from unconditional complete validation.
 
 `HOLISTIC_AUDIT` runs once and covers correctness, security, privacy, data
-integrity, lifecycle, rollout, user control, and avoidable complexity.
+integrity, lifecycle, rollout, user control, and avoidable complexity. All
+source, provenance, edge-case, and diff inspection finishes in this state.
 
 `COMPLETE_LOCAL_VALIDATION_ONCE` runs the registry's unconditional focused
 commands and every required local command once and returns a deterministic
 receipt binding repository, parent head,
 staged-tree SHA, registry digest, command-set digest, successful result, and
 reviewed-feedback digests plus explicit satisfied evidence for every registered
-manual gate. Time is informational only and cannot determine validity.
+manual gate. On entry, the tracked tree and holistic-audit result are frozen;
+independent discovery and audit do not continue in or after this state. A failed
+command produces no receipt and permits correction only of that proven failure
+with the smallest affected focused check before one new complete attempt. A
+successful complete validation is never repeated. Time is informational only
+and cannot determine validity.
 
 `IF_TRACKED_TREE_CHANGED` selects only between the proven staged tree and the
 reviewed tree. When remediation changes no tracked source file, it takes

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -153,10 +153,11 @@ staged-tree SHA, registry digest, command-set digest, successful result, and
 reviewed-feedback digests plus explicit satisfied evidence for every registered
 manual gate. On entry, the tracked tree and holistic-audit result are frozen;
 independent discovery and audit do not continue in or after this state. A failed
-command produces no receipt and permits correction only of that proven failure
-with the smallest affected focused check before one new complete attempt. A
-successful complete validation is never repeated. Time is informational only
-and cannot determine validity.
+command produces no receipt, terminates this invocation, and permits no tree
+change or complete-command retry. A new explicit remediation invocation must
+capture fresh state and audit any correction before its single complete
+validation. A successful complete validation is never repeated. Time is
+informational only and cannot determine validity.
 
 `IF_TRACKED_TREE_CHANGED` selects only between the proven staged tree and the
 reviewed tree. When remediation changes no tracked source file, it takes

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -136,11 +136,12 @@ excludes Required Check results and all other volatile readiness values.
 `CLASSIFY_AND_FIX_ALL_CURRENT_FINDINGS` independently proves each classification,
 adds failing regression coverage for valid findings, and implements the smallest
 coherent correction. `FOCUSED_VALIDATION_WHILE_EDITING` runs only affected tests.
-Focused validation must not invoke a complete, repository-wide, or aggregate suite,
-directly or through a wrapper. When the relevant regression is available only
-through such a suite, isolate the smallest direct test, filter, or fixture first.
-Commands marked `execution_policy: focused-only` remain available for that
-explicit selection and are excluded from unconditional complete validation.
+Focused validation must not invoke a complete, repository-wide, or aggregate suite
+by default, directly or through a wrapper. When the relevant regression is
+available only through such a suite, isolate the smallest direct test, filter,
+or fixture first. A registered focused-only command explicitly authorized by
+its matching manual gate is the bounded exception. It remains excluded from
+unconditional complete validation.
 
 `HOLISTIC_AUDIT` runs once and covers correctness, security, privacy, data
 integrity, lifecycle, rollout, user control, and avoidable complexity. All
@@ -153,11 +154,12 @@ staged-tree SHA, registry digest, command-set digest, successful result, and
 reviewed-feedback digests plus explicit satisfied evidence for every registered
 manual gate. On entry, the tracked tree and holistic-audit result are frozen;
 independent discovery and audit do not continue in or after this state. A failed
-command produces no receipt, terminates this invocation, and permits no tree
-change or complete-command retry. A new explicit remediation invocation must
-capture fresh state and audit any correction before its single complete
-validation. A successful complete validation is never repeated. Time is
-informational only and cannot determine validity.
+command produces no receipt; the command invalidates any report already at its
+configured output before validation begins, terminates this invocation, and
+permits no tree change or complete-command retry. A new explicit remediation
+invocation must capture fresh state and audit any correction before its single
+complete validation. A successful complete validation is never repeated. Time
+is informational only and cannot determine validity.
 
 `IF_TRACKED_TREE_CHANGED` selects only between the proven staged tree and the
 reviewed tree. When remediation changes no tracked source file, it takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ Log of notable changes to SecPal organization defaults (newest first).
 - reserved complete and aggregate suites for the single final review-validation
   pass instead of allowing them as iterative focused checks
 - made a failed final pass terminal so any correction receives fresh feedback
-  capture, focused validation, and a holistic audit in a new invocation
+  capture, focused validation, and a holistic audit in a new invocation, and
+  invalidated any stale receipt before that pass begins
+- preserved explicitly authorized, registry-bound `focused-only` integration
+  suites as the sole bounded exception to the aggregate-suite prohibition
 - reused successful validation only for an unchanged repository, HEAD, parent,
-  tree, registry, command set, and manual-gate evidence, and ran only missing
-  required checks once
+  final staged tree including new paths, registry, command set, and manual-gate
+  evidence, and ran only missing required checks once
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-04 - Bound Review And Publish Validation
+
+**Changed:**
+
+- reserved complete and aggregate suites for the single final review-validation
+  pass instead of allowing them as iterative focused checks
+- finished review discovery before final validation and prohibited repeating a
+  successful complete pass
+- reused successful validation for an exact unchanged tree during publishing
+  and ran only missing required checks once
+
+---
+
 ## 2026-08-03 - Decouple Full Validation From Push
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - reserved complete and aggregate suites for the single final review-validation
   pass instead of allowing them as iterative focused checks
-- finished review discovery before final validation and prohibited repeating a
-  successful complete pass
-- reused successful validation for an exact unchanged tree during publishing
-  and ran only missing required checks once
+- made a failed final pass terminal so any correction receives fresh feedback
+  capture, focused validation, and a holistic audit in a new invocation
+- reused successful validation only for an unchanged repository, HEAD, parent,
+  tree, registry, command set, and manual-gate evidence, and ran only missing
+  required checks once
 
 ---
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3146,8 +3146,10 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
     merge_and_push_prompt = collapse_spaces(
         f"Before push and merge for {spec['display_name']}, apply {instruction_ref}. "
         f"{NO_AI_ATTRIBUTION_RULE} "
-        "First establish whether existing validation evidence identifies the successful commands and binds the current repository, exact HEAD and parent, Git tree, validation registry, command set, and required manual-gate evidence. "
-        "Treat that evidence as stale if any bound value or tracked content changed. "
+        "First stage the complete intended change set before evaluating reusable validation evidence. "
+        "Reuse only evidence that identifies the successful commands and binds the current repository, exact HEAD and parent, exact final staged tree, including every newly added path, validation registry, command set, and required manual-gate evidence. "
+        "Treat that evidence as stale if any bound value, staged content, or tracked content changed, and do not stage additional content after deciding to reuse it. "
+        "Recheck the staged-tree identity immediately before committing and pushing. "
         "Do not rerun a check that already passed for that exact unchanged bound state. "
         "Run only missing required checks once. "
         f"Then verify: {format_bullets(select_bullets(validation, ['validation', 'smallest relevant', 'complete required', 'lint', 'typecheck', 'build', 'pest', 'reuse'], 7))}. "

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3146,9 +3146,9 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
     merge_and_push_prompt = collapse_spaces(
         f"Before push and merge for {spec['display_name']}, apply {instruction_ref}. "
         f"{NO_AI_ATTRIBUTION_RULE} "
-        "First establish whether existing validation evidence identifies the successful commands and covers the exact current Git tree. "
-        "Treat that evidence as stale if tracked content changed. "
-        "Do not rerun a check that already passed for the exact unchanged tree. "
+        "First establish whether existing validation evidence identifies the successful commands and binds the current repository, exact HEAD and parent, Git tree, validation registry, command set, and required manual-gate evidence. "
+        "Treat that evidence as stale if any bound value or tracked content changed. "
+        "Do not rerun a check that already passed for that exact unchanged bound state. "
         "Run only missing required checks once. "
         f"Then verify: {format_bullets(select_bullets(validation, ['validation', 'smallest relevant', 'complete required', 'lint', 'typecheck', 'build', 'pest', 'reuse'], 7))}. "
         f"Apply the commit and communication rules: {format_bullets(change_tracking)}. "

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3146,7 +3146,11 @@ def build_prompt_bundle(spec: dict[str, Any]) -> dict[str, str]:
     merge_and_push_prompt = collapse_spaces(
         f"Before push and merge for {spec['display_name']}, apply {instruction_ref}. "
         f"{NO_AI_ATTRIBUTION_RULE} "
-        f"Run or re-run the touched checks demanded by the repo instructions, then verify: {format_bullets(select_bullets(validation, ['validation', 'smallest relevant', 'complete required', 'lint', 'typecheck', 'build', 'pest', 'reuse'], 7))}. "
+        "First establish whether existing validation evidence identifies the successful commands and covers the exact current Git tree. "
+        "Treat that evidence as stale if tracked content changed. "
+        "Do not rerun a check that already passed for the exact unchanged tree. "
+        "Run only missing required checks once. "
+        f"Then verify: {format_bullets(select_bullets(validation, ['validation', 'smallest relevant', 'complete required', 'lint', 'typecheck', 'build', 'pest', 'reuse'], 7))}. "
         f"Apply the commit and communication rules: {format_bullets(change_tracking)}. "
         "Do not bypass hooks or force operations."
     )

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -4332,6 +4332,16 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
         getattr(arguments, "manual_gate_evidence", None), binding
     )
     tree = _staged_tree(repository_root, status)
+    if arguments.output:
+        _write_fast_report(
+            arguments.output,
+            {
+                "schema_version": "1.0",
+                "status": "VALIDATION_RECEIPT_INVALIDATED",
+                "head_sha": head,
+                "validated_tree_sha": tree,
+            },
+        )
     if not _run_registered_validations(entry, repository_root):
         raise fast_path.SecurityBlocker("complete registered validation failed")
     head_after, status_after = _attestation_local_state(repository_root, arguments.repo)

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4991,6 +4991,10 @@ assert 'Keep changes repo-local, minimal, and consistent with the repository sta
 assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
 assert 'Preserve a branch or worktree already supplied by the execution environment.' in org_prompts[0]
 assert 'Run the smallest relevant validation while iterating' in org_prompts[1]
+assert 'Treat that evidence as stale if tracked content changed.' in org_prompts[2]
+assert 'Do not rerun a check that already passed for the exact unchanged tree.' in org_prompts[2]
+assert 'Run only missing required checks once.' in org_prompts[2]
+assert 'Run or re-run the touched checks' not in org_prompts[2]
 for row in prompt_rows:
     for prompt in row:
         assert 'Do not add AI agent attribution' in prompt

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4991,11 +4991,15 @@ assert 'Keep changes repo-local, minimal, and consistent with the repository sta
 assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
 assert 'Preserve a branch or worktree already supplied by the execution environment.' in org_prompts[0]
 assert 'Run the smallest relevant validation while iterating' in org_prompts[1]
-assert 'binds the current repository, exact HEAD and parent, Git tree, validation registry, command set, and required manual-gate evidence.' in org_prompts[2]
-assert 'Treat that evidence as stale if any bound value or tracked content changed.' in org_prompts[2]
+assert 'stage the complete intended change set before evaluating reusable validation evidence' in org_prompts[2]
+assert 'exact final staged tree, including every newly added path' in org_prompts[2]
+assert 'recheck the staged-tree identity immediately before committing and pushing' in org_prompts[2]
+assert 'Treat that evidence as stale if any bound value, staged content, or tracked content changed' in org_prompts[2]
+assert 'do not stage additional content after deciding to reuse it' in org_prompts[2]
 assert 'Do not rerun a check that already passed for that exact unchanged bound state.' in org_prompts[2]
 assert 'Run only missing required checks once.' in org_prompts[2]
 assert 'covers the exact current Git tree' not in org_prompts[2]
+assert 'binds the current repository, exact HEAD and parent, Git tree' not in org_prompts[2]
 assert 'Run or re-run the touched checks' not in org_prompts[2]
 for row in prompt_rows:
     for prompt in row:

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -4991,9 +4991,11 @@ assert 'Keep changes repo-local, minimal, and consistent with the repository sta
 assert 'Write a concise English PR body for SecPal/frontend.' in frontend_prompt
 assert 'Preserve a branch or worktree already supplied by the execution environment.' in org_prompts[0]
 assert 'Run the smallest relevant validation while iterating' in org_prompts[1]
-assert 'Treat that evidence as stale if tracked content changed.' in org_prompts[2]
-assert 'Do not rerun a check that already passed for the exact unchanged tree.' in org_prompts[2]
+assert 'binds the current repository, exact HEAD and parent, Git tree, validation registry, command set, and required manual-gate evidence.' in org_prompts[2]
+assert 'Treat that evidence as stale if any bound value or tracked content changed.' in org_prompts[2]
+assert 'Do not rerun a check that already passed for that exact unchanged bound state.' in org_prompts[2]
 assert 'Run only missing required checks once.' in org_prompts[2]
+assert 'covers the exact current Git tree' not in org_prompts[2]
 assert 'Run or re-run the touched checks' not in org_prompts[2]
 for row in prompt_rows:
     for prompt in row:

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -5302,49 +5302,62 @@ class FastPathTests(TestCase):
                 ):
                     actions._command_attest_validation(arguments)
 
-    def test_failed_complete_validation_is_terminal_without_a_receipt(self) -> None:
-        arguments = SimpleNamespace(
-            expected_head=p21.HEAD,
-            repo_root=str(REPO_ROOT),
-            repo="SecPal/.github",
-            reviewed_state="reviewed.json",
-            registry="registry.json",
-            bind_commit=False,
-            receipt=None,
-            output="receipt.json",
-            manual_gate_evidence=None,
-        )
+    def test_failed_complete_validation_invalidates_a_stale_receipt(self) -> None:
         entry = registry_entry("SecPal/.github")
         entry["manual_gates"] = []
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "receipt.json"
+            output.write_text(
+                json.dumps({"receipt_digest": "stale-successful-receipt"}),
+                encoding="utf-8",
+            )
+            arguments = SimpleNamespace(
+                expected_head=p21.HEAD,
+                repo_root=str(REPO_ROOT),
+                repo="SecPal/.github",
+                reviewed_state="reviewed.json",
+                registry="registry.json",
+                bind_commit=False,
+                receipt=None,
+                output=str(output),
+                manual_gate_evidence=None,
+            )
 
-        with (
-            mock.patch.object(
-                actions,
-                "_attestation_local_state",
-                return_value=(p21.HEAD, ""),
-            ),
-            mock.patch.object(
-                actions,
-                "_load_fast_state",
-                return_value=fast_feedback(),
-            ),
-            mock.patch.object(actions, "load_registry", return_value={}),
-            mock.patch.object(actions, "select_repository", return_value=entry),
-            mock.patch.object(actions, "_staged_tree", return_value="a" * 40),
-            mock.patch.object(
-                actions,
-                "_run_registered_validations",
-                return_value=False,
-            ),
-            mock.patch.object(actions, "_write_fast_report") as write_report,
-        ):
-            with self.assertRaisesRegex(
-                fast_path.SecurityBlocker,
-                "complete registered validation failed",
+            with (
+                mock.patch.object(
+                    actions,
+                    "_attestation_local_state",
+                    return_value=(p21.HEAD, ""),
+                ),
+                mock.patch.object(
+                    actions,
+                    "_load_fast_state",
+                    return_value=fast_feedback(),
+                ),
+                mock.patch.object(actions, "load_registry", return_value={}),
+                mock.patch.object(actions, "select_repository", return_value=entry),
+                mock.patch.object(actions, "_staged_tree", return_value="a" * 40),
+                mock.patch.object(
+                    actions,
+                    "_run_registered_validations",
+                    return_value=False,
+                ),
             ):
-                actions._command_attest_validation(arguments)
+                with self.assertRaisesRegex(
+                    fast_path.SecurityBlocker,
+                    "complete registered validation failed",
+                ):
+                    actions._command_attest_validation(arguments)
 
-        write_report.assert_not_called()
+            self.assertEqual(
+                json.loads(output.read_text(encoding="utf-8")),
+                {
+                    "schema_version": "1.0",
+                    "status": "VALIDATION_RECEIPT_INVALIDATED",
+                    "head_sha": p21.HEAD,
+                    "validated_tree_sha": "a" * 40,
+                },
+            )
 
     def test_bound_commit_requires_receipt_for_reviewed_head(self) -> None:
         reviewed = fast_feedback()

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -5302,6 +5302,50 @@ class FastPathTests(TestCase):
                 ):
                     actions._command_attest_validation(arguments)
 
+    def test_failed_complete_validation_is_terminal_without_a_receipt(self) -> None:
+        arguments = SimpleNamespace(
+            expected_head=p21.HEAD,
+            repo_root=str(REPO_ROOT),
+            repo="SecPal/.github",
+            reviewed_state="reviewed.json",
+            registry="registry.json",
+            bind_commit=False,
+            receipt=None,
+            output="receipt.json",
+            manual_gate_evidence=None,
+        )
+        entry = registry_entry("SecPal/.github")
+        entry["manual_gates"] = []
+
+        with (
+            mock.patch.object(
+                actions,
+                "_attestation_local_state",
+                return_value=(p21.HEAD, ""),
+            ),
+            mock.patch.object(
+                actions,
+                "_load_fast_state",
+                return_value=fast_feedback(),
+            ),
+            mock.patch.object(actions, "load_registry", return_value={}),
+            mock.patch.object(actions, "select_repository", return_value=entry),
+            mock.patch.object(actions, "_staged_tree", return_value="a" * 40),
+            mock.patch.object(
+                actions,
+                "_run_registered_validations",
+                return_value=False,
+            ),
+            mock.patch.object(actions, "_write_fast_report") as write_report,
+        ):
+            with self.assertRaisesRegex(
+                fast_path.SecurityBlocker,
+                "complete registered validation failed",
+            ):
+                actions._command_attest_validation(arguments)
+
+        write_report.assert_not_called()
+
     def test_bound_commit_requires_receipt_for_reviewed_head(self) -> None:
         reviewed = fast_feedback()
         receipt_head = "e" * 40

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -79,8 +79,10 @@ grep -Fq 'normal_complete_validation_runs: 1' "$CONTRACT" || fail 'complete vali
 grep -Fq 'maximum_holistic_audits: 1' "$CONTRACT" || fail 'holistic audit limit drifted'
 grep -Fq 'Focused validation must not invoke a complete, repository-wide, or aggregate suite' "$CONTRACT" \
   || fail 'focused validation may still consume the complete validation gate'
-grep -Fq 'A failed command produces no receipt, terminates this invocation, and permits no tree change or complete-command retry.' <<<"$contract_text" \
-  || fail 'failed complete validation is not terminal'
+grep -Fq 'A registered focused-only command explicitly authorized by its matching manual gate is the bounded exception.' <<<"$contract_text" \
+  || fail 'authorized focused-only aggregate validation has no bounded exception'
+grep -Fq 'A failed command produces no receipt; the command invalidates any report already at its configured output before validation begins, terminates this invocation, and permits no tree change or complete-command retry.' <<<"$contract_text" \
+  || fail 'failed complete validation does not invalidate stale output or terminate'
 grep -Fq 'A new explicit remediation invocation must capture fresh state and audit any correction' <<<"$contract_text" \
   || fail 'failed complete validation may reuse the prior audit'
 if grep -Fq 'one new complete attempt' "$CONTRACT"; then
@@ -162,8 +164,10 @@ test -n "$normal_skill_section" || fail 'normal skill workflow is missing'
 normal_skill_text="$(tr '\n' ' ' <<<"$normal_skill_section" | tr -s '[:space:]' ' ')"
 grep -Fq 'scripts/secpal-resolve-fixed-threads.py' <<<"$normal_skill_section" \
   || fail 'review remediation does not use the simple fixed-thread resolver'
-grep -Fq 'Never use a complete, repository-wide, or aggregate suite as focused validation.' <<<"$normal_skill_section" \
-  || fail 'skill permits complete suites during focused iteration'
+grep -Fq 'Never use a complete, repository-wide, or aggregate suite as focused validation by default.' <<<"$normal_skill_text" \
+  || fail 'skill does not keep aggregate suites forbidden by default'
+grep -Fq 'A registered focused-only command explicitly authorized by its matching manual gate is the bounded exception.' <<<"$normal_skill_text" \
+  || fail 'skill blocks authorized focused-only aggregate validation'
 grep -Fq 'A failed command produces no receipt and is a terminal security blocker for this invocation.' <<<"$normal_skill_text" \
   || fail 'skill does not terminate after failed complete validation'
 grep -Fq 'Require a new explicit remediation invocation so any correction receives focused validation and a fresh holistic audit' <<<"$normal_skill_text" \

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -76,6 +76,10 @@ grep -Fq 'normal_stable_feedback_reads: 1' "$CONTRACT" || fail 'stable feedback 
 grep -Fq 'normal_required_check_reads_before_resolution: 0' "$CONTRACT" || fail 'default remediation still reads Required Checks'
 grep -Fq 'normal_complete_validation_runs: 1' "$CONTRACT" || fail 'complete validation limit drifted'
 grep -Fq 'maximum_holistic_audits: 1' "$CONTRACT" || fail 'holistic audit limit drifted'
+grep -Fq 'Focused validation must not invoke a complete, repository-wide, or aggregate suite' "$CONTRACT" \
+  || fail 'focused validation may still consume the complete validation gate'
+grep -Fq 'the tracked tree and holistic-audit result are frozen' "$CONTRACT" \
+  || fail 'complete validation no longer freezes the audited tree'
 grep -Fq 'normal_signed_remediation_commits: 1' "$CONTRACT" || fail 'commit limit drifted'
 grep -Fq 'normal_fast_forward_pushes: 1' "$CONTRACT" || fail 'push limit drifted'
 grep -Fq 'maximum_evidence_replies_total: 10' "$CONTRACT" || fail 'reply limit drifted'
@@ -151,6 +155,10 @@ normal_skill_section="$(sed -n '/^## Run the finite invocation$/,/^## /p' "$SKIL
 test -n "$normal_skill_section" || fail 'normal skill workflow is missing'
 grep -Fq 'scripts/secpal-resolve-fixed-threads.py' <<<"$normal_skill_section" \
   || fail 'review remediation does not use the simple fixed-thread resolver'
+grep -Fq 'Never use a complete, repository-wide, or aggregate suite as focused validation.' <<<"$normal_skill_section" \
+  || fail 'skill permits complete suites during focused iteration'
+grep -Fq 'Do not continue discovery or change the tree after this step begins.' <<<"$normal_skill_section" \
+  || fail 'skill permits another audit or edit after complete validation starts'
 if grep -Eq 'Required Checks|mergeability|branch-protection|pull-request reactions' <<<"$normal_skill_section"; then
   fail 'default remediation still gates resolution on unrelated readiness state'
 fi

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -71,6 +71,7 @@ test -x "$GOVERNANCE_SUITE" || fail 'registered governance suite is not executab
 
 # Policy cases: exact fast-path counters, one audit, explicit checkpoint, one
 # bounded read retry, no polling, and zero review-request/merge authority.
+contract_text="$(tr '\n' ' ' <"$CONTRACT" | tr -s '[:space:]' ' ')"
 grep -Fq 'normal_complete_snapshots: 0' "$CONTRACT" || fail 'normal snapshot limit drifted'
 grep -Fq 'normal_stable_feedback_reads: 1' "$CONTRACT" || fail 'stable feedback read limit drifted'
 grep -Fq 'normal_required_check_reads_before_resolution: 0' "$CONTRACT" || fail 'default remediation still reads Required Checks'
@@ -78,8 +79,13 @@ grep -Fq 'normal_complete_validation_runs: 1' "$CONTRACT" || fail 'complete vali
 grep -Fq 'maximum_holistic_audits: 1' "$CONTRACT" || fail 'holistic audit limit drifted'
 grep -Fq 'Focused validation must not invoke a complete, repository-wide, or aggregate suite' "$CONTRACT" \
   || fail 'focused validation may still consume the complete validation gate'
-grep -Fq 'the tracked tree and holistic-audit result are frozen' "$CONTRACT" \
-  || fail 'complete validation no longer freezes the audited tree'
+grep -Fq 'A failed command produces no receipt, terminates this invocation, and permits no tree change or complete-command retry.' <<<"$contract_text" \
+  || fail 'failed complete validation is not terminal'
+grep -Fq 'A new explicit remediation invocation must capture fresh state and audit any correction' <<<"$contract_text" \
+  || fail 'failed complete validation may reuse the prior audit'
+if grep -Fq 'one new complete attempt' "$CONTRACT"; then
+  fail 'contract permits a second complete validation attempt in one invocation'
+fi
 grep -Fq 'normal_signed_remediation_commits: 1' "$CONTRACT" || fail 'commit limit drifted'
 grep -Fq 'normal_fast_forward_pushes: 1' "$CONTRACT" || fail 'push limit drifted'
 grep -Fq 'maximum_evidence_replies_total: 10' "$CONTRACT" || fail 'reply limit drifted'
@@ -153,12 +159,18 @@ grep -Fq 'never polls, waits, sleeps, or repeats automatically' <<<"$readiness_c
 
 normal_skill_section="$(sed -n '/^## Run the finite invocation$/,/^## /p' "$SKILL")"
 test -n "$normal_skill_section" || fail 'normal skill workflow is missing'
+normal_skill_text="$(tr '\n' ' ' <<<"$normal_skill_section" | tr -s '[:space:]' ' ')"
 grep -Fq 'scripts/secpal-resolve-fixed-threads.py' <<<"$normal_skill_section" \
   || fail 'review remediation does not use the simple fixed-thread resolver'
 grep -Fq 'Never use a complete, repository-wide, or aggregate suite as focused validation.' <<<"$normal_skill_section" \
   || fail 'skill permits complete suites during focused iteration'
-grep -Fq 'Do not continue discovery or change the tree after this step begins.' <<<"$normal_skill_section" \
-  || fail 'skill permits another audit or edit after complete validation starts'
+grep -Fq 'A failed command produces no receipt and is a terminal security blocker for this invocation.' <<<"$normal_skill_text" \
+  || fail 'skill does not terminate after failed complete validation'
+grep -Fq 'Require a new explicit remediation invocation so any correction receives focused validation and a fresh holistic audit' <<<"$normal_skill_text" \
+  || fail 'skill permits correction without a fresh audit'
+if grep -Fq 'one new complete attempt' <<<"$normal_skill_section"; then
+  fail 'skill permits a second complete validation attempt in one invocation'
+fi
 if grep -Eq 'Required Checks|mergeability|branch-protection|pull-request reactions' <<<"$normal_skill_section"; then
   fail 'default remediation still gates resolution on unrelated readiness state'
 fi


### PR DESCRIPTION
## Summary

- reserve complete and aggregate suites for the single final review-validation pass
- require review discovery and the holistic audit to finish before final validation
- reuse successful validation during publishing only when it identifies the commands and covers the exact unchanged Git tree
- run only missing required checks once and treat evidence as stale after tracked-content changes

## Why

Review remediation and publishing could repeat the same expensive rollout and preflight suites even after they had already passed for an unchanged tree. This preserved quality but made ordinary Commit and Draft PR actions take many unnecessary minutes.

The updated contract keeps one complete validation gate while preventing large suites from being used as iterative focused checks. Publish remains fail-closed when the tree changes or the existing evidence is incomplete.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-rollout.sh` with the new prompt assertions failed against the pre-change prompt because it still instructed publishing to rerun touched checks and did not bind reuse to an unchanged tree.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` and `bash tests/secpal-pr-review-skill-policy.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/pull-request-evidence.sh`
- `bash tests/secpal-pr-review-skill-policy.sh`
- SecPal review skill validation with `quick_validate.py`
- focused generated-prompt regression
- shell and Python syntax checks
- `git diff --check`
- `bash tests/polyscope-rollout.sh`

## Impact

Commit and Draft PR actions can reuse trustworthy validation for an unchanged tree instead of rerunning it. Required checks still run once when evidence is missing or stale, and GitHub-hosted CI remains unchanged.
