### PR TITLE
Expose failed validation command details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-07 - Expose Failed Review Validation Entries
+
+**Fixed:**
+
+- made failed registered review validation report the command's one-based
+  registry index, purpose, and safe failure category while retaining terminal
+  receipt invalidation, discarded command output, single execution, no retry,
+  and no-shell process isolation
+- added unit and subprocess integration coverage for non-zero exits, timeouts,
+  unavailable executables, secret-like command output, and later-command
+  suppression
+
+---
+
 ## 2026-08-07 - Install Locked Workflow Validation Dependencies First
 
 **Fixed:**

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -212,6 +212,13 @@ python3 scripts/secpal-resolve-fixed-threads.py \
   --apply
 ```
 
+If a registered command fails during the complete validation run, the terminal
+JSON diagnostic includes `registered_validation_failure` with the command's
+one-based `index`, registry `purpose`, and a safe `category` such as
+`non-zero exit`, `timeout`, or `unavailable executable`. The helper still
+discards the command's stdout and stderr, leaves only the invalidated receipt
+placeholder, and does not run later commands or retry the failed command.
+
 `manual-gates.json` is an ordered JSON array with exactly one
 `{"gate": REGISTRY_TEXT, "satisfied": true, "evidence": CONCISE_PROOF}` object
 per registered gate. Evidence containing a token prefix, bearer authorization,

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -1222,6 +1222,12 @@ def _run_registered_validations(
                     command["purpose"],
                     "unsafe working directory",
                 )
+            if not working_directory.is_dir():
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "unavailable working directory",
+                )
             try:
                 executable = _validation_executable(
                     command, working_directory, repository_root

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -269,6 +269,54 @@ class RegistryError(ValueError):
     """The production registry is invalid or does not support a repository."""
 
 
+class RegisteredValidationResult:
+    """Secret-safe outcome of one complete registered-validation run."""
+
+    def __init__(
+        self,
+        failure_index: int | None = None,
+        failure_purpose: str | None = None,
+        failure_category: str | None = None,
+    ) -> None:
+        self.failure_index = failure_index
+        self.failure_purpose = (
+            evidence.redact_diagnostic(failure_purpose)
+            if failure_purpose is not None
+            else None
+        )
+        self.failure_category = failure_category
+
+    def __bool__(self) -> bool:
+        return self.failure_category is None
+
+    def failure_report(self) -> dict[str, Any] | None:
+        if (
+            self.failure_index is None
+            or self.failure_purpose is None
+            or self.failure_category is None
+        ):
+            return None
+        return {
+            "index": self.failure_index,
+            "purpose": self.failure_purpose,
+            "category": self.failure_category,
+        }
+
+
+class RegisteredValidationFailure(fast_path.SecurityBlocker):
+    """A registered command failed with an actionable secret-safe identity."""
+
+    def __init__(self, result: RegisteredValidationResult) -> None:
+        report = result.failure_report()
+        if report is None:
+            raise ValueError("registered validation failure details are incomplete")
+        self.report = report
+        super().__init__(
+            "complete registered validation failed at "
+            f"entry {report['index']} ({report['purpose']}): {report['category']}"
+        )
+
+
 class MutationBlocked(RuntimeError):
     """Current GitHub or remediation evidence blocks the intended mutation."""
 
@@ -1107,19 +1155,23 @@ def _complete_validation_commands(
 
 def _run_registered_validations(
     repository: dict[str, Any], repository_root: Path
-) -> bool:
-    """Run unconditional validation once, without a shell or diagnostic output."""
+) -> RegisteredValidationResult:
+    """Run unconditional validation once without a shell or command output."""
 
     repository_root = repository_root.resolve()
     if not repository_root.is_dir():
-        return False
+        return RegisteredValidationResult(
+            failure_category="validation root unavailable"
+        )
     commands = _complete_validation_commands(repository)
     try:
         validation_home = tempfile.TemporaryDirectory(
             prefix="secpal-pr-review-validation-"
         )
     except OSError:
-        return False
+        return RegisteredValidationResult(
+            failure_category="validation environment unavailable"
+        )
     with validation_home:
         sandbox = Path(validation_home.name)
         environment = {
@@ -1149,20 +1201,38 @@ def _run_registered_validations(
             "XDG_CONFIG_HOME": str(sandbox / ".config"),
             "XDG_DATA_HOME": str(sandbox / ".local/share"),
         }
-        for command in commands:
+        for index, command in enumerate(commands, start=1):
             _validate_command(command)
-            working_directory = (
-                repository_root / command["working_directory"]
-            ).resolve()
+            try:
+                working_directory = (
+                    repository_root / command["working_directory"]
+                ).resolve()
+            except (OSError, RuntimeError):
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "unavailable working directory",
+                )
             if (
                 working_directory != repository_root
                 and repository_root not in working_directory.parents
             ):
-                return False
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "unsafe working directory",
+                )
             try:
                 executable = _validation_executable(
                     command, working_directory, repository_root
                 )
+            except RegistryError:
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "unavailable executable",
+                )
+            try:
                 completed = subprocess.run(
                     [executable, *command["argv"][1:]],
                     cwd=working_directory,
@@ -1173,11 +1243,25 @@ def _run_registered_validations(
                     check=False,
                     timeout=LOCAL_VALIDATION_TIMEOUT_SECONDS,
                 )
-            except (OSError, subprocess.TimeoutExpired, RegistryError):
-                return False
+            except subprocess.TimeoutExpired:
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "timeout",
+                )
+            except OSError:
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "execution error",
+                )
             if completed.returncode != 0:
-                return False
-    return True
+                return RegisteredValidationResult(
+                    index,
+                    command["purpose"],
+                    "non-zero exit",
+                )
+    return RegisteredValidationResult()
 
 
 FAST_PATH_PREFLIGHT_QUERY = r"""
@@ -3827,9 +3911,14 @@ def build_resolution_evidence(
             if registered is None:
                 raise RegistryError("repository has no validated registry entry")
             runner = validation_runner or _run_registered_validations
-            result["registered_validation_verified"] = runner(
+            validation_result = runner(
                 registered, Path(local["repository_root"])
-            ) is True
+            )
+            result["registered_validation_verified"] = (
+                bool(validation_result)
+                if isinstance(validation_result, RegisteredValidationResult)
+                else validation_result is True
+            )
         except (OSError, RegistryError):
             result["registered_validation_verified"] = False
     if result["registered_validation_verified"]:
@@ -4342,7 +4431,13 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
                 "validated_tree_sha": tree,
             },
         )
-    if not _run_registered_validations(entry, repository_root):
+    validation_result = _run_registered_validations(entry, repository_root)
+    if not validation_result:
+        if (
+            isinstance(validation_result, RegisteredValidationResult)
+            and validation_result.failure_report() is not None
+        ):
+            raise RegisteredValidationFailure(validation_result)
         raise fast_path.SecurityBlocker("complete registered validation failed")
     head_after, status_after = _attestation_local_state(repository_root, arguments.repo)
     tree_after = _staged_tree(repository_root, status_after)
@@ -4458,6 +4553,8 @@ def main(argv: list[str] | None = None) -> int:
             "blocker": evidence.redact_diagnostic(str(exc)),
             "retry_performed": False,
         }
+        if isinstance(exc, RegisteredValidationFailure):
+            report["registered_validation_failure"] = exc.report
         print(canonical_json_bytes(report).decode("utf-8"), file=sys.stderr, end="")
         return 3
     except MutationFailure as exc:

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3964,6 +3964,102 @@ class RegistryTests(TestCase):
                 },
             )
 
+    def test_registered_validation_nonzero_exit_identifies_the_exact_entry(self) -> None:
+        repository = registry_entry("SecPal/.github")
+        completed = [
+            SimpleNamespace(returncode=0),
+            SimpleNamespace(
+                returncode=17,
+                stdout="token=github_pat_command_output_must_not_leak",
+                stderr="secret=command-output-must-not-leak",
+            ),
+        ]
+        with (
+            mock.patch.object(
+                actions,
+                "_validation_executable",
+                return_value="/usr/bin/true",
+            ),
+            mock.patch.object(
+                actions.subprocess,
+                "run",
+                side_effect=completed,
+            ) as run,
+        ):
+            result = actions._run_registered_validations(repository, REPO_ROOT)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "non-zero exit",
+                "index": 2,
+                "purpose": "Run lint",
+            },
+        )
+        self.assertNotIn("command-output", str(result.failure_report()))
+        self.assertEqual(run.call_count, 2)
+
+    def test_registered_validation_timeout_reports_no_command_output(self) -> None:
+        repository = registry_entry("SecPal/.github")
+        timeout = actions.subprocess.TimeoutExpired(
+            ["npm", "run", "test"],
+            30,
+            output="github_pat_timeout_output_must_not_leak",
+            stderr="secret=timeout-output-must-not-leak",
+        )
+        with (
+            mock.patch.object(
+                actions,
+                "_validation_executable",
+                return_value="/usr/bin/true",
+            ),
+            mock.patch.object(
+                actions.subprocess,
+                "run",
+                side_effect=timeout,
+            ) as run,
+        ):
+            result = actions._run_registered_validations(repository, REPO_ROOT)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "timeout",
+                "index": 1,
+                "purpose": "Run tests",
+            },
+        )
+        self.assertNotIn("timeout-output", str(result.failure_report()))
+        self.assertEqual(run.call_count, 1)
+
+    def test_registered_validation_unavailable_executable_is_actionable(self) -> None:
+        repository = registry_entry("SecPal/.github")
+        with (
+            mock.patch.object(
+                actions,
+                "_validation_executable",
+                side_effect=actions.RegistryError(
+                    "unavailable secret=resolution-detail-must-not-leak"
+                ),
+            ),
+            mock.patch.object(actions.subprocess, "run") as run,
+        ):
+            result = actions._run_registered_validations(repository, REPO_ROOT)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "unavailable executable",
+                "index": 1,
+                "purpose": "Run tests",
+            },
+        )
+        self.assertNotIn("resolution-detail", str(result.failure_report()))
+        run.assert_not_called()
+
     def test_complete_validation_excludes_focused_only_commands(self) -> None:
         repository = actions.select_repository(
             actions.load_registry(), "SecPal/frontend"
@@ -5349,6 +5445,87 @@ class FastPathTests(TestCase):
                 ):
                     actions._command_attest_validation(arguments)
 
+            self.assertEqual(
+                json.loads(output.read_text(encoding="utf-8")),
+                {
+                    "schema_version": "1.0",
+                    "status": "VALIDATION_RECEIPT_INVALIDATED",
+                    "head_sha": p21.HEAD,
+                    "validated_tree_sha": "a" * 40,
+                },
+            )
+
+    def test_attestation_cli_reports_failed_entry_without_output_or_retry(self) -> None:
+        entry = registry_entry("SecPal/.github")
+        entry["manual_gates"] = []
+        completed = SimpleNamespace(
+            returncode=9,
+            stdout="github_pat_cli_output_must_not_leak",
+            stderr="secret=cli-output-must-not-leak",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "receipt.json"
+            error_output = io.StringIO()
+            with (
+                mock.patch.object(
+                    actions,
+                    "_attestation_local_state",
+                    return_value=(p21.HEAD, ""),
+                ),
+                mock.patch.object(
+                    actions,
+                    "_load_fast_state",
+                    return_value=fast_feedback(),
+                ),
+                mock.patch.object(actions, "load_registry", return_value={}),
+                mock.patch.object(actions, "select_repository", return_value=entry),
+                mock.patch.object(actions, "_staged_tree", return_value="a" * 40),
+                mock.patch.object(
+                    actions,
+                    "_validation_executable",
+                    return_value="/usr/bin/true",
+                ),
+                mock.patch.object(
+                    actions.subprocess,
+                    "run",
+                    return_value=completed,
+                ) as run,
+                mock.patch.object(actions.sys, "stderr", error_output),
+            ):
+                returncode = actions.main(
+                    [
+                        "attest-validation",
+                        "--repo",
+                        "SecPal/.github",
+                        "--expected-head",
+                        p21.HEAD,
+                        "--reviewed-state",
+                        "reviewed.json",
+                        "--repo-root",
+                        str(REPO_ROOT),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            diagnostic_text = error_output.getvalue()
+            diagnostic = json.loads(diagnostic_text)
+            self.assertEqual(returncode, 3)
+            self.assertEqual(diagnostic["status"], "BLOCKED_SECURITY")
+            self.assertFalse(diagnostic["retry_performed"])
+            self.assertEqual(
+                diagnostic["registered_validation_failure"],
+                {
+                    "category": "non-zero exit",
+                    "index": 1,
+                    "purpose": "Run tests",
+                },
+            )
+            self.assertNotIn("cli-output", diagnostic_text)
+            self.assertNotIn("github_pat_", diagnostic_text)
+            self.assertEqual(run.call_count, 1)
+            self.assertIsInstance(run.call_args.args[0], list)
+            self.assertNotIn("shell", run.call_args.kwargs)
             self.assertEqual(
                 json.loads(output.read_text(encoding="utf-8")),
                 {

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -4060,6 +4060,114 @@ class RegistryTests(TestCase):
         self.assertNotIn("resolution-detail", str(result.failure_report()))
         run.assert_not_called()
 
+    def test_registered_validation_unavailable_working_directory_is_actionable(
+        self,
+    ) -> None:
+        repository = registry_entry("SecPal/.github")
+        repository["focused_validation"] = []
+        repository["required_local_validation"] = [
+            {
+                "argv": ["npm", "run", "test"],
+                "working_directory": "missing",
+                "purpose": "Run tests",
+            }
+        ]
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            mock.patch.object(actions, "_validation_executable") as executable,
+            mock.patch.object(actions.subprocess, "run") as run,
+        ):
+            result = actions._run_registered_validations(
+                repository,
+                Path(temporary_directory),
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "unavailable working directory",
+                "index": 1,
+                "purpose": "Run tests",
+            },
+        )
+        executable.assert_not_called()
+        run.assert_not_called()
+
+    def test_registered_validation_unsafe_working_directory_stays_blocked(
+        self,
+    ) -> None:
+        repository = registry_entry("SecPal/.github")
+        repository["focused_validation"] = []
+        repository["required_local_validation"] = [
+            {
+                "argv": ["npm", "run", "test"],
+                "working_directory": "linked-outside",
+                "purpose": "Run tests",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            repository_root = temporary / "repository"
+            outside = temporary / "outside"
+            repository_root.mkdir()
+            outside.mkdir()
+            (repository_root / "linked-outside").symlink_to(
+                outside,
+                target_is_directory=True,
+            )
+            with (
+                mock.patch.object(actions, "_validation_executable") as executable,
+                mock.patch.object(actions.subprocess, "run") as run,
+            ):
+                result = actions._run_registered_validations(
+                    repository,
+                    repository_root,
+                )
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "unsafe working directory",
+                "index": 1,
+                "purpose": "Run tests",
+            },
+        )
+        executable.assert_not_called()
+        run.assert_not_called()
+
+    def test_registered_validation_execution_error_discards_details_and_stops(
+        self,
+    ) -> None:
+        repository = registry_entry("SecPal/.github")
+        execution_error = OSError("secret=execution-detail-must-not-leak")
+        with (
+            mock.patch.object(
+                actions,
+                "_validation_executable",
+                return_value="/usr/bin/true",
+            ),
+            mock.patch.object(
+                actions.subprocess,
+                "run",
+                side_effect=execution_error,
+            ) as run,
+        ):
+            result = actions._run_registered_validations(repository, REPO_ROOT)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            result.failure_report(),
+            {
+                "category": "execution error",
+                "index": 1,
+                "purpose": "Run tests",
+            },
+        )
+        self.assertNotIn("execution-detail", str(result.failure_report()))
+        self.assertEqual(run.call_count, 1)
+
     def test_complete_validation_excludes_focused_only_commands(self) -> None:
         repository = actions.select_repository(
             actions.load_registry(), "SecPal/frontend"

--- a/tests/secpal-pr-review-skill-integration.sh
+++ b/tests/secpal-pr-review-skill-integration.sh
@@ -189,6 +189,126 @@ assert calls[4][calls[4].index("--method") + 1] == "POST"
 assert calls[4][3] == "repos/SecPal/.github/pulls/comments/21/reactions"
 PY
 
+# A failed complete validation identifies the exact registered entry while
+# keeping command output secret, invalidating the receipt, and stopping once.
+validation_repo="$workspace/validation-repository"
+mkdir -p "$validation_repo"
+git -C "$validation_repo" init -q -b main
+git -C "$validation_repo" config user.name "SecPal Integration Fixture"
+git -C "$validation_repo" config user.email "fixture@secpal.dev"
+git -C "$validation_repo" remote add origin https://github.com/SecPal/.github.git
+printf '#!/bin/sh\nprintf "first\\n" >>"%s"\nprintf "secret=integration-command-output-must-not-leak\\n" >&2\nexit 9\n' \
+  "$workspace/validation-runs.log" >"$validation_repo/validation-fail.sh"
+printf '#!/bin/sh\nprintf "second\\n" >>"%s"\n' \
+  "$workspace/validation-runs.log" >"$validation_repo/validation-must-not-run.sh"
+chmod 0700 \
+  "$validation_repo/validation-fail.sh" \
+  "$validation_repo/validation-must-not-run.sh"
+git -C "$validation_repo" add validation-fail.sh validation-must-not-run.sh
+git -C "$validation_repo" -c commit.gpgsign=false commit -q -m "test: add validation fixtures"
+validation_head="$(git -C "$validation_repo" rev-parse HEAD)"
+
+python3 - "$ACTIONS" "$workspace" "$validation_head" <<'PY'
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+helper = Path(sys.argv[1])
+workspace = Path(sys.argv[2])
+head = sys.argv[3]
+spec = importlib.util.spec_from_file_location("validation_actions_fixture", helper)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+entry = module.select_repository(module.load_registry(), "SecPal/.github")
+entry["focused_validation"] = []
+entry["required_local_validation"] = [
+    {
+        "argv": ["./validation-fail.sh"],
+        "working_directory": ".",
+        "purpose": "Run integration failure probe",
+    },
+    {
+        "argv": ["./validation-must-not-run.sh"],
+        "working_directory": ".",
+        "purpose": "Reject validation retries",
+    },
+]
+entry["manual_gates"] = []
+(workspace / "validation-registry.json").write_text(
+    json.dumps(
+        {"schema_version": "1.0", "repositories": [entry]},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    + "\n",
+    encoding="utf-8",
+)
+reviewed = module.fast_path.StableFeedbackState.from_payload(
+    {
+        "repository": "SecPal/.github",
+        "pull_request_number": 1,
+        "head_sha": head,
+        "base_ref": "main",
+        "base_sha": "b" * 40,
+        "pr_state": "OPEN",
+        "pull_request_reactions": [],
+        "reviews": [],
+        "conversation_comments": [],
+        "threads": [],
+    }
+)
+(workspace / "validation-reviewed.json").write_text(
+    json.dumps(reviewed.to_dict(), sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$ACTIONS" attest-validation \
+  --repo SecPal/.github \
+  --expected-head "$validation_head" \
+  --reviewed-state "$workspace/validation-reviewed.json" \
+  --repo-root "$validation_repo" \
+  --registry "$workspace/validation-registry.json" \
+  --output "$workspace/validation-receipt.json" \
+  2>"$workspace/validation-diagnostic.json"
+validation_status=$?
+set -e
+test "$validation_status" -eq 3
+
+python3 - \
+  "$workspace/validation-diagnostic.json" \
+  "$workspace/validation-receipt.json" \
+  "$workspace/validation-runs.log" \
+  "$validation_head" <<'PY'
+import json
+import sys
+
+diagnostic_text = open(sys.argv[1], encoding="utf-8").read()
+diagnostic = json.loads(diagnostic_text)
+receipt = json.load(open(sys.argv[2], encoding="utf-8"))
+runs = open(sys.argv[3], encoding="utf-8").read().splitlines()
+assert diagnostic["status"] == "BLOCKED_SECURITY", diagnostic
+assert diagnostic["retry_performed"] is False, diagnostic
+assert diagnostic["registered_validation_failure"] == {
+    "category": "non-zero exit",
+    "index": 1,
+    "purpose": "Run integration failure probe",
+}, diagnostic
+assert "integration-command-output" not in diagnostic_text, diagnostic_text
+assert "secret=" not in diagnostic_text, diagnostic_text
+assert runs == ["first"], runs
+assert receipt == {
+    "head_sha": sys.argv[4],
+    "schema_version": "1.0",
+    "status": "VALIDATION_RECEIPT_INVALIDATED",
+    "validated_tree_sha": receipt["validated_tree_sha"],
+}, receipt
+PY
+
 # Installer fixtures 70-79: clean install, idempotency, correct link, wrong-link
 # refusal/repair, non-link refusal, parent creation, missing source, direct link,
 # sibling-style user discovery and isolated user configuration.


### PR DESCRIPTION
## Problem

The complete validation pass used by `attest-validation` discarded both stdout and stderr and returned only a boolean. When a registered validation failed, the terminal report therefore exposed only `complete registered validation failed` and left a `VALIDATION_RECEIPT_INVALIDATED` placeholder.

This blocked safe recovery in SecPal/contracts PR #433: two fresh remediation invocations against reviewed head `486571ef9722f60b5e310ed5803ccaa442d5d72e` and staged tree `c2ec7b83b0d064d9a4602b055f19e1e68b13fc98` could not identify whether the failing entry was a test, repository validator, executable-resolution failure, or timeout. The workflow contract prohibited rerunning the complete validation after that terminal result.

## Change

- return a secret-safe registered-validation result that records the one-based entry index, redacted registry purpose, and fixed failure category
- expose that information in the terminal `registered_validation_failure` object while retaining the existing security blocker
- preserve receipt invalidation, discarded command output, no-shell execution, single execution, no retry, and suppression of later commands
- document the operator-facing diagnostic and record the governance contract change
- add unit coverage for non-zero exit, timeout, and unavailable executable failures
- add a real subprocess integration fixture proving that secret-like output does not leak and that later commands do not run

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py` failed with four errors because registered validation returned only a boolean and the terminal report lacked the failed-entry diagnostic.
- Passing proof after implementation: `python3 -m unittest tests/secpal-pr-review-actions-unit.py` passes all 185 tests, and `bash tests/secpal-pr-review-skill-integration.sh` passes the real subprocess failure fixture.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `python3 -m unittest tests/secpal-pr-review-actions-unit.py` — 185 tests passed
- `python3 -m unittest tests/secpal-pr-review-unit.py tests/secpal-resolve-fixed-threads-unit.py` — 224 tests passed
- `bash tests/secpal-pr-review-skill-policy.sh`
- `bash tests/secpal-pr-review-skill-integration.sh`
- `bash tests/secpal-pr-review-integration.sh`
- `bash tests/review-governance-suite.sh`
- `bash tests/reusable-workflow-policy.sh`
- `npm run lint:markdown`
- `npx prettier@3.5.3 --check CHANGELOG.md docs/secpal-pr-review-workflow.md`
- `./scripts/preflight.sh --reuse-tracked-only`
- `git diff --check`
- commit hooks: REUSE, Prettier, markdownlint, shellcheck, conflict, YAML, EOF, whitespace, line-ending, and protected-branch checks passed

## Readiness

No known in-scope dependency or unresolved local check prevents review readiness. Hosted validation must confirm this PR description.

Closes #633
