### PR TITLE
Make preview provisioning self-convergent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   prune independent removed registrations and revoke every unregistered
   worktree's preview ACL despite independent repository-local failures; stale
   units are also pruned after canonical-validation failures, invalid desired
-  unit names are rejected before mutation, malformed unit contents are replaced,
-  and independent prune/activation failures remain visible together
+  unit names are rejected before mutation, malformed contents plus ownership or
+  permission drift are replaced, and independent prune/activation failures
+  remain visible together
 - gave the worktree provision service an explicit 15-minute start budget and
   revoked an existing API preview ACL whenever scheduler-heartbeat gating fails
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   provision timer
 - limited both system- and user-scope Polyscope server startup reconciliation
   to Nginx state so unrelated repository synchronization cannot exhaust the
-  service start timeout
+  service start timeout, made that startup refresh skip cleanly when the full
+  provisioner already owns the shared lock, and passed the installer-validated
+  sudo binary into the user service
 - separated routine config/Nginx synchronization from full worktree
   provisioning and corrected the scheduler probe to use PsySH's real success
   exit status
@@ -39,7 +41,12 @@ Log of notable changes to SecPal organization defaults (newest first).
   still-registered worktrees across transient reconciliation failures, and
   retain only stale unit files whose stop or removal fails while continuing to
   prune independent removed registrations and revoke every unregistered
-  worktree's preview ACL despite independent repository-local failures
+  worktree's preview ACL despite independent repository-local failures; stale
+  units are also pruned after canonical-validation failures, invalid desired
+  unit names are rejected before mutation, malformed unit contents are replaced,
+  and independent prune/activation failures remain visible together
+- gave the worktree provision service an explicit 15-minute start budget and
+  revoked an existing API preview ACL whenever scheduler-heartbeat gating fails
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be
   interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,16 @@ Log of notable changes to SecPal organization defaults (newest first).
   worktree's preview ACL despite independent repository-local failures; stale
   units are also pruned after canonical-validation failures, invalid desired
   unit names are rejected before mutation, malformed contents plus ownership or
-  permission drift are replaced, and independent prune/activation failures
-  remain visible together
+  permission drift are replaced, ACL-reconciliation failures no longer skip
+  stale-unit pruning, and independent prune/activation failures remain visible
+  together
 - gave the worktree provision service an explicit 15-minute start budget and
-  revoked an existing API preview ACL whenever scheduler-heartbeat gating fails
+  revoked an existing API preview ACL whenever runtime-owner activation or
+  scheduler-heartbeat gating fails
+- preserved configured clone-root and provision-lock boundaries across startup
+  and routine refreshes, required the nonblocking startup hook in accepted
+  system drop-ins, and retained Polyscope autostart as the runtime fallback for
+  noncanonical installations
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be
   interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 - made the privileged Nginx consumer accept both manifest schema 1 and 2,
   advertise its supported schemas, validate its colocated renderer, and reject
-  producer activation before an incompatible manifest can replace the last
-  usable one
+  producer activation through the fixed root-owned helper before an
+  incompatible manifest can replace the last usable one
 - made canonical worktree provisioning refresh Nginx independently of stale
   installed unit flags and added a recurring recovery path through the existing
   provision timer
@@ -33,7 +33,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   heartbeat
 - made those user services the only automatic runtime owner, restart them when
   tracked code, untracked source metadata, or runtime environment metadata
-  changes, and retain stale unit files when stopping their processes fails
+  changes, preserve services for still-registered worktrees across transient
+  reconciliation failures, and retain stale unit files when stopping their
+  processes fails while continuing to prune removed registrations
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be
   interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 **Changed:**
 
 - made the privileged Nginx consumer accept both manifest schema 1 and 2,
-  advertise its supported schemas, validate its colocated renderer, and reject
-  producer activation through the fixed root-owned helper before an
-  incompatible manifest can replace the last usable one
+  advertise its supported schemas independently of the active manifest,
+  validate its colocated renderer, invalidate cached sudo credentials during
+  capability checks, and reject producer activation through the fixed
+  root-owned helper before an incompatible manifest can replace the last usable
+  one
 - made canonical worktree provisioning refresh Nginx independently of stale
   installed unit flags and added a recurring recovery path through the existing
   provision timer
-- limited the Polyscope server's synchronous startup reconciliation to Nginx
-  state so unrelated repository synchronization cannot exhaust the service
-  start timeout
+- limited both system- and user-scope Polyscope server startup reconciliation
+  to Nginx state so unrelated repository synchronization cannot exhaust the
+  service start timeout
 - separated routine config/Nginx synchronization from full worktree
   provisioning and corrected the scheduler probe to use PsySH's real success
   exit status
@@ -33,9 +35,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   heartbeat
 - made those user services the only automatic runtime owner, restart them when
   tracked code, untracked source metadata, or runtime environment metadata
-  changes, preserve services for still-registered worktrees across transient
-  reconciliation failures, and retain stale unit files when stopping their
-  processes fails while continuing to prune removed registrations
+  changes, inherit the installer-controlled tool path, preserve services for
+  still-registered worktrees across transient reconciliation failures, and
+  retain stale unit files when stopping their processes fails while continuing
+  to prune removed registrations
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be
   interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   tracked code, untracked source metadata, or runtime environment metadata
   changes, inherit the installer-controlled tool path, preserve services for
   still-registered worktrees across transient reconciliation failures, and
-  retain stale unit files when stopping their processes fails while continuing
-  to prune removed registrations
+  retain only stale unit files whose stop or removal fails while continuing to
+  prune independent removed registrations and revoke every unregistered
+  worktree's preview ACL despite independent repository-local failures
 - tightened the privileged Nginx manifest boundary so JSON booleans cannot be
   interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Log of notable changes to SecPal organization defaults (newest first).
 - added persistent, restartable scheduler and queue-worker user services for
   every registered API preview and gated preview access on a real scheduler
   heartbeat
+- made those user services the only automatic runtime owner, restart them when
+  tracked code, untracked source metadata, or runtime environment metadata
+  changes, and retain stale unit files when stopping their processes fails
+- tightened the privileged Nginx manifest boundary so JSON booleans cannot be
+  interpreted as integer schema versions
 - completed preview API public-bootstrap configuration so linked web and
   Android clients receive a usable workspace-specific bootstrap contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-04 - Make Preview Provisioning Self-Convergent
+
+**Changed:**
+
+- made the privileged Nginx consumer accept both manifest schema 1 and 2,
+  advertise its supported schemas, validate its colocated renderer, and reject
+  producer activation before an incompatible manifest can replace the last
+  usable one
+- made canonical worktree provisioning refresh Nginx independently of stale
+  installed unit flags and added a recurring recovery path through the existing
+  provision timer
+- limited the Polyscope server's synchronous startup reconciliation to Nginx
+  state so unrelated repository synchronization cannot exhaust the service
+  start timeout
+- separated routine config/Nginx synchronization from full worktree
+  provisioning and corrected the scheduler probe to use PsySH's real success
+  exit status
+- stopped treating every unrelated SQLite WAL write as a worktree change while
+  retaining the main database/config triggers and periodic recovery timer
+- added persistent, restartable scheduler and queue-worker user services for
+  every registered API preview and gated preview access on a real scheduler
+  heartbeat
+- completed preview API public-bootstrap configuration so linked web and
+  Android clients receive a usable workspace-specific bootstrap contract
+
+---
+
 ## 2026-08-04 - Bound Review And Publish Validation
 
 **Changed:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -452,7 +452,18 @@ The credential reset ensures the check proves the exact `NOPASSWD` rule rather
 than a cached interactive sudo timestamp. It never tests generic sudo access,
 rejects helper-path overrides, and exits before writing user units when the
 fixed helper, fixed manifest path, system server drop-in, or exact
-authorization is unavailable.
+authorization is unavailable. The helper check also renders the current
+manifest through the installed root-owned bundle and advertises
+`manifest_schema=2`; the unprivileged producer refuses to replace the last
+manifest unless that capability is present. This permits consumer-first schema
+upgrades without leaving Nginx on an unreadable manifest. The system server's
+synchronous startup hook skips repository config and database synchronization;
+it performs only the Nginx convergence needed before the service reports ready.
+Routine instruction/config synchronization also refreshes Nginx without
+reprovisioning every worktree; provisioning remains owned by its path/timer
+service. The path unit deliberately ignores the broad SQLite WAL stream so
+ordinary Polyscope activity cannot create a provisioning loop; the main
+database, generated configs, and periodic timer remain convergence inputs.
 
 `--source-script` accepts a custom rollout implementation only as part of a
 complete source bundle: the script must be executable, have the constrained
@@ -473,7 +484,15 @@ unregistered clone as a setup candidate. The physical hash directory remains
 the database's authoritative deletion path. Stable aliases are direct sibling
 symlinks recorded in a strict per-repository registry; after official deletion
 removes the physical path and registration, the next database-triggered
-reconciliation removes only those recorded broken aliases. The paired daily
+reconciliation removes only those recorded broken aliases.
+
+On the canonical host, `--provision-worktrees` execution always includes Nginx
+refresh even when an older installed unit does not yet contain
+`--refresh-nginx`. Registered API previews receive two managed user services,
+one scheduler and one combined queue worker. The services resolve database
+credentials at process start through the rollout wrapper, restart on failure,
+disappear when their worktree registration is removed, and must produce a
+scheduler heartbeat before new preview access is granted. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -461,7 +461,10 @@ consumer-first schema upgrades and allows a malformed active manifest to be
 replaced without leaving Nginx on an unreadable manifest. Both system- and
 user-scope server startup hooks skip repository config and database
 synchronization; they perform only the Nginx convergence needed before the
-service reports ready.
+service reports ready. If the full provisioner already holds the shared lock,
+the startup hook exits successfully because that in-flight provisioner performs
+the same final Nginx convergence. User-scope startup also receives the exact
+sudo binary validated by the installer.
 Routine instruction/config synchronization also refreshes Nginx without
 reprovisioning every worktree; provisioning remains owned by its path/timer
 service. The path unit deliberately ignores the broad SQLite WAL stream so
@@ -496,7 +499,10 @@ one scheduler and one combined queue worker. The services inherit the
 installer-controlled tool `PATH`, resolve database credentials at process start
 through the rollout wrapper, restart on failure, disappear when their worktree
 registration is removed, and must produce a scheduler heartbeat before new
-preview access is granted. They are also restarted when the worktree revision,
+preview access is granted. A failed heartbeat revokes any access retained from
+an earlier successful provision, and stale services for removed registrations
+are still pruned when another worktree fails canonical instruction validation.
+They are also restarted when the worktree revision,
 dirty tracked code, untracked source metadata, or source/worktree environment
 metadata changes. The corresponding
 Polyscope run actions remain available for explicit diagnostics but do not
@@ -505,7 +511,9 @@ managed services. A failed reconciliation preserves existing units only for
 still-registered physical worktrees; units belonging to removed registrations
 remain eligible for pruning. Stale unit files are removed only after systemd
 confirms that their services stopped successfully; a failure preserves that
-unit without blocking later independent stale-unit cleanup. Routine preview ACL
+unit without blocking later independent stale-unit cleanup. Desired unit names
+are validated before cleanup starts, unreadable unit contents are replaced, and
+independent cleanup and activation failures are reported together. Routine preview ACL
 reconciliation likewise attempts every unregistered physical worktree before
 reporting any individual denial or repository-integrity failures. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
@@ -521,6 +529,9 @@ hook, alias, setup, and marker writes.
 
 The worktree provision service waits three seconds before each activation to
 coalesce SQLite event bursts and takes a process-shared lock before provisioning.
+Its 15-minute start budget leaves the provisioner time to record scheduler
+readiness failures and perform final ACL/runtime cleanup before systemd ends the
+oneshot.
 The path and fallback timer both target that serialized service. Five starts per
 ten seconds cannot be exhausted by the three-second activations, while genuine
 service failures remain visible. A deliberate user-installer convergence clears

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -452,15 +452,16 @@ The credential reset ensures the check proves the exact `NOPASSWD` rule rather
 than a cached interactive sudo timestamp. It never tests generic sudo access,
 rejects helper-path overrides, and exits before writing user units when the
 fixed helper, fixed manifest path, system server drop-in, or exact
-authorization is unavailable. The helper check also renders the current
-manifest through the installed root-owned bundle and advertises
-`manifest_schema=2`; the unprivileged producer refuses to replace the last
-manifest unless that capability is present on the same fixed helper used for
-activation. Environment-selected helper paths cannot authorize publication.
-This permits consumer-first schema upgrades without leaving Nginx on an
-unreadable manifest. The system server's
-synchronous startup hook skips repository config and database synchronization;
-it performs only the Nginx convergence needed before the service reports ready.
+authorization is unavailable. The helper check validates the installed
+root-owned bundle independently of the current manifest and advertises
+`manifest_schema=2`; the unprivileged producer refuses to publish unless that
+capability is present on the same fixed helper used for activation.
+Environment-selected helper paths cannot authorize publication. This permits
+consumer-first schema upgrades and allows a malformed active manifest to be
+replaced without leaving Nginx on an unreadable manifest. Both system- and
+user-scope server startup hooks skip repository config and database
+synchronization; they perform only the Nginx convergence needed before the
+service reports ready.
 Routine instruction/config synchronization also refreshes Nginx without
 reprovisioning every worktree; provisioning remains owned by its path/timer
 service. The path unit deliberately ignores the broad SQLite WAL stream so
@@ -491,12 +492,13 @@ reconciliation removes only those recorded broken aliases.
 On the canonical host, `--provision-worktrees` execution always includes Nginx
 refresh even when an older installed unit does not yet contain
 `--refresh-nginx`. Registered API previews receive two managed user services,
-one scheduler and one combined queue worker. The services resolve database
-credentials at process start through the rollout wrapper, restart on failure,
-disappear when their worktree registration is removed, and must produce a
-scheduler heartbeat before new preview access is granted. They are also
-restarted when the worktree revision, dirty tracked code, untracked source
-metadata, or source/worktree environment metadata changes. The corresponding
+one scheduler and one combined queue worker. The services inherit the
+installer-controlled tool `PATH`, resolve database credentials at process start
+through the rollout wrapper, restart on failure, disappear when their worktree
+registration is removed, and must produce a scheduler heartbeat before new
+preview access is granted. They are also restarted when the worktree revision,
+dirty tracked code, untracked source metadata, or source/worktree environment
+metadata changes. The corresponding
 Polyscope run actions remain available for explicit diagnostics but do not
 autostart, preventing a second scheduler or worker from competing with the
 managed services. A failed reconciliation preserves existing units only for

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -504,7 +504,10 @@ autostart, preventing a second scheduler or worker from competing with the
 managed services. A failed reconciliation preserves existing units only for
 still-registered physical worktrees; units belonging to removed registrations
 remain eligible for pruning. Stale unit files are removed only after systemd
-confirms that their services stopped successfully. The paired daily
+confirms that their services stopped successfully; a failure preserves that
+unit without blocking later independent stale-unit cleanup. Routine preview ACL
+reconciliation likewise attempts every unregistered physical worktree before
+reporting any individual denial or repository-integrity failures. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -512,9 +512,10 @@ still-registered physical worktrees; units belonging to removed registrations
 remain eligible for pruning. Stale unit files are removed only after systemd
 confirms that their services stopped successfully; a failure preserves that
 unit without blocking later independent stale-unit cleanup. Desired unit names
-are validated before cleanup starts, unreadable unit contents are replaced, and
-independent cleanup and activation failures are reported together. Routine preview ACL
-reconciliation likewise attempts every unregistered physical worktree before
+are validated before cleanup starts, unreadable contents plus ownership or
+permission drift are replaced, and independent cleanup and activation failures
+are reported together. Routine preview ACL reconciliation likewise attempts every
+unregistered physical worktree before
 reporting any individual denial or repository-integrity failures. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -455,8 +455,10 @@ fixed helper, fixed manifest path, system server drop-in, or exact
 authorization is unavailable. The helper check also renders the current
 manifest through the installed root-owned bundle and advertises
 `manifest_schema=2`; the unprivileged producer refuses to replace the last
-manifest unless that capability is present. This permits consumer-first schema
-upgrades without leaving Nginx on an unreadable manifest. The system server's
+manifest unless that capability is present on the same fixed helper used for
+activation. Environment-selected helper paths cannot authorize publication.
+This permits consumer-first schema upgrades without leaving Nginx on an
+unreadable manifest. The system server's
 synchronous startup hook skips repository config and database synchronization;
 it performs only the Nginx convergence needed before the service reports ready.
 Routine instruction/config synchronization also refreshes Nginx without
@@ -497,8 +499,10 @@ restarted when the worktree revision, dirty tracked code, untracked source
 metadata, or source/worktree environment metadata changes. The corresponding
 Polyscope run actions remain available for explicit diagnostics but do not
 autostart, preventing a second scheduler or worker from competing with the
-managed services. Stale unit files are removed only after systemd confirms that
-their services stopped successfully. The paired daily
+managed services. A failed reconciliation preserves existing units only for
+still-registered physical worktrees; units belonging to removed registrations
+remain eligible for pruning. Stale unit files are removed only after systemd
+confirms that their services stopped successfully. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -464,12 +464,15 @@ synchronization; they perform only the Nginx convergence needed before the
 service reports ready. If the full provisioner already holds the shared lock,
 the startup hook exits successfully because that in-flight provisioner performs
 the same final Nginx convergence. User-scope startup also receives the exact
-sudo binary validated by the installer.
-Routine instruction/config synchronization also refreshes Nginx without
-reprovisioning every worktree; provisioning remains owned by its path/timer
-service. The path unit deliberately ignores the broad SQLite WAL stream so
-ordinary Polyscope activity cannot create a provisioning loop; the main
-database, generated configs, and periodic timer remain convergence inputs.
+sudo binary validated by the installer. Startup and routine refreshes use the
+same configured clone root and provision lock as the full provisioner. A
+system-scope installation accepts only the exact reviewed nonblocking startup
+hook from the privileged component installer. Routine instruction/config
+synchronization refreshes Nginx without reprovisioning every worktree;
+provisioning remains owned by its path/timer service. The path unit deliberately
+ignores the broad SQLite WAL stream so ordinary Polyscope activity cannot create
+a provisioning loop; the main database, generated configs, and periodic timer
+remain convergence inputs.
 
 `--source-script` accepts a custom rollout implementation only as part of a
 complete source bundle: the script must be executable, have the constrained
@@ -499,26 +502,27 @@ one scheduler and one combined queue worker. The services inherit the
 installer-controlled tool `PATH`, resolve database credentials at process start
 through the rollout wrapper, restart on failure, disappear when their worktree
 registration is removed, and must produce a scheduler heartbeat before new
-preview access is granted. A failed heartbeat revokes any access retained from
-an earlier successful provision, and stale services for removed registrations
-are still pruned when another worktree fails canonical instruction validation.
-They are also restarted when the worktree revision,
-dirty tracked code, untracked source metadata, or source/worktree environment
-metadata changes. The corresponding
-Polyscope run actions remain available for explicit diagnostics but do not
-autostart, preventing a second scheduler or worker from competing with the
-managed services. A failed reconciliation preserves existing units only for
-still-registered physical worktrees; units belonging to removed registrations
-remain eligible for pruning. Stale unit files are removed only after systemd
-confirms that their services stopped successfully; a failure preserves that
-unit without blocking later independent stale-unit cleanup. Desired unit names
-are validated before cleanup starts, unreadable contents plus ownership or
-permission drift are replaced, and independent cleanup and activation failures
-are reported together. Routine preview ACL reconciliation likewise attempts every
-unregistered physical worktree before
-reporting any individual denial or repository-integrity failures. The paired daily
-`polyscope-clone-reaper.timer` removes only aged orphan clone roots after
-checking the live database allowlist, locks, and processes.
+preview access is granted. Failed runtime-owner activation or heartbeat checks
+revoke any access retained from an earlier successful provision. Stale services
+for removed registrations are still pruned when another worktree fails canonical
+instruction or routine ACL reconciliation. They are also restarted when the
+worktree revision, dirty tracked code, untracked source metadata, or
+source/worktree environment metadata changes. The corresponding Polyscope run
+actions remain available for explicit diagnostics and do not autostart while
+the managed services own the runtime. Noncanonical clone-root or database
+installations instead keep those actions autostarted because no persistent
+systemd owner is managed there. A failed reconciliation preserves existing units
+only for still-registered physical worktrees; units belonging to removed
+registrations remain eligible for pruning. Stale unit files are removed only
+after systemd confirms that their services stopped successfully; a failure
+preserves that unit without blocking later independent stale-unit cleanup.
+Desired unit names are validated before cleanup starts, unreadable contents plus
+ownership or permission drift are replaced, and independent cleanup and
+activation failures are reported together. Routine preview ACL reconciliation
+likewise attempts every unregistered physical worktree before reporting any
+individual denial or repository-integrity failures. The paired daily
+`polyscope-clone-reaper.timer` removes only aged orphan clone roots after checking
+the live database allowlist, locks, and processes.
 
 Every generated repository setup sequence starts with the validation-only
 `--validate-instruction-worktree` command inside one strict shell entry. That

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -492,7 +492,13 @@ refresh even when an older installed unit does not yet contain
 one scheduler and one combined queue worker. The services resolve database
 credentials at process start through the rollout wrapper, restart on failure,
 disappear when their worktree registration is removed, and must produce a
-scheduler heartbeat before new preview access is granted. The paired daily
+scheduler heartbeat before new preview access is granted. They are also
+restarted when the worktree revision, dirty tracked code, untracked source
+metadata, or source/worktree environment metadata changes. The corresponding
+Polyscope run actions remain available for explicit diagnostics but do not
+autostart, preventing a second scheduler or worker from competing with the
+managed services. Stale unit files are removed only after systemd confirms that
+their services stopped successfully. The paired daily
 `polyscope-clone-reaper.timer` removes only aged orphan clone roots after
 checking the live database allowlist, locks, and processes.
 

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -107,7 +107,7 @@ PROVISION_PATH_UNIT="$UNIT_DIR/polyscope-worktree-provision.path"
 PROVISION_TIMER_UNIT="$UNIT_DIR/polyscope-worktree-provision.timer"
 REAPER_SERVICE_UNIT="$UNIT_DIR/polyscope-clone-reaper.service"
 REAPER_TIMER_UNIT="$UNIT_DIR/polyscope-clone-reaper.timer"
-ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
+ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --clone-root $POLYSCOPE_CLONE_ROOT --provision-lock-path $POLYSCOPE_PROVISION_LOCK --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
 detect_system_server_fragment_path() {
     "$SYSTEMCTL_BIN" show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
@@ -253,7 +253,7 @@ if [[ ! -f "$VALIDATOR_PACKAGE_LOCK" \
 fi
 
 # Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.
-for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE POLYSCOPE_PROVISION_LOCK INSTALL_TARGET; do
+for _var_name in WORKSPACE_ROOT POLYSCOPE_API_BASE POLYSCOPE_CLONE_ROOT POLYSCOPE_PROVISION_LOCK INSTALL_TARGET; do
     _val="${!_var_name}"
     if [[ "$_val" =~ [^a-zA-Z0-9/_.:-] ]]; then
         echo "Error: $_var_name contains characters that are unsafe in shell command strings; only letters, digits, /, _, ., :, - are permitted" >&2
@@ -358,7 +358,11 @@ if [[ "$server_scope" == "system" ]]; then
             exit 1
         fi
     done
-    if ! grep -qF -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx' "$installed_server_target"; then
+    _expected_system_start_post="ExecStartPost=/usr/bin/env bash -lc 'for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:4321/api/repos >/dev/null 2>&1 && exec /home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal --polyscope-api-base http://127.0.0.1:4321/api --nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1'"
+    mapfile -t _installed_start_post_lines < <(sed -n '/^ExecStartPost=/p' "$installed_server_target")
+    if [[ "${#_installed_start_post_lines[@]}" -ne 2 \
+        || "${_installed_start_post_lines[0]}" != "ExecStartPost=" \
+        || "${_installed_start_post_lines[1]}" != "$_expected_system_start_post" ]]; then
         echo "Error: reviewed system server drop-in lacks constrained nginx activation: $installed_server_target" >&2
         exit 1
     fi
@@ -442,7 +446,7 @@ Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN
 Environment=POLYSCOPE_NGINX_HELPER=$POLYSCOPE_NGINX_HELPER
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --refresh-nginx
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --clone-root $POLYSCOPE_CLONE_ROOT --provision-lock-path $POLYSCOPE_PROVISION_LOCK --refresh-nginx
 EOF
 
 cat >"$PATH_UNIT" <<EOF

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -107,7 +107,7 @@ PROVISION_PATH_UNIT="$UNIT_DIR/polyscope-worktree-provision.path"
 PROVISION_TIMER_UNIT="$UNIT_DIR/polyscope-worktree-provision.timer"
 REAPER_SERVICE_UNIT="$UNIT_DIR/polyscope-clone-reaper.service"
 REAPER_TIMER_UNIT="$UNIT_DIR/polyscope-clone-reaper.timer"
-ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --skip-local-configs --skip-db-sync --refresh-nginx; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
+ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
 detect_system_server_fragment_path() {
     "$SYSTEMCTL_BIN" show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true
@@ -414,6 +414,7 @@ Type=simple
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
+Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN
 ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
 ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
 Restart=on-failure
@@ -501,6 +502,7 @@ StartLimitBurst=5
 
 [Service]
 Type=oneshot
+TimeoutStartSec=15min
 WorkingDirectory=$WORKSPACE_ROOT/.github
 Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -107,7 +107,7 @@ PROVISION_PATH_UNIT="$UNIT_DIR/polyscope-worktree-provision.path"
 PROVISION_TIMER_UNIT="$UNIT_DIR/polyscope-worktree-provision.timer"
 REAPER_SERVICE_UNIT="$UNIT_DIR/polyscope-clone-reaper.service"
 REAPER_TIMER_UNIT="$UNIT_DIR/polyscope-clone-reaper.timer"
-ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
+ROLLOUT_READY_COMMAND="for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf $POLYSCOPE_API_BASE/repos >/dev/null 2>&1 && exec $INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --skip-local-configs --skip-db-sync --refresh-nginx; sleep 1; done; echo \"Polyscope API did not become ready in time.\" >&2; exit 1"
 
 detect_system_server_fragment_path() {
     "$SYSTEMCTL_BIN" show -p FragmentPath --value "$POLYSCOPE_SYSTEM_SERVER_UNIT" 2>/dev/null || true

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -144,8 +144,13 @@ resolve_server_scope() {
 }
 
 can_apply_nginx_non_interactively() {
+    local helper_check_output
+
     [[ -x "$POLYSCOPE_NGINX_HELPER_CHECK" ]] || return 1
-    "$SUDO_BIN" -k -n "$POLYSCOPE_NGINX_HELPER_CHECK" --check >/dev/null 2>&1
+    helper_check_output="$(
+        "$SUDO_BIN" -k -n "$POLYSCOPE_NGINX_HELPER_CHECK" --check 2>/dev/null
+    )" || return 1
+    [[ " $helper_check_output " == *" manifest_schema=2 "* ]]
 }
 
 is_managed_codex_agents_link() {
@@ -353,8 +358,12 @@ if [[ "$server_scope" == "system" ]]; then
             exit 1
         fi
     done
-    if ! grep -qF -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --install-nginx' "$installed_server_target"; then
+    if ! grep -qF -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx' "$installed_server_target"; then
         echo "Error: reviewed system server drop-in lacks constrained nginx activation: $installed_server_target" >&2
+        exit 1
+    fi
+    if grep -qF -- '--install-nginx' "$installed_server_target"; then
+        echo "Error: reviewed system server drop-in must not run full worktree provisioning: $installed_server_target" >&2
         exit 1
     fi
     if ! grep -qF -- 'exec /home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py --workspace-root /home/secpal/code/SecPal' "$installed_server_target"; then
@@ -432,7 +441,7 @@ Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN
 Environment=POLYSCOPE_NGINX_HELPER=$POLYSCOPE_NGINX_HELPER
-ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --install-nginx
+ExecStart=$INSTALL_TARGET --workspace-root $WORKSPACE_ROOT --polyscope-api-base $POLYSCOPE_API_BASE --nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST --refresh-nginx
 EOF
 
 cat >"$PATH_UNIT" <<EOF
@@ -511,7 +520,6 @@ Description=Watch SecPal Polyscope worktree metadata and generated local config 
 [Path]
 Unit=polyscope-worktree-provision.service
 PathChanged=$HOME/.polyscope/polyscope.db
-PathModified=$HOME/.polyscope/polyscope.db-wal
 PathChanged=$WORKSPACE_ROOT/api/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/frontend/polyscope.local.json
 PathChanged=$WORKSPACE_ROOT/contracts/polyscope.local.json

--- a/scripts/install-polyscope-system-components.sh
+++ b/scripts/install-polyscope-system-components.sh
@@ -166,7 +166,7 @@ User=secpal
 ExecStart=
 ExecStart=/home/secpal/.local/bin/polyscope-server serve --host 127.0.0.1 --port 4321
 ExecStartPost=
-ExecStartPost=/usr/bin/env bash -lc 'for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:4321/api/repos >/dev/null 2>&1 && exec $RUNTIME_ROLLOUT_SOURCE --workspace-root /home/secpal/code/SecPal --polyscope-api-base http://127.0.0.1:4321/api --nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx; sleep 1; done; echo "Polyscope API did not become ready in time." >&2; exit 1'
+ExecStartPost=/usr/bin/env bash -lc 'for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:4321/api/repos >/dev/null 2>&1 && exec $RUNTIME_ROLLOUT_SOURCE --workspace-root /home/secpal/code/SecPal --polyscope-api-base http://127.0.0.1:4321/api --nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked; sleep 1; done; echo "Polyscope API did not become ready in time." >&2; exit 1'
 Environment=PATH=$SYSTEM_SERVICE_PATH
 Environment=SSH_AUTH_SOCK=/run/user/$SECPAL_UID/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=/usr/bin/git

--- a/scripts/install-polyscope-system-components.sh
+++ b/scripts/install-polyscope-system-components.sh
@@ -166,7 +166,7 @@ User=secpal
 ExecStart=
 ExecStart=/home/secpal/.local/bin/polyscope-server serve --host 127.0.0.1 --port 4321
 ExecStartPost=
-ExecStartPost=/usr/bin/env bash -lc 'for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:4321/api/repos >/dev/null 2>&1 && exec $RUNTIME_ROLLOUT_SOURCE --workspace-root /home/secpal/code/SecPal --polyscope-api-base http://127.0.0.1:4321/api --nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --install-nginx; sleep 1; done; echo "Polyscope API did not become ready in time." >&2; exit 1'
+ExecStartPost=/usr/bin/env bash -lc 'for attempt in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:4321/api/repos >/dev/null 2>&1 && exec $RUNTIME_ROLLOUT_SOURCE --workspace-root /home/secpal/code/SecPal --polyscope-api-base http://127.0.0.1:4321/api --nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx; sleep 1; done; echo "Polyscope API did not become ready in time." >&2; exit 1'
 Environment=PATH=$SYSTEM_SERVICE_PATH
 Environment=SSH_AUTH_SOCK=/run/user/$SECPAL_UID/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=/usr/bin/git

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
@@ -37,6 +38,10 @@ PROVISION_MARKER_FILENAME = ".polyscope-secpal-provisioned.json"
 CANONICAL_AI_INSTRUCTIONS_VALIDATOR = ROLLOUT_SCRIPT_PATH.with_name("validate-ai-instructions.sh")
 DEFAULT_NGINX_MANIFEST_PATH = pathlib.Path("/home/secpal/.local/state/polyscope/nginx-manifest.json")
 DEFAULT_NGINX_HELPER_PATH = pathlib.Path("/usr/local/libexec/secpal-polyscope-nginx-apply")
+CANONICAL_CLONE_ROOT = pathlib.Path("/home/secpal/.polyscope/clones")
+CANONICAL_POLYSCOPE_DB_PATH = pathlib.Path("/home/secpal/.polyscope/polyscope.db")
+API_RUNTIME_UNIT_DIRECTORY = pathlib.Path("/home/secpal/.config/systemd/user")
+API_RUNTIME_UNIT_PREFIX = "polyscope-api-worktree-"
 FIXED_SETFACL_BIN = "/usr/bin/setfacl"
 NGINX_MANIFEST_USER = "secpal"
 CANONICAL_VALIDATION_SPEC_KEY = "_canonical_ai_instruction_root"
@@ -1078,6 +1083,10 @@ def build_api_preview_env_updates(
                 "https://app.secpal.dev",
             )
         ),
+        "BOOTSTRAP_PUBLIC_ENABLED": "true",
+        "BOOTSTRAP_INSTANCE_DISPLAY_NAME": f"SecPal Preview ({workspace})",
+        "BOOTSTRAP_MINIMUM_SUPPORTED_APP_VERSION": "1.4.0",
+        "BOOTSTRAP_MINIMUM_SUPPORTED_APP_BUILD": "10400",
     }
     if worktree_path is not None:
         updates["KEK_PATH"] = build_api_preview_kek_path(worktree_path)
@@ -4439,6 +4448,185 @@ def ensure_worktree_hooks(worktree_path: pathlib.Path) -> None:
     ensure_commit_msg_hook(worktree_path)
 
 
+def should_manage_api_runtime_units(
+    clone_root: pathlib.Path,
+    db_path: pathlib.Path,
+) -> bool:
+    """Keep persistent runtime management bound to the reviewed host clone root."""
+    return (
+        clone_root.resolve() == CANONICAL_CLONE_ROOT
+        and db_path.resolve() == CANONICAL_POLYSCOPE_DB_PATH
+    )
+
+
+def build_api_runtime_unit_specs(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    workspace: str,
+) -> dict[str, str]:
+    if re.fullmatch(r"[a-z0-9][a-z0-9-]*", workspace) is None:
+        raise ValueError(f"unsafe API runtime workspace name: {workspace}")
+
+    resolved_worktree = worktree_path.resolve()
+    resolved_source = source_repo_path.resolve()
+    runtime_id = hashlib.sha256(str(resolved_worktree).encode()).hexdigest()[:12]
+    unit_base = f"{API_RUNTIME_UNIT_PREFIX}{workspace}-{runtime_id}"
+    roles = {
+        "scheduler": API_SCHEDULER_COMMAND,
+        "queue": API_QUEUE_WORKER_COMMAND,
+    }
+    units: dict[str, str] = {}
+    for role, shell_command in roles.items():
+        unit_name = f"{unit_base}-{role}.service"
+        exec_start = " ".join(
+            shlex.quote(argument)
+            for argument in (
+                str(ROLLOUT_SCRIPT_PATH),
+                "--run-api-worktree",
+                str(resolved_worktree),
+                "--source-repo-path",
+                str(resolved_source),
+                "--shell-command",
+                shell_command,
+            )
+        )
+        units[unit_name] = textwrap.dedent(
+            f"""
+            # SPDX-FileCopyrightText: 2026 SecPal Contributors
+            # SPDX-License-Identifier: MIT
+            [Unit]
+            Description=SecPal preview API {role} for {workspace}
+            After=network-online.target postgresql.service redis-server.service
+            Wants=network-online.target
+            ConditionPathIsDirectory={resolved_worktree}
+
+            [Service]
+            Type=simple
+            WorkingDirectory={resolved_worktree}
+            ExecStart={exec_start}
+            Restart=on-failure
+            RestartSec=5s
+            TimeoutStopSec=30s
+            KillMode=mixed
+
+            [Install]
+            WantedBy=default.target
+            """
+        ).lstrip()
+    return units
+
+
+def _write_text_atomic(path: pathlib.Path, content: str, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp-", dir=path.parent)
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def reconcile_api_runtime_units(
+    desired_units: dict[str, str],
+    *,
+    unit_directory: pathlib.Path = API_RUNTIME_UNIT_DIRECTORY,
+    systemctl_runner: Any = subprocess.run,
+    prune: bool = True,
+) -> None:
+    """Atomically converge persistent API runtime units and their active state."""
+    systemctl_env = os.environ.copy()
+    runtime_directory = pathlib.Path(f"/run/user/{os.getuid()}")
+    systemctl_env.setdefault("XDG_RUNTIME_DIR", str(runtime_directory))
+    systemctl_env.setdefault(
+        "DBUS_SESSION_BUS_ADDRESS",
+        f"unix:path={runtime_directory}/bus",
+    )
+    unit_directory.mkdir(parents=True, exist_ok=True)
+    desired_names = set(desired_units)
+    existing_units = {
+        path.name: path
+        for path in unit_directory.glob(f"{API_RUNTIME_UNIT_PREFIX}*.service")
+        if path.is_file() or path.is_symlink()
+    }
+    stale_names = sorted(set(existing_units) - desired_names) if prune else []
+    changed = bool(stale_names)
+
+    for stale_name in stale_names:
+        systemctl_runner(
+            ["systemctl", "--user", "disable", "--now", stale_name],
+            check=False,
+            env=systemctl_env,
+        )
+        existing_units[stale_name].unlink()
+
+    for unit_name, content in sorted(desired_units.items()):
+        if re.fullmatch(rf"{re.escape(API_RUNTIME_UNIT_PREFIX)}[a-z0-9-]+\.service", unit_name) is None:
+            raise ValueError(f"unsafe API runtime unit name: {unit_name}")
+        unit_path = unit_directory / unit_name
+        if not unit_path.is_symlink() and unit_path.exists() and unit_path.read_text() == content:
+            continue
+        _write_text_atomic(unit_path, content)
+        changed = True
+
+    if changed:
+        systemctl_runner(
+            ["systemctl", "--user", "daemon-reload"],
+            check=True,
+            env=systemctl_env,
+        )
+    if desired_names:
+        systemctl_runner(
+            ["systemctl", "--user", "enable", "--now", *sorted(desired_names)],
+            check=True,
+            env=systemctl_env,
+        )
+
+
+def wait_for_api_scheduler_readiness(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    command_runner: Any = subprocess.run,
+    sleeper: Any = time.sleep,
+    attempts: int = 40,
+    interval_seconds: float = 2.0,
+) -> None:
+    """Gate preview exposure on a heartbeat produced by the supervised scheduler."""
+    worktree_env = load_optional_env_assignments(worktree_path / ".env")
+    source_env = load_optional_env_assignments(source_repo_path / ".env")
+    command_env = build_api_worktree_command_env(worktree_env, source_env)
+    command = [
+        "php",
+        "artisan",
+        "tinker",
+        "--execute=if (! app(\\App\\Services\\RuntimeHeartbeatService::class)->schedulerReadiness()['healthy']) "
+        "{ throw new \\RuntimeException('scheduler heartbeat missing'); }",
+    ]
+    for attempt in range(attempts):
+        result = command_runner(
+            command,
+            cwd=worktree_path,
+            env=command_env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        if attempt + 1 < attempts:
+            sleeper(interval_seconds)
+    raise RuntimeError(
+        f"API scheduler for {worktree_path} did not produce a readiness heartbeat "
+        f"within {attempts * interval_seconds:g} seconds"
+    )
+
+
 def provision_worktrees(
     repo_state: dict[str, dict[str, Any]],
     repo_specs: dict[str, dict[str, Any]],
@@ -4450,6 +4638,8 @@ def provision_worktrees(
     validation_cache = validated_instruction_roots if validated_instruction_roots is not None else set()
     resolved_db_path = db_path or default_polyscope_db_path()
     failed_provision_worktrees: list[dict[str, str]] = []
+    manage_api_runtimes = should_manage_api_runtime_units(clone_root, resolved_db_path)
+    desired_api_runtime_units: dict[str, str] = {}
 
     registered_worktrees = load_registered_worktree_paths(
         resolved_db_path,
@@ -4591,6 +4781,18 @@ def provision_worktrees(
                         marker.get("preview_storage_target") == preview_storage_target
                         and not preview_storage_reset_required
                     ):
+                        if repo_name == "api" and manage_api_runtimes:
+                            runtime_units = build_api_runtime_unit_specs(
+                                locked_worktree_path,
+                                pathlib.Path(spec["path"]),
+                                workspace=workspace,
+                            )
+                            desired_api_runtime_units.update(runtime_units)
+                            reconcile_api_runtime_units(runtime_units, prune=False)
+                            wait_for_api_scheduler_readiness(
+                                locked_worktree_path,
+                                pathlib.Path(spec["path"]),
+                            )
                         if preview_enabled:
                             ensure_preview_nginx_access(clone_root, locked_worktree_path)
                         continue
@@ -4624,6 +4826,19 @@ def provision_worktrees(
                 if linked_setup_context:
                     marker_payload["linked_workspaces"] = linked_setup_context
 
+                if repo_name == "api" and manage_api_runtimes:
+                    runtime_units = build_api_runtime_unit_specs(
+                        locked_worktree_path,
+                        pathlib.Path(spec["path"]),
+                        workspace=workspace,
+                    )
+                    desired_api_runtime_units.update(runtime_units)
+                    reconcile_api_runtime_units(runtime_units, prune=False)
+                    wait_for_api_scheduler_readiness(
+                        locked_worktree_path,
+                        pathlib.Path(spec["path"]),
+                    )
+
                 if preview_enabled:
                     try:
                         ensure_preview_nginx_access(clone_root, locked_worktree_path)
@@ -4650,6 +4865,21 @@ def provision_worktrees(
                     "repo": repo_name,
                     "workspace": worktree_path.name,
                     "path": str(worktree_path),
+                    "error": error_message,
+                }
+            )
+
+    if manage_api_runtimes:
+        try:
+            reconcile_api_runtime_units(desired_api_runtime_units)
+        except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+            error_message = f"failed to reconcile API runtime services: {error}"
+            print(error_message, file=sys.stderr)
+            failed_provision_worktrees.append(
+                {
+                    "repo": "api",
+                    "workspace": "runtime-services",
+                    "path": str(API_RUNTIME_UNIT_DIRECTORY),
                     "error": error_message,
                 }
             )
@@ -5302,6 +5532,41 @@ def install_nginx_config(
     subprocess.run(command, check=True)
 
 
+def check_nginx_helper_compatibility(
+    manifest_version: int,
+    *,
+    helper_runner: Any = subprocess.run,
+    sudo_bin: str | None = None,
+    helper_path: pathlib.Path | None = None,
+) -> None:
+    sudo_bin = sudo_bin or os.environ.get("POLYSCOPE_SUDO_BIN", "sudo")
+    helper_path = helper_path or pathlib.Path(
+        os.environ.get("POLYSCOPE_NGINX_HELPER", str(DEFAULT_NGINX_HELPER_PATH))
+    )
+    if helper_runner is subprocess.run and (
+        not helper_path.is_file() or not os.access(helper_path, os.X_OK)
+    ):
+        raise RuntimeError(f"constrained Polyscope nginx helper is missing or not executable: {helper_path}")
+
+    command = [str(helper_path), "--check"] if os.geteuid() == 0 else [
+        sudo_bin,
+        "-n",
+        str(helper_path),
+        "--check",
+    ]
+    result = helper_runner(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "helper check failed without output").strip()
+        raise RuntimeError(f"privileged nginx helper compatibility check failed: {details}")
+
+    capability = f"manifest_schema={manifest_version}"
+    if capability not in result.stdout.split():
+        raise RuntimeError(
+            f"privileged nginx helper does not advertise support for manifest schema {manifest_version}; "
+            "install the matching root-owned Polyscope system-component bundle before retrying"
+        )
+
+
 def write_nginx_manifest(
     manifest_path: pathlib.Path,
     payload: dict[str, Any],
@@ -5349,6 +5614,26 @@ def write_nginx_manifest(
             os.setegid(original_egid)
         if groups_changed:
             os.setgroups(original_groups)
+
+
+def write_compatible_nginx_manifest(
+    manifest_path: pathlib.Path,
+    payload: dict[str, Any],
+    *,
+    writer: Any,
+    helper_runner: Any = subprocess.run,
+    service_user: Any | None = None,
+) -> None:
+    version = payload.get("version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise ValueError("nginx manifest version must be an integer")
+    check_nginx_helper_compatibility(version, helper_runner=helper_runner)
+    write_nginx_manifest(
+        manifest_path,
+        payload,
+        writer=writer,
+        service_user=service_user,
+    )
 
 
 def validate_direct_api_worktree_roots(
@@ -5484,8 +5769,24 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def apply_canonical_reconcile_mode(args: argparse.Namespace) -> None:
+    """Make the production provisioner a complete reconcile regardless of unit drift."""
+    clone_root = getattr(args, "clone_root", None)
+    db_path = getattr(args, "db_path", None)
+    if args.provision_worktrees and (
+        clone_root is None
+        or db_path is None
+        or (
+            pathlib.Path(clone_root).resolve() == CANONICAL_CLONE_ROOT
+            and pathlib.Path(db_path).resolve() == CANONICAL_POLYSCOPE_DB_PATH
+        )
+    ):
+        args.refresh_nginx = True
+
+
 def main() -> int:
     args = parse_args()
+    apply_canonical_reconcile_mode(args)
 
     try:
         validation_only_result = dispatch_validation_only_direct_mode(args)
@@ -5589,7 +5890,7 @@ def run_rollout(args: argparse.Namespace) -> int:
             nginx_http2_syntax=nginx_http2_syntax,
             workspace_redirects=workspace_redirects,
         )
-        write_nginx_manifest(
+        write_compatible_nginx_manifest(
             args.nginx_manifest_output,
             nginx_manifest,
             writer=polyscope_nginx.write_manifest_atomic,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3707,6 +3707,14 @@ def render_worktree_local_config(
     db_path: pathlib.Path | None = None,
 ) -> str:
     config = render_local_config(spec)
+    if spec["path"].name == "api":
+        manages_runtime_units = should_manage_api_runtime_units(
+            worktree_path.parent.parent,
+            db_path or default_polyscope_db_path(),
+        )
+        for action in config.get("scripts", {}).get("run", []):
+            if action.get("label") in {"Queue Worker", "Scheduler"}:
+                action["autostart"] = not manages_runtime_units
     preview = config.get("preview")
     if isinstance(preview, dict) and "url" in preview:
         workspace = resolve_current_workspace_name(worktree_path, db_path=db_path)
@@ -4840,6 +4848,46 @@ def wait_for_api_scheduler_readiness_or_revoke_access(
         raise
 
 
+def ensure_api_runtime_owner(
+    clone_root: pathlib.Path,
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    workspace: str,
+    preview_enabled: bool,
+) -> dict[str, str]:
+    """Converge one persistent API runtime owner before allowing preview access."""
+    try:
+        runtime_units = build_api_runtime_unit_specs(
+            worktree_path,
+            source_repo_path,
+            workspace=workspace,
+            runtime_revision=build_api_runtime_revision(
+                worktree_path,
+                source_repo_path,
+            ),
+        )
+        reconcile_api_runtime_units(runtime_units, prune=False)
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError, SystemExit) as error:
+        if not preview_enabled:
+            raise
+        try:
+            deny_preview_nginx_access(clone_root, worktree_path)
+        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as rollback_error:
+            raise RuntimeError(
+                f"{error}; additionally failed to revoke preview access: {rollback_error}"
+            ) from rollback_error
+        raise
+
+    wait_for_api_scheduler_readiness_or_revoke_access(
+        clone_root,
+        worktree_path,
+        source_repo_path,
+        preview_enabled=preview_enabled,
+    )
+    return runtime_units
+
+
 def provision_worktrees(
     repo_state: dict[str, dict[str, Any]],
     repo_specs: dict[str, dict[str, Any]],
@@ -4867,7 +4915,42 @@ def provision_worktrees(
         if manage_api_runtimes
         else set()
     )
-    revoke_unregistered_preview_nginx_access(clone_root, registered_worktrees)
+
+    def prune_api_runtime_units_after_blocking_failure() -> None:
+        if not manage_api_runtimes:
+            return
+        try:
+            reconcile_api_runtime_units(
+                {},
+                preserve_runtime_ids=unreconciled_api_runtime_ids,
+            )
+        except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+            error_message = f"failed to prune API runtime services: {error}"
+            print(error_message, file=sys.stderr)
+            failed_provision_worktrees.append(
+                {
+                    "repo": "api",
+                    "workspace": "runtime-services",
+                    "path": str(API_RUNTIME_UNIT_DIRECTORY),
+                    "error": error_message,
+                }
+            )
+
+    try:
+        revoke_unregistered_preview_nginx_access(clone_root, registered_worktrees)
+    except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
+        error_message = f"failed to reconcile preview access: {error}"
+        print(error_message, file=sys.stderr)
+        failed_provision_worktrees.append(
+            {
+                "repo": "preview",
+                "workspace": "access-reconciliation",
+                "path": str(clone_root),
+                "error": error_message,
+            }
+        )
+        prune_api_runtime_units_after_blocking_failure()
+        return [], [], failed_provision_worktrees
 
     provisionable_worktrees: list[
         tuple[str, dict[str, Any], pathlib.Path, list[str], list[str]]
@@ -4931,23 +5014,7 @@ def provision_worktrees(
             )
 
     if canonical_validation_failed:
-        if manage_api_runtimes:
-            try:
-                reconcile_api_runtime_units(
-                    {},
-                    preserve_runtime_ids=unreconciled_api_runtime_ids,
-                )
-            except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
-                error_message = f"failed to prune API runtime services: {error}"
-                print(error_message, file=sys.stderr)
-                failed_provision_worktrees.append(
-                    {
-                        "repo": "api",
-                        "workspace": "runtime-services",
-                        "path": str(API_RUNTIME_UNIT_DIRECTORY),
-                        "error": error_message,
-                    }
-                )
+        prune_api_runtime_units_after_blocking_failure()
         return [], [], failed_provision_worktrees
 
     removed_workspace_aliases = cleanup_removed_workspace_aliases(
@@ -5020,25 +5087,16 @@ def provision_worktrees(
                         and not preview_storage_reset_required
                     ):
                         if repo_name == "api" and manage_api_runtimes:
-                            runtime_units = build_api_runtime_unit_specs(
+                            runtime_units = ensure_api_runtime_owner(
+                                clone_root,
                                 locked_worktree_path,
                                 pathlib.Path(spec["path"]),
                                 workspace=workspace,
-                                runtime_revision=build_api_runtime_revision(
-                                    locked_worktree_path,
-                                    pathlib.Path(spec["path"]),
-                                ),
+                                preview_enabled=preview_enabled,
                             )
                             desired_api_runtime_units.update(runtime_units)
                             unreconciled_api_runtime_ids.discard(
                                 build_api_runtime_id(locked_worktree_path)
-                            )
-                            reconcile_api_runtime_units(runtime_units, prune=False)
-                            wait_for_api_scheduler_readiness_or_revoke_access(
-                                clone_root,
-                                locked_worktree_path,
-                                pathlib.Path(spec["path"]),
-                                preview_enabled=preview_enabled,
                             )
                         if preview_enabled:
                             ensure_preview_nginx_access(clone_root, locked_worktree_path)
@@ -5074,25 +5132,16 @@ def provision_worktrees(
                     marker_payload["linked_workspaces"] = linked_setup_context
 
                 if repo_name == "api" and manage_api_runtimes:
-                    runtime_units = build_api_runtime_unit_specs(
+                    runtime_units = ensure_api_runtime_owner(
+                        clone_root,
                         locked_worktree_path,
                         pathlib.Path(spec["path"]),
                         workspace=workspace,
-                        runtime_revision=build_api_runtime_revision(
-                            locked_worktree_path,
-                            pathlib.Path(spec["path"]),
-                        ),
+                        preview_enabled=preview_enabled,
                     )
                     desired_api_runtime_units.update(runtime_units)
                     unreconciled_api_runtime_ids.discard(
                         build_api_runtime_id(locked_worktree_path)
-                    )
-                    reconcile_api_runtime_units(runtime_units, prune=False)
-                    wait_for_api_scheduler_readiness_or_revoke_access(
-                        clone_root,
-                        locked_worktree_path,
-                        pathlib.Path(spec["path"]),
-                        preview_enabled=preview_enabled,
                     )
 
                 if preview_enabled:

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4545,11 +4545,15 @@ def build_api_runtime_unit_specs(
     *,
     workspace: str,
     runtime_revision: str,
+    service_path: str | None = None,
 ) -> dict[str, str]:
     if re.fullmatch(r"[a-z0-9][a-z0-9-]*", workspace) is None:
         raise ValueError(f"unsafe API runtime workspace name: {workspace}")
     if re.fullmatch(r"[0-9a-f]{64}", runtime_revision) is None:
         raise ValueError("API runtime revision must be a lowercase SHA-256 digest")
+    runtime_service_path = os.environ.get("PATH", "") if service_path is None else service_path
+    if re.fullmatch(r"[a-zA-Z0-9/_.:+-]+", runtime_service_path) is None:
+        raise ValueError("API runtime service PATH contains unsafe characters")
 
     resolved_worktree = worktree_path.resolve()
     resolved_source = source_repo_path.resolve()
@@ -4588,6 +4592,7 @@ def build_api_runtime_unit_specs(
             [Service]
             Type=simple
             WorkingDirectory={resolved_worktree}
+            Environment=PATH={runtime_service_path}
             ExecStart={exec_start}
             Restart=on-failure
             RestartSec=5s
@@ -5691,6 +5696,7 @@ def check_nginx_helper_compatibility(
 
     command = [str(helper_path), "--check"] if os.geteuid() == 0 else [
         sudo_bin,
+        "-k",
         "-n",
         str(helper_path),
         "--check",

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4715,9 +4715,15 @@ def reconcile_api_runtime_units(
             existing_content: str | None = None
             if not unit_path.is_symlink() and unit_path.exists():
                 try:
-                    existing_content = unit_path.read_text()
-                except UnicodeError:
-                    pass
+                    unit_metadata = unit_path.lstat()
+                    if (
+                        stat.S_ISREG(unit_metadata.st_mode)
+                        and unit_metadata.st_uid == os.geteuid()
+                        and stat.S_IMODE(unit_metadata.st_mode) == 0o644
+                    ):
+                        existing_content = unit_path.read_text(encoding="utf-8")
+                except (OSError, UnicodeError):
+                    existing_content = None
             if existing_content == content:
                 start_names.add(unit_name)
                 continue

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4695,12 +4695,17 @@ def wait_for_api_scheduler_readiness(
     worktree_env = load_optional_env_assignments(worktree_path / ".env")
     source_env = load_optional_env_assignments(source_repo_path / ".env")
     command_env = build_api_worktree_command_env(worktree_env, source_env)
+    tinker_script = " ".join(
+        (
+            "if (! app(\\App\\Services\\RuntimeHeartbeatService::class)->schedulerReadiness()['healthy'])",
+            "{ throw new \\RuntimeException('scheduler heartbeat missing'); }",
+        )
+    )
     command = [
         "php",
         "artisan",
         "tinker",
-        "--execute=if (! app(\\App\\Services\\RuntimeHeartbeatService::class)->schedulerReadiness()['healthy']) "
-        "{ throw new \\RuntimeException('scheduler heartbeat missing'); }",
+        f"--execute={tinker_script}",
     ]
     for attempt in range(attempts):
         result = command_runner(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -2557,8 +2557,8 @@ REPO_SETTINGS: dict[str, dict[str, Any]] = {
                     API_BOOTSTRAP_SETUP_COMMAND_PLACEHOLDER,
                 ],
                 "run": [
-                    {"label": "Queue Worker", "command": API_QUEUE_WORKER_COMMAND, "autostart": True, "runMode": "replace"},
-                    {"label": "Scheduler", "command": API_SCHEDULER_COMMAND, "autostart": True, "runMode": "replace"},
+                    {"label": "Queue Worker", "command": API_QUEUE_WORKER_COMMAND, "autostart": False, "runMode": "replace"},
+                    {"label": "Scheduler", "command": API_SCHEDULER_COMMAND, "autostart": False, "runMode": "replace"},
                     {"label": "Pail", "command": API_PAIL_COMMAND, "runMode": "replace"},
                     # Preview-only safety note: this destructive reset is for SecPal preview/dev workspaces only.
                     # It intentionally reseeds the canonical E2E login `test@example.com` / `password` and must never target production.
@@ -4459,14 +4459,91 @@ def should_manage_api_runtime_units(
     )
 
 
+def _update_runtime_revision_path_metadata(
+    digest: Any,
+    label: str,
+    path: pathlib.Path,
+) -> None:
+    digest.update(label.encode())
+    digest.update(b"\0")
+    try:
+        path_stat = path.lstat()
+    except FileNotFoundError:
+        digest.update(b"missing\0")
+        return
+
+    digest.update(
+        (
+            f"{path_stat.st_mode}:{path_stat.st_ino}:{path_stat.st_size}:"
+            f"{path_stat.st_mtime_ns}:{path_stat.st_ctime_ns}"
+        ).encode()
+    )
+    digest.update(b"\0")
+    if stat.S_ISLNK(path_stat.st_mode):
+        digest.update(os.readlink(path).encode())
+        digest.update(b"\0")
+
+
+def build_api_runtime_revision(
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+) -> str:
+    """Fingerprint code and environment inputs consumed by long-lived API processes."""
+    git = resolve_executable("git")
+    if git is None:
+        raise RuntimeError(f"git is required to fingerprint API runtime state for {worktree_path}")
+
+    digest = hashlib.sha256()
+    commands = (
+        [git, "rev-parse", "HEAD"],
+        [git, "diff", "--binary", "HEAD", "--"],
+        [git, "ls-files", "--others", "--exclude-standard", "-z"],
+    )
+    outputs: list[bytes] = []
+    try:
+        for command in commands:
+            result = subprocess.run(
+                command,
+                cwd=worktree_path,
+                check=True,
+                capture_output=True,
+            )
+            outputs.append(result.stdout)
+            digest.update(len(result.stdout).to_bytes(8, "big"))
+            digest.update(result.stdout)
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise RuntimeError(f"unable to fingerprint API runtime state for {worktree_path}") from error
+
+    for raw_relative_path in outputs[-1].split(b"\0"):
+        if not raw_relative_path:
+            continue
+        relative_path = pathlib.Path(os.fsdecode(raw_relative_path))
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise RuntimeError(
+                f"git returned an unsafe untracked path for API runtime state: {relative_path}"
+            )
+        _update_runtime_revision_path_metadata(
+            digest,
+            f"untracked:{relative_path.as_posix()}",
+            worktree_path / relative_path,
+        )
+
+    _update_runtime_revision_path_metadata(digest, "worktree-env", worktree_path / ".env")
+    _update_runtime_revision_path_metadata(digest, "source-env", source_repo_path / ".env")
+    return digest.hexdigest()
+
+
 def build_api_runtime_unit_specs(
     worktree_path: pathlib.Path,
     source_repo_path: pathlib.Path,
     *,
     workspace: str,
+    runtime_revision: str,
 ) -> dict[str, str]:
     if re.fullmatch(r"[a-z0-9][a-z0-9-]*", workspace) is None:
         raise ValueError(f"unsafe API runtime workspace name: {workspace}")
+    if re.fullmatch(r"[0-9a-f]{64}", runtime_revision) is None:
+        raise ValueError("API runtime revision must be a lowercase SHA-256 digest")
 
     resolved_worktree = worktree_path.resolve()
     resolved_source = source_repo_path.resolve()
@@ -4495,6 +4572,7 @@ def build_api_runtime_unit_specs(
             f"""
             # SPDX-FileCopyrightText: 2026 SecPal Contributors
             # SPDX-License-Identifier: MIT
+            # RuntimeRevision={runtime_revision}
             [Unit]
             Description=SecPal preview API {role} for {workspace}
             After=network-online.target postgresql.service redis-server.service
@@ -4560,18 +4638,22 @@ def reconcile_api_runtime_units(
     for stale_name in stale_names:
         systemctl_runner(
             ["systemctl", "--user", "disable", "--now", stale_name],
-            check=False,
+            check=True,
             env=systemctl_env,
         )
         existing_units[stale_name].unlink()
 
+    restart_names: set[str] = set()
+    start_names: set[str] = set()
     for unit_name, content in sorted(desired_units.items()):
         if re.fullmatch(rf"{re.escape(API_RUNTIME_UNIT_PREFIX)}[a-z0-9-]+\.service", unit_name) is None:
             raise ValueError(f"unsafe API runtime unit name: {unit_name}")
         unit_path = unit_directory / unit_name
         if not unit_path.is_symlink() and unit_path.exists() and unit_path.read_text() == content:
+            start_names.add(unit_name)
             continue
         _write_text_atomic(unit_path, content)
+        restart_names.add(unit_name)
         changed = True
 
     if changed:
@@ -4582,7 +4664,19 @@ def reconcile_api_runtime_units(
         )
     if desired_names:
         systemctl_runner(
-            ["systemctl", "--user", "enable", "--now", *sorted(desired_names)],
+            ["systemctl", "--user", "enable", *sorted(desired_names)],
+            check=True,
+            env=systemctl_env,
+        )
+    if restart_names:
+        systemctl_runner(
+            ["systemctl", "--user", "restart", *sorted(restart_names)],
+            check=True,
+            env=systemctl_env,
+        )
+    if start_names:
+        systemctl_runner(
+            ["systemctl", "--user", "start", *sorted(start_names)],
             check=True,
             env=systemctl_env,
         )
@@ -4786,6 +4880,10 @@ def provision_worktrees(
                                 locked_worktree_path,
                                 pathlib.Path(spec["path"]),
                                 workspace=workspace,
+                                runtime_revision=build_api_runtime_revision(
+                                    locked_worktree_path,
+                                    pathlib.Path(spec["path"]),
+                                ),
                             )
                             desired_api_runtime_units.update(runtime_units)
                             reconcile_api_runtime_units(runtime_units, prune=False)
@@ -4831,6 +4929,10 @@ def provision_worktrees(
                         locked_worktree_path,
                         pathlib.Path(spec["path"]),
                         workspace=workspace,
+                        runtime_revision=build_api_runtime_revision(
+                            locked_worktree_path,
+                            pathlib.Path(spec["path"]),
+                        ),
                     )
                     desired_api_runtime_units.update(runtime_units)
                     reconcile_api_runtime_units(runtime_units, prune=False)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -121,7 +121,7 @@ def default_api_worktree_bootstrap_lock_directory() -> pathlib.Path:
 
 
 @contextlib.contextmanager
-def provision_worktree_lock(lock_path: pathlib.Path):
+def provision_worktree_lock(lock_path: pathlib.Path, *, blocking: bool = True):
     """Serialize provisioners without making the lock itself a watched input."""
     lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     if lock_path.is_symlink():
@@ -138,8 +138,13 @@ def provision_worktree_lock(lock_path: pathlib.Path):
         if lock_stat.st_uid != os.geteuid() or lock_stat.st_nlink != 1:
             raise RuntimeError(f"provision lock must be owned by the caller and have one link: {lock_path}")
         os.fchmod(descriptor, 0o600)
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        lock_flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        try:
+            fcntl.flock(descriptor, lock_flags)
+        except BlockingIOError:
+            yield False
+            return
+        yield True
     finally:
         os.close(descriptor)
 
@@ -4659,6 +4664,9 @@ def reconcile_api_runtime_units(
     preserved_ids = preserve_runtime_ids or set()
     if any(re.fullmatch(r"[0-9a-f]{12}", runtime_id) is None for runtime_id in preserved_ids):
         raise ValueError("preserved API runtime ids must be 12 lowercase hexadecimal characters")
+    for unit_name in desired_units:
+        if re.fullmatch(rf"{re.escape(API_RUNTIME_UNIT_PREFIX)}[a-z0-9-]+\.service", unit_name) is None:
+            raise ValueError(f"unsafe API runtime unit name: {unit_name}")
     systemctl_env = os.environ.copy()
     runtime_directory = pathlib.Path(f"/run/user/{os.getuid()}")
     systemctl_env.setdefault("XDG_RUNTIME_DIR", str(runtime_directory))
@@ -4699,43 +4707,59 @@ def reconcile_api_runtime_units(
             continue
         changed = True
 
-    restart_names: set[str] = set()
-    start_names: set[str] = set()
-    for unit_name, content in sorted(desired_units.items()):
-        if re.fullmatch(rf"{re.escape(API_RUNTIME_UNIT_PREFIX)}[a-z0-9-]+\.service", unit_name) is None:
-            raise ValueError(f"unsafe API runtime unit name: {unit_name}")
-        unit_path = unit_directory / unit_name
-        if not unit_path.is_symlink() and unit_path.exists() and unit_path.read_text() == content:
-            start_names.add(unit_name)
-            continue
-        _write_text_atomic(unit_path, content)
-        restart_names.add(unit_name)
-        changed = True
+    try:
+        restart_names: set[str] = set()
+        start_names: set[str] = set()
+        for unit_name, content in sorted(desired_units.items()):
+            unit_path = unit_directory / unit_name
+            existing_content: str | None = None
+            if not unit_path.is_symlink() and unit_path.exists():
+                try:
+                    existing_content = unit_path.read_text()
+                except UnicodeError:
+                    pass
+            if existing_content == content:
+                start_names.add(unit_name)
+                continue
+            _write_text_atomic(unit_path, content)
+            restart_names.add(unit_name)
+            changed = True
 
-    if changed:
-        systemctl_runner(
-            ["systemctl", "--user", "daemon-reload"],
-            check=True,
-            env=systemctl_env,
+        if changed:
+            systemctl_runner(
+                ["systemctl", "--user", "daemon-reload"],
+                check=True,
+                env=systemctl_env,
+            )
+        if desired_names:
+            systemctl_runner(
+                ["systemctl", "--user", "enable", *sorted(desired_names)],
+                check=True,
+                env=systemctl_env,
+            )
+        if restart_names:
+            systemctl_runner(
+                ["systemctl", "--user", "restart", *sorted(restart_names)],
+                check=True,
+                env=systemctl_env,
+            )
+        if start_names:
+            systemctl_runner(
+                ["systemctl", "--user", "start", *sorted(start_names)],
+                check=True,
+                env=systemctl_env,
+            )
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as activation_error:
+        if not prune_failures:
+            raise
+        prune_details = "; ".join(
+            f"{unit_name}: {error}"
+            for unit_name, error in prune_failures
         )
-    if desired_names:
-        systemctl_runner(
-            ["systemctl", "--user", "enable", *sorted(desired_names)],
-            check=True,
-            env=systemctl_env,
-        )
-    if restart_names:
-        systemctl_runner(
-            ["systemctl", "--user", "restart", *sorted(restart_names)],
-            check=True,
-            env=systemctl_env,
-        )
-    if start_names:
-        systemctl_runner(
-            ["systemctl", "--user", "start", *sorted(start_names)],
-            check=True,
-            env=systemctl_env,
-        )
+        raise RuntimeError(
+            f"failed to reconcile API runtime units: prune failures: {prune_details}; "
+            f"activation failure: {activation_error}"
+        ) from activation_error
     if prune_failures:
         details = "; ".join(
             f"{unit_name}: {error}"
@@ -4786,6 +4810,28 @@ def wait_for_api_scheduler_readiness(
         f"API scheduler for {worktree_path} did not produce a readiness heartbeat "
         f"within {attempts * interval_seconds:g} seconds"
     )
+
+
+def wait_for_api_scheduler_readiness_or_revoke_access(
+    clone_root: pathlib.Path,
+    worktree_path: pathlib.Path,
+    source_repo_path: pathlib.Path,
+    *,
+    preview_enabled: bool,
+) -> None:
+    """Fail closed when a supervised API scheduler does not become ready."""
+    try:
+        wait_for_api_scheduler_readiness(worktree_path, source_repo_path)
+    except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as error:
+        if not preview_enabled:
+            raise
+        try:
+            deny_preview_nginx_access(clone_root, worktree_path)
+        except (OSError, RuntimeError, subprocess.CalledProcessError, SystemExit) as rollback_error:
+            raise RuntimeError(
+                f"{error}; additionally failed to revoke preview access: {rollback_error}"
+            ) from rollback_error
+        raise
 
 
 def provision_worktrees(
@@ -4879,6 +4925,23 @@ def provision_worktrees(
             )
 
     if canonical_validation_failed:
+        if manage_api_runtimes:
+            try:
+                reconcile_api_runtime_units(
+                    {},
+                    preserve_runtime_ids=unreconciled_api_runtime_ids,
+                )
+            except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+                error_message = f"failed to prune API runtime services: {error}"
+                print(error_message, file=sys.stderr)
+                failed_provision_worktrees.append(
+                    {
+                        "repo": "api",
+                        "workspace": "runtime-services",
+                        "path": str(API_RUNTIME_UNIT_DIRECTORY),
+                        "error": error_message,
+                    }
+                )
         return [], [], failed_provision_worktrees
 
     removed_workspace_aliases = cleanup_removed_workspace_aliases(
@@ -4965,9 +5028,11 @@ def provision_worktrees(
                                 build_api_runtime_id(locked_worktree_path)
                             )
                             reconcile_api_runtime_units(runtime_units, prune=False)
-                            wait_for_api_scheduler_readiness(
+                            wait_for_api_scheduler_readiness_or_revoke_access(
+                                clone_root,
                                 locked_worktree_path,
                                 pathlib.Path(spec["path"]),
+                                preview_enabled=preview_enabled,
                             )
                         if preview_enabled:
                             ensure_preview_nginx_access(clone_root, locked_worktree_path)
@@ -5017,9 +5082,11 @@ def provision_worktrees(
                         build_api_runtime_id(locked_worktree_path)
                     )
                     reconcile_api_runtime_units(runtime_units, prune=False)
-                    wait_for_api_scheduler_readiness(
+                    wait_for_api_scheduler_readiness_or_revoke_access(
+                        clone_root,
                         locked_worktree_path,
                         pathlib.Path(spec["path"]),
+                        preview_enabled=preview_enabled,
                     )
 
                 if preview_enabled:
@@ -5951,6 +6018,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--install-nginx", action="store_true")
     parser.add_argument("--provision-worktrees", action="store_true")
     parser.add_argument("--refresh-nginx", action="store_true")
+    parser.add_argument("--skip-if-provision-locked", action="store_true")
     return parser.parse_args()
 
 
@@ -5973,6 +6041,15 @@ def main() -> int:
     args = parse_args()
     apply_canonical_reconcile_mode(args)
 
+    skip_if_provision_locked = getattr(args, "skip_if_provision_locked", False)
+    if skip_if_provision_locked and (
+        not args.refresh_nginx or args.provision_worktrees or args.install_nginx
+    ):
+        raise SystemExit(
+            "--skip-if-provision-locked requires refresh-only mode and cannot be used "
+            "with --provision-worktrees or --install-nginx"
+        )
+
     try:
         validation_only_result = dispatch_validation_only_direct_mode(args)
         if validation_only_result is not None:
@@ -5985,11 +6062,17 @@ def main() -> int:
         return direct_mode_result
 
     lock_context = (
-        provision_worktree_lock(args.provision_lock_path)
+        provision_worktree_lock(
+            args.provision_lock_path,
+            blocking=not skip_if_provision_locked,
+        )
         if args.provision_worktrees or args.install_nginx or args.refresh_nginx
         else contextlib.nullcontext()
     )
-    with lock_context:
+    with lock_context as lock_acquired:
+        if lock_acquired is False:
+            print("Skipping startup Nginx refresh because provisioning is already in progress")
+            return 0
         return run_rollout(args)
 
 

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4361,24 +4361,50 @@ def revoke_unregistered_preview_nginx_access(
         for repo_worktrees in registered_worktrees.values()
         for worktree_path in repo_worktrees
     }
+    reconciliation_failures: list[tuple[pathlib.Path, Exception]] = []
 
     for repo_clone_root in sorted(resolved_clone_root.iterdir(), key=lambda path: path.name):
         if repo_clone_root.is_symlink():
-            raise RuntimeError(
-                f"preview clone root contains a repository symlink: {repo_clone_root}"
+            reconciliation_failures.append(
+                (
+                    repo_clone_root,
+                    RuntimeError(
+                        f"preview clone root contains a repository symlink: {repo_clone_root}"
+                    ),
+                )
             )
+            continue
         if not repo_clone_root.is_dir():
             continue
 
-        registered_aliases = load_workspace_alias_registry(repo_clone_root)
-        children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
+        try:
+            children = sorted(repo_clone_root.iterdir(), key=lambda path: path.name)
+        except OSError as error:
+            reconciliation_failures.append((repo_clone_root, error))
+            continue
         for child in children:
             if child.is_symlink() or not child.is_dir():
                 continue
-            if child.resolve(strict=True) not in registered_paths:
-                deny_preview_nginx_access(resolved_clone_root, child)
+            try:
+                if child.resolve(strict=True) not in registered_paths:
+                    deny_preview_nginx_access(resolved_clone_root, child)
+            except (OSError, RuntimeError) as error:
+                reconciliation_failures.append((child, error))
 
-        validate_preview_nginx_workspace_aliases(repo_clone_root, registered_aliases, children)
+        try:
+            registered_aliases = load_workspace_alias_registry(repo_clone_root)
+            validate_preview_nginx_workspace_aliases(repo_clone_root, registered_aliases, children)
+        except (OSError, RuntimeError) as error:
+            reconciliation_failures.append((repo_clone_root, error))
+
+    if reconciliation_failures:
+        details = "; ".join(
+            f"{path}: {error}"
+            for path, error in reconciliation_failures
+        )
+        raise RuntimeError(
+            f"failed to reconcile unregistered preview access: {details}"
+        ) from reconciliation_failures[0][1]
 
 
 def ensure_pre_commit_hook(worktree_path: pathlib.Path) -> None:
@@ -4657,15 +4683,21 @@ def reconcile_api_runtime_units(
             if runtime_match is not None and runtime_match.group(1) in preserved_ids:
                 continue
             stale_names.append(existing_name)
-    changed = bool(stale_names)
+    changed = False
+    prune_failures: list[tuple[str, Exception]] = []
 
     for stale_name in stale_names:
-        systemctl_runner(
-            ["systemctl", "--user", "disable", "--now", stale_name],
-            check=True,
-            env=systemctl_env,
-        )
-        existing_units[stale_name].unlink()
+        try:
+            systemctl_runner(
+                ["systemctl", "--user", "disable", "--now", stale_name],
+                check=True,
+                env=systemctl_env,
+            )
+            existing_units[stale_name].unlink()
+        except (OSError, subprocess.CalledProcessError) as error:
+            prune_failures.append((stale_name, error))
+            continue
+        changed = True
 
     restart_names: set[str] = set()
     start_names: set[str] = set()
@@ -4704,6 +4736,12 @@ def reconcile_api_runtime_units(
             check=True,
             env=systemctl_env,
         )
+    if prune_failures:
+        details = "; ".join(
+            f"{unit_name}: {error}"
+            for unit_name, error in prune_failures
+        )
+        raise RuntimeError(f"failed to prune API runtime units: {details}") from prune_failures[0][1]
 
 
 def wait_for_api_scheduler_readiness(

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -4459,6 +4459,12 @@ def should_manage_api_runtime_units(
     )
 
 
+def build_api_runtime_id(worktree_path: pathlib.Path) -> str:
+    """Build the stable unit identifier for one physical API worktree."""
+    resolved_worktree = worktree_path.resolve()
+    return hashlib.sha256(str(resolved_worktree).encode()).hexdigest()[:12]
+
+
 def _update_runtime_revision_path_metadata(
     digest: Any,
     label: str,
@@ -4547,7 +4553,7 @@ def build_api_runtime_unit_specs(
 
     resolved_worktree = worktree_path.resolve()
     resolved_source = source_repo_path.resolve()
-    runtime_id = hashlib.sha256(str(resolved_worktree).encode()).hexdigest()[:12]
+    runtime_id = build_api_runtime_id(resolved_worktree)
     unit_base = f"{API_RUNTIME_UNIT_PREFIX}{workspace}-{runtime_id}"
     roles = {
         "scheduler": API_SCHEDULER_COMMAND,
@@ -4616,8 +4622,12 @@ def reconcile_api_runtime_units(
     unit_directory: pathlib.Path = API_RUNTIME_UNIT_DIRECTORY,
     systemctl_runner: Any = subprocess.run,
     prune: bool = True,
+    preserve_runtime_ids: set[str] | None = None,
 ) -> None:
     """Atomically converge persistent API runtime units and their active state."""
+    preserved_ids = preserve_runtime_ids or set()
+    if any(re.fullmatch(r"[0-9a-f]{12}", runtime_id) is None for runtime_id in preserved_ids):
+        raise ValueError("preserved API runtime ids must be 12 lowercase hexadecimal characters")
     systemctl_env = os.environ.copy()
     runtime_directory = pathlib.Path(f"/run/user/{os.getuid()}")
     systemctl_env.setdefault("XDG_RUNTIME_DIR", str(runtime_directory))
@@ -4632,7 +4642,16 @@ def reconcile_api_runtime_units(
         for path in unit_directory.glob(f"{API_RUNTIME_UNIT_PREFIX}*.service")
         if path.is_file() or path.is_symlink()
     }
-    stale_names = sorted(set(existing_units) - desired_names) if prune else []
+    stale_names: list[str] = []
+    if prune:
+        for existing_name in sorted(set(existing_units) - desired_names):
+            runtime_match = re.fullmatch(
+                rf"{re.escape(API_RUNTIME_UNIT_PREFIX)}[a-z0-9-]+-([0-9a-f]{{12}})-(?:scheduler|queue)\.service",
+                existing_name,
+            )
+            if runtime_match is not None and runtime_match.group(1) in preserved_ids:
+                continue
+            stale_names.append(existing_name)
     changed = bool(stale_names)
 
     for stale_name in stale_names:
@@ -4744,6 +4763,14 @@ def provision_worktrees(
         resolved_db_path,
         repo_state,
         clone_root,
+    )
+    unreconciled_api_runtime_ids = (
+        {
+            build_api_runtime_id(worktree_path)
+            for worktree_path in registered_worktrees["api"]
+        }
+        if manage_api_runtimes
+        else set()
     )
     revoke_unregistered_preview_nginx_access(clone_root, registered_worktrees)
 
@@ -4891,6 +4918,9 @@ def provision_worktrees(
                                 ),
                             )
                             desired_api_runtime_units.update(runtime_units)
+                            unreconciled_api_runtime_ids.discard(
+                                build_api_runtime_id(locked_worktree_path)
+                            )
                             reconcile_api_runtime_units(runtime_units, prune=False)
                             wait_for_api_scheduler_readiness(
                                 locked_worktree_path,
@@ -4940,6 +4970,9 @@ def provision_worktrees(
                         ),
                     )
                     desired_api_runtime_units.update(runtime_units)
+                    unreconciled_api_runtime_ids.discard(
+                        build_api_runtime_id(locked_worktree_path)
+                    )
                     reconcile_api_runtime_units(runtime_units, prune=False)
                     wait_for_api_scheduler_readiness(
                         locked_worktree_path,
@@ -4978,7 +5011,10 @@ def provision_worktrees(
 
     if manage_api_runtimes:
         try:
-            reconcile_api_runtime_units(desired_api_runtime_units)
+            reconcile_api_runtime_units(
+                desired_api_runtime_units,
+                preserve_runtime_ids=unreconciled_api_runtime_ids,
+            )
         except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
             error_message = f"failed to reconcile API runtime services: {error}"
             print(error_message, file=sys.stderr)
@@ -5647,9 +5683,7 @@ def check_nginx_helper_compatibility(
     helper_path: pathlib.Path | None = None,
 ) -> None:
     sudo_bin = sudo_bin or os.environ.get("POLYSCOPE_SUDO_BIN", "sudo")
-    helper_path = helper_path or pathlib.Path(
-        os.environ.get("POLYSCOPE_NGINX_HELPER", str(DEFAULT_NGINX_HELPER_PATH))
-    )
+    helper_path = helper_path or DEFAULT_NGINX_HELPER_PATH
     if helper_runner is subprocess.run and (
         not helper_path.is_file() or not os.access(helper_path, os.X_OK)
     ):

--- a/scripts/polyscope_nginx.py
+++ b/scripts/polyscope_nginx.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import os
 import pathlib
@@ -27,6 +28,8 @@ EXPECTED_REPOSITORIES = (
     "guardguide.de",
 )
 EXPECTED_UNIX_UPSTREAM = "/run/php/php8.4-fpm-secpal-preview.sock"
+SUPPORTED_MANIFEST_VERSIONS = (1, 2)
+BUNDLE_VERSION = 2
 TOP_LEVEL_KEYS = {
     "version",
     "preview_domain",
@@ -56,10 +59,18 @@ def _require_exact_keys(payload: dict[str, Any], expected: set[str], description
 def validate_manifest_data(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("nginx manifest must be a JSON object")
-    _require_exact_keys(payload, TOP_LEVEL_KEYS, "nginx manifest")
-
-    if payload["version"] != 2:
-        raise ValueError("nginx manifest version must be 2")
+    version = payload.get("version")
+    if version not in SUPPORTED_MANIFEST_VERSIONS:
+        raise ValueError("nginx manifest version must be 1 or 2")
+    expected_keys = TOP_LEVEL_KEYS if version == 2 else TOP_LEVEL_KEYS - {"workspace_redirects"}
+    _require_exact_keys(payload, expected_keys, "nginx manifest")
+    payload = dict(payload)
+    if version == 1:
+        payload["version"] = 2
+        payload["workspace_redirects"] = {
+            repo_name: {}
+            for repo_name in EXPECTED_REPOSITORIES
+        }
     if payload["preview_domain"] != EXPECTED_PREVIEW_DOMAIN:
         raise ValueError(f"preview_domain must be exactly {EXPECTED_PREVIEW_DOMAIN}")
     if payload["clone_root"] != EXPECTED_CLONE_ROOT:
@@ -220,6 +231,19 @@ def _load_rollout_renderer() -> Any:
     renderer = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(renderer)
     return renderer
+
+
+def validate_installed_bundle() -> None:
+    """Prove that the colocated renderer implements this manifest contract."""
+    renderer = _load_rollout_renderer()
+    render_function = getattr(renderer, "render_nginx_config", None)
+    if not callable(render_function):
+        raise RuntimeError("root-owned nginx renderer lacks render_nginx_config")
+    parameters = inspect.signature(render_function).parameters
+    if "workspace_redirects" not in parameters or "nginx_http2_syntax" not in parameters:
+        raise RuntimeError(
+            "root-owned nginx renderer is incompatible with manifest bundle version 2"
+        )
 
 
 def render_nginx_config(payload: dict[str, Any]) -> str:

--- a/scripts/polyscope_nginx.py
+++ b/scripts/polyscope_nginx.py
@@ -60,6 +60,8 @@ def validate_manifest_data(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("nginx manifest must be a JSON object")
     version = payload.get("version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise ValueError("nginx manifest version must be an integer")
     if version not in SUPPORTED_MANIFEST_VERSIONS:
         raise ValueError("nginx manifest version must be 1 or 2")
     expected_keys = TOP_LEVEL_KEYS if version == 2 else TOP_LEVEL_KEYS - {"workspace_redirects"}

--- a/scripts/secpal-polyscope-nginx-apply.py
+++ b/scripts/secpal-polyscope-nginx-apply.py
@@ -208,14 +208,7 @@ def main() -> int:
         )
         nginx_library = load_nginx_library(require_root_ownership=True)
         nginx_library.validate_installed_bundle()
-        if args.check:
-            if MANIFEST_PATH.exists():
-                manifest = nginx_library.load_manifest(
-                    MANIFEST_PATH,
-                    expected_uid=expected_user.pw_uid,
-                )
-                nginx_library.render_nginx_config(manifest)
-        else:
+        if not args.check:
             apply_manifest(
                 manifest_path=MANIFEST_PATH,
                 target=TARGET_PATH,

--- a/scripts/secpal-polyscope-nginx-apply.py
+++ b/scripts/secpal-polyscope-nginx-apply.py
@@ -207,7 +207,15 @@ def main() -> int:
             require_root_ownership=True,
         )
         nginx_library = load_nginx_library(require_root_ownership=True)
-        if not args.check:
+        nginx_library.validate_installed_bundle()
+        if args.check:
+            if MANIFEST_PATH.exists():
+                manifest = nginx_library.load_manifest(
+                    MANIFEST_PATH,
+                    expected_uid=expected_user.pw_uid,
+                )
+                nginx_library.render_nginx_config(manifest)
+        else:
             apply_manifest(
                 manifest_path=MANIFEST_PATH,
                 target=TARGET_PATH,
@@ -216,12 +224,21 @@ def main() -> int:
                 expected_uid=expected_user.pw_uid,
                 nginx_library=nginx_library,
             )
-    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+    except (AttributeError, OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
         print(f"Polyscope nginx helper failed: {error}", file=sys.stderr)
         return 1
 
-    action = "check passed" if args.check else "configuration applied"
-    print(f"Polyscope nginx helper {action}")
+    if args.check:
+        capabilities = " ".join(
+            f"manifest_schema={version}"
+            for version in nginx_library.SUPPORTED_MANIFEST_VERSIONS
+        )
+        print(
+            f"Polyscope nginx helper check passed bundle={nginx_library.BUNDLE_VERSION} "
+            f"{capabilities}"
+        )
+    else:
+        print("Polyscope nginx helper configuration applied")
     return 0
 
 

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -128,6 +128,15 @@ assert normalized_legacy_manifest["workspace_redirects"] == {
     for repository in library.EXPECTED_REPOSITORIES
 }
 
+boolean_version_manifest = copy.deepcopy(legacy_manifest)
+boolean_version_manifest["version"] = True
+try:
+    library.validate_manifest_data(boolean_version_manifest)
+except ValueError as error:
+    assert "version must be an integer" in str(error), error
+else:
+    raise AssertionError("boolean nginx manifest versions must be rejected")
+
 
 def write_manifest(path: pathlib.Path, payload: object, mode: int = 0o600) -> None:
     path.write_text(json.dumps(payload, separators=(",", ":")) + "\n")

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -115,6 +115,18 @@ built_manifest = library.build_manifest(
     active_repo_state,
     nginx_http2_syntax="modern",
 )
+assert library.SUPPORTED_MANIFEST_VERSIONS == (1, 2)
+library.validate_installed_bundle()
+
+legacy_manifest = copy.deepcopy(manifest)
+legacy_manifest["version"] = 1
+legacy_manifest.pop("workspace_redirects")
+normalized_legacy_manifest = library.validate_manifest_data(legacy_manifest)
+assert normalized_legacy_manifest["version"] == 2
+assert normalized_legacy_manifest["workspace_redirects"] == {
+    repository: {}
+    for repository in library.EXPECTED_REPOSITORIES
+}
 
 
 def write_manifest(path: pathlib.Path, payload: object, mode: int = 0o600) -> None:

--- a/tests/polyscope-nginx-helper.sh
+++ b/tests/polyscope-nginx-helper.sh
@@ -11,12 +11,16 @@ trap 'rm -rf "$WORKSPACE"' EXIT
 
 python3 -B - "$REPO_ROOT" "$WORKSPACE" <<'PY'
 import copy
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import pathlib
 import subprocess
 import sys
+from types import SimpleNamespace
+from unittest import mock
 
 repo_root = pathlib.Path(sys.argv[1])
 workspace = pathlib.Path(sys.argv[2])
@@ -260,6 +264,26 @@ except ValueError as error:
     assert "utf-8 json" in str(error).lower(), error
 else:
     raise AssertionError("malformed manifest accepted")
+
+# Capability checks must remain usable when the active manifest is malformed,
+# so the unprivileged producer can replace it with a compatible manifest.
+with (
+    mock.patch.object(helper, "MANIFEST_PATH", malformed),
+    mock.patch.object(helper, "parse_args", return_value=SimpleNamespace(check=True)),
+    mock.patch.object(helper.os, "geteuid", return_value=0),
+    mock.patch.object(
+        helper.pwd,
+        "getpwnam",
+        return_value=SimpleNamespace(pw_uid=os.getuid()),
+    ),
+    mock.patch.object(helper, "validate_invoker"),
+    mock.patch.object(helper, "check_helper_components"),
+    mock.patch.object(helper, "load_nginx_library", return_value=library),
+    mock.patch.dict(os.environ, {"PATH": os.environ["PATH"]}),
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    assert helper.main() == 0
 
 fake_bin = workspace / "fake-bin"
 fake_bin.mkdir()

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -264,7 +264,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 )
             )
 
-            with self.assertRaises(subprocess.CalledProcessError):
+            with self.assertRaisesRegex(RuntimeError, stale_unit.name):
                 rollout.reconcile_api_runtime_units(
                     {},
                     unit_directory=unit_directory,
@@ -272,6 +272,77 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 )
 
             self.assertTrue(stale_unit.exists())
+
+    def test_api_runtime_reconciliation_continues_pruning_after_stop_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            failed_unit = unit_directory / "polyscope-api-worktree-aaa-scheduler.service"
+            later_unit = unit_directory / "polyscope-api-worktree-zzz-scheduler.service"
+            failed_unit.write_text("failed\n")
+            later_unit.write_text("later\n")
+
+            def run_systemctl(command, **_kwargs):
+                if command[-1] == failed_unit.name:
+                    raise subprocess.CalledProcessError(1, command)
+                return SimpleNamespace(returncode=0)
+
+            systemctl = mock.Mock(side_effect=run_systemctl)
+
+            with self.assertRaisesRegex(RuntimeError, failed_unit.name):
+                rollout.reconcile_api_runtime_units(
+                    {},
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                )
+
+            self.assertTrue(failed_unit.exists())
+            self.assertFalse(later_unit.exists())
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", failed_unit.name],
+                commands,
+            )
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", later_unit.name],
+                commands,
+            )
+
+    def test_api_runtime_reconciliation_continues_pruning_after_unlink_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            failed_unit = unit_directory / "polyscope-api-worktree-aaa-scheduler.service"
+            later_unit = unit_directory / "polyscope-api-worktree-zzz-scheduler.service"
+            failed_unit.write_text("failed\n")
+            later_unit.write_text("later\n")
+            systemctl = mock.Mock(return_value=SimpleNamespace(returncode=0))
+            original_unlink = Path.unlink
+
+            def unlink(path, *args, **kwargs):
+                if path == failed_unit:
+                    raise OSError("simulated unit removal failure")
+                return original_unlink(path, *args, **kwargs)
+
+            with (
+                mock.patch.object(Path, "unlink", new=unlink),
+                self.assertRaisesRegex(RuntimeError, failed_unit.name),
+            ):
+                rollout.reconcile_api_runtime_units(
+                    {},
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                )
+
+            self.assertTrue(failed_unit.exists())
+            self.assertFalse(later_unit.exists())
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", failed_unit.name],
+                commands,
+            )
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", later_unit.name],
+                commands,
+            )
 
     def test_api_runtime_failure_preserves_only_the_registered_runtime_units(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -367,6 +438,91 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 ["systemctl", "--user", "disable", "--now", removed_unit.name],
                 commands,
             )
+
+    def test_acl_reconciliation_continues_revoking_after_one_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            clone_root = Path(temporary_directory) / "clones"
+            repo_root = clone_root / "frontend-id"
+            first_orphan = repo_root / "aaa-orphan"
+            later_orphan = repo_root / "zzz-orphan"
+            first_orphan.mkdir(parents=True)
+            later_orphan.mkdir()
+            denied: list[Path] = []
+
+            def deny(_clone_root, worktree_path, **_kwargs):
+                denied.append(worktree_path)
+                if worktree_path == first_orphan:
+                    raise RuntimeError("simulated ACL denial failure")
+
+            with (
+                mock.patch.object(rollout, "deny_preview_nginx_access", new=deny),
+                self.assertRaisesRegex(RuntimeError, first_orphan.name),
+            ):
+                rollout.revoke_unregistered_preview_nginx_access(
+                    clone_root,
+                    {"frontend": []},
+                )
+
+            self.assertEqual(denied, [first_orphan, later_orphan])
+
+    def test_acl_reconciliation_revokes_worktrees_despite_bad_alias_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            clone_root = Path(temporary_directory) / "clones"
+            first_repo = clone_root / "aaa-repo"
+            later_repo = clone_root / "zzz-repo"
+            first_orphan = first_repo / "orphan"
+            later_orphan = later_repo / "orphan"
+            first_orphan.mkdir(parents=True)
+            later_orphan.mkdir(parents=True)
+            (first_repo / rollout.WORKSPACE_ALIAS_REGISTRY_FILENAME).write_text("{bad-json\n")
+            denied: list[Path] = []
+
+            with (
+                mock.patch.object(
+                    rollout,
+                    "deny_preview_nginx_access",
+                    side_effect=lambda _root, worktree, **_kwargs: denied.append(worktree),
+                ),
+                self.assertRaisesRegex(RuntimeError, "workspace alias registry"),
+            ):
+                rollout.revoke_unregistered_preview_nginx_access(
+                    clone_root,
+                    {"frontend": []},
+                )
+
+            self.assertEqual(denied, [first_orphan, later_orphan])
+
+    def test_acl_reconciliation_continues_after_repository_listing_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            clone_root = Path(temporary_directory) / "clones"
+            first_repo = clone_root / "aaa-repo"
+            later_repo = clone_root / "zzz-repo"
+            first_repo.mkdir(parents=True)
+            later_orphan = later_repo / "orphan"
+            later_orphan.mkdir(parents=True)
+            denied: list[Path] = []
+            original_iterdir = Path.iterdir
+
+            def iterdir(path):
+                if path == first_repo:
+                    raise OSError("simulated repository listing failure")
+                return original_iterdir(path)
+
+            with (
+                mock.patch.object(Path, "iterdir", new=iterdir),
+                mock.patch.object(
+                    rollout,
+                    "deny_preview_nginx_access",
+                    side_effect=lambda _root, worktree, **_kwargs: denied.append(worktree),
+                ),
+                self.assertRaisesRegex(RuntimeError, first_repo.name),
+            ):
+                rollout.revoke_unregistered_preview_nginx_access(
+                    clone_root,
+                    {"frontend": []},
+                )
+
+            self.assertEqual(denied, [later_orphan])
 
     def test_scheduler_readiness_waits_for_a_real_heartbeat(self) -> None:
         runner = mock.Mock(

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -47,8 +47,67 @@ class PolyscopeRolloutFollowupTests(TestCase):
             "--skip-local-configs",
             "--skip-db-sync",
             "--refresh-nginx",
+            "--skip-if-provision-locked",
         ):
             self.assertIn(argument, ready_command)
+
+    def test_user_server_startup_receives_the_validated_sudo_binary(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+        server_unit = installer.split('cat >"$SERVER_UNIT" <<EOF', 1)[1].split("EOF", 1)[0]
+
+        self.assertIn("Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN", server_unit)
+
+    def test_system_server_startup_skips_refresh_while_provisioning(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-system-components.sh").read_text()
+        system_dropin = installer.split('cat >"$TEMP_DIR/zz-secpal-runtime.conf" <<EOF', 1)[
+            1
+        ].split("EOF", 1)[0]
+
+        self.assertIn("--refresh-nginx --skip-if-provision-locked", system_dropin)
+
+    def test_provision_service_allows_the_scheduler_gate_to_finish(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+        provision_unit = installer.split('cat >"$PROVISION_SERVICE_UNIT" <<EOF', 1)[1].split(
+            "EOF", 1
+        )[0]
+
+        self.assertIn("TimeoutStartSec=15min", provision_unit)
+
+    def test_nonblocking_provision_lock_reports_contention(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            lock_path = Path(temporary_directory) / "provision.lock"
+
+            with rollout.provision_worktree_lock(lock_path) as acquired:
+                self.assertTrue(acquired)
+                with rollout.provision_worktree_lock(lock_path, blocking=False) as acquired_again:
+                    self.assertFalse(acquired_again)
+
+    def test_startup_refresh_skips_cleanly_when_provisioning_holds_the_lock(self) -> None:
+        args = SimpleNamespace(
+            install_nginx=False,
+            provision_lock_path=Path("/tmp/provision.lock"),
+            provision_worktrees=False,
+            refresh_nginx=True,
+            skip_if_provision_locked=True,
+        )
+        run_rollout = mock.Mock(return_value=0)
+
+        @contextlib.contextmanager
+        def contended_lock(_path, *, blocking=True):
+            self.assertFalse(blocking)
+            yield False
+
+        with mock.patch.multiple(
+            rollout,
+            parse_args=mock.Mock(return_value=args),
+            dispatch_validation_only_direct_mode=mock.Mock(return_value=None),
+            dispatch_instruction_dependent_direct_api_mode=mock.Mock(return_value=None),
+            provision_worktree_lock=contended_lock,
+            run_rollout=run_rollout,
+        ):
+            self.assertEqual(rollout.main(), 0)
+
+        run_rollout.assert_not_called()
 
     def test_preview_api_environment_enables_complete_public_bootstrap(self) -> None:
         updates = rollout.build_api_preview_env_updates("mighty-hyena")
@@ -343,6 +402,177 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 ["systemctl", "--user", "disable", "--now", later_unit.name],
                 commands,
             )
+
+    def test_api_runtime_reconciliation_validates_desired_names_before_pruning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            stale_unit = unit_directory / "polyscope-api-worktree-stale-scheduler.service"
+            stale_unit.write_text("stale\n")
+            systemctl = mock.Mock()
+
+            with self.assertRaisesRegex(ValueError, "unsafe API runtime unit name"):
+                rollout.reconcile_api_runtime_units(
+                    {"unmanaged.service": "unsafe\n"},
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                )
+
+            self.assertTrue(stale_unit.exists())
+            systemctl.assert_not_called()
+
+    def test_api_runtime_reconciliation_replaces_non_utf8_desired_unit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            unit_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
+            unit_path = unit_directory / unit_name
+            unit_path.write_bytes(b"\xff\xfe")
+            systemctl = mock.Mock()
+
+            rollout.reconcile_api_runtime_units(
+                {unit_name: "desired\n"},
+                unit_directory=unit_directory,
+                systemctl_runner=systemctl,
+                prune=False,
+            )
+
+            self.assertEqual(unit_path.read_text(), "desired\n")
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(["systemctl", "--user", "daemon-reload"], commands)
+            self.assertIn(["systemctl", "--user", "restart", unit_name], commands)
+
+    def test_api_runtime_reconciliation_reports_prune_and_activation_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            stale_unit = unit_directory / "polyscope-api-worktree-stale-scheduler.service"
+            stale_unit.write_text("stale\n")
+            desired_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
+
+            def run_systemctl(command, **_kwargs):
+                if command[-1] == stale_unit.name:
+                    raise subprocess.CalledProcessError(1, command)
+                if command[-1] == "daemon-reload":
+                    raise subprocess.CalledProcessError(1, command)
+                return SimpleNamespace(returncode=0)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                f"{stale_unit.name}.*daemon-reload",
+            ):
+                rollout.reconcile_api_runtime_units(
+                    {desired_name: "desired\n"},
+                    unit_directory=unit_directory,
+                    systemctl_runner=run_systemctl,
+                )
+
+    def test_scheduler_failure_revokes_existing_preview_access(self) -> None:
+        worktree = Path("/home/secpal/.polyscope/clones/api-id/mighty-hyena-1c04a2fb")
+        clone_root = worktree.parents[1]
+        source = Path("/home/secpal/code/SecPal/api")
+        deny_access = mock.Mock()
+
+        with (
+            mock.patch.object(
+                rollout,
+                "wait_for_api_scheduler_readiness",
+                side_effect=RuntimeError("scheduler heartbeat missing"),
+            ),
+            mock.patch.object(rollout, "deny_preview_nginx_access", new=deny_access),
+            self.assertRaisesRegex(RuntimeError, "scheduler heartbeat missing"),
+        ):
+            rollout.wait_for_api_scheduler_readiness_or_revoke_access(
+                clone_root,
+                worktree,
+                source,
+                preview_enabled=True,
+            )
+
+        deny_access.assert_called_once_with(clone_root, worktree)
+
+    def test_scheduler_failure_reports_preview_revocation_failure(self) -> None:
+        worktree = Path("/home/secpal/.polyscope/clones/api-id/mighty-hyena-1c04a2fb")
+        clone_root = worktree.parents[1]
+        source = Path("/home/secpal/code/SecPal/api")
+
+        with (
+            mock.patch.object(
+                rollout,
+                "wait_for_api_scheduler_readiness",
+                side_effect=RuntimeError("scheduler heartbeat missing"),
+            ),
+            mock.patch.object(
+                rollout,
+                "deny_preview_nginx_access",
+                side_effect=RuntimeError("ACL update failed"),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "scheduler heartbeat missing; additionally failed to revoke preview access: ACL update failed",
+            ),
+        ):
+            rollout.wait_for_api_scheduler_readiness_or_revoke_access(
+                clone_root,
+                worktree,
+                source,
+                preview_enabled=True,
+            )
+
+    def test_canonical_validation_failure_still_prunes_removed_api_units(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            clone_root = root / "clones"
+            worktree = clone_root / "api-id" / "mighty-hyena-1c04a2fb"
+            worktree.mkdir(parents=True)
+            runtime_id = rollout.build_api_runtime_id(worktree)
+            unit_directory = root / "units"
+            unit_directory.mkdir()
+            registered_unit = unit_directory / (
+                f"polyscope-api-worktree-mighty-hyena-{runtime_id}-scheduler.service"
+            )
+            removed_unit = unit_directory / (
+                "polyscope-api-worktree-removed-workspace-bbbbbbbbbbbb-scheduler.service"
+            )
+            registered_unit.write_text("registered\n")
+            removed_unit.write_text("removed\n")
+            systemctl = mock.Mock()
+            reconcile_runtime_units = rollout.reconcile_api_runtime_units
+
+            def reconcile(desired_units, **kwargs):
+                reconcile_runtime_units(
+                    desired_units,
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                    **kwargs,
+                )
+
+            with mock.patch.multiple(
+                rollout,
+                should_manage_api_runtime_units=mock.Mock(return_value=True),
+                load_registered_worktree_paths=mock.Mock(return_value={"api": [worktree]}),
+                revoke_unregistered_preview_nginx_access=mock.Mock(),
+                is_provisionable_worktree=mock.Mock(
+                    side_effect=rollout.CanonicalInstructionValidationError(
+                        "invalid canonical instructions"
+                    )
+                ),
+                reconcile_api_runtime_units=mock.Mock(side_effect=reconcile),
+            ):
+                _provisioned, _cleaned, failures = rollout.provision_worktrees(
+                    {"api": {"id": "api-id"}},
+                    {
+                        "api": {
+                            rollout.NATIVE_SETUP_COMMANDS_KEY: ["bootstrap-api"],
+                            "path": root / "source-api",
+                            "preview_prefix": "api",
+                        }
+                    },
+                    clone_root,
+                    db_path=root / "polyscope.db",
+                )
+
+            self.assertEqual(len(failures), 1)
+            self.assertIn("invalid canonical instructions", failures[0]["error"])
+            self.assertTrue(registered_unit.exists())
+            self.assertFalse(removed_unit.exists())
 
     def test_api_runtime_failure_preserves_only_the_registered_runtime_units(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import importlib.util
 import inspect
@@ -295,7 +296,9 @@ class PolyscopeRolloutFollowupTests(TestCase):
             unit_directory = Path(temporary_directory)
             unit_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
             content = "scheduler\n"
-            (unit_directory / unit_name).write_text(content)
+            unit_path = unit_directory / unit_name
+            unit_path.write_text(content)
+            unit_path.chmod(0o644)
             systemctl = mock.Mock()
 
             rollout.reconcile_api_runtime_units(
@@ -439,6 +442,71 @@ class PolyscopeRolloutFollowupTests(TestCase):
             commands = [call.args[0] for call in systemctl.call_args_list]
             self.assertIn(["systemctl", "--user", "daemon-reload"], commands)
             self.assertIn(["systemctl", "--user", "restart", unit_name], commands)
+
+    def test_api_runtime_reconciliation_restores_desired_unit_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            unit_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
+            unit_path = unit_directory / unit_name
+            unit_path.write_text("desired\n")
+            unit_path.chmod(0o600)
+            systemctl = mock.Mock()
+
+            rollout.reconcile_api_runtime_units(
+                {unit_name: "desired\n"},
+                unit_directory=unit_directory,
+                systemctl_runner=systemctl,
+                prune=False,
+            )
+
+            self.assertEqual(unit_path.stat().st_mode & 0o777, 0o644)
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(["systemctl", "--user", "daemon-reload"], commands)
+            self.assertIn(["systemctl", "--user", "restart", unit_name], commands)
+
+    def test_api_runtime_reconciliation_restores_desired_unit_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            unit_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
+            unit_path = unit_directory / unit_name
+            unit_path.write_text("desired\n")
+            unit_path.chmod(0o644)
+            systemctl = mock.Mock()
+            original_lstat = Path.lstat
+
+            def lstat(path):
+                metadata = original_lstat(path)
+                if path == unit_path:
+                    return SimpleNamespace(
+                        st_mode=metadata.st_mode,
+                        st_uid=rollout.os.geteuid() + 1,
+                    )
+                return metadata
+
+            with mock.patch.object(Path, "lstat", new=lstat):
+                rollout.reconcile_api_runtime_units(
+                    {unit_name: "desired\n"},
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                    prune=False,
+                )
+
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(["systemctl", "--user", "daemon-reload"], commands)
+            self.assertIn(["systemctl", "--user", "restart", unit_name], commands)
+
+    def test_api_runtime_reconciliation_has_no_empty_exception_handler(self) -> None:
+        source = inspect.getsource(rollout.reconcile_api_runtime_units)
+        tree = compile(source, "reconcile_api_runtime_units", "exec", ast.PyCF_ONLY_AST)
+        empty_handlers = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ExceptHandler)
+            and len(node.body) == 1
+            and isinstance(node.body[0], ast.Pass)
+        ]
+
+        self.assertEqual(empty_handlers, [])
 
     def test_api_runtime_reconciliation_reports_prune_and_activation_failures(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -30,6 +30,143 @@ rollout = load_rollout_module()
 
 
 class PolyscopeRolloutFollowupTests(TestCase):
+    def test_preview_api_environment_enables_complete_public_bootstrap(self) -> None:
+        updates = rollout.build_api_preview_env_updates("mighty-hyena")
+
+        self.assertEqual(updates["BOOTSTRAP_PUBLIC_ENABLED"], "true")
+        self.assertEqual(
+            updates["BOOTSTRAP_INSTANCE_DISPLAY_NAME"],
+            "SecPal Preview (mighty-hyena)",
+        )
+        self.assertEqual(updates["BOOTSTRAP_MINIMUM_SUPPORTED_APP_VERSION"], "1.4.0")
+        self.assertEqual(updates["BOOTSTRAP_MINIMUM_SUPPORTED_APP_BUILD"], "10400")
+
+    def test_nginx_manifest_is_not_replaced_by_an_incompatible_helper(self) -> None:
+        writer = mock.Mock()
+        helper = mock.Mock(
+            return_value=SimpleNamespace(
+                returncode=0,
+                stdout="Polyscope nginx helper check passed\n",
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "manifest schema 2"):
+            rollout.write_compatible_nginx_manifest(
+                Path("/home/secpal/.local/state/polyscope/nginx-manifest.json"),
+                {"version": 2},
+                writer=writer,
+                helper_runner=helper,
+                service_user=SimpleNamespace(pw_uid=0, pw_gid=0),
+            )
+
+        writer.assert_not_called()
+
+    def test_api_runtime_units_are_persistent_and_contain_no_environment_secrets(self) -> None:
+        worktree = Path("/home/secpal/.polyscope/clones/api-id/mighty-hyena-1c04a2fb")
+        source = Path("/home/secpal/code/SecPal/api")
+
+        units = rollout.build_api_runtime_unit_specs(
+            worktree,
+            source,
+            workspace="mighty-hyena",
+        )
+
+        self.assertEqual(len(units), 2)
+        rendered = "\n".join(units.values())
+        self.assertIn("Restart=on-failure", rendered)
+        self.assertIn(f"ConditionPathIsDirectory={worktree}", rendered)
+        self.assertIn("--run-api-worktree", rendered)
+        self.assertIn("php artisan schedule:work", rendered)
+        self.assertIn("php artisan queue:work", rendered)
+        self.assertNotIn("DB_PASSWORD", rendered)
+        self.assertNotIn("EnvironmentFile=", rendered)
+
+    def test_api_runtime_reconciliation_removes_stale_units_and_starts_desired_units(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            stale_unit = unit_directory / "polyscope-api-worktree-stale-scheduler.service"
+            stale_unit.write_text("stale\n")
+            stale_target = unit_directory / "stale-target"
+            stale_target.write_text("must survive\n")
+            stale_link = unit_directory / "polyscope-api-worktree-stale-queue.service"
+            stale_link.symlink_to(stale_target)
+            desired_target = unit_directory / "desired-target"
+            desired_target.write_text("scheduler\n")
+            desired_link = unit_directory / "polyscope-api-worktree-mighty-hyena-scheduler.service"
+            desired_link.symlink_to(desired_target)
+            desired = {
+                "polyscope-api-worktree-mighty-hyena-scheduler.service": "scheduler\n",
+                "polyscope-api-worktree-mighty-hyena-queue.service": "queue\n",
+            }
+            systemctl = mock.Mock()
+
+            rollout.reconcile_api_runtime_units(
+                desired,
+                unit_directory=unit_directory,
+                systemctl_runner=systemctl,
+            )
+
+            self.assertFalse(stale_unit.exists())
+            self.assertFalse(stale_link.exists())
+            self.assertTrue(stale_target.exists())
+            for unit_name, content in desired.items():
+                self.assertEqual((unit_directory / unit_name).read_text(), content)
+                self.assertFalse((unit_directory / unit_name).is_symlink())
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", stale_unit.name],
+                commands,
+            )
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", stale_link.name],
+                commands,
+            )
+            self.assertIn(["systemctl", "--user", "daemon-reload"], commands)
+            self.assertIn(
+                [
+                    "systemctl",
+                    "--user",
+                    "enable",
+                    "--now",
+                    *sorted(desired),
+                ],
+                commands,
+            )
+
+    def test_scheduler_readiness_waits_for_a_real_heartbeat(self) -> None:
+        runner = mock.Mock(
+            side_effect=[
+                SimpleNamespace(returncode=1),
+                SimpleNamespace(returncode=0),
+            ]
+        )
+        sleeper = mock.Mock()
+
+        rollout.wait_for_api_scheduler_readiness(
+            Path("/preview/api"),
+            Path("/source/api"),
+            command_runner=runner,
+            sleeper=sleeper,
+            attempts=2,
+            interval_seconds=0.01,
+        )
+
+        self.assertEqual(runner.call_count, 2)
+        sleeper.assert_called_once_with(0.01)
+        command = runner.call_args_list[0].args[0]
+        self.assertEqual(command[:2], ["php", "artisan"])
+        self.assertIn("schedulerReadiness", " ".join(command[2:]))
+        self.assertIn("RuntimeException", " ".join(command[2:]))
+        self.assertNotIn("exit(", " ".join(command[2:]))
+
+    def test_provision_mode_always_refreshes_nginx_without_a_unit_flag(self) -> None:
+        args = SimpleNamespace(provision_worktrees=True, refresh_nginx=False)
+
+        rollout.apply_canonical_reconcile_mode(args)
+
+        self.assertTrue(args.refresh_nginx)
+
     def test_api_health_probe_stays_unsuccessful_while_provisioning(self) -> None:
         repo_state = {
             "api": {"id": "api-id"},

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import inspect
+import io
 import json
 import subprocess
 import tempfile
+import tokenize
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase, main, mock
@@ -248,10 +251,37 @@ class PolyscopeRolloutFollowupTests(TestCase):
         self.assertEqual(runner.call_count, 2)
         sleeper.assert_called_once_with(0.01)
         command = runner.call_args_list[0].args[0]
-        self.assertEqual(command[:2], ["php", "artisan"])
+        self.assertEqual(command[:3], ["php", "artisan", "tinker"])
+        self.assertEqual(len(command), 4)
+        self.assertTrue(command[3].startswith("--execute="), command)
         self.assertIn("schedulerReadiness", " ".join(command[2:]))
         self.assertIn("RuntimeException", " ".join(command[2:]))
         self.assertNotIn("exit(", " ".join(command[2:]))
+
+    def test_scheduler_readiness_avoids_implicit_string_concatenation(self) -> None:
+        source = inspect.getsource(rollout.wait_for_api_scheduler_readiness)
+        ignored_tokens = {
+            tokenize.COMMENT,
+            tokenize.DEDENT,
+            tokenize.ENCODING,
+            tokenize.ENDMARKER,
+            tokenize.INDENT,
+            tokenize.NEWLINE,
+            tokenize.NL,
+        }
+        significant_tokens = [
+            token
+            for token in tokenize.generate_tokens(io.StringIO(source).readline)
+            if token.type not in ignored_tokens
+        ]
+
+        adjacent_string_tokens = [
+            (left, right)
+            for left, right in zip(significant_tokens, significant_tokens[1:])
+            if left.type == tokenize.STRING and right.type == tokenize.STRING
+        ]
+
+        self.assertEqual(adjacent_string_tokens, [])
 
     def test_provision_mode_always_refreshes_nginx_without_a_unit_flag(self) -> None:
         args = SimpleNamespace(provision_worktrees=True, refresh_nginx=False)

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -34,6 +34,22 @@ rollout = load_rollout_module()
 
 
 class PolyscopeRolloutFollowupTests(TestCase):
+    def test_user_server_startup_uses_lightweight_nginx_convergence(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+        ready_command = next(
+            line
+            for line in installer.splitlines()
+            if line.startswith("ROLLOUT_READY_COMMAND=")
+        )
+
+        for argument in (
+            "--nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST",
+            "--skip-local-configs",
+            "--skip-db-sync",
+            "--refresh-nginx",
+        ):
+            self.assertIn(argument, ready_command)
+
     def test_preview_api_environment_enables_complete_public_bootstrap(self) -> None:
         updates = rollout.build_api_preview_env_updates("mighty-hyena")
 
@@ -78,6 +94,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
 
         with (
             mock.patch.object(rollout, "DEFAULT_NGINX_HELPER_PATH", fixed_helper),
+            mock.patch.object(rollout.os, "geteuid", return_value=1000),
             mock.patch.dict(
                 rollout.os.environ,
                 {"POLYSCOPE_NGINX_HELPER": "/tmp/unreviewed-nginx-helper"},
@@ -86,6 +103,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
             rollout.check_nginx_helper_compatibility(2, helper_runner=helper)
 
         command = helper.call_args.args[0]
+        self.assertEqual(command[:3], ["sudo", "-k", "-n"])
         self.assertEqual(command[-2:], [str(fixed_helper), "--check"])
         self.assertNotIn("/tmp/unreviewed-nginx-helper", command)
 
@@ -98,6 +116,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
             source,
             workspace="mighty-hyena",
             runtime_revision="a" * 64,
+            service_path="/opt/pinned-node/bin:/usr/bin",
         )
 
         self.assertEqual(len(units), 2)
@@ -108,6 +127,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
         self.assertIn("php artisan schedule:work", rendered)
         self.assertIn("php artisan queue:work", rendered)
         self.assertIn("RuntimeRevision=" + "a" * 64, rendered)
+        self.assertIn("Environment=PATH=/opt/pinned-node/bin:/usr/bin", rendered)
         self.assertNotIn("DB_PASSWORD", rendered)
         self.assertNotIn("EnvironmentFile=", rendered)
 

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -66,6 +66,29 @@ class PolyscopeRolloutFollowupTests(TestCase):
 
         writer.assert_not_called()
 
+    def test_nginx_compatibility_check_ignores_environment_helper_override(self) -> None:
+        fixed_helper = Path("/usr/local/libexec/reviewed-nginx-helper")
+        helper = mock.Mock(
+            return_value=SimpleNamespace(
+                returncode=0,
+                stdout="Polyscope nginx helper check passed manifest_schema=2\n",
+                stderr="",
+            )
+        )
+
+        with (
+            mock.patch.object(rollout, "DEFAULT_NGINX_HELPER_PATH", fixed_helper),
+            mock.patch.dict(
+                rollout.os.environ,
+                {"POLYSCOPE_NGINX_HELPER": "/tmp/unreviewed-nginx-helper"},
+            ),
+        ):
+            rollout.check_nginx_helper_compatibility(2, helper_runner=helper)
+
+        command = helper.call_args.args[0]
+        self.assertEqual(command[-2:], [str(fixed_helper), "--check"])
+        self.assertNotIn("/tmp/unreviewed-nginx-helper", command)
+
     def test_api_runtime_units_are_persistent_and_contain_no_environment_secrets(self) -> None:
         worktree = Path("/home/secpal/.polyscope/clones/api-id/mighty-hyena-1c04a2fb")
         source = Path("/home/secpal/code/SecPal/api")
@@ -229,6 +252,101 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 )
 
             self.assertTrue(stale_unit.exists())
+
+    def test_api_runtime_failure_preserves_only_the_registered_runtime_units(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            clone_root = root / "clones"
+            worktree = clone_root / "api-id" / "mighty-hyena-1c04a2fb"
+            worktree.mkdir(parents=True)
+            (worktree / ".env").write_text("")
+            runtime_id = rollout.hashlib.sha256(
+                str(worktree.resolve()).encode()
+            ).hexdigest()[:12]
+            unit_directory = root / "units"
+            unit_directory.mkdir()
+            registered_unit = unit_directory / (
+                f"polyscope-api-worktree-mighty-hyena-{runtime_id}-scheduler.service"
+            )
+            removed_unit = unit_directory / (
+                "polyscope-api-worktree-removed-workspace-bbbbbbbbbbbb-scheduler.service"
+            )
+            registered_unit.write_text("registered\n")
+            removed_unit.write_text("removed\n")
+            systemctl = mock.Mock()
+            reconcile_runtime_units = rollout.reconcile_api_runtime_units
+
+            def reconcile(desired_units, **kwargs):
+                reconcile_runtime_units(
+                    desired_units,
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                    **kwargs,
+                )
+
+            with mock.patch.multiple(
+                rollout,
+                should_manage_api_runtime_units=mock.Mock(return_value=True),
+                load_registered_worktree_paths=mock.Mock(
+                    return_value={"api": [worktree]}
+                ),
+                revoke_unregistered_preview_nginx_access=mock.Mock(),
+                is_provisionable_worktree=mock.Mock(return_value=True),
+                cleanup_removed_workspace_aliases=mock.Mock(return_value=[]),
+                cleanup_removed_api_preview_databases=mock.Mock(return_value=[]),
+                preserve_registered_workspace_physical_path=mock.Mock(),
+                render_worktree_local_config=mock.Mock(return_value="{}\n"),
+                sync_worktree_local_config=mock.Mock(),
+                ensure_workspace_alias=mock.Mock(),
+                sync_worktree_auxiliary_files=mock.Mock(),
+                ensure_worktree_hooks=mock.Mock(),
+                acquire_api_worktree_bootstrap_lock=mock.Mock(
+                    side_effect=contextlib.nullcontext
+                ),
+                collect_linked_setup_context=mock.Mock(return_value={}),
+                resolve_current_workspace_name=mock.Mock(
+                    return_value="mighty-hyena"
+                ),
+                build_setup_hash=mock.Mock(return_value="setup-hash"),
+                ensure_api_worktree_ready=mock.Mock(
+                    return_value=(True, "database:preview")
+                ),
+                load_provision_marker=mock.Mock(
+                    return_value={
+                        "setup_hash": "setup-hash",
+                        "preview_storage_target": "database:preview",
+                    }
+                ),
+                build_api_runtime_revision=mock.Mock(
+                    side_effect=RuntimeError("transient fingerprint failure")
+                ),
+                reconcile_api_runtime_units=mock.Mock(side_effect=reconcile),
+            ):
+                _provisioned, _cleaned, failures = rollout.provision_worktrees(
+                    {"api": {"id": "api-id"}},
+                    {
+                        "api": {
+                            rollout.NATIVE_SETUP_COMMANDS_KEY: ["bootstrap-api"],
+                            "path": root / "source-api",
+                            "preview_prefix": "api",
+                        }
+                    },
+                    clone_root,
+                    db_path=root / "polyscope.db",
+                )
+
+            self.assertEqual(len(failures), 1)
+            self.assertTrue(registered_unit.exists())
+            self.assertFalse(removed_unit.exists())
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertNotIn(
+                ["systemctl", "--user", "disable", "--now", registered_unit.name],
+                commands,
+            )
+            self.assertIn(
+                ["systemctl", "--user", "disable", "--now", removed_unit.name],
+                commands,
+            )
 
     def test_scheduler_readiness_waits_for_a_real_heartbeat(self) -> None:
         runner = mock.Mock(

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -70,6 +71,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
             worktree,
             source,
             workspace="mighty-hyena",
+            runtime_revision="a" * 64,
         )
 
         self.assertEqual(len(units), 2)
@@ -79,8 +81,54 @@ class PolyscopeRolloutFollowupTests(TestCase):
         self.assertIn("--run-api-worktree", rendered)
         self.assertIn("php artisan schedule:work", rendered)
         self.assertIn("php artisan queue:work", rendered)
+        self.assertIn("RuntimeRevision=" + "a" * 64, rendered)
         self.assertNotIn("DB_PASSWORD", rendered)
         self.assertNotIn("EnvironmentFile=", rendered)
+
+    def test_api_runtime_actions_are_not_autostarted_by_polyscope(self) -> None:
+        api_run_actions = rollout.REPO_SETTINGS["api"]["local_config"]["scripts"]["run"]
+
+        for label in ("Queue Worker", "Scheduler"):
+            action = next(item for item in api_run_actions if item["label"] == label)
+            self.assertFalse(action.get("autostart", False), action)
+
+    def test_api_runtime_revision_changes_with_code_and_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            worktree = root / "worktree"
+            source = root / "source"
+            worktree.mkdir()
+            source.mkdir()
+            (worktree / "app.php").write_text("first\n")
+            (worktree / ".env").write_text("APP_ENV=local\n")
+            (source / ".env").write_text("DB_PASSWORD=first\n")
+            subprocess.run(["git", "init", "-q"], cwd=worktree, check=True)
+            subprocess.run(["git", "add", "app.php"], cwd=worktree, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=SecPal Test",
+                    "-c",
+                    "user.email=test@secpal.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "-qm",
+                    "Initial fixture",
+                ],
+                cwd=worktree,
+                check=True,
+            )
+
+            initial = rollout.build_api_runtime_revision(worktree, source)
+            (worktree / "app.php").write_text("second\n")
+            code_changed = rollout.build_api_runtime_revision(worktree, source)
+            (source / ".env").write_text("DB_PASSWORD=second\n")
+            environment_changed = rollout.build_api_runtime_revision(worktree, source)
+
+            self.assertNotEqual(initial, code_changed)
+            self.assertNotEqual(code_changed, environment_changed)
 
     def test_api_runtime_reconciliation_removes_stale_units_and_starts_desired_units(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -128,11 +176,56 @@ class PolyscopeRolloutFollowupTests(TestCase):
                     "systemctl",
                     "--user",
                     "enable",
-                    "--now",
                     *sorted(desired),
                 ],
                 commands,
             )
+            self.assertIn(
+                ["systemctl", "--user", "restart", *sorted(desired)],
+                commands,
+            )
+
+    def test_api_runtime_reconciliation_does_not_restart_unchanged_units(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            unit_name = "polyscope-api-worktree-mighty-hyena-scheduler.service"
+            content = "scheduler\n"
+            (unit_directory / unit_name).write_text(content)
+            systemctl = mock.Mock()
+
+            rollout.reconcile_api_runtime_units(
+                {unit_name: content},
+                unit_directory=unit_directory,
+                systemctl_runner=systemctl,
+                prune=False,
+            )
+
+            commands = [call.args[0] for call in systemctl.call_args_list]
+            self.assertNotIn(["systemctl", "--user", "daemon-reload"], commands)
+            self.assertNotIn(["systemctl", "--user", "restart", unit_name], commands)
+            self.assertIn(["systemctl", "--user", "enable", unit_name], commands)
+            self.assertIn(["systemctl", "--user", "start", unit_name], commands)
+
+    def test_api_runtime_reconciliation_preserves_a_unit_when_stop_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            unit_directory = Path(temporary_directory)
+            stale_unit = unit_directory / "polyscope-api-worktree-stale-scheduler.service"
+            stale_unit.write_text("stale\n")
+            systemctl = mock.Mock(
+                side_effect=subprocess.CalledProcessError(
+                    1,
+                    ["systemctl", "--user", "disable", "--now", stale_unit.name],
+                )
+            )
+
+            with self.assertRaises(subprocess.CalledProcessError):
+                rollout.reconcile_api_runtime_units(
+                    {},
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                )
+
+            self.assertTrue(stale_unit.exists())
 
     def test_scheduler_readiness_waits_for_a_real_heartbeat(self) -> None:
         runner = mock.Mock(

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -45,12 +45,43 @@ class PolyscopeRolloutFollowupTests(TestCase):
 
         for argument in (
             "--nginx-manifest-output $POLYSCOPE_NGINX_MANIFEST",
+            "--clone-root $POLYSCOPE_CLONE_ROOT",
+            "--provision-lock-path $POLYSCOPE_PROVISION_LOCK",
             "--skip-local-configs",
             "--skip-db-sync",
             "--refresh-nginx",
             "--skip-if-provision-locked",
         ):
             self.assertIn(argument, ready_command)
+
+    def test_routine_sync_uses_the_configured_provision_lock(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+        sync_unit = installer.split('cat >"$SERVICE_UNIT" <<EOF', 1)[1].split("EOF", 1)[0]
+
+        self.assertIn(
+            "--provision-lock-path $POLYSCOPE_PROVISION_LOCK",
+            sync_unit,
+        )
+        self.assertIn("--clone-root $POLYSCOPE_CLONE_ROOT", sync_unit)
+
+    def test_system_dropin_validator_requires_nonblocking_startup_refresh(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+
+        self.assertIn(
+            "--skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked",
+            installer,
+        )
+        self.assertIn("_installed_start_post_lines[0]", installer)
+        self.assertIn("_installed_start_post_lines[1]", installer)
+
+    def test_shell_embedded_clone_root_is_restricted_to_safe_characters(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+        validation_block = installer.split(
+            "# Reject shell metacharacters in variables embedded in ExecStart/ExecStartPost command strings.",
+            1,
+        )[1].split("done", 1)[0]
+
+        self.assertIn("POLYSCOPE_CLONE_ROOT", validation_block)
 
     def test_user_server_startup_receives_the_validated_sudo_binary(self) -> None:
         installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
@@ -197,6 +228,74 @@ class PolyscopeRolloutFollowupTests(TestCase):
         for label in ("Queue Worker", "Scheduler"):
             action = next(item for item in api_run_actions if item["label"] == label)
             self.assertFalse(action.get("autostart", False), action)
+
+    def test_api_runtime_actions_autostart_without_a_persistent_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            spec = {
+                "path": root / "api",
+                "local_config": {
+                    "scripts": {
+                        "run": [
+                            {
+                                "label": "Queue Worker",
+                                "command": "queue",
+                                "autostart": False,
+                                "runMode": "replace",
+                            },
+                            {
+                                "label": "Scheduler",
+                                "command": "scheduler",
+                                "autostart": False,
+                                "runMode": "replace",
+                            },
+                        ]
+                    },
+                    "tasks": [],
+                },
+            }
+            worktree = root / "clones" / "api-id" / "mighty-hyena"
+
+            with mock.patch.multiple(
+                rollout,
+                require_repo_instruction_files=mock.Mock(),
+                instruction_reference=mock.Mock(return_value="AGENTS.md"),
+            ):
+                rendered = json.loads(
+                    rollout.render_worktree_local_config(
+                        spec,
+                        worktree,
+                        db_path=root / "polyscope.db",
+                    )
+                )
+                with mock.patch.object(
+                    rollout,
+                    "should_manage_api_runtime_units",
+                    return_value=True,
+                ):
+                    managed_rendered = json.loads(
+                        rollout.render_worktree_local_config(
+                            spec,
+                            worktree,
+                            db_path=root / "polyscope.db",
+                        )
+                    )
+
+            runtime_actions = {
+                action["label"]: action
+                for action in rendered["scripts"]["run"]
+                if action["label"] in {"Queue Worker", "Scheduler"}
+            }
+            self.assertEqual(set(runtime_actions), {"Queue Worker", "Scheduler"})
+            self.assertTrue(runtime_actions["Queue Worker"]["autostart"])
+            self.assertTrue(runtime_actions["Scheduler"]["autostart"])
+            managed_runtime_actions = {
+                action["label"]: action
+                for action in managed_rendered["scripts"]["run"]
+                if action["label"] in {"Queue Worker", "Scheduler"}
+            }
+            self.assertFalse(managed_runtime_actions["Queue Worker"]["autostart"])
+            self.assertFalse(managed_runtime_actions["Scheduler"]["autostart"])
 
     def test_api_runtime_revision_changes_with_code_and_environment(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -584,6 +683,79 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 preview_enabled=True,
             )
 
+    def test_runtime_owner_failure_revokes_existing_preview_access(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            clone_root = root / "clones"
+            worktree = clone_root / "api-id" / "mighty-hyena-1c04a2fb"
+            worktree.mkdir(parents=True)
+            (worktree / ".env").write_text("")
+            deny_access = mock.Mock()
+
+            with mock.patch.multiple(
+                rollout,
+                should_manage_api_runtime_units=mock.Mock(return_value=True),
+                load_registered_worktree_paths=mock.Mock(
+                    return_value={"api": [worktree]}
+                ),
+                revoke_unregistered_preview_nginx_access=mock.Mock(),
+                is_provisionable_worktree=mock.Mock(return_value=True),
+                cleanup_removed_workspace_aliases=mock.Mock(return_value=[]),
+                cleanup_removed_api_preview_databases=mock.Mock(return_value=[]),
+                preserve_registered_workspace_physical_path=mock.Mock(),
+                render_worktree_local_config=mock.Mock(return_value="{}\n"),
+                sync_worktree_local_config=mock.Mock(),
+                ensure_workspace_alias=mock.Mock(),
+                sync_worktree_auxiliary_files=mock.Mock(),
+                ensure_worktree_hooks=mock.Mock(),
+                acquire_api_worktree_bootstrap_lock=mock.Mock(
+                    side_effect=contextlib.nullcontext
+                ),
+                collect_linked_setup_context=mock.Mock(return_value={}),
+                resolve_current_workspace_name=mock.Mock(
+                    return_value="mighty-hyena"
+                ),
+                build_setup_hash=mock.Mock(return_value="setup-hash"),
+                ensure_api_worktree_ready=mock.Mock(
+                    return_value=(True, "database:preview")
+                ),
+                load_provision_marker=mock.Mock(
+                    return_value={
+                        "setup_hash": "setup-hash",
+                        "preview_storage_target": "database:preview",
+                    }
+                ),
+                build_api_runtime_revision=mock.Mock(return_value="a" * 64),
+                build_api_runtime_unit_specs=mock.Mock(
+                    return_value={"runtime.service": "runtime\n"}
+                ),
+                deny_preview_nginx_access=deny_access,
+                reconcile_api_runtime_units=mock.Mock(
+                    side_effect=RuntimeError("runtime owner preparation failed")
+                ),
+            ):
+                _provisioned, _cleaned, failures = rollout.provision_worktrees(
+                    {"api": {"id": "api-id"}},
+                    {
+                        "api": {
+                            rollout.NATIVE_SETUP_COMMANDS_KEY: ["bootstrap-api"],
+                            "path": root / "source-api",
+                            "preview_prefix": "api",
+                        }
+                    },
+                    clone_root,
+                    db_path=root / "polyscope.db",
+                )
+
+            self.assertTrue(
+                any(
+                    "runtime owner preparation failed" in failure["error"]
+                    for failure in failures
+                ),
+                failures,
+            )
+            deny_access.assert_called_once_with(clone_root, worktree)
+
     def test_canonical_validation_failure_still_prunes_removed_api_units(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -639,6 +811,64 @@ class PolyscopeRolloutFollowupTests(TestCase):
 
             self.assertEqual(len(failures), 1)
             self.assertIn("invalid canonical instructions", failures[0]["error"])
+            self.assertTrue(registered_unit.exists())
+            self.assertFalse(removed_unit.exists())
+
+    def test_acl_reconciliation_failure_still_prunes_removed_api_units(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            clone_root = root / "clones"
+            worktree = clone_root / "api-id" / "mighty-hyena-1c04a2fb"
+            worktree.mkdir(parents=True)
+            runtime_id = rollout.build_api_runtime_id(worktree)
+            unit_directory = root / "units"
+            unit_directory.mkdir()
+            registered_unit = unit_directory / (
+                f"polyscope-api-worktree-mighty-hyena-{runtime_id}-scheduler.service"
+            )
+            removed_unit = unit_directory / (
+                "polyscope-api-worktree-removed-workspace-bbbbbbbbbbbb-scheduler.service"
+            )
+            registered_unit.write_text("registered\n")
+            removed_unit.write_text("removed\n")
+            systemctl = mock.Mock()
+            reconcile_runtime_units = rollout.reconcile_api_runtime_units
+
+            def reconcile(desired_units, **kwargs):
+                reconcile_runtime_units(
+                    desired_units,
+                    unit_directory=unit_directory,
+                    systemctl_runner=systemctl,
+                    **kwargs,
+                )
+
+            with mock.patch.multiple(
+                rollout,
+                should_manage_api_runtime_units=mock.Mock(return_value=True),
+                load_registered_worktree_paths=mock.Mock(
+                    return_value={"api": [worktree]}
+                ),
+                revoke_unregistered_preview_nginx_access=mock.Mock(
+                    side_effect=RuntimeError("simulated ACL reconciliation failure")
+                ),
+                is_provisionable_worktree=mock.Mock(),
+                reconcile_api_runtime_units=mock.Mock(side_effect=reconcile),
+            ):
+                _provisioned, _cleaned, failures = rollout.provision_worktrees(
+                    {"api": {"id": "api-id"}},
+                    {
+                        "api": {
+                            rollout.NATIVE_SETUP_COMMANDS_KEY: ["bootstrap-api"],
+                            "path": root / "source-api",
+                            "preview_prefix": "api",
+                        }
+                    },
+                    clone_root,
+                    db_path=root / "polyscope.db",
+                )
+
+            self.assertEqual(len(failures), 1)
+            self.assertIn("ACL reconciliation failure", failures[0]["error"])
             self.assertTrue(registered_unit.exists())
             self.assertFalse(removed_unit.exists())
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -7206,6 +7206,38 @@ grep -qF 'reviewed system server drop-in is incomplete' "$stale_system_error"
 test ! -e "$stale_system_bin_dir/polyscope-secpal-rollout.py"
 test ! -e "$stale_system_unit_dir/polyscope-rollout-sync.service"
 
+legacy_startup_dropin_dir="$workspace/legacy-startup-service-units/polyscope-server.service.d"
+legacy_startup_bin_dir="$workspace/legacy-startup-bin"
+legacy_startup_unit_dir="$workspace/legacy-startup-user-units"
+legacy_startup_error="$workspace/legacy-startup-install.error"
+mkdir -p "$legacy_startup_dropin_dir"
+cp "$system_dropin_dir/zz-secpal-runtime.conf" \
+    "$legacy_startup_dropin_dir/zz-secpal-runtime.conf"
+sed -i 's/ --skip-if-provision-locked//' \
+    "$legacy_startup_dropin_dir/zz-secpal-runtime.conf"
+legacy_startup_exit=0
+env HOME="$system_home_dir" \
+    CODEX_HOME="$system_home_dir/.codex-legacy-startup" \
+    WORKSPACE_ROOT="$workspace_root" \
+    SYSTEMCTL_BIN="$fake_systemctl_dir/systemctl" \
+    SYSTEMCTL_LOG="$system_systemctl_log" \
+    SUDO_BIN="$fake_sudo_dir/sudo" \
+    SUDO_LOG="$system_sudo_log" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_FRAGMENT="$system_fragment_path" \
+    FAKE_SYSTEM_POLYSCOPE_SERVER_USER="$system_server_user" \
+    POLYSCOPE_SYSTEM_SERVER_DROPIN_DIR="$legacy_startup_dropin_dir" \
+    PATH="$fake_systemctl_dir:$PATH" \
+    bash "$INSTALL_SCRIPT" --bin-dir "$legacy_startup_bin_dir" --unit-dir "$legacy_startup_unit_dir" --polyscope-server-bin "$fake_server_bin" \
+    2>"$legacy_startup_error" \
+    || legacy_startup_exit=$?
+if [[ "$legacy_startup_exit" -eq 0 ]]; then
+    echo "unprivileged installer must reject a blocking system startup refresh" >&2
+    exit 1
+fi
+grep -qF 'lacks constrained nginx activation' "$legacy_startup_error"
+test ! -e "$legacy_startup_bin_dir/polyscope-secpal-rollout.py"
+test ! -e "$legacy_startup_unit_dir/polyscope-rollout-sync.service"
+
 cat >"$system_polyscope_bin_dir/expose-linux-x64" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FAKE_EXPOSE_REAL_LOG"
@@ -7237,6 +7269,7 @@ grep -q "Environment=PATH=$system_node_dir:/home/secpal/.local/lib/polyscope/bin
 grep -q 'Environment=SSH_AUTH_SOCK=/run/user/1000/openssh_agent' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'After=network-online.target' "$system_user_unit_dir/polyscope-rollout-sync.service"
+grep -q -- "--clone-root $system_home_dir/.polyscope/clones --provision-lock-path $system_home_dir/.local/state/polyscope/worktree-provision.lock --refresh-nginx" "$system_user_unit_dir/polyscope-rollout-sync.service"
 grep -q 'After=polyscope-rollout-sync.service' "$system_user_unit_dir/polyscope-worktree-provision.service"
 if grep -Eq '^(daemon-reload|enable --now polyscope-server\.service|restart polyscope-server\.service)$' "$system_systemctl_log"; then
   echo "unprivileged installer must not mutate the system service" >&2
@@ -7265,11 +7298,13 @@ grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-s
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-server.service"
 grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-server.service"
 grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-server.service"
+grep -q -- "--clone-root $home_dir/.polyscope/clones --provision-lock-path $home_dir/.local/state/polyscope/worktree-provision.lock" "$fake_unit_dir/polyscope-server.service"
 grep -q -- '--refresh-nginx --skip-if-provision-locked' "$fake_unit_dir/polyscope-server.service"
 grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
 grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.* --refresh-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q -- "--clone-root $home_dir/.polyscope/clones --provision-lock-path $home_dir/.local/state/polyscope/worktree-provision.lock --refresh-nginx" "$fake_unit_dir/polyscope-rollout-sync.service"
 if grep -q -- '--install-nginx' "$fake_unit_dir/polyscope-rollout-sync.service"; then
   echo "routine rollout sync must not run full worktree provisioning" >&2
   exit 1
@@ -7280,7 +7315,7 @@ grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-r
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=POLYSCOPE_NGINX_HELPER=/usr/local/libexec/secpal-polyscope-nginx-apply' "$fake_unit_dir/polyscope-rollout-sync.service"
-grep -q -- '--nginx-manifest-output .*nginx-manifest.json --refresh-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q -- '--nginx-manifest-output .*nginx-manifest.json --clone-root .* --provision-lock-path .* --refresh-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 if grep -q '/retired-docs/' "$fake_unit_dir/polyscope-rollout-sync.path"; then

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -7232,6 +7232,7 @@ test -f "$system_dropin_dir/zz-secpal-runtime.conf"
 test "$(file_sha256 "$system_dropin_dir/zz-secpal-runtime.conf")" = "$system_dropin_hash_before"
 grep -q 'ExecStart=/home/secpal/.local/bin/polyscope-server serve --host 127.0.0.1 --port 4321' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$system_dropin_dir/zz-secpal-runtime.conf"
+grep -q -- '--refresh-nginx --skip-if-provision-locked' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q "Environment=PATH=$system_node_dir:/home/secpal/.local/lib/polyscope/bin:/home/secpal/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=SSH_AUTH_SOCK=/run/user/1000/openssh_agent' "$system_dropin_dir/zz-secpal-runtime.conf"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$system_dropin_dir/zz-secpal-runtime.conf"
@@ -7262,7 +7263,9 @@ grep -q 'ExecStartPost=/usr/bin/env bash -lc ' "$fake_unit_dir/polyscope-server.
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-server.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-server.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-server.service"
+grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-server.service"
 grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-server.service"
+grep -q -- '--refresh-nginx --skip-if-provision-locked' "$fake_unit_dir/polyscope-server.service"
 grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
 grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
@@ -7297,6 +7300,7 @@ if grep -qF '/../' "$fake_unit_dir/polyscope-rollout-sync.path"; then
 fi
 grep -q 'After=polyscope-rollout-sync.service' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^Type=oneshot$' "$fake_unit_dir/polyscope-worktree-provision.service"
+grep -q '^TimeoutStartSec=15min$' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^StartLimitIntervalSec=10$' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^StartLimitBurst=5$' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^ExecStartPre=/usr/bin/sleep 3$' "$fake_unit_dir/polyscope-worktree-provision.service"
@@ -8081,10 +8085,11 @@ main_order: list[str] = []
 
 
 @contextlib.contextmanager
-def observed_provision_lock(_lock_path):
+def observed_provision_lock(_lock_path, *, blocking=True):
+    assert blocking is True
     main_order.append("lock-enter")
     try:
-        yield
+        yield True
     finally:
         main_order.append("lock-exit")
 

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1861,7 +1861,10 @@ grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-
 grep -qF '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan schedule:work'" "$workspace_root/api/polyscope.local.json"
 grep -qF "python3 $PYTHON_SCRIPT --run-api-worktree \\\"\$PWD\\\" --source-repo-path $workspace_root/api --shell-command 'php artisan pail --timeout=0'" "$workspace_root/api/polyscope.local.json"
-grep -A3 '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json" | grep -qF '"autostart": true'
+if grep -A3 '"label": "Scheduler"' "$workspace_root/api/polyscope.local.json" | grep -qF '"autostart": true'; then
+    echo "preview API scheduler must have only the persistent systemd runtime owner" >&2
+    exit 1
+fi
 if grep -qF 'php artisan queue:listen --tries=1' "$workspace_root/api/polyscope.local.json"; then
     echo "preview API queue worker must use combined queue:work and not queue:listen" >&2
     exit 1
@@ -1888,7 +1891,7 @@ queue_worker_action = next(
     None,
 )
 assert queue_worker_action is not None, api_run_actions
-assert queue_worker_action.get("autostart") is True, queue_worker_action
+assert queue_worker_action.get("autostart") is False, queue_worker_action
 assert "--max-time" not in queue_worker_action["command"], queue_worker_action
 api_run_actions[0]["label"] = "Background Queue"
 api_run_actions[1]["label"] = "Cron Loop"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -5273,7 +5273,7 @@ assert 'Preserve a branch or worktree already supplied by the execution environm
 assert 'Run the smallest relevant validation while iterating' in org_prompts[1]
 assert 'stage the complete intended change set before evaluating reusable validation evidence' in org_prompts[2]
 assert 'exact final staged tree, including every newly added path' in org_prompts[2]
-assert 'recheck the staged-tree identity immediately before committing and pushing' in org_prompts[2]
+assert 'Recheck the staged-tree identity immediately before committing and pushing' in org_prompts[2]
 assert 'Treat that evidence as stale if any bound value, staged content, or tracked content changed' in org_prompts[2]
 assert 'do not stage additional content after deciding to reuse it' in org_prompts[2]
 assert 'Do not rerun a check that already passed for that exact unchanged bound state.' in org_prompts[2]
@@ -6703,7 +6703,11 @@ chmod +x "$fake_sudo_dir/sudo"
 
 cat >"$fake_nginx_helper" <<'STUB'
 #!/usr/bin/env bash
-if [[ $# -eq 0 || ( $# -eq 1 && "$1" == "--check" ) ]]; then
+if [[ $# -eq 0 ]]; then
+    exit 0
+fi
+if [[ $# -eq 1 && "$1" == "--check" ]]; then
+    echo "Polyscope nginx helper check passed bundle=2 manifest_schema=1 manifest_schema=2"
     exit 0
 fi
 exit 64
@@ -7259,14 +7263,18 @@ grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscop
 grep -q 'Restart=on-failure' "$fake_unit_dir/polyscope-server.service"
 grep -q 'After=polyscope-server.service' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api' "$fake_unit_dir/polyscope-rollout-sync.service"
-grep -q 'ExecStart=.* --install-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q 'ExecStart=.* --refresh-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
+if grep -q -- '--install-nginx' "$fake_unit_dir/polyscope-rollout-sync.service"; then
+  echo "routine rollout sync must not run full worktree provisioning" >&2
+  exit 1
+fi
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q 'Environment=POLYSCOPE_NGINX_HELPER=/usr/local/libexec/secpal-polyscope-nginx-apply' "$fake_unit_dir/polyscope-rollout-sync.service"
-grep -q -- '--nginx-manifest-output .*nginx-manifest.json --install-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
+grep -q -- '--nginx-manifest-output .*nginx-manifest.json --refresh-nginx$' "$fake_unit_dir/polyscope-rollout-sync.service"
 grep -q '/api/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 grep -q '/GuardGuide/AGENTS.md' "$fake_unit_dir/polyscope-rollout-sync.path"
 if grep -q '/retired-docs/' "$fake_unit_dir/polyscope-rollout-sync.path"; then
@@ -7295,6 +7303,10 @@ if grep -qE '^(Restart=|SuccessExitStatus=|ExecStart=-)' "$fake_unit_dir/polysco
 fi
 grep -q 'ExecStart=.*/polyscope-secpal-rollout.py --workspace-root .* --polyscope-api-base http://127.0.0.1:4321/api --clone-root .* --provision-lock-path .*worktree-provision.lock --skip-local-configs --skip-db-sync --provision-worktrees --refresh-nginx' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q '^Unit=polyscope-worktree-provision.service$' "$fake_unit_dir/polyscope-worktree-provision.path"
+if grep -q 'polyscope\.db-wal' "$fake_unit_dir/polyscope-worktree-provision.path"; then
+    echo "worktree provision watcher must not react to unrelated SQLite WAL writes" >&2
+    exit 1
+fi
 if grep -q '/retired-docs/' "$fake_unit_dir/polyscope-worktree-provision.path"; then
     echo "worktree provision watcher must not retain an unmanaged repository" >&2
     exit 1
@@ -7319,7 +7331,6 @@ grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-worktree-provision.service"
 grep -qE '^PathChanged=.*/\.polyscope/polyscope\.db$' "$fake_unit_dir/polyscope-worktree-provision.path"
-grep -qE '^PathModified=.*/\.polyscope/polyscope\.db-wal$' "$fake_unit_dir/polyscope-worktree-provision.path"
 if grep -qE '^PathModified=.*/\.polyscope/clones$' "$fake_unit_dir/polyscope-worktree-provision.path"; then
   echo "worktree provision path must not watch clone contents it modifies" >&2
   exit 1
@@ -8141,7 +8152,7 @@ with tempfile.TemporaryDirectory() as temporary_directory:
     module.provision_worktrees = lambda *_args, **_kwargs: (
         rollout_order.append("provision") or ([], [], [])
     )
-    module.write_nginx_manifest = lambda *_args, **_kwargs: rollout_order.append("manifest")
+    module.write_compatible_nginx_manifest = lambda *_args, **_kwargs: rollout_order.append("manifest")
     module.install_nginx_config = lambda _path: rollout_order.append("install")
     module.build_summary = lambda *_args: {}
     sys.modules["polyscope_nginx"] = SimpleNamespace(

--- a/tests/polyscope-system-installer.sh
+++ b/tests/polyscope-system-installer.sh
@@ -118,11 +118,16 @@ grep -q '^User=secpal$' "$dropin"
 grep -q '^Environment=SSH_AUTH_SOCK=/run/user/1000/openssh_agent$' "$dropin"
 grep -q 'ExecStart=/home/secpal/.local/bin/polyscope-server serve --host 127.0.0.1 --port 4321' "$dropin"
 grep -q 'exec /home/secpal/code/SecPal/.github/scripts/polyscope-rollout.py ' "$dropin"
+grep -q -- '--skip-local-configs --skip-db-sync' "$dropin"
 if grep -qF 'exec /home/secpal/.local/bin/polyscope-secpal-rollout.py ' "$dropin"; then
     echo "system installer must not depend on a target created by the later user installer" >&2
     exit 1
 fi
-grep -q -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --install-nginx' "$dropin"
+grep -q -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx' "$dropin"
+if grep -q -- '--install-nginx' "$dropin"; then
+    echo "system startup must not run full worktree provisioning" >&2
+    exit 1
+fi
 
 if command -v visudo >/dev/null 2>&1; then
     visudo -c -f "$sudoers" >/dev/null

--- a/tests/polyscope-system-installer.sh
+++ b/tests/polyscope-system-installer.sh
@@ -123,7 +123,7 @@ if grep -qF 'exec /home/secpal/.local/bin/polyscope-secpal-rollout.py ' "$dropin
     echo "system installer must not depend on a target created by the later user installer" >&2
     exit 1
 fi
-grep -q -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx' "$dropin"
+grep -q -- '--nginx-manifest-output /home/secpal/.local/state/polyscope/nginx-manifest.json --skip-local-configs --skip-db-sync --refresh-nginx --skip-if-provision-locked' "$dropin"
 if grep -q -- '--install-nginx' "$dropin"; then
     echo "system startup must not run full worktree provisioning" >&2
     exit 1


### PR DESCRIPTION
## Description

Make Polyscope preview provisioning self-convergent across every registered workspace instead of repairing individual preview hosts.

The rollout now negotiates the Nginx manifest schema before replacing the last usable manifest, keeps canonical provisioning responsible for Nginx convergence, and separates lightweight startup/config synchronization from full worktree provisioning. Registered API previews receive persistent scheduler and queue services, must produce a real scheduler heartbeat before exposure, and receive a complete public-bootstrap configuration.

## Root Cause

Several lifecycle gaps combined into intermittent 404s and unusable previews:

- the unprivileged manifest producer could publish schema 2 before the privileged consumer supported it
- routine synchronization and Polyscope startup performed full provisioning, while every SQLite WAL write retriggered the same expensive path
- canonical provisioning depended on stale installed unit flags to refresh Nginx
- API scheduler and queue processes were not persistently supervised, and the PsySH heartbeat probe returned the wrong process status
- preview bootstrap variables required by linked web and Android clients were incomplete

## Impact

- canonical workspace URLs converge automatically after registration and restart
- legacy physical hash hosts redirect to their canonical workspace host
- API previews remain ready through supervised scheduler and queue processes
- incompatible Nginx rollout ordering fails before the active manifest is replaced
- ordinary Polyscope database activity no longer causes continuous provisioning loops

## Related Issues

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [x] Manual testing performed

Commands:

```text
python3 -B tests/polyscope-rollout-followups-unit.py
bash tests/polyscope-nginx-helper.sh
bash tests/polyscope-system-installer.sh
bash tests/polyscope-rollout.sh
bash -n scripts/install-polyscope-rollout.sh scripts/install-polyscope-system-components.sh
python3 -m py_compile scripts/polyscope-rollout.py scripts/polyscope_nginx.py scripts/secpal-polyscope-nginx-apply.py
git diff --check
sudo nginx -t
```

Manual verification covered all 11 registered frontend preview URLs in a headless browser, all 10 registered API live/ready endpoints, canonical redirects from representative physical hash hosts, the installed Nginx helper contract, and the installed systemd services.

## TDD / Validate-First Evidence

- Failing proof before implementation: focused regression tests were added first and failed for missing manifest capability negotiation, missing persistent API runtime units, the incorrect PsySH heartbeat exit behavior, startup/sync full-provisioning, canonical Nginx refresh dependence, and the SQLite WAL provision trigger.
- Passing proof after implementation: `bash tests/polyscope-rollout.sh` completed with exit 0 on the final staged tree; the focused 11-test unit suite and the Nginx/system-installer suites also completed with exit 0.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [ ] Related issues linked above (no related issue)

## Screenshots (if applicable)

Not applicable; this changes preview provisioning and runtime behavior.
