### PR TITLE
Complete workflow pinning follow-ups

### DIFF
--- a/.github/actions/setup-node-with-deps/action.yml
+++ b/.github/actions/setup-node-with-deps/action.yml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -1,15 +1,16 @@
 ---
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
-name: GitHub Workflow Rules
+name: GitHub Workflow and Action Rules
 description: Applies focused security and validation criteria to GitHub automation.
-applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependabot.yml,.github/dependabot.yaml,workflow-templates/**/*.yml,workflow-templates/**/*.yaml,EXAMPLE_workflow_for_other_repos.yml,tests/*workflow*.sh,tests/dependabot-auto-merge.sh,tests/codeql-applicability.sh,tests/copilot-review-memory*.sh,tests/license-compatibility.sh,tests/prettier-version-alignment.sh,tests/project-automation-core.sh,tests/pull-request-*.sh,tests/reusable-markdown-lint-scope.sh"
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/actions/**/action.yml,.github/actions/**/action.yaml,.github/dependabot.yml,.github/dependabot.yaml,workflow-templates/**/*.yml,workflow-templates/**/*.yaml,EXAMPLE_workflow_for_other_repos.yml,tests/*workflow*.sh,tests/dependabot-auto-merge.sh,tests/codeql-applicability.sh,tests/copilot-review-memory*.sh,tests/license-compatibility.sh,tests/prettier-version-alignment.sh,tests/project-automation-core.sh,tests/pull-request-*.sh,tests/reusable-markdown-lint-scope.sh"
 ---
 
-# GitHub Workflow Review Rules
+# GitHub Workflow and Action Review Rules
 
-Apply these criteria only to GitHub Actions workflows, Dependabot configuration,
-workflow templates, and their direct validation fixtures.
+Apply these criteria only to GitHub Actions workflows, composite action
+manifests, Dependabot configuration, workflow templates, and their direct
+validation fixtures.
 
 ## Permissions and Execution Bounds
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     # Keep auto-merge decisions on the reviewed immutable workflow revision so
     # Dependabot PRs cannot execute unreviewed policy changes from the same PR.
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@eb4001ca178929496be476e2639c4acf28111f8f # main
     with:
       # Phase 1: Only PATCH updates auto-merge
       phase: "1"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -42,7 +42,9 @@ jobs:
         env:
           SECPAL_BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
           VERIFY_ACTION_PIN_PROVENANCE: "true"
-        run: bash tests/android-consumed-workflow-action-pins.sh
+        run: |
+          bash tests/android-consumed-workflow-action-pins.sh
+          bash tests/dependabot-auto-merge.sh
 
   pr-review-workflow:
     name: Finite PR Review Workflow

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.x"
+
+      - name: Install Node dependencies
+        run: npm ci
+
       - name: Verify external workflow references
         env:
           SECPAL_BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-07 - Install Locked Workflow Validation Dependencies First
+
+**Fixed:**
+
+- moved the committed Node dependency installation ahead of local workflow and
+  action pin validators in `scripts/preflight.sh`, then reused that installation
+  for the later Node checks so a fresh checkout cannot fail before its locked
+  YAML parser is available
+- added positive ordering enforcement and a late-install negative fixture to
+  keep the full local preflight aligned with the hosted workflow-pin job
+
+---
+
 ## 2026-08-05 - Pin Android-Consumed Workflow Actions
 
 **Security:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -73,6 +73,12 @@ echo "Using base branch: $BASE"
 # Fetch base branch for PR size check (failure is handled later)
 git fetch origin "$BASE" 2>/dev/null || true
 
+# Install the committed Node dependency graph before any validator that imports
+# repository-owned tooling. The later Node phase reuses this exact install.
+if [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
+  npm ci
+fi
+
 # 0) Formatting & Compliance
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
@@ -451,7 +457,6 @@ if [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
   pnpm run --if-present typecheck
   pnpm run --if-present test
 elif [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
-  npm ci
   npm run --if-present lint
   npm run --if-present typecheck
   npm run --if-present test

--- a/tests/android-consumed-workflow-action-pins.sh
+++ b/tests/android-consumed-workflow-action-pins.sh
@@ -254,8 +254,8 @@ for workflow in "${governance_checkout_workflows[@]}"; do
   grep -Fq "ref: \${{ fromJSON(toJSON(job)).workflow_sha }}" "$workflow_path"
 done
 
-while IFS= read -r workflow_path; do
-  workflow="${workflow_path##*/}"
+while IFS= read -r action_definition_path; do
+  action_definition="${action_definition_path#"$repo_root"/}"
 
   while IFS= read -r line; do
     payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
@@ -263,24 +263,28 @@ while IFS= read -r workflow_path; do
       continue
     fi
     if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
-      echo "$workflow: external action lacks same-line version documentation: $payload" >&2
+      echo "$action_definition: external action lacks same-line version documentation: $payload" >&2
       exit 1
     fi
 
     reference="${BASH_REMATCH[1]}"
     version="${BASH_REMATCH[2]}"
     if ! is_accepted_action_pin "$reference" "$version"; then
-      echo "$workflow: external action is not a verified documented full-SHA pin: $payload" >&2
+      echo "$action_definition: external action is not a verified documented full-SHA pin: $payload" >&2
       exit 1
     fi
-  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$workflow_path")
-done < <(find "$repo_root/.github/workflows" -maxdepth 1 -type f \
-  \( -name '*.yml' -o -name '*.yaml' \) -print | sort)
+  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$action_definition_path")
+done < <(
+  find "$repo_root/.github/workflows" -maxdepth 1 -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) -print
+  find "$repo_root/.github/actions" -type f \
+    \( -name 'action.yml' -o -name 'action.yaml' \) -print
+  ) | sort
 
 has_github_actions_dependabot "$(<"$repo_root/.github/dependabot.yml")"
 
 if [[ "${VERIFY_ACTION_PIN_PROVENANCE:-false}" == "true" ]]; then
-  echo "Workflow external action and reusable-workflow pin provenance verified."
+  echo "Workflow and composite-action external pin provenance verified."
 else
-  echo "Workflow external action and reusable-workflow pin structure verified."
+  echo "Workflow and composite-action external pin structure verified."
 fi

--- a/tests/android-consumed-workflow-action-pins.sh
+++ b/tests/android-consumed-workflow-action-pins.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 full_commit_sha='^[0-9a-f]{40}$'
 null_commit_sha='^0{40}$'
 documented_source='^[A-Za-z0-9][A-Za-z0-9._/-]*$'
@@ -118,6 +118,97 @@ verify_reusable_workflow_pin() {
   git -C "$repo_root" merge-base --is-ancestor "${reference##*@}" "$base_revision"
 }
 
+list_yaml_action_references() {
+  local action_definition_path="$1"
+  local parser=()
+  local yaml_json
+
+  if [[ -x "$repo_root/node_modules/.bin/js-yaml" ]]; then
+    parser=("$repo_root/node_modules/.bin/js-yaml")
+  elif command -v npx >/dev/null 2>&1; then
+    parser=(npx --yes js-yaml@4.2.0)
+  else
+    echo "Action reference validation requires npm dependencies or npx." >&2
+    return 1
+  fi
+
+  yaml_json="$("${parser[@]}" "$action_definition_path")" || return 1
+  # shellcheck disable=SC2016 # JavaScript template literals are intentionally passed verbatim.
+  printf '%s\n' "$yaml_json" |
+    node -e '
+      const fs = require("node:fs");
+      const sourceName = process.argv[1];
+      const definition = JSON.parse(fs.readFileSync(0, "utf8"));
+      const references = [];
+
+      function addReference(value, location) {
+        if (typeof value !== "string" || value.includes("\n")) {
+          process.stderr.write(`${sourceName}: ${location} must be a single-line string\n`);
+          process.exitCode = 1;
+          return;
+        }
+        references.push(value);
+      }
+
+      function visit(value, location) {
+        if (!value || typeof value !== "object") return;
+        if (Array.isArray(value)) {
+          value.forEach((item, index) => visit(item, `${location}[${index}]`));
+          return;
+        }
+        for (const [key, child] of Object.entries(value)) {
+          const childLocation = location ? `${location}.${key}` : key;
+          if (key === "uses") addReference(child, childLocation);
+          visit(child, childLocation);
+        }
+      }
+
+      visit(definition, "");
+
+      if (!process.exitCode) process.stdout.write(references.join("\n"));
+    ' "$action_definition_path"
+}
+
+validate_action_definition_pins() {
+  local action_definition_path="$1"
+  local action_definition="${2:-${action_definition_path#"$repo_root"/}}"
+  local parsed_references documented_references parsed_sorted documented_sorted
+  local line payload reference version
+
+  parsed_references="$(list_yaml_action_references "$action_definition_path")" || return 1
+  if ! documented_references="$({
+    while IFS= read -r line; do
+      payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
+      reference="${payload%%[[:space:]#]*}"
+      if [[ "$reference" == ./* ]]; then
+        printf '%s\n' "$reference"
+        continue
+      fi
+      if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
+        echo "$action_definition: external action lacks same-line version documentation: $payload" >&2
+        return 1
+      fi
+
+      reference="${BASH_REMATCH[1]}"
+      version="${BASH_REMATCH[2]}"
+      if ! is_accepted_action_pin "$reference" "$version"; then
+        echo "$action_definition: external action is not a verified documented full-SHA pin: $payload" >&2
+        return 1
+      fi
+      printf '%s\n' "$reference"
+    done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$action_definition_path" || true)
+  })"; then
+    return 1
+  fi
+
+  parsed_sorted="$(printf '%s\n' "$parsed_references" | sed '/^$/d' | LC_ALL=C sort)"
+  documented_sorted="$(printf '%s\n' "$documented_references" | sed '/^$/d' | LC_ALL=C sort)"
+  if [[ "$parsed_sorted" != "$documented_sorted" ]]; then
+    echo "$action_definition: every uses reference must use canonical 'uses:' YAML with required same-line provenance." >&2
+    return 1
+  fi
+}
+
 has_github_actions_dependabot() {
   local configuration="$1"
 
@@ -154,8 +245,9 @@ has_github_actions_dependabot() {
   ' <<<"$configuration"
 }
 
-# Dependabot owns action references and their version comments. The structural
-# guard must accept a valid updated pair without requiring a second fixture.
+main() {
+  # Dependabot owns action references and their version comments. The structural
+  # guard must accept a valid updated pair without requiring a second fixture.
 if ! is_documented_pin \
   'actions/example@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' 'v1.2.3'; then
   echo "Rejected a structurally documented action pin." >&2
@@ -255,31 +347,15 @@ for workflow in "${governance_checkout_workflows[@]}"; do
 done
 
 while IFS= read -r action_definition_path; do
-  action_definition="${action_definition_path#"$repo_root"/}"
-
-  while IFS= read -r line; do
-    payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
-    if [[ "$payload" == ./* ]]; then
-      continue
-    fi
-    if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
-      echo "$action_definition: external action lacks same-line version documentation: $payload" >&2
-      exit 1
-    fi
-
-    reference="${BASH_REMATCH[1]}"
-    version="${BASH_REMATCH[2]}"
-    if ! is_accepted_action_pin "$reference" "$version"; then
-      echo "$action_definition: external action is not a verified documented full-SHA pin: $payload" >&2
-      exit 1
-    fi
-  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$action_definition_path")
+  validate_action_definition_pins "$action_definition_path" || exit 1
 done < <(
-  find "$repo_root/.github/workflows" -maxdepth 1 -type f \
-    \( -name '*.yml' -o -name '*.yaml' \) -print
-  find "$repo_root/.github/actions" -type f \
-    \( -name 'action.yml' -o -name 'action.yaml' \) -print
-  ) | sort
+  {
+    find "$repo_root/.github/workflows" -maxdepth 1 -type f \
+      \( -name '*.yml' -o -name '*.yaml' \) -print
+    find "$repo_root/.github/actions" -type f \
+      \( -name 'action.yml' -o -name 'action.yaml' \) -print
+  } | sort
+)
 
 has_github_actions_dependabot "$(<"$repo_root/.github/dependabot.yml")"
 
@@ -287,4 +363,9 @@ if [[ "${VERIFY_ACTION_PIN_PROVENANCE:-false}" == "true" ]]; then
   echo "Workflow and composite-action external pin provenance verified."
 else
   echo "Workflow and composite-action external pin structure verified."
+fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/tests/android-consumed-workflow-action-pins.sh
+++ b/tests/android-consumed-workflow-action-pins.sh
@@ -9,6 +9,7 @@ full_commit_sha='^[0-9a-f]{40}$'
 null_commit_sha='^0{40}$'
 documented_source='^[A-Za-z0-9][A-Za-z0-9._/-]*$'
 documented_release='^v?[0-9]+([.][0-9]+){2}([-+][A-Za-z0-9.-]+)?$'
+immutable_docker_reference='^docker://[^@[:space:]]+@sha256:[0-9a-f]{64}$'
 
 is_documented_pin() {
   local reference="$1"
@@ -44,6 +45,10 @@ is_accepted_action_pin() {
   else
     verify_action_release_pin "$reference" "$version"
   fi
+}
+
+is_immutable_docker_pin() {
+  [[ "$1" =~ $immutable_docker_reference ]]
 }
 
 release_pin_matches_refs() {
@@ -120,93 +125,150 @@ verify_reusable_workflow_pin() {
 
 list_yaml_action_references() {
   local action_definition_path="$1"
-  local parser=()
-  local yaml_json
+  local parser_module="$repo_root/node_modules/js-yaml"
 
-  if [[ -x "$repo_root/node_modules/.bin/js-yaml" ]]; then
-    parser=("$repo_root/node_modules/.bin/js-yaml")
-  elif command -v npx >/dev/null 2>&1; then
-    parser=(npx --yes js-yaml@4.2.0)
-  else
-    echo "Action reference validation requires npm dependencies or npx." >&2
+  if [[ ! -d "$parser_module" ]]; then
+    echo "Action reference validation requires dependencies installed with npm ci." >&2
     return 1
   fi
 
-  yaml_json="$("${parser[@]}" "$action_definition_path")" || return 1
   # shellcheck disable=SC2016 # JavaScript template literals are intentionally passed verbatim.
-  printf '%s\n' "$yaml_json" |
-    node -e '
+  node - "$repo_root" "$action_definition_path" <<'NODE'
       const fs = require("node:fs");
-      const sourceName = process.argv[1];
-      const definition = JSON.parse(fs.readFileSync(0, "utf8"));
+      const path = require("node:path");
+      const repoRoot = process.argv[2];
+      const sourceName = process.argv[3];
+      const yaml = require(path.join(repoRoot, "node_modules/js-yaml"));
+      const source = fs.readFileSync(sourceName, "utf8");
       const references = [];
 
-      function addReference(value, location) {
-        if (typeof value !== "string" || value.includes("\n")) {
+      function parseNode(events, state) {
+        const event = events[state.cursor++];
+        if (!event) throw new Error(`${sourceName}: incomplete YAML event stream`);
+        if (event.type === yaml.EVENT_SCALAR) {
+          return {
+            kind: "scalar",
+            event,
+            value: source.slice(event.valueStart, event.valueEnd),
+          };
+        }
+        if (event.type === yaml.EVENT_ALIAS) return { kind: "alias", event };
+        if (event.type === yaml.EVENT_MAPPING) {
+          const entries = [];
+          while (events[state.cursor]?.type !== yaml.EVENT_POP) {
+            entries.push({
+              key: parseNode(events, state),
+              value: parseNode(events, state),
+            });
+          }
+          state.cursor += 1;
+          return { kind: "mapping", entries };
+        }
+        if (event.type === yaml.EVENT_SEQUENCE) {
+          const items = [];
+          while (events[state.cursor]?.type !== yaml.EVENT_POP) {
+            items.push(parseNode(events, state));
+          }
+          state.cursor += 1;
+          return { kind: "sequence", items };
+        }
+        throw new Error(`${sourceName}: unsupported YAML event ${event.type}`);
+      }
+
+      function mappingEntry(mapping, key) {
+        if (!mapping || mapping.kind !== "mapping") return undefined;
+        return mapping.entries.find((entry) =>
+          entry.key.kind === "scalar" && entry.key.value === key);
+      }
+
+      function addReference(entry, location) {
+        if (!entry || entry.value.kind !== "scalar" || entry.value.value.includes("\n")) {
           process.stderr.write(`${sourceName}: ${location} must be a single-line string\n`);
           process.exitCode = 1;
           return;
         }
-        references.push(value);
-      }
 
-      function visit(value, location) {
-        if (!value || typeof value !== "object") return;
-        if (Array.isArray(value)) {
-          value.forEach((item, index) => visit(item, `${location}[${index}]`));
+        const lineStart = source.lastIndexOf("\n", entry.key.event.valueStart - 1) + 1;
+        const nextLine = source.indexOf("\n", entry.key.event.valueStart);
+        const lineEnd = nextLine === -1 ? source.length : nextLine;
+        const line = source.slice(lineStart, lineEnd);
+        const match = line.match(
+          /^[ \t]*(?:-[ \t]+)?uses:[ \t]+([^ \t#]+)(?:[ \t]+#[ \t]+([^ \t#]+))?[ \t]*$/,
+        );
+        if (!match || match[1] !== entry.value.value) {
+          process.stderr.write(
+            `${sourceName}: ${location} must use canonical uses YAML with same-line provenance\n`,
+          );
+          process.exitCode = 1;
           return;
         }
-        for (const [key, child] of Object.entries(value)) {
-          const childLocation = location ? `${location}.${key}` : key;
-          if (key === "uses") addReference(child, childLocation);
-          visit(child, childLocation);
+        references.push([entry.value.value, match[2] || ""]);
+      }
+
+      function collectSteps(steps, location) {
+        if (!steps || steps.kind !== "sequence") return;
+        steps.items.forEach((step, index) => {
+          const uses = mappingEntry(step, "uses");
+          if (uses) addReference(uses, `${location}[${index}].uses`);
+        });
+      }
+
+      let events;
+      try {
+        yaml.load(source);
+        events = yaml.parseEvents(source);
+      } catch (error) {
+        process.stderr.write(`${sourceName}: ${error.message}\n`);
+        process.exit(1);
+      }
+      const state = { cursor: 0 };
+      if (events[state.cursor]?.type === yaml.EVENT_DOCUMENT) state.cursor += 1;
+      const definition = parseNode(events, state);
+      if (definition.kind !== "mapping") {
+        process.stderr.write(`${sourceName}: action definition must be a mapping\n`);
+        process.exit(1);
+      }
+
+      const jobs = mappingEntry(definition, "jobs")?.value;
+      if (jobs?.kind === "mapping") {
+        for (const jobEntry of jobs.entries) {
+          const job = jobEntry.value;
+          const jobId = jobEntry.key.kind === "scalar" ? jobEntry.key.value : "<job>";
+          const uses = mappingEntry(job, "uses");
+          if (uses) addReference(uses, `jobs.${jobId}.uses`);
+          collectSteps(mappingEntry(job, "steps")?.value, `jobs.${jobId}.steps`);
         }
       }
 
-      visit(definition, "");
+      const runs = mappingEntry(definition, "runs")?.value;
+      collectSteps(mappingEntry(runs, "steps")?.value, "runs.steps");
 
-      if (!process.exitCode) process.stdout.write(references.join("\n"));
-    ' "$action_definition_path"
+      if (!process.exitCode) {
+        process.stdout.write(references.map((item) => item.join("\t")).join("\n"));
+      }
+NODE
 }
 
 validate_action_definition_pins() {
   local action_definition_path="$1"
   local action_definition="${2:-${action_definition_path#"$repo_root"/}}"
-  local parsed_references documented_references parsed_sorted documented_sorted
-  local line payload reference version
+  local action_references reference version
 
-  parsed_references="$(list_yaml_action_references "$action_definition_path")" || return 1
-  if ! documented_references="$({
-    while IFS= read -r line; do
-      payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
-      reference="${payload%%[[:space:]#]*}"
-      if [[ "$reference" == ./* ]]; then
-        printf '%s\n' "$reference"
-        continue
-      fi
-      if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
-        echo "$action_definition: external action lacks same-line version documentation: $payload" >&2
-        return 1
-      fi
-
-      reference="${BASH_REMATCH[1]}"
-      version="${BASH_REMATCH[2]}"
-      if ! is_accepted_action_pin "$reference" "$version"; then
-        echo "$action_definition: external action is not a verified documented full-SHA pin: $payload" >&2
-        return 1
-      fi
-      printf '%s\n' "$reference"
-    done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$action_definition_path" || true)
-  })"; then
-    return 1
-  fi
-
-  parsed_sorted="$(printf '%s\n' "$parsed_references" | sed '/^$/d' | LC_ALL=C sort)"
-  documented_sorted="$(printf '%s\n' "$documented_references" | sed '/^$/d' | LC_ALL=C sort)"
-  if [[ "$parsed_sorted" != "$documented_sorted" ]]; then
-    echo "$action_definition: every uses reference must use canonical 'uses:' YAML with required same-line provenance." >&2
-    return 1
-  fi
+  action_references="$(list_yaml_action_references "$action_definition_path")" || return 1
+  while IFS=$'\t' read -r reference version; do
+    [[ -n "$reference" ]] || continue
+    if [[ "$reference" == ./* ]] || is_immutable_docker_pin "$reference"; then
+      continue
+    fi
+    if [[ -z "$version" ]]; then
+      echo "$action_definition: external action lacks same-line version documentation: $reference" >&2
+      return 1
+    fi
+    if ! is_accepted_action_pin "$reference" "$version"; then
+      echo "$action_definition: external action is not a verified documented full-SHA pin: $reference # $version" >&2
+      return 1
+    fi
+  done <<<"$action_references"
 }
 
 has_github_actions_dependabot() {

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -101,6 +101,7 @@ workflow_instruction_scope="$(
 )"
 IFS=',' read -r -a workflow_instruction_patterns <<< "$workflow_instruction_scope"
 for direct_fixture in \
+  .github/actions/setup-node-with-deps/action.yml \
   tests/android-consumed-workflow-action-pins.sh \
   tests/codeql-applicability.sh \
   tests/copilot-review-memory-errors.sh \
@@ -340,6 +341,45 @@ validate_immutable_action_references() {
   ' "$source_name"
 }
 
+validate_documented_action_release_pins() {
+  local source_name="$1"
+  local line payload reference version revision
+  local documented_release='^v?[0-9]+([.][0-9]+){2}([-+][A-Za-z0-9.-]+)?$'
+  local documented_source='^[A-Za-z0-9][A-Za-z0-9._/-]*$'
+
+  while IFS= read -r line; do
+    payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
+    reference="${payload%%[[:space:]#]*}"
+    if [[ "$reference" == ./* ]] || [[ "$reference" == docker://* ]]; then
+      continue
+    fi
+
+    if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
+      echo "$source_name: external reference lacks same-line provenance: $payload" >&2
+      return 1
+    fi
+
+    reference="${BASH_REMATCH[1]}"
+    version="${BASH_REMATCH[2]}"
+    revision="${reference##*@}"
+    if [[ ! "$reference" == *@* ]] || [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]] ||
+      [[ "$revision" =~ ^0{40}$ ]]; then
+      echo "$source_name: external action lacks a documented full-SHA pin: $payload" >&2
+      return 1
+    fi
+    if [[ "${reference%@*}" == */.github/workflows/*.yml ]] ||
+      [[ "${reference%@*}" == */.github/workflows/*.yaml ]]; then
+      if [[ ! "$version" =~ $documented_source ]] || [[ "$version" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "$source_name: reusable workflow lacks a documented source ref: $payload" >&2
+        return 1
+      fi
+    elif [[ ! "$version" =~ $documented_release ]]; then
+      echo "$source_name: external action lacks an exact same-line release: $payload" >&2
+      return 1
+    fi
+  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' || true)
+}
+
 immutable_action_fixture='jobs:
   reusable-workflow:
     uses: actions/example/.github/workflows/example.yml@0123456789abcdef0123456789abcdef01234567
@@ -372,6 +412,27 @@ for movable_action_fixture in \
   fi
 done
 
+documented_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3'
+if ! printf '%s\n' "$documented_release_fixture" |
+  validate_documented_action_release_pins "documented release fixture"; then
+  echo "Documented action release validation must accept exact releases." >&2
+  exit 1
+fi
+
+documented_workflow_source_fixture=$'jobs:\n  fixture:\n    uses: actions/example/.github/workflows/example.yml@0123456789abcdef0123456789abcdef01234567 # main'
+if ! printf '%s\n' "$documented_workflow_source_fixture" |
+  validate_documented_action_release_pins "documented workflow source fixture"; then
+  echo "Documented reusable workflow validation must accept source refs." >&2
+  exit 1
+fi
+
+major_only_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1'
+if printf '%s\n' "$major_only_release_fixture" |
+  validate_documented_action_release_pins "major-only release fixture" 2>/dev/null; then
+  echo "Documented action release validation accepted a mutable major-only label." >&2
+  exit 1
+fi
+
 # Cross-repository callers pin this reusable workflow to a commit, but that
 # pin is only meaningful when every action it invokes is also immutable.
 # Require a full commit SHA for repository actions and a canonical SHA-256
@@ -379,6 +440,24 @@ done
 # silently change the code executed by consumers.
 if ! validate_immutable_action_references "$REUSABLE_WORKFLOW"; then
   echo "Reusable Dependabot workflow must pin every nested repository action to a full commit SHA and every Docker action to a canonical SHA-256 digest; caller-local references are not allowed." >&2
+  exit 1
+fi
+
+pinned_reusable_workflow="$(
+  git -C "$REPO_ROOT" show \
+    "$caller_revision:.github/workflows/reusable-dependabot-auto-merge.yml"
+)" || {
+  echo "Pinned Dependabot reusable workflow is unavailable from the reviewed revision." >&2
+  exit 1
+}
+if ! printf '%s\n' "$pinned_reusable_workflow" |
+  validate_immutable_action_references; then
+  echo "Pinned Dependabot reusable workflow must keep every nested action immutable." >&2
+  exit 1
+fi
+if ! printf '%s\n' "$pinned_reusable_workflow" |
+  validate_documented_action_release_pins "pinned Dependabot reusable workflow"; then
+  echo "Pinned Dependabot reusable workflow must retain exact release provenance for every nested action." >&2
   exit 1
 fi
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -243,14 +243,22 @@ if [[ "$normalized_workflow_instructions" != *'A reusable-workflow caller job us
 fi
 
 awk '
-  /^      - name: Verify external workflow references$/ { in_step = 1; next }
+  /^  workflow-pins:$/ { in_job = 1; next }
+  in_job && /^  [A-Za-z0-9_-]+:$/ { in_job = 0 }
+  in_job && /^      - name: Setup Node\.js$/ { sets_up_node = 1 }
+  in_job && /^      - name: Install Node dependencies$/ { installs_dependencies = 1 }
+  in_job && /^        run: npm ci$/ { uses_lockfile = 1 }
+  in_job && /^      - name: Verify external workflow references$/ { in_step = 1; next }
   in_step && /^      - name:/ { in_step = 0 }
   in_step && /^          VERIFY_ACTION_PIN_PROVENANCE: "true"$/ { verifies_provenance = 1 }
   in_step && /^          bash tests\/android-consumed-workflow-action-pins\.sh$/ { validates_working_tree = 1 }
   in_step && /^          bash tests\/dependabot-auto-merge\.sh$/ { validates_pinned_snapshot = 1 }
-  END { exit !(verifies_provenance && validates_working_tree && validates_pinned_snapshot) }
+  END {
+    exit !(sets_up_node && installs_dependencies && uses_lockfile &&
+      verifies_provenance && validates_working_tree && validates_pinned_snapshot)
+  }
 ' "$QUALITY_WORKFLOW" || {
-  echo "Workflow pin validation must verify both the working tree and pinned Dependabot snapshot with live provenance enabled." >&2
+  echo "Workflow pin validation must install locked Node dependencies and verify both the working tree and pinned Dependabot snapshot with live provenance enabled." >&2
   exit 1
 }
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
@@ -288,10 +296,8 @@ validate_immutable_action_references() {
 
   if [[ -x "$REPO_ROOT/node_modules/.bin/js-yaml" ]]; then
     parser=("$REPO_ROOT/node_modules/.bin/js-yaml")
-  elif command -v npx >/dev/null 2>&1; then
-    parser=(npx --yes js-yaml@4.2.0)
   else
-    echo "Immutable action reference validation requires npm dependencies or npx." >&2
+    echo "Immutable action reference validation requires dependencies installed with npm ci." >&2
     return 1
   fi
 
@@ -412,6 +418,51 @@ if ! printf '%s\n' "$documented_workflow_source_fixture" |
   exit 1
 fi
 
+fake_parser_bin="$base_fixture/fake-parser-bin"
+unlocked_fixture_root="$base_fixture/unlocked-repository"
+mkdir -p "$fake_parser_bin" "$unlocked_fixture_root"
+cat >"$fake_parser_bin/npx" <<'EOF'
+#!/usr/bin/env bash
+printf '{}\n'
+EOF
+chmod +x "$fake_parser_bin/npx"
+rejects_unlocked_action_parser() {
+  local repo_root="$unlocked_fixture_root"
+  local PATH="$fake_parser_bin:$PATH"
+
+  ! list_yaml_action_references "$base_fixture/action-pin-definition.yml" >/dev/null 2>&1
+}
+if ! rejects_unlocked_action_parser; then
+  echo "Action reference validation downloaded a parser outside the repository lockfile." >&2
+  exit 1
+fi
+rejects_unlocked_immutable_parser() {
+  local REPO_ROOT="$unlocked_fixture_root"
+  local PATH="$fake_parser_bin:$PATH"
+
+  ! validate_immutable_action_references "$base_fixture/action-pin-definition.yml" >/dev/null 2>&1
+}
+if ! rejects_unlocked_immutable_parser; then
+  echo "Immutable reference validation downloaded a parser outside the repository lockfile." >&2
+  exit 1
+fi
+
+documented_docker_digest_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: docker://alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+if ! printf '%s\n' "$documented_docker_digest_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "documented Docker digest fixture"; then
+  echo "Documented action validation must accept canonical Docker digests." >&2
+  exit 1
+fi
+
+unrelated_uses_fixture=$'inputs:\n  uses:\n    description: Ordinary composite action input\nenv:\n  uses: ordinary-value\nruns:\n  using: composite\n  steps:\n    - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3'
+if ! printf '%s\n' "$unrelated_uses_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "unrelated uses fixture"; then
+  echo "Action reference validation must ignore uses keys outside action-bearing schema locations." >&2
+  exit 1
+fi
+
 major_only_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1'
 if printf '%s\n' "$major_only_release_fixture" |
   VERIFY_ACTION_PIN_PROVENANCE=false \
@@ -441,6 +492,22 @@ if printf '%s\n' "$decoy_documentation_fixture" |
   VERIFY_ACTION_PIN_PROVENANCE=false \
     validate_documented_action_release_pins "decoy documentation fixture" 2>/dev/null; then
   echo "Documented action release validation matched provenance from a different YAML location." >&2
+  exit 1
+fi
+
+duplicate_jobs_fixture=$'jobs:\n  verified:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3\njobs:\n  movable:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@main'
+if printf '%s\n' "$duplicate_jobs_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "duplicate jobs fixture" 2>/dev/null; then
+  echo "Action reference validation accepted duplicate mappings that hide a movable reference." >&2
+  exit 1
+fi
+
+multiple_documents_fixture=$'jobs:\n  verified:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3\n---\njobs:\n  movable:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@main'
+if printf '%s\n' "$multiple_documents_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "multiple documents fixture" 2>/dev/null; then
+  echo "Action reference validation accepted an unchecked additional YAML document." >&2
   exit 1
 fi
 

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=tests/android-consumed-workflow-action-pins.sh
+source "$SCRIPT_DIR/android-consumed-workflow-action-pins.sh"
 CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
 DEPENDABOT_CONFIG="$REPO_ROOT/.github/dependabot.yml"
@@ -22,6 +24,7 @@ WORKFLOW_INSTRUCTIONS="$REPO_ROOT/.github/instructions/github-workflows.instruct
 WORKFLOW_EXAMPLE="$REPO_ROOT/EXAMPLE_workflow_for_other_repos.yml"
 WORKFLOW_CATALOG_README="$REPO_ROOT/.github/workflows/README.md"
 ROLLOUT_GUIDE="$REPO_ROOT/docs/workflows/ROLLOUT_GUIDE.md"
+QUALITY_WORKFLOW="$REPO_ROOT/.github/workflows/quality.yml"
 
 resolve_base_revision() {
   local repository="$1"
@@ -238,6 +241,18 @@ if [[ "$normalized_workflow_instructions" != *'A reusable-workflow caller job us
   echo "Workflow instructions must document the reusable-workflow caller timeout-minutes exception." >&2
   exit 1
 fi
+
+awk '
+  /^      - name: Verify external workflow references$/ { in_step = 1; next }
+  in_step && /^      - name:/ { in_step = 0 }
+  in_step && /^          VERIFY_ACTION_PIN_PROVENANCE: "true"$/ { verifies_provenance = 1 }
+  in_step && /^          bash tests\/android-consumed-workflow-action-pins\.sh$/ { validates_working_tree = 1 }
+  in_step && /^          bash tests\/dependabot-auto-merge\.sh$/ { validates_pinned_snapshot = 1 }
+  END { exit !(verifies_provenance && validates_working_tree && validates_pinned_snapshot) }
+' "$QUALITY_WORKFLOW" || {
+  echo "Workflow pin validation must verify both the working tree and pinned Dependabot snapshot with live provenance enabled." >&2
+  exit 1
+}
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
 # gate on the PR author so the same maintainer-triggered events are not
 # skipped when other repositories invoke this reusable workflow directly.
@@ -343,41 +358,10 @@ validate_immutable_action_references() {
 
 validate_documented_action_release_pins() {
   local source_name="$1"
-  local line payload reference version revision
-  local documented_release='^v?[0-9]+([.][0-9]+){2}([-+][A-Za-z0-9.-]+)?$'
-  local documented_source='^[A-Za-z0-9][A-Za-z0-9._/-]*$'
+  local fixture_path="$base_fixture/action-pin-definition.yml"
 
-  while IFS= read -r line; do
-    payload="$(sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//' <<<"$line")"
-    reference="${payload%%[[:space:]#]*}"
-    if [[ "$reference" == ./* ]] || [[ "$reference" == docker://* ]]; then
-      continue
-    fi
-
-    if [[ ! "$payload" =~ ^([^[:space:]#]+)[[:space:]]+#[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]]; then
-      echo "$source_name: external reference lacks same-line provenance: $payload" >&2
-      return 1
-    fi
-
-    reference="${BASH_REMATCH[1]}"
-    version="${BASH_REMATCH[2]}"
-    revision="${reference##*@}"
-    if [[ ! "$reference" == *@* ]] || [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]] ||
-      [[ "$revision" =~ ^0{40}$ ]]; then
-      echo "$source_name: external action lacks a documented full-SHA pin: $payload" >&2
-      return 1
-    fi
-    if [[ "${reference%@*}" == */.github/workflows/*.yml ]] ||
-      [[ "${reference%@*}" == */.github/workflows/*.yaml ]]; then
-      if [[ ! "$version" =~ $documented_source ]] || [[ "$version" =~ ^[0-9a-f]{40}$ ]]; then
-        echo "$source_name: reusable workflow lacks a documented source ref: $payload" >&2
-        return 1
-      fi
-    elif [[ ! "$version" =~ $documented_release ]]; then
-      echo "$source_name: external action lacks an exact same-line release: $payload" >&2
-      return 1
-    fi
-  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' || true)
+  cat >"$fixture_path"
+  validate_action_definition_pins "$fixture_path" "$source_name"
 }
 
 immutable_action_fixture='jobs:
@@ -414,22 +398,61 @@ done
 
 documented_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3'
 if ! printf '%s\n' "$documented_release_fixture" |
-  validate_documented_action_release_pins "documented release fixture"; then
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "documented release fixture"; then
   echo "Documented action release validation must accept exact releases." >&2
   exit 1
 fi
 
 documented_workflow_source_fixture=$'jobs:\n  fixture:\n    uses: actions/example/.github/workflows/example.yml@0123456789abcdef0123456789abcdef01234567 # main'
 if ! printf '%s\n' "$documented_workflow_source_fixture" |
-  validate_documented_action_release_pins "documented workflow source fixture"; then
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "documented workflow source fixture"; then
   echo "Documented reusable workflow validation must accept source refs." >&2
   exit 1
 fi
 
 major_only_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1'
 if printf '%s\n' "$major_only_release_fixture" |
-  validate_documented_action_release_pins "major-only release fixture" 2>/dev/null; then
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "major-only release fixture" 2>/dev/null; then
   echo "Documented action release validation accepted a mutable major-only label." >&2
+  exit 1
+fi
+
+spaced_uses_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses : actions/example@0123456789abcdef0123456789abcdef01234567'
+if printf '%s\n' "$spaced_uses_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "spaced uses fixture" 2>/dev/null; then
+  echo "Documented action release validation ignored a spaced uses key without provenance." >&2
+  exit 1
+fi
+
+inline_uses_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - { name: Example, uses: actions/example@0123456789abcdef0123456789abcdef01234567 }'
+if printf '%s\n' "$inline_uses_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "inline uses fixture" 2>/dev/null; then
+  echo "Documented action release validation ignored an inline uses key without provenance." >&2
+  exit 1
+fi
+
+decoy_documentation_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    env:\n      uses: actions/example@0123456789abcdef0123456789abcdef01234567 # v1.2.3\n    steps:\n      - uses : actions/example@0123456789abcdef0123456789abcdef01234567'
+if printf '%s\n' "$decoy_documentation_fixture" |
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_documented_action_release_pins "decoy documentation fixture" 2>/dev/null; then
+  echo "Documented action release validation matched provenance from a different YAML location." >&2
+  exit 1
+fi
+
+mismatched_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@1111111111111111111111111111111111111111 # v1.2.3'
+if (
+  # shellcheck disable=SC2329 # The validation function invokes this provenance hook indirectly.
+  verify_action_release_pin() { return 1; }
+  VERIFY_ACTION_PIN_PROVENANCE=true \
+    validate_documented_action_release_pins \
+      "mismatched release fixture" <<<"$mismatched_release_fixture" 2>/dev/null
+); then
+  echo "Pinned action provenance validation accepted a SHA that was not verified against its documented release." >&2
   exit 1
 fi
 

--- a/tests/prettier-version-alignment.sh
+++ b/tests/prettier-version-alignment.sh
@@ -100,6 +100,28 @@ assert_quality_workflow_uses_package_lock_step() {
   fi
 }
 
+assert_preflight_installs_dependencies_before_pin_validators() {
+  local path="$1"
+  local npm_install_count npm_install_line android_validator_line dependabot_validator_line
+
+  npm_install_count="$(grep -Ec '^[[:space:]]+npm ci$' "$path" || true)"
+  npm_install_line="$(grep -nE '^[[:space:]]+npm ci$' "$path" | head -n 1 | cut -d: -f1 || true)"
+  android_validator_line="$(grep -nF 'bash tests/android-consumed-workflow-action-pins.sh' "$path" | head -n 1 | cut -d: -f1 || true)"
+  dependabot_validator_line="$(grep -nF 'bash tests/dependabot-auto-merge.sh' "$path" | head -n 1 | cut -d: -f1 || true)"
+
+  if [ "$npm_install_count" -ne 1 ] || [ -z "$npm_install_line" ] ||
+    [ -z "$android_validator_line" ] || [ -z "$dependabot_validator_line" ]; then
+    echo "Preflight must install locked Node dependencies exactly once and invoke both pin validators: $path" >&2
+    return 1
+  fi
+
+  if [ "$npm_install_line" -ge "$android_validator_line" ] ||
+    [ "$npm_install_line" -ge "$dependabot_validator_line" ]; then
+    echo "Preflight must install locked Node dependencies before invoking pin validators: $path" >&2
+    return 1
+  fi
+}
+
 check_alignment() {
   local expected_version="$1"
   local package_json_path="$2"
@@ -126,6 +148,7 @@ check_alignment() {
 
   assert_contains_expected_pin "$pre_commit_config_path" "$expected_version" ".pre-commit-config.yaml" || return 1
   assert_contains_expected_pin "$preflight_script_path" "$expected_version" "scripts/preflight.sh" || return 1
+  assert_preflight_installs_dependencies_before_pin_validators "$preflight_script_path" || return 1
   assert_quality_workflow_uses_package_lock_step "$quality_workflow_path" || return 1
 }
 
@@ -178,6 +201,39 @@ run_negative_scenario() {
   fi
 }
 
+run_dependency_order_negative_scenario() {
+  local scratch late_install_fixture output_file
+
+  scratch="$(mktemp -d "${TMPDIR:-/tmp}/preflight-dependency-order.XXXXXX")"
+  trap 'rm -rf "'"$scratch"'"' RETURN EXIT
+  late_install_fixture="$scratch/late-install-preflight.sh"
+  output_file="$scratch/negative-output.txt"
+
+  cat >"$late_install_fixture" <<'EOF'
+if [ -f tests/android-consumed-workflow-action-pins.sh ]; then
+  bash tests/android-consumed-workflow-action-pins.sh
+fi
+if [ -f tests/dependabot-auto-merge.sh ]; then
+  bash tests/dependabot-auto-merge.sh
+fi
+if [ -f package-lock.json ]; then
+  npm ci
+fi
+EOF
+
+  if assert_preflight_installs_dependencies_before_pin_validators \
+    "$late_install_fixture" >"$output_file" 2>&1; then
+    echo "Negative scenario failed: late dependency installation unexpectedly passed preflight ordering checks." >&2
+    return 1
+  fi
+
+  if ! grep -Fq 'Preflight must install locked Node dependencies before invoking pin validators' "$output_file"; then
+    echo "Negative scenario failed: late dependency installation did not produce the expected ordering message." >&2
+    cat "$output_file" >&2
+    return 1
+  fi
+}
+
 main() {
   local expected_version
   expected_version="$(extract_package_prettier_version "$PACKAGE_JSON_PATH")"
@@ -195,6 +251,8 @@ main() {
     "$PRE_COMMIT_CONFIG_PATH" \
     "$PREFLIGHT_SCRIPT_PATH" \
     "$QUALITY_WORKFLOW_PATH"
+
+  run_dependency_order_negative_scenario
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Point the Dependabot caller at the integrated workflow revision from #628.
- Validate the action references and exact release provenance in the pinned reusable-workflow snapshot, not only in the current checkout.
- Pin the retained composite action dependency and extend workflow policy coverage to composite action manifests.

## Problem and evidence

The Dependabot caller still referenced `480e66d1c9f287f9fbaa25a219c2cab8cadb6a83`. Although that revision was reachable from `main`, its reusable Dependabot workflow did not contain the exact release comments introduced by #628. The existing regression checked reachability and the current callee file, so it could not detect that the actually executed pinned snapshot was provenance-incomplete.

The retained `.github/actions/setup-node-with-deps/action.yml` also used mutable `actions/setup-node@v6`. Composite action manifests were outside both the focused instruction scope and the repository-wide pin validator.

## Changes

- Pin the Dependabot caller to merge commit `eb4001ca178929496be476e2639c4acf28111f8f`.
- Add positive and negative regression fixtures for documented action releases and reusable-workflow source refs.
- Load and validate the pinned reusable Dependabot workflow snapshot for immutable nested references and exact action release provenance.
- Pin `actions/setup-node` to the verified `v6.5.0` commit.
- Scan `.github/actions/**/action.yml` and `action.yaml` alongside workflow definitions.
- Apply the focused workflow and action instructions to composite action manifests.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/dependabot-auto-merge.sh` rejected the provenance-incomplete pinned callee, and `bash tests/android-consumed-workflow-action-pins.sh` rejected `actions/setup-node@v6` in the composite action.
- Passing proof after implementation: `bash tests/dependabot-auto-merge.sh`; `bash tests/android-consumed-workflow-action-pins.sh`; `VERIFY_ACTION_PIN_PROVENANCE=true bash tests/android-consumed-workflow-action-pins.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `bash tests/dependabot-auto-merge.sh`
- `bash tests/android-consumed-workflow-action-pins.sh`
- `VERIFY_ACTION_PIN_PROVENANCE=true bash tests/android-consumed-workflow-action-pins.sh`
- `shellcheck tests/android-consumed-workflow-action-pins.sh tests/dependabot-auto-merge.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `bash scripts/preflight.sh`
- Commit hooks: REUSE, Prettier, markdownlint, yamllint, actionlint, ShellCheck, YAML validation, large-file and conflict checks

## Readiness

No in-scope dependency or unresolved local check prevents review.

Follow-up to #628.