### PR TITLE
Pin Android workflow actions by SHA

### DIFF
--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -32,6 +32,10 @@ workflow templates, and their direct validation fixtures.
 - Cross-repository reusable workflows must use a reviewed 40-character commit
   SHA. A `governance-ref` that selects scripts or dependencies must resolve to
   that same SHA; mixed governance versions are invalid.
+- Reusable workflows published for callers that require full-SHA action pins
+  must also pin every nested external action to a reviewed 40-character commit
+  SHA and retain its version as a same-line comment. Pinning only the reusable
+  workflow does not make mutable action tags inside it immutable.
 - Do not use productive branch references such as `@main` for cross-repository
   reusable workflows.
 - Keep dependency installation reproducible from committed lockfiles. Do not

--- a/.github/workflows/draft-pr-reminder.yml
+++ b/.github/workflows/draft-pr-reminder.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post reminder comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const message = [

--- a/.github/workflows/project-automation-core.yml
+++ b/.github/workflows/project-automation-core.yml
@@ -42,13 +42,13 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 
@@ -58,7 +58,7 @@ jobs:
       - name: Add issue to project (if opened/reopened)
         id: add-to-project
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -173,7 +173,7 @@ jobs:
       - name: Get project item ID for status update
         id: get-item-id
         if: github.event.action == 'closed'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -226,7 +226,7 @@ jobs:
         if: |
           (steps.add-to-project.outputs.success == 'true' && steps.determine-status.outputs.statusId) ||
           (steps.get-item-id.outputs.found == 'true' && steps.determine-closed-status.outputs.statusId)
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -269,7 +269,7 @@ jobs:
 
       - name: Comment on issue
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -325,13 +325,13 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 
@@ -340,7 +340,7 @@ jobs:
 
       - name: Extract linked issues
         id: linked-issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -408,7 +408,7 @@ jobs:
 
       - name: Update linked issues status
         if: steps.linked-issues.outputs.count != '0' && steps.pr-status.outputs.shouldUpdate == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -501,13 +501,13 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js for Octokit
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 
@@ -516,7 +516,7 @@ jobs:
 
       - name: Extract linked issues
         id: linked-issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
@@ -537,7 +537,7 @@ jobs:
 
       - name: Update linked issues to In Progress
         if: steps.linked-issues.outputs.count != '0'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}

--- a/.github/workflows/reusable-ai-instructions.yml
+++ b/.github/workflows/reusable-ai-instructions.yml
@@ -32,18 +32,18 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Checkout governance repository
         if: ${{ github.repository != 'SecPal/.github' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: SecPal/.github
           ref: ${{ inputs.governance-ref }}
           path: .secpal-governance
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/reusable-check-conflict-markers.yml
+++ b/.github/workflows/reusable-check-conflict-markers.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.checkout-ref }}
 

--- a/.github/workflows/reusable-license-compatibility.yml
+++ b/.github/workflows/reusable-license-compatibility.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -37,18 +37,18 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Checkout governance repository
         if: ${{ github.repository != 'SecPal/.github' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: SecPal/.github
           ref: ${{ inputs.governance-ref }}
           path: .secpal-governance
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/reusable-node-build.yml
+++ b/.github/workflows/reusable-node-build.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"

--- a/.github/workflows/reusable-node-lint.yml
+++ b/.github/workflows/reusable-node-lint.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-prettier.yml
+++ b/.github/workflows/reusable-prettier.yml
@@ -34,10 +34,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/reusable-reuse.yml
+++ b/.github/workflows/reusable-reuse.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -20,6 +20,10 @@ rules:
   # Allow comments to be indented differently
   comments-indentation: disable
 
+  # Match Prettier's spacing for required same-line version comments
+  comments:
+    min-spaces-from-content: 1
+
   # Allow empty values in workflows
   empty-values:
     forbid-in-block-mappings: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-05 - Pin Android-Consumed Workflow Actions
+
+**Security:**
+
+- pinned every external action used by reusable workflows consumed by the
+  Android repository to a verified full commit SHA with same-line version
+  documentation
+- added a regression check that rejects mutable tags, abbreviated SHAs,
+  missing version documentation, and removal of GitHub Actions Dependabot
+  coverage for these workflows
+
 ## 2026-08-04 - Make Preview Provisioning Self-Convergent
 
 **Changed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -162,6 +162,15 @@ if [ -f tests/reusable-workflow-policy.sh ]; then
   }
 fi
 
+if [ -f tests/android-consumed-workflow-action-pins.sh ]; then
+  bash tests/android-consumed-workflow-action-pins.sh || {
+    echo "" >&2
+    echo "❌ Android-consumed reusable workflow action pin validation failed!" >&2
+    echo "Pin every nested external action to a documented full commit SHA before continuing." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/project-automation-core.sh ]; then
   bash tests/project-automation-core.sh || {
     echo "" >&2

--- a/tests/android-consumed-workflow-action-pins.sh
+++ b/tests/android-consumed-workflow-action-pins.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+full_commit_sha='^[0-9a-f]{40}$'
+documented_version='^(main|v[0-9]+([.][0-9]+){0,2}([.-][A-Za-z0-9.-]+)?)$'
+
+is_documented_pin() {
+  local reference="$1"
+  local version="$2"
+  local revision="${reference##*@}"
+
+  [[ "$reference" == *@* ]] &&
+    [[ "$revision" =~ $full_commit_sha ]] &&
+    [[ "$version" =~ $documented_version ]]
+}
+
+is_documented_pin \
+  'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' 'v1'
+is_documented_pin \
+  'actions/example@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' 'v1.2.3'
+
+for invalid_fixture in \
+  'actions/example@v1|v1' \
+  'actions/example@abcdef0|v1' \
+  'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|' \
+  'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|version-one'; do
+  IFS='|' read -r reference version <<<"$invalid_fixture"
+  if is_documented_pin "$reference" "$version"; then
+    echo "Accepted an invalid action pin fixture: $invalid_fixture" >&2
+    exit 1
+  fi
+done
+
+workflows=(
+  reusable-reuse.yml
+  reusable-license-compatibility.yml
+  reusable-prettier.yml
+  reusable-markdown-lint.yml
+  reusable-ai-instructions.yml
+  reusable-node-lint.yml
+  reusable-node-build.yml
+  reusable-check-conflict-markers.yml
+  project-automation-core.yml
+  draft-pr-reminder.yml
+  reusable-pr-size.yml
+)
+
+for workflow in "${workflows[@]}"; do
+  workflow_path="$repo_root/.github/workflows/$workflow"
+  test -f "$workflow_path"
+
+  while IFS= read -r line; do
+    payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
+    if [[ "$payload" == ./* ]]; then
+      continue
+    fi
+    if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
+      echo "$workflow: external action lacks same-line version documentation: $payload" >&2
+      exit 1
+    fi
+
+    reference="${BASH_REMATCH[1]}"
+    version="${BASH_REMATCH[2]}"
+    if ! is_documented_pin "$reference" "$version"; then
+      echo "$workflow: external action is not a documented full-SHA pin: $payload" >&2
+      exit 1
+    fi
+  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$workflow_path")
+done
+
+grep -q 'package-ecosystem: "github-actions"' "$repo_root/.github/dependabot.yml"
+
+echo "Android-consumed reusable workflow action pins verified."

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -65,6 +65,7 @@ workflow_instruction_scope="$(
 )"
 IFS=',' read -r -a workflow_instruction_patterns <<< "$workflow_instruction_scope"
 for direct_fixture in \
+  tests/android-consumed-workflow-action-pins.sh \
   tests/codeql-applicability.sh \
   tests/copilot-review-memory-errors.sh \
   tests/copilot-review-memory.sh \

--- a/tests/project-automation-core.sh
+++ b/tests/project-automation-core.sh
@@ -24,7 +24,7 @@ if ! awk '
     }
   }
 
-  /^        uses: actions\/create-github-app-token@v3$/ {
+  /^        uses: actions\/create-github-app-token@[0-9a-f]{40}[[:space:]]+# v3$/ {
     if (in_token_step) {
       validate_token_step()
     }


### PR DESCRIPTION
## Problem and evidence

Reusable workflows consumed by the Android repository referenced third-party GitHub Actions by mutable major-version tags. Pinning the caller workflow alone does not make nested actions immutable.

## Change

- Pin each external action in the Android-consumed reusable workflows to a documented 40-character commit SHA.
- Add a regression test for mutable tags, abbreviated SHAs, missing version comments, and missing GitHub Actions Dependabot coverage.
- Run the regression check from local preflight and document the requirement for reusable workflows.

## Validation

- bash tests/android-consumed-workflow-action-pins.sh && bash tests/project-automation-core.sh && bash tests/dependabot-auto-merge.sh
- timeout 30 actionlint for all changed workflows
- yamllint for all changed workflows and .yamllint.yml (two existing line-length warnings in reusable-pr-size.yml)
- git diff --check origin/main...HEAD

The full bash scripts/preflight.sh reached an unrelated GuardGuide fixture failure: .github/instructions/php-laravel.instructions.md has invalid instruction frontmatter, and Markdownlint is unavailable there. The focused checks for this change passed.