### PR TITLE
Keep workflow pin checks Dependabot-compatible

### DIFF
--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -37,9 +37,10 @@ workflow templates, and their direct validation fixtures.
 - Reusable workflows published for callers that require full-SHA action pins
   must also pin every nested external action to a reviewed 40-character commit
   SHA and retain its source-verified exact release version as a same-line
-  comment. Regression coverage must reject mismatched SHA/version pairs;
-  pinning only the reusable workflow does not make mutable action tags inside it
-  immutable.
+  comment. Regression coverage must enforce that structure without duplicating
+  action versions; review or automation operating on the workflow reference
+  must verify SHA-to-release provenance. Pinning only the reusable workflow
+  does not make mutable action tags inside it immutable.
 - Do not use productive branch references such as `@main` for cross-repository
   reusable workflows.
 - Keep dependency installation reproducible from committed lockfiles. Do not

--- a/tests/android-consumed-workflow-action-pins.sh
+++ b/tests/android-consumed-workflow-action-pins.sh
@@ -8,29 +8,6 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 full_commit_sha='^[0-9a-f]{40}$'
 documented_version='^v[0-9]+([.][0-9]+){2}([-+][A-Za-z0-9.-]+)?$'
 
-# Keep this offline provenance allowlist synchronized with source-verified
-# upstream release tags. Annotated tags use their peeled commit SHA.
-verified_action_releases=(
-  'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1|v7.0.1'
-  'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1|v3.2.0'
-  'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3|v9.0.0'
-  'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020|v7.0.0'
-  'actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97|v7.0.0'
-  'fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5|v6.0.0'
-)
-
-is_verified_action_release() {
-  local candidate="$1|$2"
-  local verified_release
-
-  for verified_release in "${verified_action_releases[@]}"; do
-    if [[ "$verified_release" == "$candidate" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
 is_documented_pin() {
   local reference="$1"
   local version="$2"
@@ -38,8 +15,7 @@ is_documented_pin() {
 
   [[ "$reference" == *@* ]] &&
     [[ "$revision" =~ $full_commit_sha ]] &&
-    [[ "$version" =~ $documented_version ]] &&
-    is_verified_action_release "$reference" "$version"
+    [[ "$version" =~ $documented_version ]]
 }
 
 has_github_actions_dependabot() {
@@ -78,15 +54,20 @@ has_github_actions_dependabot() {
   ' <<<"$configuration"
 }
 
-is_documented_pin \
-  'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' 'v7.0.1'
+# Dependabot owns action references and their version comments. The structural
+# guard must accept a valid updated pair without requiring a second fixture.
+if ! is_documented_pin \
+  'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' 'v1.2.3'; then
+  echo "Rejected a structurally documented action pin." >&2
+  exit 1
+fi
 
 for invalid_fixture in \
   'actions/example@v1|v1' \
   'actions/example@abcdef0|v1' \
+  'actions/example@AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA|v1.2.3' \
   'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|v1' \
   'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|v1.2' \
-  'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1|v7.0.0' \
   'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|' \
   'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|version-one'; do
   IFS='|' read -r reference version <<<"$invalid_fixture"


### PR DESCRIPTION
## Summary

- Remove the detached action SHA/version allowlist from the Android-consumed workflow pin regression guard.
- Retain structural checks for lowercase 40-character SHA pins and same-line release-version documentation.
- Document that SHA-to-release provenance is verified from the workflow reference during dependency review or reference-based automation.

## Problem and evidence

Dependabot updates each workflow `uses:` reference and its same-line version comment, but it cannot update the separate `verified_action_releases` shell array. Consequently, a legitimate action update would fail `tests/android-consumed-workflow-action-pins.sh` until the same SHA/version pair was manually duplicated.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/android-consumed-workflow-action-pins.sh` rejected the structurally valid generic pin `actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` with release documentation `v1.2.3` because it was absent from the detached allowlist.
- Passing proof after implementation: `bash tests/android-consumed-workflow-action-pins.sh` completed with `Android-consumed reusable workflow action pins verified.` after the structural guard replaced the allowlist lookup.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash -n tests/android-consumed-workflow-action-pins.sh`
- `bash tests/android-consumed-workflow-action-pins.sh`
- `bash tests/dependabot-auto-merge.sh`
- `bash scripts/preflight.sh`
- Commit hooks: REUSE, Prettier, markdownlint, shellcheck, YAML, and repository hygiene checks

## Readiness

No in-scope dependency or unresolved check prevents readiness. SHA-to-release provenance remains a dependency-review responsibility against the updated workflow reference; the regression guard deliberately does not repeat Dependabot-owned values.

Closes #624
