### PR TITLE
Harden Copilot reusable workflow provenance

### DIFF
--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: GitHub Workflow and Action Rules
 description: Applies focused security and validation criteria to GitHub automation.
-applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/actions/**/action.yml,.github/actions/**/action.yaml,.github/dependabot.yml,.github/dependabot.yaml,workflow-templates/**/*.yml,workflow-templates/**/*.yaml,EXAMPLE_workflow_for_other_repos.yml,tests/*workflow*.sh,tests/dependabot-auto-merge.sh,tests/codeql-applicability.sh,tests/copilot-review-memory*.sh,tests/license-compatibility.sh,tests/prettier-version-alignment.sh,tests/project-automation-core.sh,tests/pull-request-*.sh,tests/reusable-markdown-lint-scope.sh"
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/actions/**/action.yml,.github/actions/**/action.yaml,.github/dependabot.yml,.github/dependabot.yaml,workflow-templates/**/*.yml,workflow-templates/**/*.yaml,EXAMPLE_workflow_for_other_repos.yml,tests/*workflow*.sh,tests/dependabot-auto-merge.sh,tests/codeql-applicability.sh,tests/copilot-review-memory*.sh,tests/license-compatibility.sh,tests/prettier-version-alignment.sh,tests/project-automation-core.sh,tests/pull-request-*.sh,tests/reusable-copilot-instructions-provenance.sh,tests/reusable-markdown-lint-scope.sh"
 ---
 
 # GitHub Workflow and Action Review Rules

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -52,6 +52,7 @@ jobs:
           VERIFY_ACTION_PIN_PROVENANCE: "true"
         run: |
           bash tests/android-consumed-workflow-action-pins.sh
+          bash tests/reusable-copilot-instructions-provenance.sh
           bash tests/dependabot-auto-merge.sh
 
   pr-review-workflow:

--- a/.github/workflows/reusable-copilot-instructions.yml
+++ b/.github/workflows/reusable-copilot-instructions.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Checkout governance repository
-        if: ${{ github.repository != 'SecPal/.github' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
@@ -46,26 +45,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install governance Node dependencies
+        working-directory: .secpal-governance
         run: |
-          if [ "${{ github.repository }}" = "SecPal/.github" ]; then
-            npm ci
-            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          else
-            cd .secpal-governance
-            npm ci
-            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-          fi
-
-      - name: Select validator path
-        id: validator
-        run: |
-          if [ "${{ github.repository }}" = "SecPal/.github" ]; then
-            echo "path=./scripts/validate-copilot-instructions.sh" >> "$GITHUB_OUTPUT"
-          else
-            echo "path=./.secpal-governance/scripts/validate-copilot-instructions.sh" >> "$GITHUB_OUTPUT"
-          fi
+          npm ci
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Run validation script
         env:
-          VALIDATOR_PATH: ${{ steps.validator.outputs.path }}
+          VALIDATOR_PATH: ./.secpal-governance/scripts/validate-copilot-instructions.sh
         run: "$VALIDATOR_PATH"

--- a/.github/workflows/reusable-copilot-instructions.yml
+++ b/.github/workflows/reusable-copilot-instructions.yml
@@ -9,10 +9,8 @@ on:
     inputs:
       governance-ref:
         description: >
-          Ref of SecPal/.github to use when validating sibling repositories.
-          Defaults to 'main' (always tracks the latest governance HEAD). Pin to a
-          specific commit SHA for reproducible, supply-chain-safe runs, because this
-          ref controls the validator script and lint binary — not just configuration.
+          Deprecated compatibility input. Governance files are always loaded
+          from the immutable revision of this called workflow.
         required: false
         type: string
         default: "main"
@@ -38,8 +36,8 @@ jobs:
         if: ${{ github.repository != 'SecPal/.github' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: SecPal/.github
-          ref: ${{ inputs.governance-ref }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           path: .secpal-governance
 
       - name: Setup Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-07 - Harden Copilot Reusable Workflow Provenance
+
+**Security:**
+
+- bound the Copilot governance checkout to the immutable repository and commit
+  selected for the called workflow, retaining `governance-ref` only as a
+  deprecated compatibility input
+- added positive and negative regression coverage for immutable governance
+  checkout and external-action pin invariants
+
+---
+
 ## 2026-08-07 - Expose Failed Review Validation Entries
 
 **Fixed:**

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -168,6 +168,15 @@ if [ -f tests/reusable-workflow-policy.sh ]; then
   }
 fi
 
+if [ -f tests/reusable-copilot-instructions-provenance.sh ]; then
+  bash tests/reusable-copilot-instructions-provenance.sh || {
+    echo "" >&2
+    echo "❌ Reusable Copilot workflow provenance regression test failed!" >&2
+    echo "Bind governance code to the called workflow revision and pin every external action." >&2
+    exit 1
+  }
+fi
+
 if [ -f tests/android-consumed-workflow-action-pins.sh ]; then
   bash tests/android-consumed-workflow-action-pins.sh || {
     echo "" >&2

--- a/tests/dependabot-auto-merge.sh
+++ b/tests/dependabot-auto-merge.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=tests/android-consumed-workflow-action-pins.sh
+# shellcheck disable=SC1091 # Source path is resolved through SCRIPT_DIR at runtime.
 source "$SCRIPT_DIR/android-consumed-workflow-action-pins.sh"
 CALLER_WORKFLOW="$REPO_ROOT/.github/workflows/dependabot-auto-merge.yml"
 REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/reusable-dependabot-auto-merge.yml"
@@ -117,6 +118,7 @@ for direct_fixture in \
   tests/pull-request-commit-signatures.sh \
   tests/pull-request-english.sh \
   tests/pull-request-evidence.sh \
+  tests/reusable-copilot-instructions-provenance.sh \
   tests/reusable-markdown-lint-scope.sh \
   tests/reusable-workflow-policy.sh \
   tests/reusable-workflow-timeouts.sh; do
@@ -252,13 +254,15 @@ awk '
   in_step && /^      - name:/ { in_step = 0 }
   in_step && /^          VERIFY_ACTION_PIN_PROVENANCE: "true"$/ { verifies_provenance = 1 }
   in_step && /^          bash tests\/android-consumed-workflow-action-pins\.sh$/ { validates_working_tree = 1 }
+  in_step && /^          bash tests\/reusable-copilot-instructions-provenance\.sh$/ { validates_copilot_provenance = 1 }
   in_step && /^          bash tests\/dependabot-auto-merge\.sh$/ { validates_pinned_snapshot = 1 }
   END {
     exit !(sets_up_node && installs_dependencies && uses_lockfile &&
-      verifies_provenance && validates_working_tree && validates_pinned_snapshot)
+      verifies_provenance && validates_working_tree && validates_copilot_provenance &&
+      validates_pinned_snapshot)
   }
 ' "$QUALITY_WORKFLOW" || {
-  echo "Workflow pin validation must install locked Node dependencies and verify both the working tree and pinned Dependabot snapshot with live provenance enabled." >&2
+  echo "Workflow pin validation must install locked Node dependencies and verify action pins, Copilot provenance, and the pinned Dependabot snapshot with live provenance enabled." >&2
   exit 1
 }
 # The reusable workflow's check-eligibility and skip-auto-merge jobs must also
@@ -427,6 +431,7 @@ printf '{}\n'
 EOF
 chmod +x "$fake_parser_bin/npx"
 rejects_unlocked_action_parser() {
+  # shellcheck disable=SC2034 # The sourced helper reads this dynamically scoped value.
   local repo_root="$unlocked_fixture_root"
   local PATH="$fake_parser_bin:$PATH"
 
@@ -513,7 +518,7 @@ fi
 
 mismatched_release_fixture=$'jobs:\n  fixture:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/example@1111111111111111111111111111111111111111 # v1.2.3'
 if (
-  # shellcheck disable=SC2329 # The validation function invokes this provenance hook indirectly.
+  # shellcheck disable=SC2317,SC2329 # The validation function invokes this provenance hook indirectly.
   verify_action_release_pin() { return 1; }
   VERIFY_ACTION_PIN_PROVENANCE=true \
     validate_documented_action_release_pins \

--- a/tests/reusable-copilot-instructions-provenance.sh
+++ b/tests/reusable-copilot-instructions-provenance.sh
@@ -6,22 +6,66 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 workflow_path="$repo_root/.github/workflows/reusable-copilot-instructions.yml"
+# shellcheck source=tests/android-consumed-workflow-action-pins.sh
+# shellcheck disable=SC1091 # Source path is resolved through repo_root at runtime.
+source "$repo_root/tests/android-consumed-workflow-action-pins.sh"
 
 assert_immutable_provenance() {
   local path="$1"
-  local uses_count pinned_uses_count
 
-  grep -Fqx '      governance-ref:' "$path" || return 1
-  grep -Fq 'Deprecated compatibility input.' "$path" || return 1
-  if grep -Fq "ref: \${{ inputs.governance-ref }}" "$path"; then
-    return 1
-  fi
-  grep -Fqx "          repository: \${{ fromJSON(toJSON(job)).workflow_repository }}" "$path" || return 1
-  grep -Fqx "          ref: \${{ fromJSON(toJSON(job)).workflow_sha }}" "$path" || return 1
+  node - "$repo_root" "$path" <<'NODE' || return 1
+const fs = require("node:fs");
+const path = require("node:path");
+const repoRoot = process.argv[2];
+const workflowPath = process.argv[3];
+const yaml = require(path.join(repoRoot, "node_modules/js-yaml"));
+const workflow = yaml.load(fs.readFileSync(workflowPath, "utf8"));
+const compatibilityInput = workflow?.on?.workflow_call?.inputs?.["governance-ref"];
 
-  uses_count="$(grep -Ec '^[[:space:]]+uses:[[:space:]]+' "$path")"
-  pinned_uses_count="$(grep -Ec '^[[:space:]]+uses:[[:space:]]+[^@[:space:]]+@[0-9a-f]{40}[[:space:]]+#[[:space:]]+v[0-9]+([.][0-9]+){2}([-.+][A-Za-z0-9.-]+)?$' "$path")"
-  [ "$uses_count" -gt 0 ] && [ "$uses_count" -eq "$pinned_uses_count" ] || return 1
+if (!compatibilityInput ||
+    !compatibilityInput.description?.includes("Deprecated compatibility input.")) {
+  process.exit(1);
+}
+
+const validateSteps = workflow?.jobs?.validate?.steps || [];
+if (JSON.stringify(workflow?.jobs || {}).includes("governance-ref")) process.exit(1);
+
+const governanceCheckouts = validateSteps.filter(
+  (step) => step?.with?.path === ".secpal-governance",
+);
+if (governanceCheckouts.length !== 1) process.exit(1);
+
+const governanceCheckout = governanceCheckouts[0];
+if (Object.hasOwn(governanceCheckout, "if")) process.exit(1);
+if (!/^actions\/checkout@[0-9a-f]{40}$/.test(governanceCheckout.uses)) process.exit(1);
+if (governanceCheckout.with.repository !==
+    "${{ fromJSON(toJSON(job)).workflow_repository }}") process.exit(1);
+if (governanceCheckout.with.ref !==
+    "${{ fromJSON(toJSON(job)).workflow_sha }}") process.exit(1);
+
+const dependencySteps = validateSteps.filter(
+  (step) => step?.name === "Install governance Node dependencies",
+);
+if (dependencySteps.length !== 1) process.exit(1);
+const dependencyStep = dependencySteps[0];
+if (Object.hasOwn(dependencyStep, "if")) process.exit(1);
+if (dependencyStep["working-directory"] !== ".secpal-governance") process.exit(1);
+if (!dependencyStep.run?.includes("npm ci") ||
+    !dependencyStep.run?.includes('$PWD/node_modules/.bin')) process.exit(1);
+
+const validatorSteps = validateSteps.filter(
+  (step) => step?.name === "Run validation script",
+);
+if (validatorSteps.length !== 1) process.exit(1);
+const validatorStep = validatorSteps[0];
+if (Object.hasOwn(validatorStep, "if")) process.exit(1);
+if (validatorStep.env?.VALIDATOR_PATH !==
+    "./.secpal-governance/scripts/validate-copilot-instructions.sh") process.exit(1);
+if (validatorStep.run !== "$VALIDATOR_PATH") process.exit(1);
+NODE
+
+  VERIFY_ACTION_PIN_PROVENANCE=false \
+    validate_action_definition_pins "$path" "${path#"$repo_root"/}"
 }
 
 assert_immutable_provenance "$workflow_path"
@@ -39,21 +83,79 @@ assert_rejected() {
   fi
 }
 
+replace_once() {
+  local path="$1"
+  local expected="$2"
+  local replacement="$3"
+
+  node - "$path" "$expected" "$replacement" <<'NODE'
+const fs = require("node:fs");
+const path = process.argv[2];
+const expected = process.argv[3];
+const replacement = process.argv[4];
+const source = fs.readFileSync(path, "utf8");
+const first = source.indexOf(expected);
+if (first === -1 || source.indexOf(expected, first + expected.length) !== -1) {
+  process.exit(1);
+}
+fs.writeFileSync(path, source.slice(0, first) + replacement + source.slice(first + expected.length));
+NODE
+}
+
+same_repository_skip_fixture="$workspace/same-repository-skip.yml"
+cp "$workflow_path" "$same_repository_skip_fixture"
+replace_once "$same_repository_skip_fixture" \
+  $'      - name: Checkout governance repository\n        uses:' \
+  $'      - name: Checkout governance repository\n        if: ${{ github.repository != '\''SecPal/.github'\'' }}\n        uses:'
+assert_rejected 'same-repository caller skips immutable governance checkout' \
+  "$same_repository_skip_fixture"
+
 mutable_ref_fixture="$workspace/mutable-ref.yml"
 cp "$workflow_path" "$mutable_ref_fixture"
-sed -i 's|ref: ${{ fromJSON(toJSON(job)).workflow_sha }}|ref: ${{ inputs.governance-ref }}|' \
-  "$mutable_ref_fixture"
+# shellcheck disable=SC2016 # GitHub expressions are literal fixture content.
+replace_once "$mutable_ref_fixture" \
+  '          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}' \
+  '          ref: ${{ inputs.governance-ref }}'
 assert_rejected 'caller-selectable governance ref' "$mutable_ref_fixture"
 
 mutable_repository_fixture="$workspace/mutable-repository.yml"
 cp "$workflow_path" "$mutable_repository_fixture"
-sed -i 's|repository: ${{ fromJSON(toJSON(job)).workflow_repository }}|repository: SecPal/.github|' \
-  "$mutable_repository_fixture"
+# shellcheck disable=SC2016 # GitHub expressions are literal fixture content.
+replace_once "$mutable_repository_fixture" \
+  '          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}' \
+  '          repository: SecPal/.github'
 assert_rejected 'hard-coded governance repository' "$mutable_repository_fixture"
+
+decoy_fixture="$workspace/decoy.yml"
+cp "$workflow_path" "$decoy_fixture"
+replace_once "$decoy_fixture" \
+  $'          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}\n          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}' \
+  $'          repository: ${{ github.repository }}\n          ref: "${{ inputs.governance-ref }}"'
+replace_once "$decoy_fixture" \
+  $'        env:\n          VALIDATOR_PATH:' \
+  $'        env:\n          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}\n          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}\n          VALIDATOR_PATH:'
+assert_rejected 'immutable provenance strings outside governance checkout' "$decoy_fixture"
+
+caller_dependencies_fixture="$workspace/caller-dependencies.yml"
+cp "$workflow_path" "$caller_dependencies_fixture"
+replace_once "$caller_dependencies_fixture" \
+  '        working-directory: .secpal-governance' \
+  '        working-directory: .'
+assert_rejected 'governance dependencies installed from caller checkout' \
+  "$caller_dependencies_fixture"
+
+caller_validator_fixture="$workspace/caller-validator.yml"
+cp "$workflow_path" "$caller_validator_fixture"
+replace_once "$caller_validator_fixture" \
+  '          VALIDATOR_PATH: ./.secpal-governance/scripts/validate-copilot-instructions.sh' \
+  '          VALIDATOR_PATH: ./scripts/validate-copilot-instructions.sh'
+assert_rejected 'validator executed from caller checkout' "$caller_validator_fixture"
 
 mutable_action_fixture="$workspace/mutable-action.yml"
 cp "$workflow_path" "$mutable_action_fixture"
-sed -i 's|actions/checkout@[0-9a-f]\{40\}|actions/checkout@v7|' "$mutable_action_fixture"
+replace_once "$mutable_action_fixture" \
+  'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' \
+  'actions/setup-node@v7'
 assert_rejected 'mutable external action tag' "$mutable_action_fixture"
 
 echo 'Reusable Copilot workflow provenance invariants passed.'

--- a/tests/reusable-copilot-instructions-provenance.sh
+++ b/tests/reusable-copilot-instructions-provenance.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow_path="$repo_root/.github/workflows/reusable-copilot-instructions.yml"
+
+assert_immutable_provenance() {
+  local path="$1"
+  local uses_count pinned_uses_count
+
+  grep -Fqx '      governance-ref:' "$path" || return 1
+  grep -Fq 'Deprecated compatibility input.' "$path" || return 1
+  if grep -Fq "ref: \${{ inputs.governance-ref }}" "$path"; then
+    return 1
+  fi
+  grep -Fqx "          repository: \${{ fromJSON(toJSON(job)).workflow_repository }}" "$path" || return 1
+  grep -Fqx "          ref: \${{ fromJSON(toJSON(job)).workflow_sha }}" "$path" || return 1
+
+  uses_count="$(grep -Ec '^[[:space:]]+uses:[[:space:]]+' "$path")"
+  pinned_uses_count="$(grep -Ec '^[[:space:]]+uses:[[:space:]]+[^@[:space:]]+@[0-9a-f]{40}[[:space:]]+#[[:space:]]+v[0-9]+([.][0-9]+){2}([-.+][A-Za-z0-9.-]+)?$' "$path")"
+  [ "$uses_count" -gt 0 ] && [ "$uses_count" -eq "$pinned_uses_count" ] || return 1
+}
+
+assert_immutable_provenance "$workflow_path"
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/reusable-copilot-provenance.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+assert_rejected() {
+  local scenario="$1"
+  local fixture="$2"
+
+  if assert_immutable_provenance "$fixture" >/dev/null 2>&1; then
+    echo "Accepted mutable Copilot workflow provenance: $scenario" >&2
+    exit 1
+  fi
+}
+
+mutable_ref_fixture="$workspace/mutable-ref.yml"
+cp "$workflow_path" "$mutable_ref_fixture"
+sed -i 's|ref: ${{ fromJSON(toJSON(job)).workflow_sha }}|ref: ${{ inputs.governance-ref }}|' \
+  "$mutable_ref_fixture"
+assert_rejected 'caller-selectable governance ref' "$mutable_ref_fixture"
+
+mutable_repository_fixture="$workspace/mutable-repository.yml"
+cp "$workflow_path" "$mutable_repository_fixture"
+sed -i 's|repository: ${{ fromJSON(toJSON(job)).workflow_repository }}|repository: SecPal/.github|' \
+  "$mutable_repository_fixture"
+assert_rejected 'hard-coded governance repository' "$mutable_repository_fixture"
+
+mutable_action_fixture="$workspace/mutable-action.yml"
+cp "$workflow_path" "$mutable_action_fixture"
+sed -i 's|actions/checkout@[0-9a-f]\{40\}|actions/checkout@v7|' "$mutable_action_fixture"
+assert_rejected 'mutable external action tag' "$mutable_action_fixture"
+
+echo 'Reusable Copilot workflow provenance invariants passed.'


### PR DESCRIPTION
## Summary

- Bind the Copilot governance checkout to the repository and commit that define the called workflow.
- Retain `governance-ref` as a deprecated compatibility input without allowing it to select executed code.
- Add immutable-provenance regression coverage to local and workflow-pin validation.

## Problem and evidence

A caller could pin `reusable-copilot-instructions.yml` to a commit while supplying `governance-ref` to select a different governance checkout. That allowed the validator and its locked dependencies to differ from the called workflow revision. The workflow's external action pins were already immutable; this change closes the remaining caller-selectable governance checkout path.

## Changes

- Use `job.workflow_repository` and `job.workflow_sha` for the governance checkout.
- Preserve the public compatibility input and document that it no longer controls execution.
- Add positive coverage and negative fixtures for a mutable governance ref, a hard-coded governance repository, and a mutable action tag.
- Run the new invariant check in preflight and the workflow-pin validation job.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/reusable-copilot-instructions-provenance.sh` rejected the original workflow because the governance checkout remained caller-selectable.
- Passing proof after implementation: `bash tests/reusable-copilot-instructions-provenance.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Validation

- `pre-commit run --files CHANGELOG.md .github/workflows/reusable-copilot-instructions.yml .github/workflows/quality.yml .github/instructions/github-workflows.instructions.md scripts/preflight.sh tests/dependabot-auto-merge.sh tests/reusable-copilot-instructions-provenance.sh`
- `bash tests/reusable-copilot-instructions-provenance.sh`
- `bash tests/reusable-workflow-timeouts.sh`
- `bash tests/reusable-workflow-policy.sh`
- `bash tests/android-consumed-workflow-action-pins.sh`
- `VERIFY_ACTION_PIN_PROVENANCE=true bash tests/android-consumed-workflow-action-pins.sh`
- `bash tests/dependabot-auto-merge.sh`
- `bash tests/prettier-version-alignment.sh`
- `actionlint .github/workflows/reusable-copilot-instructions.yml .github/workflows/quality.yml`
- `yamllint -c .yamllint.yml .github/workflows/reusable-copilot-instructions.yml .github/workflows/quality.yml`
- `npx prettier --check CHANGELOG.md .github/workflows/reusable-copilot-instructions.yml .github/workflows/quality.yml`
- `reuse lint`
- `git diff --check`

## Readiness

No in-scope dependency or unresolved local check prevents review.