### PR TITLE
Fix preview provisioning follow-ups

### DIFF
--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4568,6 +4568,7 @@ def provision_worktrees(
                 )
 
                 preview_storage_target: str | None = None
+                preview_storage_reset_required = False
                 if repo_name == "api":
                     ready, preview_storage_target = ensure_api_worktree_ready(
                         locked_worktree_path,
@@ -4576,11 +4577,20 @@ def provision_worktrees(
                     )
                     if not ready:
                         continue
+                    preview_storage_reset_required = (
+                        load_env_assignments(locked_worktree_path / ".env")
+                        .get(PREVIEW_STORAGE_RESET_REQUIRED_ENV_KEY, "")
+                        .strip()
+                        == "1"
+                    )
 
                 marker_path = locked_worktree_path / PROVISION_MARKER_FILENAME
                 marker = load_provision_marker(marker_path)
                 if marker is not None and marker.get("setup_hash") == setup_hash:
-                    if repo_name != "api" or marker.get("preview_storage_target") == preview_storage_target:
+                    if repo_name != "api" or (
+                        marker.get("preview_storage_target") == preview_storage_target
+                        and not preview_storage_reset_required
+                    ):
                         if preview_enabled:
                             ensure_preview_nginx_access(clone_root, locked_worktree_path)
                         continue
@@ -5033,6 +5043,13 @@ def render_nginx_config(
 
             location ~ /\\.(?!well-known) {{
                 deny all;
+            }}
+
+            location = /health/ready {{
+                if ($preview_ready = 0) {{
+                    return 503;
+                }}
+                try_files $uri @preview_router;
             }}
 
             location / {{
@@ -5516,15 +5533,6 @@ def run_rollout(args: argparse.Namespace) -> int:
     if args.install_nginx or args.refresh_nginx or nginx_http2_syntax == "auto":
         nginx_http2_syntax = detect_nginx_http2_syntax()
 
-    initial_workspace_redirects = build_preview_workspace_redirects(repo_state, args.clone_root)
-    args.nginx_output.write_text(
-        render_nginx_config(
-            repo_state,
-            nginx_http2_syntax=nginx_http2_syntax,
-            workspace_redirects=initial_workspace_redirects,
-        )
-    )
-
     provisioned_worktrees: list[str] = []
     cleaned_preview_storage_targets: list[str] = []
     failed_provision_worktrees: list[dict[str, str]] = []
@@ -5548,6 +5556,15 @@ def run_rollout(args: argparse.Namespace) -> int:
             validated_instruction_roots=validated_instruction_roots,
         )
 
+    workspace_redirects = build_preview_workspace_redirects(repo_state, args.clone_root)
+    args.nginx_output.write_text(
+        render_nginx_config(
+            repo_state,
+            nginx_http2_syntax=nginx_http2_syntax,
+            workspace_redirects=workspace_redirects,
+        )
+    )
+
     if args.install_nginx or args.refresh_nginx:
         try:
             import polyscope_nginx
@@ -5558,7 +5575,7 @@ def run_rollout(args: argparse.Namespace) -> int:
         nginx_manifest = polyscope_nginx.build_manifest(
             repo_state,
             nginx_http2_syntax=nginx_http2_syntax,
-            workspace_redirects=build_preview_workspace_redirects(repo_state, args.clone_root),
+            workspace_redirects=workspace_redirects,
         )
         write_nginx_manifest(
             args.nginx_manifest_output,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -5533,6 +5533,18 @@ def run_rollout(args: argparse.Namespace) -> int:
     if args.install_nginx or args.refresh_nginx or nginx_http2_syntax == "auto":
         nginx_http2_syntax = detect_nginx_http2_syntax()
 
+    initial_workspace_redirects = build_preview_workspace_redirects(
+        repo_state,
+        args.clone_root,
+    )
+    args.nginx_output.write_text(
+        render_nginx_config(
+            repo_state,
+            nginx_http2_syntax=nginx_http2_syntax,
+            workspace_redirects=initial_workspace_redirects,
+        )
+    )
+
     provisioned_worktrees: list[str] = []
     cleaned_preview_storage_targets: list[str] = []
     failed_provision_worktrees: list[dict[str, str]] = []

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase, main, mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROLLOUT_SCRIPT = REPO_ROOT / "scripts/polyscope-rollout.py"
+
+
+def load_rollout_module():
+    spec = importlib.util.spec_from_file_location("polyscope_rollout_followups", ROLLOUT_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load rollout script at {ROLLOUT_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rollout = load_rollout_module()
+
+
+class PolyscopeRolloutFollowupTests(TestCase):
+    def test_api_health_probe_stays_unsuccessful_while_provisioning(self) -> None:
+        repo_state = {
+            "api": {"id": "api-id"},
+            "frontend": {"id": "frontend-id"},
+            "GuardGuide": {"id": "guardguide-id"},
+            "secpal.app": {"id": "secpal-app-id"},
+            "guardguide.de": {"id": "guardguide-de-id"},
+        }
+
+        rendered = rollout.render_nginx_config(repo_state)
+
+        self.assertIn("location = /health/ready {", rendered)
+        health_location = rendered.split("location = /health/ready {", 1)[1].split("}", 1)[0]
+        self.assertIn("return 503;", health_location)
+
+    def test_pending_api_storage_reset_bypasses_matching_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            clone_root = root / "clones"
+            worktree = clone_root / "api-id" / "mighty-hyena-1c04a2fb"
+            worktree.mkdir(parents=True)
+            (worktree / ".env").write_text(
+                f"{rollout.PREVIEW_STORAGE_RESET_REQUIRED_ENV_KEY}=1\n"
+            )
+            bootstrap = mock.Mock(return_value=(True, "database:secpal__preview__mighty_hyena"))
+
+            with mock.patch.multiple(
+                rollout,
+                load_registered_worktree_paths=mock.Mock(
+                    return_value={"api": [worktree]}
+                ),
+                revoke_unregistered_preview_nginx_access=mock.Mock(),
+                is_provisionable_worktree=mock.Mock(return_value=True),
+                cleanup_removed_workspace_aliases=mock.Mock(return_value=[]),
+                cleanup_removed_api_preview_databases=mock.Mock(return_value=[]),
+                preserve_registered_workspace_physical_path=mock.Mock(),
+                render_worktree_local_config=mock.Mock(return_value="{}\n"),
+                sync_worktree_local_config=mock.Mock(),
+                ensure_workspace_alias=mock.Mock(),
+                sync_worktree_auxiliary_files=mock.Mock(),
+                ensure_worktree_hooks=mock.Mock(),
+                acquire_api_worktree_bootstrap_lock=mock.Mock(
+                    side_effect=lambda path: contextlib.nullcontext(path)
+                ),
+                collect_linked_setup_context=mock.Mock(return_value={}),
+                resolve_current_workspace_name=mock.Mock(return_value="mighty-hyena"),
+                build_setup_hash=mock.Mock(return_value="setup-hash"),
+                ensure_api_worktree_ready=mock.Mock(
+                    return_value=(True, "database:secpal__preview__mighty_hyena")
+                ),
+                load_provision_marker=mock.Mock(
+                    return_value={
+                        "setup_hash": "setup-hash",
+                        "preview_storage_target": "database:secpal__preview__mighty_hyena",
+                    }
+                ),
+                _bootstrap_api_worktree_locked=bootstrap,
+                ensure_preview_nginx_access=mock.Mock(),
+                write_provision_marker=mock.Mock(),
+            ):
+                provisioned, _cleaned, failures = rollout.provision_worktrees(
+                    {"api": {"id": "api-id"}},
+                    {
+                        "api": {
+                            rollout.NATIVE_SETUP_COMMANDS_KEY: ["bootstrap-api"],
+                            "path": root / "source-api",
+                            "preview_prefix": "api",
+                        }
+                    },
+                    clone_root,
+                    db_path=root / "polyscope.db",
+                )
+
+            bootstrap.assert_called_once()
+            self.assertEqual(provisioned, ["api:mighty-hyena"])
+            self.assertEqual(failures, [])
+
+    def test_exported_nginx_config_uses_post_provision_redirects(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            alias_created = False
+
+            def provision(*_args, **_kwargs):
+                nonlocal alias_created
+                alias_created = True
+                return [], [], []
+
+            def redirects(*_args, **_kwargs):
+                if not alias_created:
+                    return {}
+                return {"frontend": {"mighty-hyena-1c04a2fb": "mighty-hyena"}}
+
+            args = SimpleNamespace(
+                clone_root=root / "clones",
+                db_path=root / "polyscope.db",
+                install_nginx=False,
+                refresh_nginx=False,
+                nginx_http2_syntax="modern",
+                nginx_output=root / "preview.nginx.conf",
+                polyscope_api_base="http://127.0.0.1:4321/api",
+                provision_worktrees=True,
+                repo_state_file=root / "repo-state.json",
+                skip_db_sync=True,
+                skip_local_configs=True,
+                summary_output=None,
+                workspace_root=root / "workspace",
+            )
+            args.clone_root.mkdir()
+
+            with mock.patch.multiple(
+                rollout,
+                build_repo_specs=mock.Mock(return_value={}),
+                validate_repo_instruction_files=mock.Mock(),
+                validate_repo_local_configs=mock.Mock(),
+                load_repo_state=mock.Mock(return_value={}),
+                build_preview_workspace_redirects=mock.Mock(side_effect=redirects),
+                render_nginx_config=mock.Mock(
+                    side_effect=lambda *_args, **kwargs: json.dumps(
+                        kwargs["workspace_redirects"], sort_keys=True
+                    )
+                    + "\n"
+                ),
+                provision_worktrees=mock.Mock(side_effect=provision),
+            ):
+                self.assertEqual(rollout.run_rollout(args), 0)
+
+            exported = json.loads(args.nginx_output.read_text())
+            self.assertEqual(
+                exported,
+                {"frontend": {"mighty-hyena-1c04a2fb": "mighty-hyena"}},
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -72,7 +72,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 sync_worktree_auxiliary_files=mock.Mock(),
                 ensure_worktree_hooks=mock.Mock(),
                 acquire_api_worktree_bootstrap_lock=mock.Mock(
-                    side_effect=lambda path: contextlib.nullcontext(path)
+                    side_effect=contextlib.nullcontext
                 ),
                 collect_linked_setup_context=mock.Mock(return_value={}),
                 resolve_current_workspace_name=mock.Mock(return_value="mighty-hyena"),

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -162,6 +162,87 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 {"frontend": {"mighty-hyena-1c04a2fb": "mighty-hyena"}},
             )
 
+    def test_install_validates_redirects_before_mutating_preview_access(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            revoke_access = mock.Mock()
+            provision = mock.Mock(return_value=([], [], []))
+            args = SimpleNamespace(
+                clone_root=root / "clones",
+                db_path=root / "polyscope.db",
+                install_nginx=True,
+                refresh_nginx=False,
+                nginx_http2_syntax="modern",
+                nginx_output=root / "preview.nginx.conf",
+                polyscope_api_base="http://127.0.0.1:4321/api",
+                provision_worktrees=True,
+                repo_state_file=root / "repo-state.json",
+                skip_db_sync=True,
+                skip_local_configs=True,
+                summary_output=None,
+                workspace_root=root / "workspace",
+            )
+
+            with mock.patch.multiple(
+                rollout,
+                build_repo_specs=mock.Mock(return_value={}),
+                validate_repo_instruction_files=mock.Mock(),
+                validate_repo_local_configs=mock.Mock(),
+                load_repo_state=mock.Mock(return_value={}),
+                detect_nginx_http2_syntax=mock.Mock(return_value="modern"),
+                revoke_all_preview_nginx_access=revoke_access,
+                provision_worktrees=provision,
+                build_preview_workspace_redirects=mock.Mock(
+                    side_effect=RuntimeError("invalid workspace alias registry")
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, "invalid workspace alias registry"
+                ):
+                    rollout.run_rollout(args)
+
+            revoke_access.assert_not_called()
+            provision.assert_not_called()
+
+    def test_install_validates_nginx_output_before_mutating_preview_access(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            revoke_access = mock.Mock()
+            provision = mock.Mock(return_value=([], [], []))
+            args = SimpleNamespace(
+                clone_root=root / "clones",
+                db_path=root / "polyscope.db",
+                install_nginx=True,
+                refresh_nginx=False,
+                nginx_http2_syntax="modern",
+                nginx_output=root / "missing" / "preview.nginx.conf",
+                polyscope_api_base="http://127.0.0.1:4321/api",
+                provision_worktrees=True,
+                repo_state_file=root / "repo-state.json",
+                skip_db_sync=True,
+                skip_local_configs=True,
+                summary_output=None,
+                workspace_root=root / "workspace",
+            )
+
+            with mock.patch.multiple(
+                rollout,
+                build_repo_specs=mock.Mock(return_value={}),
+                validate_repo_instruction_files=mock.Mock(),
+                validate_repo_local_configs=mock.Mock(),
+                load_repo_state=mock.Mock(return_value={}),
+                detect_nginx_http2_syntax=mock.Mock(return_value="modern"),
+                revoke_all_preview_nginx_access=revoke_access,
+                provision_worktrees=provision,
+                build_preview_workspace_redirects=mock.Mock(return_value={}),
+                render_nginx_config=mock.Mock(return_value="valid nginx\n"),
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    rollout.run_rollout(args)
+
+            revoke_access.assert_not_called()
+            provision.assert_not_called()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -58,6 +58,7 @@ export POLYSCOPE_TEST_ALLOW_SETFACL_OVERRIDE=1
 export POLYSCOPE_TEST_SETFACL_BIN="$fake_setfacl"
 
 python3 "$SCRIPT_DIR/polyscope-rollout-hooks.py" "$PYTHON_SCRIPT"
+python3 "$SCRIPT_DIR/polyscope-rollout-followups-unit.py"
 
 workspace_root="$workspace/SecPal"
 home_dir="$workspace/home"


### PR DESCRIPTION
## Description

Fix the three actionable post-merge findings from #611:

- keep `/health/ready` unsuccessful while a preview is still provisioning;
- consume a pending API preview-storage reset even when the provision marker otherwise matches; and
- render the exported Nginx configuration from the same post-provision alias snapshot as the install manifest.

The readiness route now returns HTTP 503 until the selected preview entrypoint exists. API marker reuse is skipped while `POLYSCOPE_PREVIEW_STORAGE_RESET_REQUIRED=1`, allowing the locked bootstrap to perform and clear the reset. Nginx export rendering now happens after worktree provisioning and shares one redirect map with manifest generation.

## Related Issues

Follow-up to #611 and its post-merge review findings:

- https://github.com/SecPal/.github/pull/611#discussion_r3714761822
- https://github.com/SecPal/.github/pull/611#discussion_r3714761828
- https://github.com/SecPal/.github/pull/611#discussion_r3714761833

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [ ] Manual testing performed

Commands:

- `python3 tests/polyscope-rollout-followups-unit.py`
- `bash tests/polyscope-rollout.sh`
- `pre-commit run --files scripts/polyscope-rollout.py tests/polyscope-rollout.sh tests/polyscope-rollout-followups-unit.py`
- `git verify-commit HEAD`

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 tests/polyscope-rollout-followups-unit.py` failed with three focused assertions: missing non-2xx health handling, skipped bootstrap for a pending storage reset, and stale pre-provision Nginx redirects.
- Passing proof after implementation: `python3 tests/polyscope-rollout-followups-unit.py` and `bash tests/polyscope-rollout.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [ ] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## Screenshots

Not applicable.