### PR TITLE
Fix PR-size workflow yamllint warnings

### DIFF
--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -179,12 +179,16 @@ jobs:
           fi
 
           CHANGED=$((INSERTIONS + DELETIONS))
-          SIZE_REPORT="PR size: $CHANGED changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $ADVISORY_THRESHOLD)"
+          SIZE_REPORT="PR size: $CHANGED changed lines \
+          ($INSERTIONS insertions, $DELETIONS deletions; \
+          advisory threshold: $ADVISORY_THRESHOLD)"
 
           echo "$SIZE_REPORT"
 
           if [ "$CHANGED" -gt "$ADVISORY_THRESHOLD" ]; then
-            echo "::warning::PR size advisory threshold exceeded ($CHANGED > $ADVISORY_THRESHOLD). Keep this pull request focused on one logical topic and make the review plan explicit."
+            echo "::warning::PR size advisory threshold exceeded \
+            ($CHANGED > $ADVISORY_THRESHOLD). Keep this pull request focused \
+            on one logical topic and make the review plan explicit."
           else
             echo "✅ PR size is within the advisory threshold ($CHANGED <= $ADVISORY_THRESHOLD lines)"
           fi

--- a/.github/workflows/reusable-pr-size.yml
+++ b/.github/workflows/reusable-pr-size.yml
@@ -186,9 +186,9 @@ jobs:
           echo "$SIZE_REPORT"
 
           if [ "$CHANGED" -gt "$ADVISORY_THRESHOLD" ]; then
-            echo "::warning::PR size advisory threshold exceeded \
-            ($CHANGED > $ADVISORY_THRESHOLD). Keep this pull request focused \
-            on one logical topic and make the review plan explicit."
+            echo "::warning::PR size advisory threshold exceeded" \
+              "($CHANGED > $ADVISORY_THRESHOLD). Keep this pull request focused" \
+              "on one logical topic and make the review plan explicit."
           else
             echo "✅ PR size is within the advisory threshold ($CHANGED <= $ADVISORY_THRESHOLD lines)"
           fi

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -423,6 +423,10 @@ assert_contains \
   "$large_workflow_output" \
   "::warning::PR size advisory threshold exceeded" \
   "reusable workflow must emit a GitHub warning above the threshold"
+assert_contains \
+  "$large_workflow_output" \
+  "::warning::PR size advisory threshold exceeded (601 > 600). Keep this pull request focused on one logical topic and make the review plan explicit." \
+  "reusable workflow must preserve the advisory warning text exactly"
 
 excluded_workflow_repo="$workspace/workflow-excluded"
 excluded_workflow_output="$workspace/workflow-excluded.out"


### PR DESCRIPTION
Fixes #619.

## Problem and evidence

`yamllint .github/workflows/reusable-pr-size.yml` reported line-length warnings at lines 182 and 187. The corresponding shell assignment was 143 characters and the warning output command was 186 characters. Both lines predated the immutable action-pin work in #618.

## Change

Split the two quoted shell strings with escaped newlines. Bash removes the continuations, so the PR-size report and advisory warning content remain unchanged.

## TDD / Validate-First Evidence

- Failing proof before implementation: `yamllint .github/workflows/reusable-pr-size.yml` reported line-length warnings at lines 182 and 187.
- Passing proof after implementation: `bash tests/pr-size-advisory.sh`, `yamllint .github/workflows/reusable-pr-size.yml`, `actionlint .github/workflows/reusable-pr-size.yml`, and `git diff --check`.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Dependencies and readiness

No in-scope dependency or unresolved check prevents readiness.