### PR TITLE
Require stable Android certificate transparency check

### DIFF
--- a/scripts/sync-required-checks.sh
+++ b/scripts/sync-required-checks.sh
@@ -50,7 +50,8 @@ REQUIRED_CONTEXTS_JSON="$(cat <<'EOF'
     "Analyze with CodeQL (javascript-typescript)",
     "Check PR Size / Check PR Size",
     "AI Instructions / Validate AI Instructions",
-    "Markdown Lint / Lint Markdown Files"
+    "Markdown Lint / Lint Markdown Files",
+    "Certificate transparency"
   ],
   "api": [
     "Check REUSE Compliance / Check REUSE Compliance",

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -41,6 +41,8 @@ assert_payload_contexts_equal() {
   if ! jq -e --argjson expected "$expected" '
     .strict == true and
     (.checks | length) == ($expected | length) and
+    ([.checks[].context] | length) == ([.checks[].context] | unique | length) and
+    ($expected | length) == ($expected | unique | length) and
     ([.checks[].context] | sort) == ($expected | sort) and
     all(.checks[]; .app_id == -1)
   ' >/dev/null <<<"$payload"; then
@@ -49,6 +51,19 @@ assert_payload_contexts_equal() {
     exit 1
   fi
 }
+
+duplicate_payload='{
+  "strict": true,
+  "checks": [
+    {"context": "duplicate", "app_id": -1},
+    {"context": "duplicate", "app_id": -1}
+  ]
+}'
+duplicate_contexts='["duplicate", "duplicate"]'
+if (assert_payload_contexts_equal "$duplicate_payload" "$duplicate_contexts") >/dev/null 2>&1; then
+  echo "Exact payload assertion must reject duplicate payload and expected contexts" >&2
+  exit 1
+fi
 
 if [[ ! -x "$SYNC_SCRIPT" ]]; then
   echo "Expected executable sync script at $SYNC_SCRIPT" >&2

--- a/tests/sync-required-checks.sh
+++ b/tests/sync-required-checks.sh
@@ -34,6 +34,22 @@ assert_payload_has_context() {
   fi
 }
 
+assert_payload_contexts_equal() {
+  local payload="$1"
+  local expected="$2"
+
+  if ! jq -e --argjson expected "$expected" '
+    .strict == true and
+    (.checks | length) == ($expected | length) and
+    ([.checks[].context] | sort) == ($expected | sort) and
+    all(.checks[]; .app_id == -1)
+  ' >/dev/null <<<"$payload"; then
+    echo "Payload did not contain exactly the expected required checks" >&2
+    echo "$payload" >&2
+    exit 1
+  fi
+}
+
 if [[ ! -x "$SYNC_SCRIPT" ]]; then
   echo "Expected executable sync script at $SYNC_SCRIPT" >&2
   exit 1
@@ -55,9 +71,21 @@ assert_payload_has_context "$api_payload" "AI Instructions / Validate AI Instruc
 assert_payload_has_context "$api_payload" "PEST Tests"
 
 android_payload="$(bash "$SYNC_SCRIPT" --repo android --print-payload)"
-assert_payload_has_context "$android_payload" "Check PR Size / Check PR Size"
-assert_payload_has_context "$android_payload" "Markdown Lint / Lint Markdown Files"
-assert_payload_has_context "$android_payload" "AI Instructions / Validate AI Instructions"
+android_contexts='[
+  "Check REUSE Compliance / Check REUSE Compliance",
+  "Check License Compatibility / Check License Compatibility",
+  "Formatting Check / Check Code Formatting",
+  "check-conflicts / Detect Git Conflict Markers",
+  "ESLint / Run Linter",
+  "TypeScript Check / Build Project",
+  "Vitest Tests",
+  "Analyze with CodeQL (javascript-typescript)",
+  "Check PR Size / Check PR Size",
+  "AI Instructions / Validate AI Instructions",
+  "Markdown Lint / Lint Markdown Files",
+  "Certificate transparency"
+]'
+assert_payload_contexts_equal "$android_payload" "$android_contexts"
 
 guardguide_payload="$(bash "$SYNC_SCRIPT" --repo GuardGuide --print-payload)"
 assert_payload_has_context "$guardguide_payload" "Pest Tests (PostgreSQL)"


### PR DESCRIPTION
## Problem

The canonical Android required-check payload did not have a stable certificate-transparency gate. Requiring the five path-filtered matrix job contexts directly would leave unrelated pull requests waiting for jobs that are never created, while omitting them allows required-check synchronization to remove certificate-transparency protection.

The Android workflow emits these matrix jobs only for relevant changes:

- `Platform policy (API 24)`
- `Platform policy (API 29)`
- `Platform policy (API 35)`
- `Platform policy (API 36)`
- `Platform policy (API 37)`

## Change

- Require the stable `Certificate transparency` aggregate context in the canonical Android payload.
- Replace partial Android payload assertions with an exact contract covering all 12 contexts, strict mode, uniqueness, and unrestricted app identity.

## Validation

- `bash tests/sync-required-checks.sh`
- `shellcheck scripts/sync-required-checks.sh tests/sync-required-checks.sh`
- `bash scripts/preflight.sh`
- `git diff --check`
- Repository commit hooks, including REUSE and ShellCheck

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/sync-required-checks.sh` failed with `Payload did not contain exactly the expected required checks` because the Android payload contained the five matrix contexts instead of the stable aggregate context.
- Passing proof after implementation: `bash tests/sync-required-checks.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Dependency and draft status

This PR depends on SecPal/android#522, which introduces the always-reported `Certificate transparency` aggregate job, skips the emulator matrix only for irrelevant pull-request changes, fails closed when change detection or any matrix job fails, and closes SecPal/android#521.

Do not apply this canonical payload to `SecPal/android/main` until the Android workflow is present on `main` and has reported the aggregate context. Applying it earlier would create a required check that no current workflow can report.

Part of #612.