### PR TITLE
Decouple fixed-thread resolution from hosted CI

### DIFF
--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -20,13 +20,14 @@ committed, and pushed, use the central source repository's
 `scripts/secpal-resolve-fixed-threads.py`. Require the exact repository, pull
 request number, expected current head OID, reviewed-state file, and thread IDs.
 Also require the captured reviewed-state digest and successful validation
-evidence: the head-bound receipt for an unchanged validated head or the final
-attestation for a new verified fix commit. Require the target repository root
-and an eligibility manifest that covers every requested thread exactly with an
+evidence in the final attestation for a new verified fix commit. A raw
+validation receipt for an unchanged head is not authenticated by that existing
+commit and cannot authorize resolution. Require the target repository root and
+an eligibility manifest that covers every requested thread exactly with an
 allowed classification/disposition, finding IDs, evidence digest, and the fix
 commit. The command rejects a swapped state file, a non-matching local commit,
-and stale, missing, incomplete, or differently bound evidence before any GitHub
-read.
+and stale, missing, incomplete, unauthenticated, or differently bound evidence
+before any GitHub read.
 The command first reads every target completely and requires its current
 comment identities, body digests, and resolution state to match that reviewed
 state. It then performs two complete stable target rechecks of the open PR,
@@ -152,7 +153,9 @@ The following state machine applies only to the full feedback-remediation path.
    validation. When remediation changes no tracked source file and every finding
    is safely disposed, prove the local, remote, and PR heads still equal the
    reviewed head and skip the commit and push states; never create an artificial
-   empty commit.
+   empty commit. A receipt created after that existing commit is not
+   authenticated by it and cannot authorize a thread-resolution mutation; stop
+   without resolution when no authenticated fix-commit attestation exists.
 7. For the changed-tree path only, recheck the remote predecessor, push once
    without bypassing local hooks, and verify that local, remote, and PR heads
    equal the signed commit. Do not inspect hosted CI as a consequence of the

--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -19,6 +19,14 @@ findings have already been evaluated, fixed where necessary, validated,
 committed, and pushed, use the central source repository's
 `scripts/secpal-resolve-fixed-threads.py`. Require the exact repository, pull
 request number, expected current head OID, reviewed-state file, and thread IDs.
+Also require the captured reviewed-state digest and successful validation
+evidence: the head-bound receipt for an unchanged validated head or the final
+attestation for a new verified fix commit. Require the target repository root
+and an eligibility manifest that covers every requested thread exactly with an
+allowed classification/disposition, finding IDs, evidence digest, and the fix
+commit. The command rejects a swapped state file, a non-matching local commit,
+and stale, missing, incomplete, or differently bound evidence before any GitHub
+read.
 The command first reads every target completely and requires its current
 comment identities, body digests, and resolution state to match that reviewed
 state. It then performs two complete stable target rechecks of the open PR,
@@ -32,8 +40,12 @@ Invoke the resolver in write mode; omitting `--apply` is only a dry run:
 python3 scripts/secpal-resolve-fixed-threads.py \
   --repo OWNER/REPOSITORY \
   --pr PULL_REQUEST_NUMBER \
+  --repo-root /path/to/OWNER/REPOSITORY \
   --expected-head FULL_40_CHARACTER_HEAD_OID \
   --reviewed-state REVIEWED_STATE.json \
+  --expected-reviewed-state-digest REVIEWED_STATE_SHA256 \
+  --validation-evidence VALIDATION_EVIDENCE.json \
+  --eligibility-evidence ELIGIBILITY_EVIDENCE.json \
   --thread-id REVIEW_THREAD_NODE_ID \
   --apply
 ```
@@ -147,7 +159,9 @@ The following state machine applies only to the full feedback-remediation path.
    push.
 8. Resolve every eligible fixed thread with
    `scripts/secpal-resolve-fixed-threads.py --apply`, binding the exact
-   repository, PR, current head OID, reviewed-state file, and thread IDs. This
+   repository, PR, repository root, current head OID, reviewed-state file and
+   digest, successful validation evidence for that fix commit, exact
+   per-thread eligibility evidence, and thread IDs. This
    reads only the named targets, requires their comments to equal the reviewed
    feedback, and does not reclassify or gate on unrelated PR state.
 9. Report the commit, branch, remote synchronization, local validation,

--- a/.agents/skills/secpal-pr-review/SKILL.md
+++ b/.agents/skills/secpal-pr-review/SKILL.md
@@ -24,8 +24,10 @@ evidence in the final attestation for a new verified fix commit. A raw
 validation receipt for an unchanged head is not authenticated by that existing
 commit and cannot authorize resolution. Require the target repository root and
 an eligibility manifest that covers every requested thread exactly with an
-allowed classification/disposition, finding IDs, evidence digest, and the fix
-commit. The command rejects a swapped state file, a non-matching local commit,
+allowed classification/disposition, finding IDs, and evidence digest. Finalize
+the manifest before complete validation and bind its canonical digest into the
+signed validation receipt and final attestation for the fix commit. The command
+rejects a swapped state file, a non-matching local commit,
 and stale, missing, incomplete, unauthenticated, or differently bound evidence
 before any GitHub read.
 The command first reads every target completely and requires its current
@@ -135,10 +137,13 @@ The following state machine applies only to the full feedback-remediation path.
    integrity, lifecycle, rollout, and avoidable complexity. Complete all source,
    provenance, edge-case, and diff inspection here, and fix material in-scope
    defects before the complete validation.
-5. Stage the finished tree and run the registered unconditional focused commands
-   plus every required local validation exactly once through
-   `attest-validation`, supplying explicit satisfied evidence for every
-   registered manual gate. Preserve its deterministic staged-tree,
+5. Finalize the eligibility manifest for every thread that may be resolved,
+   binding its classifications, dispositions, finding IDs, evidence digests,
+   reviewed head, and reviewed-state digest. Stage the finished tree and run
+   the registered unconditional focused commands plus every required local
+   validation exactly once through `attest-validation`, supplying that manifest
+   and explicit satisfied evidence for every registered manual gate. Preserve
+   its deterministic staged-tree,
    parent-head, registry, command-set, manual-gate, result, and reviewed-feedback
    receipt. Do not continue discovery or change the tree after this step begins.
    A failed command produces no receipt and is a terminal security blocker for
@@ -164,7 +169,8 @@ The following state machine applies only to the full feedback-remediation path.
    `scripts/secpal-resolve-fixed-threads.py --apply`, binding the exact
    repository, PR, repository root, current head OID, reviewed-state file and
    digest, successful validation evidence for that fix commit, exact
-   per-thread eligibility evidence, and thread IDs. This
+   per-thread eligibility evidence whose canonical digest is authenticated by
+   the signed receipt, and thread IDs. This
    reads only the named targets, requires their comments to equal the reviewed
    feedback, and does not reclassify or gate on unrelated PR state.
 9. Report the commit, branch, remote synchronization, local validation,

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -120,17 +120,19 @@ INITIALIZE
   → IF_TRACKED_TREE_CHANGED
       → SIGNED_COMMIT
       → PUSH_ONCE
+      → RESOLVE_FIXED_THREADS
+      → STOP
     ELSE_VERIFY_UNCHANGED_HEAD
-  → RESOLVE_FIXED_THREADS
-  → STOP
+      → STOP_WITHOUT_THREAD_RESOLUTION
 ```
 
 A security blocker terminates at the state that detects it. A recoverable local
 error does not advance the state or consume a remediation cycle. When
 remediation changes no tracked source file and every finding is safely disposed,
 the invocation does not create an artificial commit: it verifies the unchanged
-local, remote, and PR head, resolves eligible reviewed threads against that
-head, and reports `NO_ACTIONABLE_FINDINGS`.
+local, remote, and PR head, stops without thread resolution because the raw
+receipt is not authenticated by that existing commit, and reports the retained
+dispositions.
 
 ### State rules
 
@@ -173,7 +175,10 @@ is informational only and cannot determine validity.
 `IF_TRACKED_TREE_CHANGED` selects only between the proven staged tree and the
 reviewed tree. When remediation changes no tracked source file, it takes
 `ELSE_VERIFY_UNCHANGED_HEAD`, proves local, remote, and PR heads still equal the
-reviewed head, and skips `SIGNED_COMMIT` and `PUSH_ONCE`.
+reviewed head, and skips `SIGNED_COMMIT` and `PUSH_ONCE`. The resulting raw
+receipt is not authenticated by the already-existing commit and cannot
+authorize thread resolution. The workflow stops without resolution rather than
+creating an artificial commit or trusting self-hashed evidence.
 
 `SIGNED_COMMIT` creates one cryptographically
 signed commit with the receipt digest as its single
@@ -196,6 +201,10 @@ reviewed target-comment identities and digests, two equal complete current
 target projections, and exact mutation response. It does not read or depend on
 hosted CI, Required Checks, CodeQL, mergeability, branch protection, PR
 reactions, unrelated feedback, or worktree cleanliness.
+
+Only the final attestation for a new signed fix commit is accepted as validation
+evidence. A raw validation receipt for an unchanged head has no receipt trailer
+in that pre-existing commit and fails closed before any GitHub read.
 
 `STOP` reports the commit, branch, remote synchronization, local validation,
 worktree state, PR identity, and resolution results. The workflow never merges;

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -76,9 +76,11 @@ successful validation evidence bound to the verified fix commit, local
 repository root, and per-thread eligibility evidence, plus thread IDs. It
 verifies the registered origin, local head, validated tree, accepted local
 commit signature, and, for a new fix commit, the sole parent and validation
-receipt trailer before any GitHub read. It also requires the eligibility
-manifest to cover the requested threads exactly and bind their allowed
-classifications/dispositions, finding IDs, evidence digests, and fix commit.
+receipt trailer before any GitHub read. The receipt and final attestation must
+authenticate the canonical eligibility-manifest digest. It also requires the
+eligibility manifest to cover the requested threads exactly and bind their allowed
+classifications/dispositions, finding IDs, evidence digests, reviewed head, and
+reviewed-state digest.
 It then reads every named target
 completely, and requires its comment
 identities, body digests, reply relationships, and resolution state to match the
@@ -163,9 +165,14 @@ commands and every required local command once and returns a deterministic
 receipt binding repository, parent head,
 staged-tree SHA, registry digest, command-set digest, successful result, and
 reviewed-feedback digests plus explicit satisfied evidence for every registered
-manual gate. On entry, the tracked tree and holistic-audit result are frozen;
-independent discovery and audit do not continue in or after this state. A failed
-command produces no receipt; the command invalidates any report already at its
+manual gate and the canonical digest of the finalized eligibility manifest.
+The manifest is finalized after classification and before this state; it binds
+the reviewed head/state and every eligible thread's classification,
+disposition, finding IDs, and evidence digest without referring to the not-yet-
+created fix commit. On entry, the tracked tree, eligibility manifest, and
+holistic-audit result are frozen; independent discovery and audit do not
+continue in or after this state. A failed command produces no receipt; the
+command invalidates any report already at its
 configured output before validation begins, terminates this invocation, and
 permits no tree change or complete-command retry. A new explicit remediation
 invocation must capture fresh state and audit any correction before its single
@@ -194,7 +201,8 @@ remote, and PR head equality.
 `RESOLVE_FIXED_THREADS` invokes `scripts/secpal-resolve-fixed-threads.py` for
 the exact eligible thread IDs, current head, reviewed-state file and captured
 digest, successful validation evidence bound to the verified fix commit, local
-commit proof, and exact per-thread eligibility evidence. Resolution depends
+commit proof, and exact per-thread eligibility evidence authenticated by the
+signed validation receipt. Resolution depends
 only on those inputs, the open PR, exact head, target
 membership, equality with the
 reviewed target-comment identities and digests, two equal complete current
@@ -320,12 +328,14 @@ classifications, signed validation-receipt trailer, and validation-attestation
 identity. It is read at most once only under the explicit CI and readiness path.
 
 A validation receipt is produced by the single complete run and binds its staged
-tree and normalized satisfied evidence for every registered manual gate. After
+tree, canonical eligibility-manifest digest, and normalized satisfied evidence
+for every registered manual gate. After
 the signed commit, that receipt may be bound once only when the commit's parent,
 tree, and single `SecPal-Validation-Receipt` trailer match exactly. The final
 validation attestation contains at least `repository`, `head_sha`,
 `registry_digest`, `command_set_digest`, `successful_result`, validated tree,
-receipt digest, and manual-gate evidence. It also binds the reviewed state and
+receipt digest, manual-gate evidence, and authenticated eligibility digest. It
+also binds the reviewed state and
 feedback digests. The batch independently reconstructs the receipt from the
 live signed commit and rejects a caller-authored attestation file that lacks the
 matching signed trailer. Canonical JSON and SHA-256 make it deterministic;

--- a/.agents/skills/secpal-pr-review/references/contract.md
+++ b/.agents/skills/secpal-pr-review/references/contract.md
@@ -71,8 +71,16 @@ evaluated, fixed where necessary, validated, committed, and pushed uses
 state machine.
 
 This path requires the exact repository, pull request number, expected current
-head OID, reviewed-state file, and thread IDs. It verifies the reviewed-state
-digests, reads every named target completely, and requires its comment
+head OID, reviewed-state file, caller-captured reviewed-state digest, and
+successful validation evidence bound to the verified fix commit, local
+repository root, and per-thread eligibility evidence, plus thread IDs. It
+verifies the registered origin, local head, validated tree, accepted local
+commit signature, and, for a new fix commit, the sole parent and validation
+receipt trailer before any GitHub read. It also requires the eligibility
+manifest to cover the requested threads exactly and bind their allowed
+classifications/dispositions, finding IDs, evidence digests, and fix commit.
+It then reads every named target
+completely, and requires its comment
 identities, body digests, reply relationships, and resolution state to match the
 feedback that was actually classified. It then verifies PR membership and
 records current resolved/outdated state. Immediately before each write or
@@ -94,8 +102,9 @@ without retry, emits one structured report naming resolved, failed, and
 unattempted targets, and exits nonzero.
 
 The resolution-only path performs no feedback classification, validation,
-attestation, commit, push, Required Check read, readiness audit, review request,
-or merge operation. It is also the default post-push resolution step after
+attestation creation, commit, push, Required Check read, readiness audit, review
+request, or merge operation. It consumes already-produced validation evidence
+only. It is also the default post-push resolution step after
 feedback remediation. It is not selected for a separately requested readiness
 audit, forensic evidence capture, or merge evaluation.
 
@@ -178,12 +187,15 @@ hooks, or uses administrator authority. After the push it verifies only local,
 remote, and PR head equality.
 
 `RESOLVE_FIXED_THREADS` invokes `scripts/secpal-resolve-fixed-threads.py` for
-the exact eligible thread IDs, current head, and reviewed-state file. Resolution
-depends only on the open PR, exact head, target membership, equality with the
+the exact eligible thread IDs, current head, reviewed-state file and captured
+digest, successful validation evidence bound to the verified fix commit, local
+commit proof, and exact per-thread eligibility evidence. Resolution depends
+only on those inputs, the open PR, exact head, target
+membership, equality with the
 reviewed target-comment identities and digests, two equal complete current
 target projections, and exact mutation response. It does not read or depend on
 hosted CI, Required Checks, CodeQL, mergeability, branch protection, PR
-reactions, unrelated feedback, validation attestations, or worktree state.
+reactions, unrelated feedback, or worktree cleanliness.
 
 `STOP` reports the commit, branch, remote synchronization, local validation,
 worktree state, PR identity, and resolution results. The workflow never merges;

--- a/.agents/skills/secpal-pr-review/references/repositories.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.json
@@ -1,6 +1,38 @@
 {
   "$comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors; SPDX-License-Identifier: CC0-1.0",
   "schema_version": "1.0",
+  "fixed_thread_resolution": {
+    "resolver": "scripts/secpal-resolve-fixed-threads.py",
+    "required_bindings": [
+      "repository",
+      "pull_request_number",
+      "repository_root",
+      "expected_head",
+      "reviewed_state_digest",
+      "validation_evidence",
+      "eligibility_evidence",
+      "thread_ids"
+    ],
+    "allowed_github_operations": ["READ_NAMED_REVIEW_THREAD", "RESOLVE_NAMED_REVIEW_THREAD"],
+    "prohibited_hosted_reads": [
+      "GITHUB_ACTIONS",
+      "CODEQL",
+      "CHECK_SUITES",
+      "COMMIT_STATUSES",
+      "REQUIRED_CHECKS",
+      "MERGEABILITY",
+      "BRANCH_PROTECTION",
+      "MERGE_READINESS"
+    ],
+    "prohibited_mutations": [
+      "REVIEW_REQUEST",
+      "READY_TRANSITION",
+      "MERGE",
+      "LABEL",
+      "GENERIC_COMMENT"
+    ],
+    "readiness_authorization": "SEPARATE_EXPLICIT_WORKFLOW"
+  },
   "repositories": [
     {
       "repository": "SecPal/.github",

--- a/.agents/skills/secpal-pr-review/references/repositories.schema.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.schema.json
@@ -5,11 +5,14 @@
   "title": "SecPal PR review workflow repository registry",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "fixed_thread_resolution", "repositories"],
+  "required": ["schema_version", "repositories"],
   "properties": {
     "$comment": { "type": "string" },
     "schema_version": { "const": "1.0" },
-    "fixed_thread_resolution": { "$ref": "#/$defs/fixed_thread_resolution" },
+    "fixed_thread_resolution": {
+      "$ref": "#/$defs/fixed_thread_resolution",
+      "description": "Required in the canonical registry; optional for schema-1.0 custom registries retained for compatibility."
+    },
     "repositories": {
       "type": "array",
       "minItems": 1,

--- a/.agents/skills/secpal-pr-review/references/repositories.schema.json
+++ b/.agents/skills/secpal-pr-review/references/repositories.schema.json
@@ -5,10 +5,11 @@
   "title": "SecPal PR review workflow repository registry",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "repositories"],
+  "required": ["schema_version", "fixed_thread_resolution", "repositories"],
   "properties": {
     "$comment": { "type": "string" },
     "schema_version": { "const": "1.0" },
+    "fixed_thread_resolution": { "$ref": "#/$defs/fixed_thread_resolution" },
     "repositories": {
       "type": "array",
       "minItems": 1,
@@ -16,6 +17,52 @@
     }
   },
   "$defs": {
+    "fixed_thread_resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resolver",
+        "required_bindings",
+        "allowed_github_operations",
+        "prohibited_hosted_reads",
+        "prohibited_mutations",
+        "readiness_authorization"
+      ],
+      "properties": {
+        "resolver": { "const": "scripts/secpal-resolve-fixed-threads.py" },
+        "required_bindings": {
+          "const": [
+            "repository",
+            "pull_request_number",
+            "repository_root",
+            "expected_head",
+            "reviewed_state_digest",
+            "validation_evidence",
+            "eligibility_evidence",
+            "thread_ids"
+          ]
+        },
+        "allowed_github_operations": {
+          "const": ["READ_NAMED_REVIEW_THREAD", "RESOLVE_NAMED_REVIEW_THREAD"]
+        },
+        "prohibited_hosted_reads": {
+          "const": [
+            "GITHUB_ACTIONS",
+            "CODEQL",
+            "CHECK_SUITES",
+            "COMMIT_STATUSES",
+            "REQUIRED_CHECKS",
+            "MERGEABILITY",
+            "BRANCH_PROTECTION",
+            "MERGE_READINESS"
+          ]
+        },
+        "prohibited_mutations": {
+          "const": ["REVIEW_REQUEST", "READY_TRANSITION", "MERGE", "LABEL", "GENERIC_COMMENT"]
+        },
+        "readiness_authorization": { "const": "SEPARATE_EXPLICIT_WORKFLOW" }
+      }
+    },
     "repository": {
       "type": "object",
       "additionalProperties": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 - made its target-thread-only GitHub surface explicit in the canonical
   repository registry while keeping hosted CI, CodeQL, mergeability, branch
   protection, readiness, polling, and unrelated mutations outside the path
+- rejected unauthenticated raw validation receipts for unchanged heads while
+  retaining schema-1.0 custom-registry compatibility; the canonical registry
+  remains contract-bound
 - added regressions for pending, failed, unavailable, and omitted hosted checks,
   zero readiness API calls, head drift, reviewed-state drift, and missing
   validation evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-11 - Decouple Fixed Review-Thread Resolution
+
+**Changed:**
+
+- bound the dedicated fixed-thread resolver to the caller-captured reviewed-state
+  digest, exact locally verified signed commit, successful validation evidence,
+  and explicit eligibility evidence for every target thread
+- made its target-thread-only GitHub surface explicit in the canonical
+  repository registry while keeping hosted CI, CodeQL, mergeability, branch
+  protection, readiness, polling, and unrelated mutations outside the path
+- added regressions for pending, failed, unavailable, and omitted hosted checks,
+  zero readiness API calls, head drift, reviewed-state drift, and missing
+  validation evidence
+
+---
+
 ## 2026-08-10 - Restore Dependabot Update Classification
 
 **Changed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Log of notable changes to SecPal organization defaults (newest first).
 - rejected unauthenticated raw validation receipts for unchanged heads while
   retaining schema-1.0 custom-registry compatibility; the canonical registry
   remains contract-bound
+- authenticated the complete per-thread eligibility manifest through the
+  signed validation receipt and final attestation so callers cannot synthesize
+  or reclassify resolution evidence after validation
 - added regressions for pending, failed, unavailable, and omitted hosted checks,
   zero readiness API calls, head drift, reviewed-state drift, and missing
   validation evidence

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -239,7 +239,10 @@ signed receipt, manual gates, and reviewed-feedback digests. Before the commit
 exists on GitHub, binding checks its local signature and configured format only.
 When remediation changes no tracked source file and every finding is safely
 disposed, verify unchanged local, remote, and PR heads and skip the commit and
-push; never create an artificial empty commit.
+push; never create an artificial empty commit. Because a receipt produced after
+that existing commit is not authenticated by it, the raw receipt cannot
+authorize thread resolution. Stop without resolution unless a final attestation
+is bound to a new signed fix commit.
 
 The simple resolver first verifies the caller-captured reviewed-state digest,
 successful validation attestation, actual local signed commit, and exact

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -173,7 +173,8 @@ workflow never posts fixed/addressed/SHA/progress messages.
 
 The normal path captures stable feedback once, creates one reusable local
 validation attestation, pushes one signed commit, and resolves only the named
-fixed threads:
+fixed threads. Finalize `SESSION/thread-eligibility.json` from the completed
+classifications and dispositions before starting the complete validation:
 
 ```bash
 python3 scripts/secpal-pr-review-actions.py resolve-batch \
@@ -186,6 +187,7 @@ python3 scripts/secpal-pr-review-actions.py attest-validation \
   --expected-head PARENT_HEAD \
   --reviewed-state SESSION/reviewed-feedback.json \
   --manual-gate-evidence SESSION/manual-gates.json \
+  --eligibility-evidence SESSION/thread-eligibility.json \
   --repo-root /path/to/SecPal/api \
   --output SESSION/validation-receipt.json
 
@@ -200,6 +202,7 @@ python3 scripts/secpal-pr-review-actions.py attest-validation \
   --reviewed-state SESSION/reviewed-feedback.json \
   --repo-root /path/to/SecPal/api \
   --receipt SESSION/validation-receipt.json \
+  --eligibility-evidence SESSION/thread-eligibility.json \
   --bind-commit \
   --output SESSION/validation-attestation.json
 
@@ -230,13 +233,15 @@ or private-key marker is rejected rather than copied into the receipt. The
 capture reads one canonical projection containing feedback identities,
 digests, states, reactions, actors, the current head, and the reviewed base
 branch/SHA. It excludes Required Checks. The complete run produces a staged-tree
-receipt that includes the manual-gate evidence. When the tracked tree changed,
+receipt that includes the manual-gate evidence and the canonical digest of the
+pre-validation eligibility manifest. When the tracked tree changed,
 the same command binds that receipt after the signed commit only when the
 commit's sole parent, tree, signature, and receipt trailer match exactly; this
 does not rerun validation. The final attestation binds the repository, finished
 head, registry digest, command-set digest, successful result, validated tree,
-signed receipt, manual gates, and reviewed-feedback digests. Before the commit
-exists on GitHub, binding checks its local signature and configured format only.
+signed receipt, manual gates, authenticated eligibility digest, and
+reviewed-feedback digests. Before the commit exists on GitHub, binding checks
+its local signature and configured format only.
 When remediation changes no tracked source file and every finding is safely
 disposed, verify unchanged local, remote, and PR heads and skip the commit and
 push; never create an artificial empty commit. Because a receipt produced after
@@ -246,8 +251,8 @@ is bound to a new signed fix commit.
 
 The simple resolver first verifies the caller-captured reviewed-state digest,
 successful validation attestation, actual local signed commit, and exact
-per-thread eligibility manifest bound to the fix commit. It then verifies the
-exact PR head and target identity without reading checks,
+per-thread eligibility manifest authenticated by the signed validation
+receipt. It then verifies the exact PR head and target identity without reading checks,
 rules, reactions, unrelated feedback, mergeability, or branch protection. It
 reads each target completely and requires its comments to match the
 reviewed-state identities and digests. Immediately before each

--- a/docs/secpal-pr-review-workflow.md
+++ b/docs/secpal-pr-review-workflow.md
@@ -206,8 +206,12 @@ python3 scripts/secpal-pr-review-actions.py attest-validation \
 python3 scripts/secpal-resolve-fixed-threads.py \
   --repo SecPal/api \
   --pr 123 \
+  --repo-root /path/to/SecPal/api \
   --expected-head HEAD \
   --reviewed-state SESSION/reviewed-feedback.json \
+  --expected-reviewed-state-digest REVIEWED_STATE_SHA256 \
+  --validation-evidence SESSION/validation-attestation.json \
+  --eligibility-evidence SESSION/thread-eligibility.json \
   --thread-id REVIEW_THREAD_NODE_ID \
   --apply
 ```
@@ -237,10 +241,13 @@ When remediation changes no tracked source file and every finding is safely
 disposed, verify unchanged local, remote, and PR heads and skip the commit and
 push; never create an artificial empty commit.
 
-The simple resolver verifies the exact PR head and target identity without
-reading checks, rules, reactions, unrelated feedback, mergeability, or branch
-protection. It first reads each target completely and requires its comments to
-match the reviewed-state identities and digests. Immediately before each
+The simple resolver first verifies the caller-captured reviewed-state digest,
+successful validation attestation, actual local signed commit, and exact
+per-thread eligibility manifest bound to the fix commit. It then verifies the
+exact PR head and target identity without reading checks,
+rules, reactions, unrelated feedback, mergeability, or branch protection. It
+reads each target completely and requires its comments to match the
+reviewed-state identities and digests. Immediately before each
 mutation or successful already-resolved report, it requires two more equal
 complete target projections; every mutation response must confirm the exact
 resolved thread.

--- a/docs/simple-pr-thread-resolution.md
+++ b/docs/simple-pr-thread-resolution.md
@@ -19,7 +19,9 @@ Thread resolution and merge readiness are different operations:
 
 The simple resolver keeps those concerns separate. It does not run tests, read
 CI, classify reactions, compare unrelated PR feedback, create commits, push, or
-make a merge decision.
+make a merge decision. It requires already-produced successful validation
+evidence bound to the exact fix commit; consuming that evidence is not a
+readiness inspection.
 
 GitHub-hosted CI may be inspected only when the current user instruction
 explicitly requests CI status, check status, merge readiness, or merge
@@ -56,6 +58,19 @@ The command verifies only the invariants required for this operation:
 - repository is an exact entry in the canonical production registry;
 - PR is open;
 - current PR head equals the caller-provided expected current head OID;
+- the reviewed-state file equals the caller-provided captured state digest;
+- successful validation evidence binds that reviewed state to the exact
+  verified fix commit: a receipt when the validated head is unchanged, or a
+  final attestation when remediation created a new commit;
+- the local repository has the exact registered origin and expected `HEAD`, the
+  commit tree equals the validated tree, and the commit has a locally verified
+  accepted signature;
+- a new fix commit has exactly the reviewed head as its parent and exactly one
+  matching `SecPal-Validation-Receipt` trailer;
+- the eligibility manifest binds the repository, PR, expected head,
+  reviewed-state digest, validation-evidence digest, and every requested thread
+  exactly; each thread has an allowed classification/disposition, finding IDs,
+  evidence digest, and matching fix commit;
 - every requested thread belongs to that PR;
 - every requested thread and its comment identities, body digests, reply
   relationships, and resolution state match the supplied reviewed-state
@@ -78,9 +93,7 @@ It intentionally does **not** block resolution because of:
 - PR-level or comment reactions;
 - unrelated new comments or reviews;
 - mergeability or branch-protection state;
-- validation receipts or attestation files;
-- an unclean local worktree;
-- missing local repository access.
+- an unclean local worktree.
 
 Those signals remain relevant to a later merge decision, not to recording that
 an individual conversation has been addressed.
@@ -93,8 +106,12 @@ Dry run:
 python3 scripts/secpal-resolve-fixed-threads.py \
   --repo SecPal/api \
   --pr 123 \
+  --repo-root /path/to/SecPal/api \
   --expected-head 0123456789abcdef0123456789abcdef01234567 \
   --reviewed-state REVIEWED_STATE.json \
+  --expected-reviewed-state-digest REVIEWED_STATE_SHA256 \
+  --validation-evidence VALIDATION_EVIDENCE.json \
+  --eligibility-evidence ELIGIBILITY_EVIDENCE.json \
   --thread-id PRRT_example
 ```
 
@@ -104,18 +121,52 @@ Apply:
 python3 scripts/secpal-resolve-fixed-threads.py \
   --repo SecPal/api \
   --pr 123 \
+  --repo-root /path/to/SecPal/api \
   --expected-head 0123456789abcdef0123456789abcdef01234567 \
   --reviewed-state REVIEWED_STATE.json \
+  --expected-reviewed-state-digest REVIEWED_STATE_SHA256 \
+  --validation-evidence VALIDATION_EVIDENCE.json \
+  --eligibility-evidence ELIGIBILITY_EVIDENCE.json \
   --thread-id PRRT_example \
   --apply
 ```
 
 Repeat `--thread-id` to resolve several fixed threads in one invocation.
+The ordered `eligible_threads` array in the eligibility manifest must list
+those IDs in the same order and cover no additional thread. Its top-level
+bindings are `repository`, `pull_request_number`, `expected_head`,
+`reviewed_state_digest`, and `validation_evidence_digest`. The resolver
+calculates and reports the canonical SHA-256 digest of the validated manifest;
+the manifest does not self-certify a caller-provided digest.
+
+```json
+{
+  "schema_version": "1.0",
+  "repository": "SecPal/api",
+  "pull_request_number": 123,
+  "expected_head": "0123456789abcdef0123456789abcdef01234567",
+  "reviewed_state_digest": "REVIEWED_STATE_SHA256",
+  "validation_evidence_digest": "VALIDATION_EVIDENCE_SHA256",
+  "eligible_threads": [
+    {
+      "thread_id": "PRRT_example",
+      "classification": "VALID_ACTIONABLE",
+      "disposition": "CORRECTED_AND_VERIFIED",
+      "finding_ids": ["finding-1"],
+      "evidence_digest": "FINDING_EVIDENCE_SHA256",
+      "fix_commit_sha": "0123456789abcdef0123456789abcdef01234567"
+    }
+  ]
+}
+```
 
 ## Operational rule
 
 When the user explicitly asks to resolve comments that have been fixed and
-pushed, use this simple path with the reviewed-state capture for those findings.
+pushed, use this simple path with the reviewed-state capture, its recorded
+`state_digest`, and the successful validation evidence for the fix commit.
+Also provide the exact local repository root and the eligibility manifest
+created from the completed finding classifications and dispositions.
 Full review remediation also uses this path after its signed push or after
 proving that a no-change remediation retained the already-pushed head. Do not
 route resolution through the readiness or forensic workflow unless the current

--- a/docs/simple-pr-thread-resolution.md
+++ b/docs/simple-pr-thread-resolution.md
@@ -61,16 +61,18 @@ The command verifies only the invariants required for this operation:
 - the reviewed-state file equals the caller-provided captured state digest;
 - successful validation evidence binds that reviewed state to the exact
   verified fix commit through a final attestation and the signed commit's
-  matching validation-receipt trailer;
+  matching validation-receipt trailer; the signed receipt also authenticates
+  the canonical eligibility-manifest digest;
 - the local repository has the exact registered origin and expected `HEAD`, the
   commit tree equals the validated tree, and the commit has a locally verified
   accepted signature;
 - a new fix commit has exactly the reviewed head as its parent and exactly one
   matching `SecPal-Validation-Receipt` trailer;
-- the eligibility manifest binds the repository, PR, expected head,
-  reviewed-state digest, validation-evidence digest, and every requested thread
-  exactly; each thread has an allowed classification/disposition, finding IDs,
-  evidence digest, and matching fix commit;
+- the eligibility manifest binds the repository, PR, reviewed head,
+  reviewed-state digest, and every requested thread exactly; each thread has an
+  allowed classification/disposition, finding IDs, and evidence digest, and
+  the complete canonical manifest must match the digest authenticated by the
+  signed validation receipt;
 - every requested thread belongs to that PR;
 - every requested thread and its comment identities, body digests, reply
   relationships, and resolution state match the supplied reviewed-state
@@ -134,27 +136,28 @@ python3 scripts/secpal-resolve-fixed-threads.py \
 Repeat `--thread-id` to resolve several fixed threads in one invocation.
 The ordered `eligible_threads` array in the eligibility manifest must list
 those IDs in the same order and cover no additional thread. Its top-level
-bindings are `repository`, `pull_request_number`, `expected_head`,
-`reviewed_state_digest`, and `validation_evidence_digest`. The resolver
-calculates and reports the canonical SHA-256 digest of the validated manifest;
-the manifest does not self-certify a caller-provided digest.
+bindings are `repository`, `pull_request_number`, `reviewed_head_sha`, and
+`reviewed_state_digest`. Create it after classification but before complete
+validation. `attest-validation --eligibility-evidence` places its canonical
+SHA-256 digest in the validation receipt, which the signed commit trailer and
+final attestation authenticate. The resolver recalculates that digest and
+rejects any post-validation classification, disposition, finding, or evidence
+change before its first GitHub read.
 
 ```json
 {
   "schema_version": "1.0",
   "repository": "SecPal/api",
   "pull_request_number": 123,
-  "expected_head": "0123456789abcdef0123456789abcdef01234567",
+  "reviewed_head_sha": "0123456789abcdef0123456789abcdef01234567",
   "reviewed_state_digest": "REVIEWED_STATE_SHA256",
-  "validation_evidence_digest": "VALIDATION_EVIDENCE_SHA256",
   "eligible_threads": [
     {
       "thread_id": "PRRT_example",
       "classification": "VALID_ACTIONABLE",
       "disposition": "CORRECTED_AND_VERIFIED",
       "finding_ids": ["finding-1"],
-      "evidence_digest": "FINDING_EVIDENCE_SHA256",
-      "fix_commit_sha": "0123456789abcdef0123456789abcdef01234567"
+      "evidence_digest": "FINDING_EVIDENCE_SHA256"
     }
   ]
 }
@@ -166,7 +169,8 @@ When the user explicitly asks to resolve comments that have been fixed and
 pushed, use this simple path with the reviewed-state capture, its recorded
 `state_digest`, and the successful validation evidence for the fix commit.
 Also provide the exact local repository root and the eligibility manifest
-created from the completed finding classifications and dispositions.
+created from the completed finding classifications and dispositions and
+authenticated by the signed validation receipt.
 Full review remediation also uses this path after its signed push. A raw
 validation receipt for an unchanged head is not authenticated by that existing
 commit and cannot authorize resolution; do not create an artificial commit to

--- a/docs/simple-pr-thread-resolution.md
+++ b/docs/simple-pr-thread-resolution.md
@@ -60,8 +60,8 @@ The command verifies only the invariants required for this operation:
 - current PR head equals the caller-provided expected current head OID;
 - the reviewed-state file equals the caller-provided captured state digest;
 - successful validation evidence binds that reviewed state to the exact
-  verified fix commit: a receipt when the validated head is unchanged, or a
-  final attestation when remediation created a new commit;
+  verified fix commit through a final attestation and the signed commit's
+  matching validation-receipt trailer;
 - the local repository has the exact registered origin and expected `HEAD`, the
   commit tree equals the validated tree, and the commit has a locally verified
   accepted signature;
@@ -167,9 +167,11 @@ pushed, use this simple path with the reviewed-state capture, its recorded
 `state_digest`, and the successful validation evidence for the fix commit.
 Also provide the exact local repository root and the eligibility manifest
 created from the completed finding classifications and dispositions.
-Full review remediation also uses this path after its signed push or after
-proving that a no-change remediation retained the already-pushed head. Do not
-route resolution through the readiness or forensic workflow unless the current
-user instruction explicitly asks for CI inspection, readiness, or merge
-authorization. Even then, the CI observation is one bounded current-state read
-with no polling, waiting, sleeping, or automatic repetition.
+Full review remediation also uses this path after its signed push. A raw
+validation receipt for an unchanged head is not authenticated by that existing
+commit and cannot authorize resolution; do not create an artificial commit to
+work around this boundary. Do not route resolution through the readiness or
+forensic workflow unless the current user instruction explicitly asks for CI
+inspection, readiness, or merge authorization. Even then, the CI observation
+is one bounded current-state read with no polling, waiting, sleeping, or
+automatic repetition.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,9 +62,11 @@ mutation because the pre-existing commit does not authenticate that receipt.
 The resolver verifies that evidence against the actual local commit tree,
 signature, origin, and, for a new fix commit, its parent and receipt trailer. A
 separate eligibility manifest must cover every requested thread exactly and
-bind its allowed classification/disposition and finding evidence to the same
-commit. Together they bind the operation to the caller-provided PR head and
-reviewed target-comment identities, digests, and resolution state. After one
+bind its allowed classification/disposition and finding evidence to the
+reviewed state. Its canonical digest must be authenticated by the signed
+validation receipt and final attestation, so it cannot be created or changed
+after validation. Together they bind the operation to the caller-provided PR
+head and reviewed target-comment identities, digests, and resolution state. After one
 initial complete target read, it requires two more equal complete target
 projections immediately before each write or successful already-resolved
 report, and keeps thread resolution separate from CI and merge-readiness

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,8 +56,9 @@ signed push, or no commit movement for a no-push session.
 Resolves only explicitly named review threads after their findings have already
 been evaluated, fixed where necessary, and validated. The supplied reviewed-state
 capture must match the caller-provided captured state digest, and a successful
-validation receipt or final attestation must bind that reviewed state to the
-exact fix commit.
+final attestation must bind that reviewed state to the exact fix commit. A raw
+validation receipt for an unchanged head cannot authorize a resolution
+mutation because the pre-existing commit does not authenticate that receipt.
 The resolver verifies that evidence against the actual local commit tree,
 signature, origin, and, for a new fix commit, its parent and receipt trailer. A
 separate eligibility manifest must cover every requested thread exactly and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,11 +55,19 @@ signed push, or no commit movement for a no-push session.
 
 Resolves only explicitly named review threads after their findings have already
 been evaluated, fixed where necessary, and validated. The supplied reviewed-state
-capture binds the operation to the caller-provided PR head and reviewed
-target-comment identities, digests, and resolution state. After one initial
-complete target read, it requires two more equal complete target projections
-immediately before each write or successful already-resolved report, and keeps
-thread resolution separate from CI and merge-readiness decisions. It accepts
+capture must match the caller-provided captured state digest, and a successful
+validation receipt or final attestation must bind that reviewed state to the
+exact fix commit.
+The resolver verifies that evidence against the actual local commit tree,
+signature, origin, and, for a new fix commit, its parent and receipt trailer. A
+separate eligibility manifest must cover every requested thread exactly and
+bind its allowed classification/disposition and finding evidence to the same
+commit. Together they bind the operation to the caller-provided PR head and
+reviewed target-comment identities, digests, and resolution state. After one
+initial complete target read, it requires two more equal complete target
+projections immediately before each write or successful already-resolved
+report, and keeps thread resolution separate from CI and merge-readiness
+decisions. It accepts
 only canonical registry repositories, enforces their shared API, thread, and
 comment limits, preflights every known read/write cost, uses the trusted GitHub
 CLI boundary, and reports partial failure without retrying a write.

--- a/scripts/secpal-pr-review-actions.py
+++ b/scripts/secpal-pr-review-actions.py
@@ -3995,6 +3995,7 @@ def build_parser() -> argparse.ArgumentParser:
     attestation_parser.add_argument("--bind-commit", action="store_true")
     attestation_parser.add_argument("--receipt")
     attestation_parser.add_argument("--manual-gate-evidence")
+    attestation_parser.add_argument("--eligibility-evidence")
     batch_parser = subparsers.add_parser("resolve-batch")
     batch_parser.add_argument("--repo", required=True)
     batch_parser.add_argument("--pr", required=True, type=_positive_integer)
@@ -4294,6 +4295,7 @@ def _validation_receipt(
     binding: dict[str, Any],
     reviewed: Any,
     manual_gate_evidence: Any,
+    eligibility_evidence_digest: str | None = None,
 ) -> dict[str, Any]:
     return fast_path.create_validation_receipt(
         repository=repository,
@@ -4304,7 +4306,93 @@ def _validation_receipt(
         successful_result=True,
         reviewed_state=reviewed,
         manual_gate_evidence=manual_gate_evidence,
+        eligibility_evidence_digest=eligibility_evidence_digest,
     )
+
+
+def _resolution_eligibility_digest(
+    path: str,
+    repository: str,
+    reviewed: Any,
+) -> str:
+    payload = _read_json(path, "resolution eligibility evidence")
+    expected_keys = {
+        "schema_version",
+        "repository",
+        "pull_request_number",
+        "reviewed_head_sha",
+        "reviewed_state_digest",
+        "eligible_threads",
+    }
+    threads = payload.get("eligible_threads") if isinstance(payload, dict) else None
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != expected_keys
+        or payload.get("schema_version") != "1.0"
+        or payload.get("repository") != repository
+        or payload.get("pull_request_number") != reviewed.pull_request_number
+        or isinstance(payload.get("pull_request_number"), bool)
+        or payload.get("reviewed_head_sha") != reviewed.head_sha
+        or payload.get("reviewed_state_digest") != reviewed.state_digest
+        or not isinstance(threads, list)
+        or not threads
+    ):
+        raise fast_path.SecurityBlocker(
+            "resolution eligibility evidence is invalid or stale"
+        )
+    reviewed_threads = {
+        item.get("node_id"): item
+        for item in reviewed.feedback.get("threads", [])
+        if isinstance(item, dict)
+    }
+    observed_thread_ids: list[str] = []
+    for item in threads:
+        if not isinstance(item, dict) or set(item) != {
+            "thread_id",
+            "classification",
+            "disposition",
+            "finding_ids",
+            "evidence_digest",
+        }:
+            raise fast_path.SecurityBlocker(
+                "resolution eligibility evidence thread is malformed"
+            )
+        thread_id = item.get("thread_id")
+        classification = item.get("classification")
+        disposition = item.get("disposition")
+        finding_ids = item.get("finding_ids")
+        reviewed_thread = reviewed_threads.get(thread_id)
+        if (
+            not isinstance(thread_id, str)
+            or not re.fullmatch(r"PRRT_[A-Za-z0-9_-]+", thread_id)
+            or not isinstance(classification, str)
+            or disposition
+            not in fast_path.CLASSIFICATION_DISPOSITIONS.get(
+                classification, frozenset()
+            )
+            or not isinstance(finding_ids, list)
+            or not finding_ids
+            or any(
+                not isinstance(finding_id, str)
+                or not fast_path.IDENTITY.fullmatch(finding_id)
+                or fast_path.SECRET_VALUE.search(finding_id)
+                for finding_id in finding_ids
+            )
+            or len(finding_ids) != len(set(finding_ids))
+            or not isinstance(item.get("evidence_digest"), str)
+            or not fast_path.DIGEST.fullmatch(item["evidence_digest"])
+            or not isinstance(reviewed_thread, dict)
+            or reviewed_thread.get("is_resolved") is not False
+        ):
+            raise fast_path.SecurityBlocker(
+                "resolution eligibility evidence thread is ineligible"
+            )
+        observed_thread_ids.append(thread_id)
+    if len(observed_thread_ids) != len(set(observed_thread_ids)):
+        raise fast_path.SecurityBlocker(
+            "resolution eligibility evidence contains duplicate threads"
+        )
+    return fast_path.digest_json(payload)
 
 
 def _command_attest_validation(arguments: argparse.Namespace) -> int:
@@ -4350,6 +4438,9 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
             binding=binding,
             reviewed=reviewed,
             manual_gate_evidence=receipt.get("manual_gate_evidence"),
+            eligibility_evidence_digest=receipt.get(
+                "eligibility_evidence_digest"
+            ),
         )
         if receipt != expected_receipt or fast_path.digest_json(receipt_fields) != receipt.get("receipt_digest"):
             raise fast_path.SecurityBlocker("validation receipt is invalid or stale")
@@ -4374,6 +4465,15 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
         ) != receipt["manual_gate_evidence"]:
             raise fast_path.SecurityBlocker(
                 "manual-gate evidence differs from the validated receipt"
+            )
+        supplied_eligibility = getattr(arguments, "eligibility_evidence", None)
+        if supplied_eligibility and _resolution_eligibility_digest(
+            supplied_eligibility,
+            arguments.repo,
+            reviewed,
+        ) != receipt.get("eligibility_evidence_digest"):
+            raise fast_path.SecurityBlocker(
+                "eligibility evidence differs from the validated receipt"
             )
         commit_object = _run_attestation_git(
             repository_root, ["cat-file", "commit", head], allow_failure=True
@@ -4426,6 +4526,16 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
     manual_gate_evidence = _load_fast_manual_gate_evidence(
         getattr(arguments, "manual_gate_evidence", None), binding
     )
+    eligibility_evidence = getattr(arguments, "eligibility_evidence", None)
+    eligibility_evidence_digest = (
+        _resolution_eligibility_digest(
+            eligibility_evidence,
+            arguments.repo,
+            reviewed,
+        )
+        if eligibility_evidence
+        else None
+    )
     tree = _staged_tree(repository_root, status)
     if arguments.output:
         _write_fast_report(
@@ -4451,6 +4561,14 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
         raise fast_path.SecurityBlocker(
             "local head, staged tree, or worktree changed during complete validation"
         )
+    if eligibility_evidence and _resolution_eligibility_digest(
+        eligibility_evidence,
+        arguments.repo,
+        reviewed,
+    ) != eligibility_evidence_digest:
+        raise fast_path.SecurityBlocker(
+            "eligibility evidence changed during complete validation"
+        )
     receipt = _validation_receipt(
         repository=arguments.repo,
         head_sha=head,
@@ -4458,6 +4576,7 @@ def _command_attest_validation(arguments: argparse.Namespace) -> int:
         binding=binding,
         reviewed=reviewed,
         manual_gate_evidence=manual_gate_evidence,
+        eligibility_evidence_digest=eligibility_evidence_digest,
     )
     _write_fast_report(arguments.output, receipt)
     return 0

--- a/scripts/secpal-resolve-fixed-threads.py
+++ b/scripts/secpal-resolve-fixed-threads.py
@@ -1283,7 +1283,6 @@ def resolve_threads(
         reviewed_target = reviewed_targets[thread_id]
         if (
             target.thread.is_resolved != reviewed_target.is_resolved
-            or target.thread.is_outdated != reviewed_target.is_outdated
             or target.thread.comments != reviewed_target.comments
         ):
             raise ResolutionError(

--- a/scripts/secpal-resolve-fixed-threads.py
+++ b/scripts/secpal-resolve-fixed-threads.py
@@ -733,20 +733,9 @@ def load_validation_evidence(
         _load_repository_entry(repository)
     )
     if isinstance(payload, dict) and payload.get("kind") == "VALIDATION_RECEIPT":
-        expected_receipt = _expected_validation_receipt(
-            repository,
-            reviewed,
-            payload.get("validated_tree_sha"),
-            payload.get("manual_gate_evidence"),
-            registry_binding,
-        )
-        if expected_head.lower() != reviewed.head_sha or payload != expected_receipt:
-            raise ResolutionError("validation evidence is invalid or stale")
-        return ValidationEvidence(
-            kind="receipt",
-            evidence_digest=payload["receipt_digest"],
-            validated_tree_sha=payload["validated_tree_sha"],
-            validation_receipt_digest=payload["receipt_digest"],
+        raise ResolutionError(
+            "validation evidence requires an authenticated fix-commit "
+            "attestation"
         )
     if not isinstance(payload, dict):
         raise ResolutionError("validation evidence is unavailable or malformed")
@@ -782,17 +771,13 @@ def verify_local_fix_commit(
 ) -> None:
     if (
         not isinstance(validation, ValidationEvidence)
-        or validation.kind not in {"receipt", "attestation"}
+        or validation.kind != "attestation"
         or not isinstance(validation.evidence_digest, str)
         or not DIGEST.fullmatch(validation.evidence_digest)
         or not isinstance(validation.validated_tree_sha, str)
         or not OID.fullmatch(validation.validated_tree_sha)
         or not isinstance(validation.validation_receipt_digest, str)
         or not DIGEST.fullmatch(validation.validation_receipt_digest)
-        or (
-            validation.kind == "receipt"
-            and expected_head.lower() != reviewed.head_sha
-        )
     ):
         raise ResolutionError("validation evidence binding is invalid or stale")
     try:
@@ -819,34 +804,33 @@ def verify_local_fix_commit(
         or commit_tree != validation.validated_tree_sha
     ):
         raise ResolutionError("validated tree does not match the fix commit tree")
-    if validation.kind == "attestation":
-        ancestry = runner(
-            root,
-            ("rev-list", "--parents", "-n", "1", expected_head.lower()),
-        ).stdout.split()
-        if ancestry != [expected_head.lower(), reviewed.head_sha]:
-            raise ResolutionError(
-                "validated fix commit parent does not match reviewed head"
-            )
-        trailer_output = runner(
-            root,
-            (
-                "show",
-                "-s",
-                "--format=%(trailers:key=SecPal-Validation-Receipt,"
-                "valueonly,separator=%x00)",
-                expected_head.lower(),
-            ),
-        ).stdout
-        trailers = [
-            value.strip()
-            for value in trailer_output.rstrip("\n").split("\x00")
-            if value.strip()
-        ]
-        if trailers != [validation.validation_receipt_digest]:
-            raise ResolutionError(
-                "fix commit validation-receipt trailer does not match evidence"
-            )
+    ancestry = runner(
+        root,
+        ("rev-list", "--parents", "-n", "1", expected_head.lower()),
+    ).stdout.split()
+    if ancestry != [expected_head.lower(), reviewed.head_sha]:
+        raise ResolutionError(
+            "validated fix commit parent does not match reviewed head"
+        )
+    trailer_output = runner(
+        root,
+        (
+            "show",
+            "-s",
+            "--format=%(trailers:key=SecPal-Validation-Receipt,"
+            "valueonly,separator=%x00)",
+            expected_head.lower(),
+        ),
+    ).stdout
+    trailers = [
+        value.strip()
+        for value in trailer_output.rstrip("\n").split("\x00")
+        if value.strip()
+    ]
+    if trailers != [validation.validation_receipt_digest]:
+        raise ResolutionError(
+            "fix commit validation-receipt trailer does not match evidence"
+        )
     commit_object = runner(
         root,
         ("cat-file", "commit", expected_head.lower()),

--- a/scripts/secpal-resolve-fixed-threads.py
+++ b/scripts/secpal-resolve-fixed-threads.py
@@ -207,6 +207,7 @@ class ValidationEvidence:
     evidence_digest: str
     validated_tree_sha: str
     validation_receipt_digest: str
+    eligibility_evidence_digest: str
 
 
 @dataclass(frozen=True)
@@ -369,10 +370,16 @@ def _expected_validation_receipt(
     reviewed: ReviewedState,
     validated_tree_sha: Any,
     manual_gate_evidence: Any,
+    eligibility_evidence_digest: Any,
     registry_binding: dict[str, Any],
 ) -> dict[str, Any]:
     if not isinstance(validated_tree_sha, str) or not OID.fullmatch(
         validated_tree_sha
+    ):
+        raise ResolutionError("validation evidence is invalid or stale")
+    if (
+        not isinstance(eligibility_evidence_digest, str)
+        or not DIGEST.fullmatch(eligibility_evidence_digest)
     ):
         raise ResolutionError("validation evidence is invalid or stale")
     fields = {
@@ -390,6 +397,7 @@ def _expected_validation_receipt(
             manual_gate_evidence,
             registry_binding["manual_gates"],
         ),
+        "eligibility_evidence_digest": eligibility_evidence_digest,
     }
     return {**fields, "receipt_digest": _digest_json(fields)}
 
@@ -406,6 +414,7 @@ def _expected_validation_attestation(
         reviewed,
         payload.get("validated_tree_sha"),
         payload.get("manual_gate_evidence"),
+        payload.get("eligibility_evidence_digest"),
         registry_binding,
     )
     fields = {
@@ -421,6 +430,9 @@ def _expected_validation_attestation(
         "validated_tree_sha": receipt["validated_tree_sha"],
         "validation_receipt_digest": receipt["receipt_digest"],
         "manual_gate_evidence": receipt["manual_gate_evidence"],
+        "eligibility_evidence_digest": receipt[
+            "eligibility_evidence_digest"
+        ],
     }
     return {**fields, "attestation_digest": _digest_json(fields)}
 
@@ -757,6 +769,9 @@ def load_validation_evidence(
         evidence_digest=payload["attestation_digest"],
         validated_tree_sha=payload["validated_tree_sha"],
         validation_receipt_digest=payload["validation_receipt_digest"],
+        eligibility_evidence_digest=payload[
+            "eligibility_evidence_digest"
+        ],
     )
 
 
@@ -778,6 +793,8 @@ def verify_local_fix_commit(
         or not OID.fullmatch(validation.validated_tree_sha)
         or not isinstance(validation.validation_receipt_digest, str)
         or not DIGEST.fullmatch(validation.validation_receipt_digest)
+        or not isinstance(validation.eligibility_evidence_digest, str)
+        or not DIGEST.fullmatch(validation.eligibility_evidence_digest)
     ):
         raise ResolutionError("validation evidence binding is invalid or stale")
     try:
@@ -866,10 +883,11 @@ def load_eligibility_evidence(
     path: Path,
     repository: str,
     number: int,
-    expected_head: str,
+    reviewed_head_sha: str,
     reviewed_state_digest: str,
-    validation_evidence_digest: str,
     thread_ids: tuple[str, ...],
+    *,
+    authenticated_evidence_digest: str,
 ) -> str:
     try:
         payload = json.loads(
@@ -884,23 +902,27 @@ def load_eligibility_evidence(
         "schema_version",
         "repository",
         "pull_request_number",
-        "expected_head",
+        "reviewed_head_sha",
         "reviewed_state_digest",
-        "validation_evidence_digest",
         "eligible_threads",
     }
     if not isinstance(payload, dict) or set(payload) != expected_keys:
         raise ResolutionError("eligibility evidence is unavailable or malformed")
+    observed_evidence_digest = _digest_json(payload)
+    if (
+        not isinstance(authenticated_evidence_digest, str)
+        or not DIGEST.fullmatch(authenticated_evidence_digest)
+        or observed_evidence_digest != authenticated_evidence_digest
+    ):
+        raise ResolutionError("eligibility evidence is not authenticated")
     threads = payload.get("eligible_threads")
     if (
         payload.get("schema_version") != "1.0"
         or payload.get("repository") != repository
         or payload.get("pull_request_number") != number
         or isinstance(payload.get("pull_request_number"), bool)
-        or payload.get("expected_head") != expected_head.lower()
+        or payload.get("reviewed_head_sha") != reviewed_head_sha.lower()
         or payload.get("reviewed_state_digest") != reviewed_state_digest
-        or payload.get("validation_evidence_digest")
-        != validation_evidence_digest
         or not isinstance(threads, list)
     ):
         raise ResolutionError("eligibility evidence binding is invalid or stale")
@@ -912,7 +934,6 @@ def load_eligibility_evidence(
             "disposition",
             "finding_ids",
             "evidence_digest",
-            "fix_commit_sha",
         }:
             raise ResolutionError("eligibility evidence thread is malformed")
         thread_id = item.get("thread_id")
@@ -936,7 +957,6 @@ def load_eligibility_evidence(
             or len(finding_ids) != len(set(finding_ids))
             or not isinstance(item.get("evidence_digest"), str)
             or not DIGEST.fullmatch(item["evidence_digest"])
-            or item.get("fix_commit_sha") != expected_head.lower()
         ):
             raise ResolutionError("eligibility evidence thread is ineligible")
         observed_thread_ids.append(thread_id)
@@ -944,7 +964,7 @@ def load_eligibility_evidence(
         raise ResolutionError(
             "eligibility evidence must cover requested threads exactly"
         )
-    return _digest_json(payload)
+    return observed_evidence_digest
 
 
 def read_target_thread(
@@ -1462,10 +1482,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             Path(arguments.eligibility_evidence),
             arguments.repo,
             arguments.pr,
-            arguments.expected_head,
+            reviewed.head_sha,
             reviewed.state_digest,
-            validation.evidence_digest,
             arguments.thread_id,
+            authenticated_evidence_digest=(
+                validation.eligibility_evidence_digest
+            ),
         )
         result = resolve_threads(
             arguments.repo,

--- a/scripts/secpal-resolve-fixed-threads.py
+++ b/scripts/secpal-resolve-fixed-threads.py
@@ -5,10 +5,11 @@
 """Resolve explicitly named, already-fixed pull-request review threads.
 
 This command deliberately separates thread resolution from merge readiness.
-It verifies the pull request, expected head, exact target thread identities, and
-the target comments and resolution state captured when feedback was reviewed,
-then resolves each still-open target once. It does not inspect CI, reactions,
-unrelated feedback, signatures, local validation receipts, or mergeability.
+It verifies the pull request, expected head, caller-captured reviewed-state
+digest, successful validation evidence for the fix commit, exact target thread
+identities, and the target state captured when feedback was reviewed, then
+resolves each still-open target once. It does not inspect CI, reactions,
+unrelated feedback, mergeability, or any broader readiness state.
 """
 
 from __future__ import annotations
@@ -39,6 +40,11 @@ REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 OID = re.compile(r"^[0-9a-fA-F]{40}$")
 DIGEST = re.compile(r"^[0-9a-f]{64}$")
 THREAD_ID = re.compile(r"^PRRT_[A-Za-z0-9_-]+$")
+EVIDENCE_TEXT = re.compile(r"^[^\x00-\x1f\x7f]+$")
+SECRET_VALUE = re.compile(
+    r"(?i)(?:github_pat_|gh[opsu]_|-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+    r"authorization\s*:\s*bearer)"
+)
 GH_GRAPHQL_PREFIX = ("api", "--hostname", "github.com", "graphql")
 
 TARGET_QUERY = """
@@ -76,6 +82,58 @@ mutation($threadId: ID!) {
 }
 """
 ALLOWED_GRAPHQL_DOCUMENTS = frozenset({TARGET_QUERY, RESOLVE_MUTATION})
+FIXED_THREAD_RESOLUTION_CONTRACT = {
+    "resolver": "scripts/secpal-resolve-fixed-threads.py",
+    "required_bindings": [
+        "repository",
+        "pull_request_number",
+        "repository_root",
+        "expected_head",
+        "reviewed_state_digest",
+        "validation_evidence",
+        "eligibility_evidence",
+        "thread_ids",
+    ],
+    "allowed_github_operations": [
+        "READ_NAMED_REVIEW_THREAD",
+        "RESOLVE_NAMED_REVIEW_THREAD",
+    ],
+    "prohibited_hosted_reads": [
+        "GITHUB_ACTIONS",
+        "CODEQL",
+        "CHECK_SUITES",
+        "COMMIT_STATUSES",
+        "REQUIRED_CHECKS",
+        "MERGEABILITY",
+        "BRANCH_PROTECTION",
+        "MERGE_READINESS",
+    ],
+    "prohibited_mutations": [
+        "REVIEW_REQUEST",
+        "READY_TRANSITION",
+        "MERGE",
+        "LABEL",
+        "GENERIC_COMMENT",
+    ],
+    "readiness_authorization": "SEPARATE_EXPLICIT_WORKFLOW",
+}
+ELIGIBLE_DISPOSITIONS = {
+    "VALID_ACTIONABLE": frozenset(
+        {"CORRECTED_AND_VERIFIED", "PROVEN_EXISTING_FIX"}
+    ),
+    "INVALID_FALSE_OR_MISLEADING": frozenset({"DISPROVEN_WITH_EVIDENCE"}),
+    "INFORMATIONAL": frozenset({"NON_ACTIONABLE"}),
+    "DUPLICATE": frozenset({"DUPLICATE_OF_CANONICAL"}),
+    "OUTDATED_BUT_STILL_VALID": frozenset(
+        {"CORRECTED_AND_VERIFIED", "PROVEN_EXISTING_FIX"}
+    ),
+    "OUTDATED_AND_OBSOLETE": frozenset({"OBSOLETE_ON_CURRENT_HEAD"}),
+    "ALREADY_FIXED_ON_SNAPSHOT_HEAD": frozenset({"PROVEN_EXISTING_FIX"}),
+    "SUPERSEDED": frozenset({"SUPERSEDED_BY_CANONICAL"}),
+    "SECURITY_WEAKENING_SUGGESTION": frozenset(
+        {"REJECTED_SECURITY_WEAKENING"}
+    ),
+}
 
 
 class ResolutionError(RuntimeError):
@@ -131,7 +189,24 @@ class ThreadState:
 class ExpectedThreadState:
     thread_id: str
     is_resolved: bool
+    is_outdated: bool
     comments: tuple[ThreadCommentState, ...]
+
+
+@dataclass(frozen=True)
+class ReviewedState:
+    head_sha: str
+    state_digest: str
+    feedback_digest: str
+    targets: dict[str, ExpectedThreadState]
+
+
+@dataclass(frozen=True)
+class ValidationEvidence:
+    kind: str
+    evidence_digest: str
+    validated_tree_sha: str
+    validation_receipt_digest: str
 
 
 @dataclass(frozen=True)
@@ -179,7 +254,7 @@ def _consume_comment(budget: InvocationBudget) -> None:
     budget.comments += 1
 
 
-def load_repository_limits(repository: str) -> RepositoryLimits:
+def _load_repository_entry(repository: str) -> dict[str, Any]:
     try:
         registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -192,6 +267,10 @@ def load_repository_limits(repository: str) -> RepositoryLimits:
         )
     except evidence.ContractError as exc:
         raise ResolutionError("repository registry is invalid") from exc
+    if registry.get("fixed_thread_resolution") != (
+        FIXED_THREAD_RESOLUTION_CONTRACT
+    ):
+        raise ResolutionError("fixed-thread resolution registry contract is invalid")
     repositories = registry.get("repositories") if isinstance(registry, dict) else None
     if not isinstance(repositories, list):
         raise ResolutionError("repository registry is malformed")
@@ -202,7 +281,11 @@ def load_repository_limits(repository: str) -> RepositoryLimits:
     ]
     if len(matches) != 1:
         raise ResolutionError(f"unsupported repository: {repository}")
-    entry = matches[0]
+    return matches[0]
+
+
+def load_repository_limits(repository: str) -> RepositoryLimits:
+    entry = _load_repository_entry(repository)
     maximum_api_calls = entry.get("maximum_api_calls")
     maximum_threads = entry.get("maximum_threads")
     maximum_comments = entry.get("maximum_comments")
@@ -223,6 +306,123 @@ def load_repository_limits(repository: str) -> RepositoryLimits:
         maximum_threads=maximum_threads,
         maximum_comments=maximum_comments,
     )
+
+
+def _validation_registry_binding(entry: dict[str, Any]) -> dict[str, Any]:
+    focused_validation = entry["focused_validation"]
+    validation = [
+        command
+        for command in focused_validation
+        if command.get("execution_policy", "always") == "always"
+    ] + list(entry["required_local_validation"])
+    return {
+        "repository": entry["repository"],
+        "default_branch": entry["default_branch"],
+        "allowed_base_repositories": entry["allowed_base_repositories"],
+        "manual_gates": entry["manual_gates"],
+        "signature_policy": entry["signature_policy"],
+        "check_policy": entry["check_policy"],
+        "limits": {
+            key: entry[key] for key in ("maximum_api_calls", "maximum_items")
+        },
+        "validation": validation,
+        "focused_only_validation": [
+            command
+            for command in focused_validation
+            if command.get("execution_policy") == "focused-only"
+        ],
+    }
+
+
+def _validate_manual_gate_evidence(
+    value: Any,
+    registered_gates: Any,
+) -> list[dict[str, Any]]:
+    if not isinstance(registered_gates, list) or any(
+        not isinstance(gate, str) or not gate for gate in registered_gates
+    ):
+        raise ResolutionError("registered manual gates are malformed")
+    if not isinstance(value, list) or len(value) != len(registered_gates):
+        raise ResolutionError("validation evidence is invalid or stale")
+    normalized: list[dict[str, Any]] = []
+    for index, gate in enumerate(registered_gates):
+        item = value[index]
+        evidence_text = item.get("evidence") if isinstance(item, dict) else None
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"gate", "satisfied", "evidence"}
+            or item.get("gate") != gate
+            or item.get("satisfied") is not True
+            or not isinstance(evidence_text, str)
+            or not EVIDENCE_TEXT.fullmatch(evidence_text)
+            or SECRET_VALUE.search(evidence_text)
+        ):
+            raise ResolutionError("validation evidence is invalid or stale")
+        normalized.append(
+            {"gate": gate, "satisfied": True, "evidence": evidence_text}
+        )
+    return normalized
+
+
+def _expected_validation_receipt(
+    repository: str,
+    reviewed: ReviewedState,
+    validated_tree_sha: Any,
+    manual_gate_evidence: Any,
+    registry_binding: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(validated_tree_sha, str) or not OID.fullmatch(
+        validated_tree_sha
+    ):
+        raise ResolutionError("validation evidence is invalid or stale")
+    fields = {
+        "schema_version": "1.0",
+        "kind": "VALIDATION_RECEIPT",
+        "repository": repository,
+        "head_sha": reviewed.head_sha,
+        "validated_tree_sha": validated_tree_sha.lower(),
+        "registry_digest": _digest_json(registry_binding),
+        "command_set_digest": _digest_json(registry_binding["validation"]),
+        "successful_result": True,
+        "reviewed_state_digest": reviewed.state_digest,
+        "reviewed_feedback_digest": reviewed.feedback_digest,
+        "manual_gate_evidence": _validate_manual_gate_evidence(
+            manual_gate_evidence,
+            registry_binding["manual_gates"],
+        ),
+    }
+    return {**fields, "receipt_digest": _digest_json(fields)}
+
+
+def _expected_validation_attestation(
+    repository: str,
+    expected_head: str,
+    reviewed: ReviewedState,
+    payload: dict[str, Any],
+    registry_binding: dict[str, Any],
+) -> dict[str, Any]:
+    receipt = _expected_validation_receipt(
+        repository,
+        reviewed,
+        payload.get("validated_tree_sha"),
+        payload.get("manual_gate_evidence"),
+        registry_binding,
+    )
+    fields = {
+        "schema_version": "1.0",
+        "repository": repository,
+        "head_sha": expected_head.lower(),
+        "registry_digest": receipt["registry_digest"],
+        "command_set_digest": receipt["command_set_digest"],
+        "successful_result": True,
+        "reviewed_head_sha": reviewed.head_sha,
+        "reviewed_state_digest": reviewed.state_digest,
+        "reviewed_feedback_digest": reviewed.feedback_digest,
+        "validated_tree_sha": receipt["validated_tree_sha"],
+        "validation_receipt_digest": receipt["receipt_digest"],
+        "manual_gate_evidence": receipt["manual_gate_evidence"],
+    }
+    return {**fields, "attestation_digest": _digest_json(fields)}
 
 
 def _run_gh(arguments: Sequence[str]) -> dict[str, Any]:
@@ -267,6 +467,51 @@ def _run_gh(arguments: Sequence[str]) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ResolutionError("gh returned an unexpected response")
     return value
+
+
+def _run_git(
+    repository_root: Path,
+    arguments: Sequence[str],
+    *,
+    allow_failure: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        executable = evidence.resolve_trusted_executable("git")
+        completed = subprocess.run(
+            [executable, *arguments],
+            cwd=repository_root,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=evidence.command_environment("git"),
+            timeout=30,
+        )
+    except evidence.CommandPolicyError as exc:
+        raise ResolutionError("trusted Git executable is unavailable") from exc
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ResolutionError("local Git command is unavailable") from exc
+    if completed.returncode != 0 and not allow_failure:
+        raise ResolutionError(
+            evidence.redact_diagnostic(
+                completed.stderr or "local Git command failed"
+            )
+        )
+    return completed
+
+
+def _remote_repository(value: str) -> str:
+    normalized = value.strip()
+    match = re.fullmatch(
+        r"(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+        r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?/?",
+        normalized,
+    )
+    if match is None:
+        raise ResolutionError("local origin repository identity is unsupported")
+    return match.group(1)
 
 
 def _graphql(
@@ -314,12 +559,13 @@ def _reject_nonfinite_json_constant(value: str) -> Any:
     raise ValueError(f"non-finite JSON constant: {value}")
 
 
-def load_expected_targets(
+def load_reviewed_state(
     path: Path,
     repository: str,
     number: int,
+    expected_state_digest: str,
     thread_ids: tuple[str, ...],
-) -> dict[str, ExpectedThreadState]:
+) -> ReviewedState:
     try:
         payload = json.loads(
             path.read_text(encoding="utf-8"),
@@ -391,6 +637,14 @@ def load_expected_targets(
         )
     ):
         raise ResolutionError("reviewed feedback state digest is invalid")
+    if (
+        not isinstance(expected_state_digest, str)
+        or not DIGEST.fullmatch(expected_state_digest)
+        or state_digest != expected_state_digest
+    ):
+        raise ResolutionError(
+            "reviewed feedback state does not match the captured digest"
+        )
 
     threads = payload["threads"]
     indexed_threads: dict[str, dict[str, Any]] = {}
@@ -447,11 +701,266 @@ def load_expected_targets(
         expected_targets[thread_id] = ExpectedThreadState(
             thread_id=thread_id,
             is_resolved=thread["is_resolved"],
+            is_outdated=thread["is_outdated"],
             comments=tuple(
                 sorted(comments.values(), key=operator.attrgetter("comment_id"))
             ),
         )
-    return expected_targets
+    return ReviewedState(
+        head_sha=payload["head_sha"].lower(),
+        state_digest=state_digest,
+        feedback_digest=feedback_digest,
+        targets=expected_targets,
+    )
+
+
+def load_validation_evidence(
+    path: Path,
+    repository: str,
+    expected_head: str,
+    reviewed: ReviewedState,
+) -> ValidationEvidence:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (OSError, ValueError) as exc:
+        raise ResolutionError(
+            "validation evidence is unavailable or malformed"
+        ) from exc
+    registry_binding = _validation_registry_binding(
+        _load_repository_entry(repository)
+    )
+    if isinstance(payload, dict) and payload.get("kind") == "VALIDATION_RECEIPT":
+        expected_receipt = _expected_validation_receipt(
+            repository,
+            reviewed,
+            payload.get("validated_tree_sha"),
+            payload.get("manual_gate_evidence"),
+            registry_binding,
+        )
+        if expected_head.lower() != reviewed.head_sha or payload != expected_receipt:
+            raise ResolutionError("validation evidence is invalid or stale")
+        return ValidationEvidence(
+            kind="receipt",
+            evidence_digest=payload["receipt_digest"],
+            validated_tree_sha=payload["validated_tree_sha"],
+            validation_receipt_digest=payload["receipt_digest"],
+        )
+    if not isinstance(payload, dict):
+        raise ResolutionError("validation evidence is unavailable or malformed")
+    expected_attestation = _expected_validation_attestation(
+        repository,
+        expected_head,
+        reviewed,
+        payload,
+        registry_binding,
+    )
+    if payload != expected_attestation:
+        if payload.get("head_sha") != expected_head.lower():
+            raise ResolutionError(
+                "validation evidence does not match the fix commit"
+            )
+        raise ResolutionError("validation evidence is invalid or stale")
+    return ValidationEvidence(
+        kind="attestation",
+        evidence_digest=payload["attestation_digest"],
+        validated_tree_sha=payload["validated_tree_sha"],
+        validation_receipt_digest=payload["validation_receipt_digest"],
+    )
+
+
+def verify_local_fix_commit(
+    repository_root: Path,
+    repository: str,
+    expected_head: str,
+    reviewed: ReviewedState,
+    validation: ValidationEvidence,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = _run_git,
+) -> None:
+    if (
+        not isinstance(validation, ValidationEvidence)
+        or validation.kind not in {"receipt", "attestation"}
+        or not isinstance(validation.evidence_digest, str)
+        or not DIGEST.fullmatch(validation.evidence_digest)
+        or not isinstance(validation.validated_tree_sha, str)
+        or not OID.fullmatch(validation.validated_tree_sha)
+        or not isinstance(validation.validation_receipt_digest, str)
+        or not DIGEST.fullmatch(validation.validation_receipt_digest)
+        or (
+            validation.kind == "receipt"
+            and expected_head.lower() != reviewed.head_sha
+        )
+    ):
+        raise ResolutionError("validation evidence binding is invalid or stale")
+    try:
+        root = repository_root.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ResolutionError("local repository root is unavailable") from exc
+    if not root.is_dir():
+        raise ResolutionError("local repository root is unavailable")
+    origin = runner(root, ("remote", "get-url", "origin")).stdout.strip()
+    if _remote_repository(origin) != repository:
+        raise ResolutionError("local origin repository identity mismatch")
+    local_head = runner(root, ("rev-parse", "HEAD")).stdout.strip().lower()
+    if local_head != expected_head.lower():
+        raise ResolutionError(
+            f"local head mismatch: expected {expected_head.lower()}, "
+            f"observed {local_head or 'missing'}"
+        )
+    commit_tree = runner(
+        root,
+        ("rev-parse", f"{expected_head.lower()}^{{tree}}"),
+    ).stdout.strip().lower()
+    if (
+        not OID.fullmatch(commit_tree)
+        or commit_tree != validation.validated_tree_sha
+    ):
+        raise ResolutionError("validated tree does not match the fix commit tree")
+    if validation.kind == "attestation":
+        ancestry = runner(
+            root,
+            ("rev-list", "--parents", "-n", "1", expected_head.lower()),
+        ).stdout.split()
+        if ancestry != [expected_head.lower(), reviewed.head_sha]:
+            raise ResolutionError(
+                "validated fix commit parent does not match reviewed head"
+            )
+        trailer_output = runner(
+            root,
+            (
+                "show",
+                "-s",
+                "--format=%(trailers:key=SecPal-Validation-Receipt,"
+                "valueonly,separator=%x00)",
+                expected_head.lower(),
+            ),
+        ).stdout
+        trailers = [
+            value.strip()
+            for value in trailer_output.rstrip("\n").split("\x00")
+            if value.strip()
+        ]
+        if trailers != [validation.validation_receipt_digest]:
+            raise ResolutionError(
+                "fix commit validation-receipt trailer does not match evidence"
+            )
+    commit_object = runner(
+        root,
+        ("cat-file", "commit", expected_head.lower()),
+        allow_failure=True,
+    )
+    verified = runner(
+        root,
+        ("verify-commit", "--raw", expected_head.lower()),
+        allow_failure=True,
+    )
+    local_signature = evidence.interpret_local_signature(
+        verified.returncode,
+        f"{verified.stdout}\n{verified.stderr}",
+        signature_format_hint=(
+            evidence._commit_signature_format(commit_object.stdout)
+            if commit_object.returncode == 0
+            else "unknown"
+        ),
+    )
+    signature_policy = _load_repository_entry(repository)["signature_policy"]
+    accepted_formats = signature_policy.get("accepted_formats")
+    if (
+        signature_policy.get("require_local_verified") is not True
+        or local_signature.get("state") != "valid"
+        or local_signature.get("verified") is not True
+        or not isinstance(accepted_formats, list)
+        or local_signature.get("format") not in accepted_formats
+    ):
+        raise ResolutionError("fix commit local signature is not verified")
+
+
+def load_eligibility_evidence(
+    path: Path,
+    repository: str,
+    number: int,
+    expected_head: str,
+    reviewed_state_digest: str,
+    validation_evidence_digest: str,
+    thread_ids: tuple[str, ...],
+) -> str:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (OSError, ValueError) as exc:
+        raise ResolutionError(
+            "eligibility evidence is unavailable or malformed"
+        ) from exc
+    expected_keys = {
+        "schema_version",
+        "repository",
+        "pull_request_number",
+        "expected_head",
+        "reviewed_state_digest",
+        "validation_evidence_digest",
+        "eligible_threads",
+    }
+    if not isinstance(payload, dict) or set(payload) != expected_keys:
+        raise ResolutionError("eligibility evidence is unavailable or malformed")
+    threads = payload.get("eligible_threads")
+    if (
+        payload.get("schema_version") != "1.0"
+        or payload.get("repository") != repository
+        or payload.get("pull_request_number") != number
+        or isinstance(payload.get("pull_request_number"), bool)
+        or payload.get("expected_head") != expected_head.lower()
+        or payload.get("reviewed_state_digest") != reviewed_state_digest
+        or payload.get("validation_evidence_digest")
+        != validation_evidence_digest
+        or not isinstance(threads, list)
+    ):
+        raise ResolutionError("eligibility evidence binding is invalid or stale")
+    observed_thread_ids: list[str] = []
+    for item in threads:
+        if not isinstance(item, dict) or set(item) != {
+            "thread_id",
+            "classification",
+            "disposition",
+            "finding_ids",
+            "evidence_digest",
+            "fix_commit_sha",
+        }:
+            raise ResolutionError("eligibility evidence thread is malformed")
+        thread_id = item.get("thread_id")
+        classification = item.get("classification")
+        disposition = item.get("disposition")
+        finding_ids = item.get("finding_ids")
+        if (
+            not isinstance(thread_id, str)
+            or not THREAD_ID.fullmatch(thread_id)
+            or not isinstance(classification, str)
+            or disposition not in ELIGIBLE_DISPOSITIONS.get(
+                classification,
+                frozenset(),
+            )
+            or not isinstance(finding_ids, list)
+            or not finding_ids
+            or any(
+                not isinstance(finding_id, str) or not finding_id
+                for finding_id in finding_ids
+            )
+            or len(finding_ids) != len(set(finding_ids))
+            or not isinstance(item.get("evidence_digest"), str)
+            or not DIGEST.fullmatch(item["evidence_digest"])
+            or item.get("fix_commit_sha") != expected_head.lower()
+        ):
+            raise ResolutionError("eligibility evidence thread is ineligible")
+        observed_thread_ids.append(thread_id)
+    if tuple(observed_thread_ids) != thread_ids:
+        raise ResolutionError(
+            "eligibility evidence must cover requested threads exactly"
+        )
+    return _digest_json(payload)
 
 
 def read_target_thread(
@@ -697,6 +1206,7 @@ def validate_expected_targets(
             not isinstance(target, ExpectedThreadState)
             or target.thread_id != thread_id
             or not isinstance(target.is_resolved, bool)
+            or not isinstance(target.is_outdated, bool)
             or tuple(
                 sorted(target.comments, key=operator.attrgetter("comment_id"))
             )
@@ -732,9 +1242,27 @@ def resolve_threads(
     *,
     apply: bool,
     expected_targets: dict[str, ExpectedThreadState] | None = None,
+    reviewed_state_digest: str | None = None,
+    validation_evidence_digest: str | None = None,
+    eligibility_evidence_digest: str | None = None,
     runner: Callable[[Sequence[str]], dict[str, Any]] = _run_gh,
 ) -> dict[str, Any]:
     validate_request(repository, number, expected_head, thread_ids, apply)
+    if (
+        not isinstance(reviewed_state_digest, str)
+        or not DIGEST.fullmatch(reviewed_state_digest)
+    ):
+        raise ResolutionError("reviewed state digest is required")
+    if (
+        not isinstance(validation_evidence_digest, str)
+        or not DIGEST.fullmatch(validation_evidence_digest)
+    ):
+        raise ResolutionError("validation evidence digest is required")
+    if (
+        not isinstance(eligibility_evidence_digest, str)
+        or not DIGEST.fullmatch(eligibility_evidence_digest)
+    ):
+        raise ResolutionError("eligibility evidence digest is required")
     reviewed_targets = validate_expected_targets(thread_ids, expected_targets)
     limits = load_repository_limits(repository)
     budget = InvocationBudget(
@@ -755,6 +1283,7 @@ def resolve_threads(
         reviewed_target = reviewed_targets[thread_id]
         if (
             target.thread.is_resolved != reviewed_target.is_resolved
+            or target.thread.is_outdated != reviewed_target.is_outdated
             or target.thread.comments != reviewed_target.comments
         ):
             raise ResolutionError(
@@ -845,6 +1374,9 @@ def resolve_threads(
                     "repository": repository,
                     "pull_request_number": number,
                     "head_sha": expected_head.lower(),
+                    "reviewed_state_digest": reviewed_state_digest,
+                    "validation_evidence_digest": validation_evidence_digest,
+                    "eligibility_evidence_digest": eligibility_evidence_digest,
                     "mode": "apply",
                     "status": "failed",
                     "already_resolved": already_resolved,
@@ -876,6 +1408,9 @@ def resolve_threads(
         "repository": repository,
         "pull_request_number": number,
         "head_sha": expected_head.lower(),
+        "reviewed_state_digest": reviewed_state_digest,
+        "validation_evidence_digest": validation_evidence_digest,
+        "eligibility_evidence_digest": eligibility_evidence_digest,
         "mode": "apply" if apply else "dry-run",
         "status": "success",
         "already_resolved": already_resolved,
@@ -890,8 +1425,12 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True)
     parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--repo-root", required=True)
     parser.add_argument("--expected-head", required=True)
     parser.add_argument("--reviewed-state", required=True)
+    parser.add_argument("--expected-reviewed-state-digest", required=True)
+    parser.add_argument("--validation-evidence", required=True)
+    parser.add_argument("--eligibility-evidence", required=True)
     parser.add_argument("--thread-id", action="append", required=True)
     parser.add_argument("--apply", action="store_true")
     arguments = parser.parse_args(argv)
@@ -904,6 +1443,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
             arguments.thread_id,
             arguments.apply,
         )
+        if not DIGEST.fullmatch(arguments.expected_reviewed_state_digest):
+            raise ResolutionError(
+                "expected reviewed state digest must be a SHA-256 digest"
+            )
     except ResolutionError as exc:
         parser.error(str(exc))
     return arguments
@@ -912,10 +1455,33 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = parse_args(sys.argv[1:] if argv is None else argv)
     try:
-        expected_targets = load_expected_targets(
+        reviewed = load_reviewed_state(
             Path(arguments.reviewed_state),
             arguments.repo,
             arguments.pr,
+            arguments.expected_reviewed_state_digest,
+            arguments.thread_id,
+        )
+        validation = load_validation_evidence(
+            Path(arguments.validation_evidence),
+            arguments.repo,
+            arguments.expected_head,
+            reviewed,
+        )
+        verify_local_fix_commit(
+            Path(arguments.repo_root),
+            arguments.repo,
+            arguments.expected_head,
+            reviewed,
+            validation,
+        )
+        eligibility_evidence_digest = load_eligibility_evidence(
+            Path(arguments.eligibility_evidence),
+            arguments.repo,
+            arguments.pr,
+            arguments.expected_head,
+            reviewed.state_digest,
+            validation.evidence_digest,
             arguments.thread_id,
         )
         result = resolve_threads(
@@ -924,7 +1490,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             arguments.expected_head,
             arguments.thread_id,
             apply=arguments.apply,
-            expected_targets=expected_targets,
+            expected_targets=reviewed.targets,
+            reviewed_state_digest=reviewed.state_digest,
+            validation_evidence_digest=validation.evidence_digest,
+            eligibility_evidence_digest=eligibility_evidence_digest,
         )
     except ResolutionError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/secpal_pr_review/fast_path.py
+++ b/scripts/secpal_pr_review/fast_path.py
@@ -789,6 +789,7 @@ def create_validation_receipt(
     successful_result: bool,
     reviewed_state: StableFeedbackState,
     manual_gate_evidence: Any,
+    eligibility_evidence_digest: str | None = None,
 ) -> dict[str, Any]:
     gates = registry.get("manual_gates") if isinstance(registry, dict) else None
     normalized_gates = validate_manual_gate_evidence(manual_gate_evidence, gates)
@@ -807,6 +808,13 @@ def create_validation_receipt(
         "reviewed_feedback_digest": reviewed_state.feedback_digest,
         "manual_gate_evidence": normalized_gates,
     }
+    if eligibility_evidence_digest is not None:
+        if (
+            not isinstance(eligibility_evidence_digest, str)
+            or not DIGEST.fullmatch(eligibility_evidence_digest)
+        ):
+            raise SecurityBlocker("eligibility evidence digest is malformed")
+        fields["eligibility_evidence_digest"] = eligibility_evidence_digest
     return {**fields, "receipt_digest": digest_json(fields)}
 
 
@@ -831,6 +839,9 @@ def create_validation_attestation(
         successful_result=True,
         reviewed_state=reviewed_state,
         manual_gate_evidence=validation_receipt.get("manual_gate_evidence"),
+        eligibility_evidence_digest=validation_receipt.get(
+            "eligibility_evidence_digest"
+        ),
     )
     if validation_receipt != expected_receipt:
         raise SecurityBlocker("validation receipt is invalid or stale")
@@ -850,6 +861,10 @@ def create_validation_attestation(
             validation_receipt["manual_gate_evidence"]
         ),
     }
+    if "eligibility_evidence_digest" in validation_receipt:
+        fields["eligibility_evidence_digest"] = validation_receipt[
+            "eligibility_evidence_digest"
+        ]
     return {**fields, "attestation_digest": digest_json(fields)}
 
 
@@ -881,6 +896,9 @@ def verify_validation_attestation(
         successful_result=True,
         reviewed_state=reviewed_state,
         manual_gate_evidence=attestation.get("manual_gate_evidence"),
+        eligibility_evidence_digest=attestation.get(
+            "eligibility_evidence_digest"
+        ),
     )
     if (
         commit_validation_receipt_digest != receipt["receipt_digest"]

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -5394,6 +5394,62 @@ class FastPathTests(TestCase):
                 commit_validation_receipt_digest=receipt["receipt_digest"],
             )
 
+    def test_resolution_eligibility_is_bound_into_the_signed_receipt(self) -> None:
+        payload = fast_feedback(thread_count=1).to_dict()
+        payload["threads"][0]["node_id"] = "PRRT_exampleOne"
+        reviewed = fast_path.StableFeedbackState.from_payload(payload)
+        manifest = {
+            "schema_version": "1.0",
+            "repository": "SecPal/.github",
+            "pull_request_number": 1,
+            "reviewed_head_sha": reviewed.head_sha,
+            "reviewed_state_digest": reviewed.state_digest,
+            "eligible_threads": [
+                {
+                    "thread_id": "PRRT_exampleOne",
+                    "classification": "VALID_ACTIONABLE",
+                    "disposition": "CORRECTED_AND_VERIFIED",
+                    "finding_ids": ["finding-1"],
+                    "evidence_digest": "a" * 64,
+                }
+            ],
+        }
+        registry = fast_registry()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "eligibility.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            eligibility_digest = actions._resolution_eligibility_digest(
+                str(path), "SecPal/.github", reviewed
+            )
+
+        receipt = fast_path.create_validation_receipt(
+            repository="SecPal/.github",
+            head_sha=reviewed.head_sha,
+            validated_tree_sha="a" * 40,
+            registry=registry,
+            command_set=registry["validation"],
+            successful_result=True,
+            reviewed_state=reviewed,
+            manual_gate_evidence=[],
+            eligibility_evidence_digest=eligibility_digest,
+        )
+        attestation = fast_path.create_validation_attestation(
+            repository="SecPal/.github",
+            head_sha=p21.HEAD,
+            registry=registry,
+            command_set=registry["validation"],
+            successful_result=True,
+            reviewed_state=reviewed,
+            validation_receipt=receipt,
+        )
+
+        self.assertEqual(
+            receipt["eligibility_evidence_digest"], eligibility_digest
+        )
+        self.assertEqual(
+            attestation["eligibility_evidence_digest"], eligibility_digest
+        )
+
     def test_registered_manual_gates_require_explicit_satisfied_evidence(self) -> None:
         binding = actions._fast_registry_binding(registry_entry("SecPal/.github"))
         with self.assertRaisesRegex(

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3800,8 +3800,10 @@ class RegistryTests(TestCase):
         self.assertEqual([item["repository"] for item in actions.validate_registry(registry)["repositories"]], self.repositories)
         missing_resolution_contract = copy.deepcopy(registry)
         missing_resolution_contract.pop("fixed_thread_resolution")
-        with self.assertRaises(actions.RegistryError):
-            actions.validate_registry(missing_resolution_contract)
+        self.assertEqual(
+            actions.validate_registry(missing_resolution_contract)["repositories"],
+            registry["repositories"],
+        )
         duplicate = copy.deepcopy(registry)
         duplicate["repositories"].append(copy.deepcopy(duplicate["repositories"][0]))
         with self.assertRaisesRegex(actions.RegistryError, "duplicate"):

--- a/tests/secpal-pr-review-actions-unit.py
+++ b/tests/secpal-pr-review-actions-unit.py
@@ -3790,8 +3790,18 @@ class RegistryTests(TestCase):
                 self.assertLessEqual(entry["maximum_reactions"], 50)
 
     def test_registry_cases_61_to_69(self) -> None:
-        registry = {"schema_version": "1.0", "repositories": [registry_entry(repo) for repo in self.repositories]}
+        registry = {
+            "schema_version": "1.0",
+            "fixed_thread_resolution": copy.deepcopy(
+                actions.load_registry()["fixed_thread_resolution"]
+            ),
+            "repositories": [registry_entry(repo) for repo in self.repositories],
+        }
         self.assertEqual([item["repository"] for item in actions.validate_registry(registry)["repositories"]], self.repositories)
+        missing_resolution_contract = copy.deepcopy(registry)
+        missing_resolution_contract.pop("fixed_thread_resolution")
+        with self.assertRaises(actions.RegistryError):
+            actions.validate_registry(missing_resolution_contract)
         duplicate = copy.deepcopy(registry)
         duplicate["repositories"].append(copy.deepcopy(duplicate["repositories"][0]))
         with self.assertRaisesRegex(actions.RegistryError, "duplicate"):
@@ -4258,7 +4268,13 @@ class RegistryTests(TestCase):
         )
 
     def test_required_validation_rejects_focused_only_execution(self) -> None:
-        registry = {"schema_version": "1.0", "repositories": [frontend_registry_entry()]}
+        registry = {
+            "schema_version": "1.0",
+            "fixed_thread_resolution": copy.deepcopy(
+                actions.load_registry()["fixed_thread_resolution"]
+            ),
+            "repositories": [frontend_registry_entry()],
+        }
         registry["repositories"][0]["required_local_validation"][0][
             "execution_policy"
         ] = "focused-only"

--- a/tests/secpal-pr-review-skill-integration.sh
+++ b/tests/secpal-pr-review-skill-integration.sh
@@ -222,7 +222,8 @@ module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
-entry = module.select_repository(module.load_registry(), "SecPal/.github")
+registry = module.load_registry()
+entry = module.select_repository(registry, "SecPal/.github")
 entry["focused_validation"] = []
 entry["required_local_validation"] = [
     {
@@ -239,7 +240,11 @@ entry["required_local_validation"] = [
 entry["manual_gates"] = []
 (workspace / "validation-registry.json").write_text(
     json.dumps(
-        {"schema_version": "1.0", "repositories": [entry]},
+        {
+            "schema_version": "1.0",
+            "fixed_thread_resolution": registry["fixed_thread_resolution"],
+            "repositories": [entry],
+        },
         sort_keys=True,
         separators=(",", ":"),
     )

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -332,6 +332,12 @@ grep -Fq 'expected current head OID' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation is not head-bound'
 grep -Fq 'every requested thread belongs to that PR' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation is not target-bound'
+grep -Fq 'canonical eligibility-manifest digest' "$CONTRACT" \
+  || fail 'contract does not authenticate per-thread eligibility evidence'
+grep -Fq 'signed validation receipt and final attestation' "$SKILL" \
+  || fail 'skill does not authenticate the eligibility manifest before resolution'
+grep -Fq 'attest-validation --eligibility-evidence' "$SIMPLE_RESOLUTION_DOC" \
+  || fail 'simple resolver documentation omits eligibility attestation'
 jq -e '
   .fixed_thread_resolution == {
     "resolver": "scripts/secpal-resolve-fixed-threads.py",

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -267,6 +267,10 @@ if jq -e \
 fi
 grep -Fq -- '--reviewed-state REVIEWED_STATE' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation does not bind mutations to reviewed feedback'
+grep -Fq -- '--expected-reviewed-state-digest REVIEWED_STATE_SHA256' "$SIMPLE_RESOLUTION_DOC" \
+  || fail 'simple resolver documentation does not bind the captured reviewed-state digest'
+grep -Fq -- '--validation-evidence VALIDATION_EVIDENCE.json' "$SIMPLE_RESOLUTION_DOC" \
+  || fail 'simple resolver documentation does not require validation evidence'
 grep -Fq 'three complete target reads' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation undercounts stable target rechecks'
 grep -Fq 'When remediation changes no tracked source file' "$CONTRACT" \
@@ -328,6 +332,28 @@ grep -Fq 'expected current head OID' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation is not head-bound'
 grep -Fq 'every requested thread belongs to that PR' "$SIMPLE_RESOLUTION_DOC" \
   || fail 'simple resolver documentation is not target-bound'
+jq -e '
+  .fixed_thread_resolution == {
+    "resolver": "scripts/secpal-resolve-fixed-threads.py",
+    "required_bindings": [
+      "repository", "pull_request_number", "repository_root", "expected_head",
+      "reviewed_state_digest", "validation_evidence", "eligibility_evidence",
+      "thread_ids"
+    ],
+    "allowed_github_operations": [
+      "READ_NAMED_REVIEW_THREAD", "RESOLVE_NAMED_REVIEW_THREAD"
+    ],
+    "prohibited_hosted_reads": [
+      "GITHUB_ACTIONS", "CODEQL", "CHECK_SUITES", "COMMIT_STATUSES",
+      "REQUIRED_CHECKS", "MERGEABILITY", "BRANCH_PROTECTION", "MERGE_READINESS"
+    ],
+    "prohibited_mutations": [
+      "REVIEW_REQUEST", "READY_TRANSITION", "MERGE", "LABEL", "GENERIC_COMMENT"
+    ],
+    "readiness_authorization": "SEPARATE_EXPLICIT_WORKFLOW"
+  }
+' "$REGISTRY" >/dev/null \
+  || fail 'repository registry does not define the CI-independent fixed-thread contract'
 
 git -C "$REPO_ROOT" cat-file -e "$P21_BASELINE^{commit}" 2>/dev/null \
   || fail "accepted P2.1 baseline commit is unavailable: $P21_BASELINE"

--- a/tests/secpal-pr-review-static-policy.py
+++ b/tests/secpal-pr-review-static-policy.py
@@ -145,6 +145,23 @@ RESOLVER_CALLS = (
             ("timeout", "30"),
         ),
     ),
+    ProcessCall(
+        None,
+        "_run_git",
+        "executable",
+        "arguments",
+        (
+            ("capture_output", "True"),
+            ("check", "False"),
+            ("cwd", "repository_root"),
+            ("encoding", "'utf-8'"),
+            ("env", "evidence.command_environment('git')"),
+            ("errors", "'replace'"),
+            ("stdin", "subprocess.DEVNULL"),
+            ("text", "True"),
+            ("timeout", "30"),
+        ),
+    ),
 )
 
 EXPECTED_CALLS = {
@@ -391,7 +408,9 @@ LOADED_MODULE_ATTRIBUTES = {
         "evidence": {
             "CommandPolicyError",
             "ContractError",
+            "_commit_signature_format",
             "command_environment",
+            "interpret_local_signature",
             "redact_diagnostic",
             "resolve_trusted_executable",
             "validate_against_authoritative_schema",
@@ -517,10 +536,19 @@ RESOLVER_TOP_LEVEL_FUNCTIONS = {
     "_digest_json",
     "_graphql",
     "_load_evidence_helper",
+    "_load_repository_entry",
+    "_expected_validation_attestation",
+    "_expected_validation_receipt",
     "_reject_nonfinite_json_constant",
+    "_remote_repository",
     "_run_gh",
-    "load_expected_targets",
+    "_run_git",
+    "_validate_manual_gate_evidence",
+    "_validation_registry_binding",
     "load_repository_limits",
+    "load_eligibility_evidence",
+    "load_reviewed_state",
+    "load_validation_evidence",
     "main",
     "parse_args",
     "read_stable_target_thread",
@@ -529,20 +557,35 @@ RESOLVER_TOP_LEVEL_FUNCTIONS = {
     "resolve_threads",
     "validate_expected_targets",
     "validate_request",
+    "verify_local_fix_commit",
 }
 RESOLVER_CLASS_SHAPES = {
     "ExpectedThreadState": ClassShape((), (), ("dataclass(frozen=True)",)),
     "InvocationBudget": ClassShape((), (), ("dataclass",)),
     "RepositoryLimits": ClassShape((), (), ("dataclass(frozen=True)",)),
+    "ReviewedState": ClassShape((), (), ("dataclass(frozen=True)",)),
     "ResolutionError": ClassShape(("RuntimeError",), (), ()),
     "TargetRead": ClassShape((), (), ("dataclass(frozen=True)",)),
     "ThreadCommentState": ClassShape((), (), ("dataclass(frozen=True)",)),
     "ThreadState": ClassShape((), (), ("dataclass(frozen=True)",)),
+    "ValidationEvidence": ClassShape((), (), ("dataclass(frozen=True)",)),
 }
 SAFE_RESOLVER_FUNCTION_REFERENCES = {
     DynamicImportCall(
-        ("load_expected_targets",),
+        ("load_reviewed_state",),
         "_reject_nonfinite_json_constant",
+    ),
+    DynamicImportCall(
+        ("load_validation_evidence",),
+        "_reject_nonfinite_json_constant",
+    ),
+    DynamicImportCall(
+        ("load_eligibility_evidence",),
+        "_reject_nonfinite_json_constant",
+    ),
+    DynamicImportCall(
+        ("verify_local_fix_commit",),
+        "_run_git",
     ),
     DynamicImportCall(
         ("resolve_threads",),
@@ -551,9 +594,15 @@ SAFE_RESOLVER_FUNCTION_REFERENCES = {
 }
 RESOLVER_LOOP_SITES = {
     LoopSite("for", ("_graphql",), "variables.items()"),
-    LoopSite("for", ("load_expected_targets",), "threads"),
-    LoopSite("for", ("load_expected_targets",), "thread_ids"),
-    LoopSite("for", ("load_expected_targets",), "thread['comments']"),
+    LoopSite("for", ("load_reviewed_state",), "threads"),
+    LoopSite("for", ("load_reviewed_state",), "thread_ids"),
+    LoopSite("for", ("load_reviewed_state",), "thread['comments']"),
+    LoopSite(
+        "for",
+        ("_validate_manual_gate_evidence",),
+        "enumerate(registered_gates)",
+    ),
+    LoopSite("for", ("load_eligibility_evidence",), "threads"),
     LoopSite(
         "for",
         ("read_target_thread",),
@@ -568,8 +617,23 @@ RESOLVER_LOOP_SITES = {
     LoopSite("for", ("validate_expected_targets",), "target.comments"),
     LoopSite("for", ("resolve_threads",), "thread_ids"),
     LoopSite("for", ("resolve_threads",), "enumerate(thread_ids)"),
-    LoopSite("comprehension", ("load_repository_limits",), "repositories"),
-    LoopSite("comprehension", ("load_expected_targets",), "feedback.values()"),
+    LoopSite("comprehension", ("_load_repository_entry",), "repositories"),
+    LoopSite("comprehension", ("load_reviewed_state",), "feedback.values()"),
+    LoopSite(
+        "comprehension",
+        ("_validate_manual_gate_evidence",),
+        "registered_gates",
+    ),
+    LoopSite(
+        "comprehension",
+        ("_validation_registry_binding",),
+        "focused_validation",
+    ),
+    LoopSite(
+        "comprehension",
+        ("_validation_registry_binding",),
+        "('maximum_api_calls', 'maximum_items')",
+    ),
     LoopSite(
         "comprehension",
         ("validate_expected_targets",),
@@ -579,6 +643,16 @@ RESOLVER_LOOP_SITES = {
         "comprehension",
         ("_run_gh",),
         "arguments[len(GH_GRAPHQL_PREFIX):]",
+    ),
+    LoopSite(
+        "comprehension",
+        ("verify_local_fix_commit",),
+        "trailer_output.rstrip('\\n').split('\\x00')",
+    ),
+    LoopSite(
+        "comprehension",
+        ("load_eligibility_evidence",),
+        "finding_ids",
     ),
     LoopSite("comprehension", ("resolve_threads",), "thread_ids"),
     LoopSite("comprehension", ("validate_request",), "thread_ids"),

--- a/tests/secpal-pr-review-static-policy.py
+++ b/tests/secpal-pr-review-static-policy.py
@@ -387,6 +387,9 @@ LOADED_MODULE_ATTRIBUTES = {
         },
         "fast_path": {
             "BatchRequest",
+            "CLASSIFICATION_DISPOSITIONS",
+            "DIGEST",
+            "IDENTITY",
             "ReadinessState",
             "RecoverableLocalError",
             "SECRET_VALUE",
@@ -471,6 +474,10 @@ SAFE_GETATTR_CALLS = {
         DynamicImportCall(
             ("_command_attest_validation",),
             "getattr(arguments, 'manual_gate_evidence', None)",
+        ),
+        DynamicImportCall(
+            ("_command_attest_validation",),
+            "getattr(arguments, 'eligibility_evidence', None)",
         ),
     },
     "secpal-resolve-fixed-threads.py": {

--- a/tests/secpal-resolve-fixed-threads-unit.py
+++ b/tests/secpal-resolve-fixed-threads-unit.py
@@ -1141,26 +1141,30 @@ class ResolveFixedThreadsTests(TestCase):
 
         self.assertEqual(len(fake.calls), 1)
 
-    def test_outdated_change_after_reviewed_capture_blocks_before_mutation(
+    def test_outdated_change_after_reviewed_capture_remains_allowed_and_stable(
         self,
     ) -> None:
         thread_id = "PRRT_exampleOne"
-        fake = FakeGh([target_response(thread_id, outdated=True)])
+        fake = FakeGh(
+            [
+                target_response(thread_id, outdated=True),
+                target_response(thread_id, outdated=True),
+                target_response(thread_id, outdated=True),
+                resolve_response(thread_id),
+            ]
+        )
 
-        with self.assertRaisesRegex(
-            MODULE.ResolutionError,
-            "differs from reviewed feedback",
-        ):
-            resolve_threads(
-                "SecPal/api",
-                123,
-                "a" * 40,
-                [thread_id],
-                apply=True,
-                runner=fake,
-            )
+        result = resolve_threads(
+            "SecPal/api",
+            123,
+            "a" * 40,
+            [thread_id],
+            apply=True,
+            runner=fake,
+        )
 
-        self.assertEqual(len(fake.calls), 1)
+        self.assertEqual(result["resolved"], [thread_id])
+        self.assertEqual(len(fake.calls), 4)
 
     def test_reviewed_state_digest_drift_blocks_before_validation_or_github(
         self,

--- a/tests/secpal-resolve-fixed-threads-unit.py
+++ b/tests/secpal-resolve-fixed-threads-unit.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import subprocess
@@ -258,7 +259,10 @@ def reviewed_state_payload(
     }
 
 
-def validation_attestation_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
+def validation_attestation_payload(
+    reviewed: dict[str, Any],
+    eligibility_evidence_digest: str = "e" * 64,
+) -> dict[str, Any]:
     binding = MODULE._validation_registry_binding(
         MODULE._load_repository_entry(reviewed["repository"])
     )
@@ -282,6 +286,7 @@ def validation_attestation_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
         "reviewed_state_digest": reviewed["state_digest"],
         "reviewed_feedback_digest": reviewed["feedback_digest"],
         "manual_gate_evidence": manual_gate_evidence,
+        "eligibility_evidence_digest": eligibility_evidence_digest,
     }
     fields = {
         "schema_version": "1.0",
@@ -296,6 +301,7 @@ def validation_attestation_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
         "validated_tree_sha": "f" * 40,
         "validation_receipt_digest": MODULE._digest_json(receipt_fields),
         "manual_gate_evidence": manual_gate_evidence,
+        "eligibility_evidence_digest": eligibility_evidence_digest,
     }
     return {**fields, "attestation_digest": MODULE._digest_json(fields)}
 
@@ -330,16 +336,14 @@ def validation_receipt_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
 
 def eligibility_payload(
     reviewed: dict[str, Any],
-    validation_evidence_digest: str,
     thread_ids: Sequence[str],
 ) -> dict[str, Any]:
     fields = {
         "schema_version": "1.0",
         "repository": reviewed["repository"],
         "pull_request_number": reviewed["pull_request_number"],
-        "expected_head": "c" * 40,
+        "reviewed_head_sha": reviewed["head_sha"],
         "reviewed_state_digest": reviewed["state_digest"],
-        "validation_evidence_digest": validation_evidence_digest,
         "eligible_threads": [
             {
                 "thread_id": thread_id,
@@ -347,7 +351,6 @@ def eligibility_payload(
                 "disposition": "CORRECTED_AND_VERIFIED",
                 "finding_ids": [f"finding-{index}"],
                 "evidence_digest": f"{index:x}" * 64,
-                "fix_commit_sha": "c" * 40,
             }
             for index, thread_id in enumerate(thread_ids, start=1)
         ],
@@ -1238,11 +1241,13 @@ class ResolveFixedThreadsTests(TestCase):
             feedback_digest=payload["feedback_digest"],
         )
         attestation = validation_attestation_payload(payload)
-        for mutation in ("receipt", "gates", "secret"):
+        for mutation in ("receipt", "eligibility", "gates", "secret"):
             with self.subTest(mutation=mutation):
                 changed = dict(attestation)
                 if mutation == "receipt":
                     changed["validation_receipt_digest"] = "0" * 64
+                elif mutation == "eligibility":
+                    changed["eligibility_evidence_digest"] = "0" * 64
                 else:
                     changed["manual_gate_evidence"] = (
                         []
@@ -1428,6 +1433,7 @@ class ResolveFixedThreadsTests(TestCase):
             evidence_digest="d" * 64,
             validated_tree_sha="f" * 40,
             validation_receipt_digest="e" * 64,
+            eligibility_evidence_digest="f" * 64,
         )
         fake = mock.Mock()
         with self.assertRaisesRegex(
@@ -1500,7 +1506,7 @@ class ResolveFixedThreadsTests(TestCase):
         payload["state_digest"] = MODULE._digest_json(
             {**identity, "feedback": feedback}
         )
-        manifest = eligibility_payload(payload, "d" * 64, (first, second))
+        manifest = eligibility_payload(payload, (first, second))
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "eligibility.json"
             path.write_text(json.dumps(manifest), encoding="utf-8")
@@ -1509,10 +1515,10 @@ class ResolveFixedThreadsTests(TestCase):
                 path,
                 "SecPal/api",
                 123,
-                "c" * 40,
+                payload["head_sha"],
                 payload["state_digest"],
-                "d" * 64,
                 (first, second),
+                authenticated_evidence_digest=MODULE._digest_json(manifest),
             )
 
         self.assertEqual(evidence_digest, MODULE._digest_json(manifest))
@@ -1520,7 +1526,7 @@ class ResolveFixedThreadsTests(TestCase):
     def test_ineligible_or_unlisted_thread_blocks_before_github(self) -> None:
         thread_id = "PRRT_exampleOne"
         payload = reviewed_state_payload(thread_id, [])
-        manifest = eligibility_payload(payload, "d" * 64, (thread_id,))
+        manifest = eligibility_payload(payload, (thread_id,))
         cases = {
             "unlisted": [],
             "unsafe disposition": [
@@ -1544,22 +1550,23 @@ class ResolveFixedThreadsTests(TestCase):
                         path,
                         "SecPal/api",
                         123,
-                        "c" * 40,
+                        payload["head_sha"],
                         payload["state_digest"],
-                        "d" * 64,
                         (thread_id,),
+                        authenticated_evidence_digest=MODULE._digest_json(
+                            changed
+                        ),
                     )
 
     def test_eligibility_manifest_rejects_rehashed_binding_drift(self) -> None:
         thread_id = "PRRT_exampleOne"
         payload = reviewed_state_payload(thread_id, [])
-        manifest = eligibility_payload(payload, "d" * 64, (thread_id,))
+        manifest = eligibility_payload(payload, (thread_id,))
         cases = {
             "repository": "SecPal/frontend",
             "pull_request_number": 124,
-            "expected_head": "b" * 40,
+            "reviewed_head_sha": "b" * 40,
             "reviewed_state_digest": "0" * 64,
-            "validation_evidence_digest": "1" * 64,
         }
         for field, value in cases.items():
             with self.subTest(field=field), tempfile.TemporaryDirectory() as directory:
@@ -1575,11 +1582,39 @@ class ResolveFixedThreadsTests(TestCase):
                         path,
                         "SecPal/api",
                         123,
-                        "c" * 40,
+                        payload["head_sha"],
                         payload["state_digest"],
-                        "d" * 64,
                         (thread_id,),
+                        authenticated_evidence_digest=MODULE._digest_json(
+                            changed
+                        ),
                     )
+
+    def test_eligibility_manifest_rejects_caller_rehashed_decision(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        trusted = eligibility_payload(payload, (thread_id,))
+        changed = copy.deepcopy(trusted)
+        changed["eligible_threads"][0]["finding_ids"] = ["unaddressed-finding"]
+        changed["eligible_threads"][0]["evidence_digest"] = "f" * 64
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "eligibility.json"
+            path.write_text(json.dumps(changed), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                MODULE.ResolutionError,
+                "eligibility evidence is not authenticated",
+            ):
+                MODULE.load_eligibility_evidence(
+                    path,
+                    "SecPal/api",
+                    123,
+                    payload["head_sha"],
+                    payload["state_digest"],
+                    (thread_id,),
+                    authenticated_evidence_digest=MODULE._digest_json(trusted),
+                )
 
     def test_nonfinite_reviewed_state_is_reported_without_traceback(self) -> None:
         for constant in ("NaN", "Infinity", "-Infinity"):
@@ -1955,6 +1990,7 @@ class ResolveFixedThreadsTests(TestCase):
                     evidence_digest="d" * 64,
                     validated_tree_sha="f" * 40,
                     validation_receipt_digest="b" * 64,
+                    eligibility_evidence_digest="e" * 64,
                 ),
             ),
             mock.patch.object(MODULE, "verify_local_fix_commit") as verify_commit,

--- a/tests/secpal-resolve-fixed-threads-unit.py
+++ b/tests/secpal-resolve-fixed-threads-unit.py
@@ -37,6 +37,60 @@ class FakeGh:
         return self.responses.pop(0)
 
 
+class FakeGit:
+    def __init__(
+        self,
+        *,
+        expected_head: str,
+        reviewed_head: str,
+        tree: str,
+        receipt_digest: str,
+        repository: str = "SecPal/api",
+        signature_valid: bool = True,
+    ) -> None:
+        self.expected_head = expected_head
+        self.reviewed_head = reviewed_head
+        self.tree = tree
+        self.receipt_digest = receipt_digest
+        self.repository = repository
+        self.signature_valid = signature_valid
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(
+        self,
+        repository_root: Path,
+        arguments: Sequence[str],
+        *,
+        allow_failure: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        del repository_root, allow_failure
+        call = tuple(arguments)
+        self.calls.append(call)
+        if call == ("remote", "get-url", "origin"):
+            stdout = f"https://github.com/{self.repository}.git\n"
+        elif call == ("rev-parse", "HEAD"):
+            stdout = f"{self.expected_head}\n"
+        elif call == ("rev-parse", f"{self.expected_head}^{{tree}}"):
+            stdout = f"{self.tree}\n"
+        elif call == ("rev-list", "--parents", "-n", "1", self.expected_head):
+            stdout = f"{self.expected_head} {self.reviewed_head}\n"
+        elif call[0:2] == ("show", "-s"):
+            stdout = f"{self.receipt_digest}\n"
+        elif call == ("cat-file", "commit", self.expected_head):
+            stdout = (
+                f"tree {self.tree}\nparent {self.reviewed_head}\n"
+                "gpgsig -----BEGIN SSH SIGNATURE-----\n signature\n"
+                " -----END SSH SIGNATURE-----\n\nmessage\n"
+            )
+        elif call == ("verify-commit", "--raw", self.expected_head):
+            if not self.signature_valid:
+                return subprocess.CompletedProcess(call, 1, "", "bad signature")
+            stdout = 'Good "git" signature for fixture\n'
+        else:
+            raise AssertionError(f"unexpected git call: {call}")
+        return subprocess.CompletedProcess(call, 0, stdout, "")
+
+
 def resolve_response(thread_id: str) -> dict[str, Any]:
     return {
         "data": {
@@ -101,6 +155,7 @@ def expected_thread_state(
     comments: list[tuple[str, str, str | None]] | None = None,
     *,
     resolved: bool = False,
+    outdated: bool = False,
 ) -> Any:
     states = [
         MODULE.ThreadCommentState(
@@ -113,6 +168,7 @@ def expected_thread_state(
     return MODULE.ExpectedThreadState(
         thread_id=thread_id,
         is_resolved=resolved,
+        is_outdated=outdated,
         comments=tuple(sorted(states, key=lambda item: item.comment_id)),
     )
 
@@ -145,6 +201,9 @@ def resolve_threads(
         immutable_thread_ids,
         apply=apply,
         expected_targets=expected_targets,
+        reviewed_state_digest="c" * 64,
+        validation_evidence_digest="d" * 64,
+        eligibility_evidence_digest="e" * 64,
         runner=runner,
     )
 
@@ -197,6 +256,103 @@ def reviewed_state_payload(
         "feedback_digest": MODULE._digest_json(feedback),
         "state_digest": MODULE._digest_json({**identity, "feedback": feedback}),
     }
+
+
+def validation_attestation_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
+    binding = MODULE._validation_registry_binding(
+        MODULE._load_repository_entry(reviewed["repository"])
+    )
+    manual_gate_evidence = [
+        {
+            "gate": gate,
+            "satisfied": True,
+            "evidence": f"Verified integration evidence {index}",
+        }
+        for index, gate in enumerate(binding["manual_gates"], start=1)
+    ]
+    receipt_fields = {
+        "schema_version": "1.0",
+        "kind": "VALIDATION_RECEIPT",
+        "repository": reviewed["repository"],
+        "head_sha": reviewed["head_sha"],
+        "validated_tree_sha": "f" * 40,
+        "registry_digest": MODULE._digest_json(binding),
+        "command_set_digest": MODULE._digest_json(binding["validation"]),
+        "successful_result": True,
+        "reviewed_state_digest": reviewed["state_digest"],
+        "reviewed_feedback_digest": reviewed["feedback_digest"],
+        "manual_gate_evidence": manual_gate_evidence,
+    }
+    fields = {
+        "schema_version": "1.0",
+        "repository": reviewed["repository"],
+        "head_sha": "c" * 40,
+        "registry_digest": MODULE._digest_json(binding),
+        "command_set_digest": MODULE._digest_json(binding["validation"]),
+        "successful_result": True,
+        "reviewed_head_sha": reviewed["head_sha"],
+        "reviewed_state_digest": reviewed["state_digest"],
+        "reviewed_feedback_digest": reviewed["feedback_digest"],
+        "validated_tree_sha": "f" * 40,
+        "validation_receipt_digest": MODULE._digest_json(receipt_fields),
+        "manual_gate_evidence": manual_gate_evidence,
+    }
+    return {**fields, "attestation_digest": MODULE._digest_json(fields)}
+
+
+def validation_receipt_payload(reviewed: dict[str, Any]) -> dict[str, Any]:
+    binding = MODULE._validation_registry_binding(
+        MODULE._load_repository_entry(reviewed["repository"])
+    )
+    manual_gate_evidence = [
+        {
+            "gate": gate,
+            "satisfied": True,
+            "evidence": f"Verified integration evidence {index}",
+        }
+        for index, gate in enumerate(binding["manual_gates"], start=1)
+    ]
+    fields = {
+        "schema_version": "1.0",
+        "kind": "VALIDATION_RECEIPT",
+        "repository": reviewed["repository"],
+        "head_sha": reviewed["head_sha"],
+        "validated_tree_sha": "f" * 40,
+        "registry_digest": MODULE._digest_json(binding),
+        "command_set_digest": MODULE._digest_json(binding["validation"]),
+        "successful_result": True,
+        "reviewed_state_digest": reviewed["state_digest"],
+        "reviewed_feedback_digest": reviewed["feedback_digest"],
+        "manual_gate_evidence": manual_gate_evidence,
+    }
+    return {**fields, "receipt_digest": MODULE._digest_json(fields)}
+
+
+def eligibility_payload(
+    reviewed: dict[str, Any],
+    validation_evidence_digest: str,
+    thread_ids: Sequence[str],
+) -> dict[str, Any]:
+    fields = {
+        "schema_version": "1.0",
+        "repository": reviewed["repository"],
+        "pull_request_number": reviewed["pull_request_number"],
+        "expected_head": "c" * 40,
+        "reviewed_state_digest": reviewed["state_digest"],
+        "validation_evidence_digest": validation_evidence_digest,
+        "eligible_threads": [
+            {
+                "thread_id": thread_id,
+                "classification": "VALID_ACTIONABLE",
+                "disposition": "CORRECTED_AND_VERIFIED",
+                "finding_ids": [f"finding-{index}"],
+                "evidence_digest": f"{index:x}" * 64,
+                "fix_commit_sha": "c" * 40,
+            }
+            for index, thread_id in enumerate(thread_ids, start=1)
+        ],
+    }
+    return fields
 
 
 class ResolveFixedThreadsTests(TestCase):
@@ -677,6 +833,22 @@ class ResolveFixedThreadsTests(TestCase):
             ):
                 MODULE.load_repository_limits("SecPal/api")
 
+    def test_registry_contract_keeps_resolution_ci_independent(self) -> None:
+        registry = json.loads(MODULE.REGISTRY_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            registry["fixed_thread_resolution"],
+            MODULE.FIXED_THREAD_RESOLUTION_CONTRACT,
+        )
+        self.assertEqual(
+            registry["fixed_thread_resolution"]["allowed_github_operations"],
+            ["READ_NAMED_REVIEW_THREAD", "RESOLVE_NAMED_REVIEW_THREAD"],
+        )
+        self.assertIn(
+            "MERGE_READINESS",
+            registry["fixed_thread_resolution"]["prohibited_hosted_reads"],
+        )
+
     def test_dry_run_reads_once_and_does_not_mutate(self) -> None:
         thread_id = "PRRT_exampleOne"
         fake = FakeGh([target_response(thread_id)])
@@ -735,6 +907,47 @@ class ResolveFixedThreadsTests(TestCase):
         self.assertEqual(result["resolved"], [first, second])
         self.assertEqual(len(fake.calls), 8)
 
+    def test_resolution_succeeds_for_every_hosted_check_condition_without_reading_it(
+        self,
+    ) -> None:
+        thread_id = "PRRT_exampleOne"
+        for condition in ("PENDING", "FAILED", None, "OMITTED"):
+            with self.subTest(condition=condition):
+                responses = [
+                    target_response(thread_id),
+                    target_response(thread_id),
+                    target_response(thread_id),
+                    resolve_response(thread_id),
+                ]
+                if condition != "OMITTED":
+                    for response in responses[:3]:
+                        response["data"]["node"]["pullRequest"][
+                            "hostedChecks"
+                        ] = condition
+                fake = FakeGh(responses)
+
+                result = resolve_threads(
+                    "SecPal/api",
+                    123,
+                    "a" * 40,
+                    [thread_id],
+                    apply=True,
+                    runner=fake,
+                )
+
+                self.assertEqual(result["resolved"], [thread_id])
+                serialized_calls = "\n".join(" ".join(call) for call in fake.calls)
+                for prohibited in (
+                    "checkSuites",
+                    "statusCheckRollup",
+                    "mergeable",
+                    "mergeStateStatus",
+                    "branchProtectionRule",
+                    "codeScanningAlerts",
+                    "workflowRuns",
+                ):
+                    self.assertNotIn(prohibited, serialized_calls)
+
     def test_already_resolved_target_is_idempotent(self) -> None:
         thread_id = "PRRT_exampleOne"
         fake = FakeGh(
@@ -789,7 +1002,7 @@ class ResolveFixedThreadsTests(TestCase):
         self.assertEqual(result["failed"][0]["phase"], "recheck")
         self.assertEqual(len(fake.calls), 3)
 
-    def test_cli_requires_reviewed_state(self) -> None:
+    def test_cli_requires_reviewed_state_digest_and_validation_evidence(self) -> None:
         with self.assertRaises(SystemExit):
             MODULE.parse_args(
                 [
@@ -799,10 +1012,36 @@ class ResolveFixedThreadsTests(TestCase):
                     "123",
                     "--expected-head",
                     "a" * 40,
+                    "--reviewed-state",
+                    "reviewed.json",
                     "--thread-id",
                     "PRRT_exampleOne",
                 ]
             )
+
+    def test_callable_requires_validation_binding_before_reading(self) -> None:
+        fake = FakeGh([])
+
+        with self.assertRaisesRegex(
+            MODULE.ResolutionError,
+            "validation evidence digest is required",
+        ):
+            MODULE.resolve_threads(
+                "SecPal/api",
+                123,
+                "a" * 40,
+                ("PRRT_exampleOne",),
+                apply=True,
+                expected_targets={
+                    "PRRT_exampleOne": expected_thread_state(
+                        "PRRT_exampleOne"
+                    ),
+                },
+                reviewed_state_digest="c" * 64,
+                runner=fake,
+            )
+
+        self.assertEqual(fake.calls, [])
 
     def test_callable_requires_reviewed_target_state_before_reading(self) -> None:
         fake = FakeGh([])
@@ -817,6 +1056,9 @@ class ResolveFixedThreadsTests(TestCase):
                 "a" * 40,
                 ("PRRT_exampleOne",),
                 apply=True,
+                reviewed_state_digest="c" * 64,
+                validation_evidence_digest="d" * 64,
+                eligibility_evidence_digest="e" * 64,
                 runner=fake,
             )
 
@@ -832,14 +1074,18 @@ class ResolveFixedThreadsTests(TestCase):
                 encoding="utf-8",
             )
 
-            targets = MODULE.load_expected_targets(
+            reviewed = MODULE.load_reviewed_state(
                 path,
                 "SecPal/api",
                 123,
-                [thread_id],
+                reviewed_state_payload(thread_id, comments)["state_digest"],
+                (thread_id,),
             )
 
-        self.assertEqual(targets[thread_id], expected_thread_state(thread_id, comments))
+        self.assertEqual(
+            reviewed.targets[thread_id],
+            expected_thread_state(thread_id, comments),
+        )
 
     def test_reviewed_state_loader_binds_resolution_state(self) -> None:
         thread_id = "PRRT_exampleOne"
@@ -853,19 +1099,21 @@ class ResolveFixedThreadsTests(TestCase):
             path = Path(directory) / "reviewed.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
 
-            targets = MODULE.load_expected_targets(
+            reviewed = MODULE.load_reviewed_state(
                 path,
                 "SecPal/api",
                 123,
-                [thread_id],
+                payload["state_digest"],
+                (thread_id,),
             )
 
         self.assertEqual(
-            targets[thread_id],
+            reviewed.targets[thread_id],
             expected_thread_state(
                 thread_id,
                 [("PRRC_root", "reviewed body", None)],
                 resolved=True,
+                outdated=True,
             ),
         )
 
@@ -893,21 +1141,459 @@ class ResolveFixedThreadsTests(TestCase):
 
         self.assertEqual(len(fake.calls), 1)
 
-    def test_outdated_change_after_reviewed_capture_remains_allowed(self) -> None:
+    def test_outdated_change_after_reviewed_capture_blocks_before_mutation(
+        self,
+    ) -> None:
         thread_id = "PRRT_exampleOne"
         fake = FakeGh([target_response(thread_id, outdated=True)])
 
-        result = resolve_threads(
-            "SecPal/api",
-            123,
-            "a" * 40,
-            [thread_id],
-            apply=False,
-            runner=fake,
+        with self.assertRaisesRegex(
+            MODULE.ResolutionError,
+            "differs from reviewed feedback",
+        ):
+            resolve_threads(
+                "SecPal/api",
+                123,
+                "a" * 40,
+                [thread_id],
+                apply=True,
+                runner=fake,
+            )
+
+        self.assertEqual(len(fake.calls), 1)
+
+    def test_reviewed_state_digest_drift_blocks_before_validation_or_github(
+        self,
+    ) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "reviewed.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                MODULE.ResolutionError,
+                "does not match the captured digest",
+            ):
+                MODULE.load_reviewed_state(
+                    path,
+                    "SecPal/api",
+                    123,
+                    "0" * 64,
+                    (thread_id,),
+                )
+
+    def test_validation_attestation_binds_fix_head_and_reviewed_state(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        attestation = validation_attestation_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "attestation.json"
+            path.write_text(json.dumps(attestation), encoding="utf-8")
+
+            digest = MODULE.load_validation_evidence(
+                path,
+                "SecPal/api",
+                "c" * 40,
+                reviewed,
+            )
+
+        self.assertEqual(
+            digest.evidence_digest,
+            attestation["attestation_digest"],
         )
 
-        self.assertEqual(result["pending"], [thread_id])
-        self.assertEqual(len(fake.calls), 1)
+    def test_attestation_rejects_forged_receipt_and_missing_manual_gates(
+        self,
+    ) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        attestation = validation_attestation_payload(payload)
+        for mutation in ("receipt", "gates", "secret"):
+            with self.subTest(mutation=mutation):
+                changed = dict(attestation)
+                if mutation == "receipt":
+                    changed["validation_receipt_digest"] = "0" * 64
+                else:
+                    changed["manual_gate_evidence"] = (
+                        []
+                        if mutation == "gates"
+                        else [
+                            {
+                                **attestation["manual_gate_evidence"][0],
+                                "evidence": "Authorization: Bearer secret",
+                            },
+                            *attestation["manual_gate_evidence"][1:],
+                        ]
+                    )
+                fields = {
+                    key: value
+                    for key, value in changed.items()
+                    if key != "attestation_digest"
+                }
+                changed["attestation_digest"] = MODULE._digest_json(fields)
+                with tempfile.TemporaryDirectory() as directory:
+                    path = Path(directory) / "attestation.json"
+                    path.write_text(json.dumps(changed), encoding="utf-8")
+
+                    with self.assertRaisesRegex(
+                        MODULE.ResolutionError,
+                        "validation evidence is invalid or stale",
+                    ):
+                        MODULE.load_validation_evidence(
+                            path,
+                            "SecPal/api",
+                            "c" * 40,
+                            reviewed,
+                        )
+
+    def test_validation_evidence_head_drift_blocks(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        attestation = validation_attestation_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "attestation.json"
+            path.write_text(json.dumps(attestation), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                MODULE.ResolutionError,
+                "validation evidence does not match the fix commit",
+            ):
+                MODULE.load_validation_evidence(
+                    path,
+                    "SecPal/api",
+                    "b" * 40,
+                    reviewed,
+                )
+
+    def test_validation_receipt_supports_an_unchanged_validated_head(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        receipt = validation_receipt_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "receipt.json"
+            path.write_text(json.dumps(receipt), encoding="utf-8")
+
+            digest = MODULE.load_validation_evidence(
+                path,
+                "SecPal/api",
+                "a" * 40,
+                reviewed,
+            )
+
+        self.assertEqual(digest.evidence_digest, receipt["receipt_digest"])
+
+    def test_local_commit_binding_rejects_tree_parent_and_trailer_drift(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        attestation = validation_attestation_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            evidence_path = Path(directory) / "attestation.json"
+            evidence_path.write_text(json.dumps(attestation), encoding="utf-8")
+            validation = MODULE.load_validation_evidence(
+                evidence_path,
+                "SecPal/api",
+                "c" * 40,
+                reviewed,
+            )
+            cases = {
+                "tree": {"tree": "0" * 40},
+                "parent": {"reviewed_head": "0" * 40},
+                "trailer": {"receipt_digest": "0" * 64},
+            }
+            for expected_error, changes in cases.items():
+                with self.subTest(expected_error=expected_error):
+                    fake = FakeGit(
+                        expected_head="c" * 40,
+                        reviewed_head=changes.get(
+                            "reviewed_head", reviewed.head_sha
+                        ),
+                        tree=changes.get("tree", attestation["validated_tree_sha"]),
+                        receipt_digest=changes.get(
+                            "receipt_digest",
+                            attestation["validation_receipt_digest"],
+                        ),
+                    )
+                    with self.assertRaisesRegex(
+                        MODULE.ResolutionError,
+                        expected_error,
+                    ):
+                        MODULE.verify_local_fix_commit(
+                            Path(directory),
+                            "SecPal/api",
+                            "c" * 40,
+                            reviewed,
+                            validation,
+                            runner=fake,
+                        )
+
+    def test_unchanged_receipt_requires_the_actual_commit_tree(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        receipt = validation_receipt_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            evidence_path = Path(directory) / "receipt.json"
+            evidence_path.write_text(json.dumps(receipt), encoding="utf-8")
+            validation = MODULE.load_validation_evidence(
+                evidence_path,
+                "SecPal/api",
+                "a" * 40,
+                reviewed,
+            )
+            fake = FakeGit(
+                expected_head="a" * 40,
+                reviewed_head="b" * 40,
+                tree="0" * 40,
+                receipt_digest=receipt["receipt_digest"],
+            )
+
+            with self.assertRaisesRegex(MODULE.ResolutionError, "tree"):
+                MODULE.verify_local_fix_commit(
+                    Path(directory),
+                    "SecPal/api",
+                    "a" * 40,
+                    reviewed,
+                    validation,
+                    runner=fake,
+                )
+
+    def test_local_commit_binding_rejects_wrong_origin_and_invalid_signature(
+        self,
+    ) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        attestation = validation_attestation_payload(payload)
+        with tempfile.TemporaryDirectory() as directory:
+            evidence_path = Path(directory) / "attestation.json"
+            evidence_path.write_text(json.dumps(attestation), encoding="utf-8")
+            validation = MODULE.load_validation_evidence(
+                evidence_path,
+                "SecPal/api",
+                "c" * 40,
+                reviewed,
+            )
+            cases = {
+                "origin": {"repository": "SecPal/frontend"},
+                "signature": {"signature_valid": False},
+            }
+            for expected_error, changes in cases.items():
+                with self.subTest(expected_error=expected_error):
+                    fake = FakeGit(
+                        expected_head="c" * 40,
+                        reviewed_head=reviewed.head_sha,
+                        tree=attestation["validated_tree_sha"],
+                        receipt_digest=attestation[
+                            "validation_receipt_digest"
+                        ],
+                        **changes,
+                    )
+                    with self.assertRaisesRegex(
+                        MODULE.ResolutionError,
+                        expected_error,
+                    ):
+                        MODULE.verify_local_fix_commit(
+                            Path(directory),
+                            "SecPal/api",
+                            "c" * 40,
+                            reviewed,
+                            validation,
+                            runner=fake,
+                        )
+
+    def test_local_commit_binding_rejects_an_unknown_evidence_kind(self) -> None:
+        reviewed = mock.Mock(head_sha="a" * 40)
+        validation = MODULE.ValidationEvidence(
+            kind="caller-constructed",
+            evidence_digest="d" * 64,
+            validated_tree_sha="f" * 40,
+            validation_receipt_digest="e" * 64,
+        )
+        fake = mock.Mock()
+        with self.assertRaisesRegex(
+            MODULE.ResolutionError,
+            "validation evidence binding",
+        ):
+            MODULE.verify_local_fix_commit(
+                Path("."),
+                "SecPal/api",
+                "c" * 40,
+                reviewed,
+                validation,
+                runner=fake,
+            )
+        fake.assert_not_called()
+
+    def test_missing_validation_evidence_blocks_before_github(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        reviewed = mock.Mock(
+            head_sha=payload["head_sha"],
+            state_digest=payload["state_digest"],
+            feedback_digest=payload["feedback_digest"],
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                MODULE.ResolutionError,
+                "validation evidence is unavailable",
+            ):
+                MODULE.load_validation_evidence(
+                    Path(directory) / "missing-attestation.json",
+                    "SecPal/api",
+                    "a" * 40,
+                    reviewed,
+                )
+
+    def test_eligibility_manifest_binds_every_requested_thread(self) -> None:
+        first = "PRRT_exampleOne"
+        second = "PRRT_exampleTwo"
+        payload = reviewed_state_payload(first, [])
+        payload["threads"].append(
+            {
+                "node_id": second,
+                "is_resolved": False,
+                "is_outdated": False,
+                "comments": [],
+            }
+        )
+        feedback = {
+            key: payload[key]
+            for key in (
+                "pull_request_reactions",
+                "reviews",
+                "conversation_comments",
+                "threads",
+            )
+        }
+        payload["feedback_digest"] = MODULE._digest_json(feedback)
+        identity = {
+            key: payload[key]
+            for key in (
+                "repository",
+                "pull_request_number",
+                "head_sha",
+                "base_ref",
+                "base_sha",
+                "pr_state",
+            )
+        }
+        payload["state_digest"] = MODULE._digest_json(
+            {**identity, "feedback": feedback}
+        )
+        manifest = eligibility_payload(payload, "d" * 64, (first, second))
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "eligibility.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            evidence_digest = MODULE.load_eligibility_evidence(
+                path,
+                "SecPal/api",
+                123,
+                "c" * 40,
+                payload["state_digest"],
+                "d" * 64,
+                (first, second),
+            )
+
+        self.assertEqual(evidence_digest, MODULE._digest_json(manifest))
+
+    def test_ineligible_or_unlisted_thread_blocks_before_github(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        manifest = eligibility_payload(payload, "d" * 64, (thread_id,))
+        cases = {
+            "unlisted": [],
+            "unsafe disposition": [
+                {
+                    **manifest["eligible_threads"][0],
+                    "disposition": "UNRESOLVED_VALID_FINDING",
+                }
+            ],
+        }
+        for label, threads in cases.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                changed = {**manifest, "eligible_threads": threads}
+                path = Path(directory) / "eligibility.json"
+                path.write_text(json.dumps(changed), encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    MODULE.ResolutionError,
+                    "eligibility evidence",
+                ):
+                    MODULE.load_eligibility_evidence(
+                        path,
+                        "SecPal/api",
+                        123,
+                        "c" * 40,
+                        payload["state_digest"],
+                        "d" * 64,
+                        (thread_id,),
+                    )
+
+    def test_eligibility_manifest_rejects_rehashed_binding_drift(self) -> None:
+        thread_id = "PRRT_exampleOne"
+        payload = reviewed_state_payload(thread_id, [])
+        manifest = eligibility_payload(payload, "d" * 64, (thread_id,))
+        cases = {
+            "repository": "SecPal/frontend",
+            "pull_request_number": 124,
+            "expected_head": "b" * 40,
+            "reviewed_state_digest": "0" * 64,
+            "validation_evidence_digest": "1" * 64,
+        }
+        for field, value in cases.items():
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as directory:
+                changed = {**manifest, field: value}
+                path = Path(directory) / "eligibility.json"
+                path.write_text(json.dumps(changed), encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    MODULE.ResolutionError,
+                    "eligibility evidence binding",
+                ):
+                    MODULE.load_eligibility_evidence(
+                        path,
+                        "SecPal/api",
+                        123,
+                        "c" * 40,
+                        payload["state_digest"],
+                        "d" * 64,
+                        (thread_id,),
+                    )
 
     def test_nonfinite_reviewed_state_is_reported_without_traceback(self) -> None:
         for constant in ("NaN", "Infinity", "-Infinity"):
@@ -932,10 +1618,18 @@ class ResolveFixedThreadsTests(TestCase):
                             "SecPal/api",
                             "--pr",
                             "123",
+                            "--repo-root",
+                            ".",
                             "--expected-head",
                             "a" * 40,
                             "--reviewed-state",
                             str(path),
+                            "--expected-reviewed-state-digest",
+                            "c" * 64,
+                            "--validation-evidence",
+                            "attestation.json",
+                            "--eligibility-evidence",
+                            "eligibility.json",
                             "--thread-id",
                             "PRRT_exampleOne",
                         ]
@@ -964,11 +1658,12 @@ class ResolveFixedThreadsTests(TestCase):
                 MODULE.ResolutionError,
                 "digest is invalid",
             ):
-                MODULE.load_expected_targets(
+                MODULE.load_reviewed_state(
                     path,
                     "SecPal/api",
                     123,
-                    [thread_id],
+                    payload["state_digest"],
+                    (thread_id,),
                 )
 
     def test_head_mismatch_blocks_before_mutation(self) -> None:
@@ -1252,13 +1947,35 @@ class ResolveFixedThreadsTests(TestCase):
             "unattempted": [],
         }
         output = StringIO()
+        reviewed = MODULE.ReviewedState(
+            head_sha="a" * 40,
+            state_digest="c" * 64,
+            feedback_digest="e" * 64,
+            targets={
+                "PRRT_exampleOne": expected_thread_state("PRRT_exampleOne"),
+            },
+        )
         with (
             mock.patch.object(
                 MODULE,
-                "load_expected_targets",
-                return_value={
-                    "PRRT_exampleOne": expected_thread_state("PRRT_exampleOne"),
-                },
+                "load_reviewed_state",
+                return_value=reviewed,
+            ),
+            mock.patch.object(
+                MODULE,
+                "load_validation_evidence",
+                return_value=MODULE.ValidationEvidence(
+                    kind="attestation",
+                    evidence_digest="d" * 64,
+                    validated_tree_sha="f" * 40,
+                    validation_receipt_digest="b" * 64,
+                ),
+            ),
+            mock.patch.object(MODULE, "verify_local_fix_commit") as verify_commit,
+            mock.patch.object(
+                MODULE,
+                "load_eligibility_evidence",
+                return_value="e" * 64,
             ),
             mock.patch.object(MODULE, "resolve_threads", return_value=report),
             redirect_stdout(output),
@@ -1269,10 +1986,18 @@ class ResolveFixedThreadsTests(TestCase):
                     "SecPal/api",
                     "--pr",
                     "123",
+                    "--repo-root",
+                    ".",
                     "--expected-head",
                     "a" * 40,
                     "--reviewed-state",
                     "reviewed.json",
+                    "--expected-reviewed-state-digest",
+                    "c" * 64,
+                    "--validation-evidence",
+                    "attestation.json",
+                    "--eligibility-evidence",
+                    "eligibility.json",
                     "--thread-id",
                     "PRRT_exampleOne",
                 ]
@@ -1280,6 +2005,7 @@ class ResolveFixedThreadsTests(TestCase):
 
         self.assertEqual(returncode, 1)
         self.assertEqual(json.loads(output.getvalue()), report)
+        verify_commit.assert_called_once()
 
     def test_run_gh_uses_trusted_absolute_executable_and_environment(self) -> None:
         completed = subprocess.CompletedProcess(

--- a/tests/secpal-resolve-fixed-threads-unit.py
+++ b/tests/secpal-resolve-fixed-threads-unit.py
@@ -849,6 +849,21 @@ class ResolveFixedThreadsTests(TestCase):
             registry["fixed_thread_resolution"]["prohibited_hosted_reads"],
         )
 
+    def test_resolver_rejects_registry_without_resolution_contract(self) -> None:
+        registry = json.loads(MODULE.REGISTRY_PATH.read_text(encoding="utf-8"))
+        registry.pop("fixed_thread_resolution")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "repositories.json"
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with (
+                mock.patch.object(MODULE, "REGISTRY_PATH", path),
+                self.assertRaisesRegex(
+                    MODULE.ResolutionError,
+                    "fixed-thread resolution registry contract is invalid",
+                ),
+            ):
+                MODULE.load_repository_limits("SecPal/.github")
+
     def test_dry_run_reads_once_and_does_not_mutate(self) -> None:
         thread_id = "PRRT_exampleOne"
         fake = FakeGh([target_response(thread_id)])
@@ -1285,7 +1300,7 @@ class ResolveFixedThreadsTests(TestCase):
                     reviewed,
                 )
 
-    def test_validation_receipt_supports_an_unchanged_validated_head(self) -> None:
+    def test_validation_receipt_cannot_authorize_no_change_resolution(self) -> None:
         thread_id = "PRRT_exampleOne"
         payload = reviewed_state_payload(thread_id, [])
         reviewed = mock.Mock(
@@ -1298,14 +1313,16 @@ class ResolveFixedThreadsTests(TestCase):
             path = Path(directory) / "receipt.json"
             path.write_text(json.dumps(receipt), encoding="utf-8")
 
-            digest = MODULE.load_validation_evidence(
-                path,
-                "SecPal/api",
-                "a" * 40,
-                reviewed,
-            )
-
-        self.assertEqual(digest.evidence_digest, receipt["receipt_digest"])
+            with self.assertRaisesRegex(
+                MODULE.ResolutionError,
+                "authenticated fix-commit attestation",
+            ):
+                MODULE.load_validation_evidence(
+                    path,
+                    "SecPal/api",
+                    "a" * 40,
+                    reviewed,
+                )
 
     def test_local_commit_binding_rejects_tree_parent_and_trailer_drift(self) -> None:
         thread_id = "PRRT_exampleOne"
@@ -1355,41 +1372,6 @@ class ResolveFixedThreadsTests(TestCase):
                             validation,
                             runner=fake,
                         )
-
-    def test_unchanged_receipt_requires_the_actual_commit_tree(self) -> None:
-        thread_id = "PRRT_exampleOne"
-        payload = reviewed_state_payload(thread_id, [])
-        reviewed = mock.Mock(
-            head_sha=payload["head_sha"],
-            state_digest=payload["state_digest"],
-            feedback_digest=payload["feedback_digest"],
-        )
-        receipt = validation_receipt_payload(payload)
-        with tempfile.TemporaryDirectory() as directory:
-            evidence_path = Path(directory) / "receipt.json"
-            evidence_path.write_text(json.dumps(receipt), encoding="utf-8")
-            validation = MODULE.load_validation_evidence(
-                evidence_path,
-                "SecPal/api",
-                "a" * 40,
-                reviewed,
-            )
-            fake = FakeGit(
-                expected_head="a" * 40,
-                reviewed_head="b" * 40,
-                tree="0" * 40,
-                receipt_digest=receipt["receipt_digest"],
-            )
-
-            with self.assertRaisesRegex(MODULE.ResolutionError, "tree"):
-                MODULE.verify_local_fix_commit(
-                    Path(directory),
-                    "SecPal/api",
-                    "a" * 40,
-                    reviewed,
-                    validation,
-                    runner=fake,
-                )
 
     def test_local_commit_binding_rejects_wrong_origin_and_invalid_signature(
         self,


### PR DESCRIPTION
## Description

Fixed-thread resolution could be blocked by unrelated GitHub-hosted CI, CodeQL, mergeability, branch-protection, or broader readiness state even after review fixes had been validated, committed, and pushed. The resolver also did not bind the mutation strongly enough to the captured reviewed state, verified fix commit, validation evidence, and explicit per-thread eligibility.

This change:

- binds resolution to the exact repository, pull request, local repository root, expected PR head, captured reviewed-state digest, validation evidence, eligibility evidence, and named thread IDs;
- verifies the registered origin, local HEAD, validated commit tree, accepted commit signature, and the parent plus validation-receipt trailer for a new fix commit before the first GitHub read;
- requires an exact per-thread eligibility manifest with an allowed classification/disposition, finding IDs, evidence digest, and matching fix commit;
- restricts GitHub access to complete reads of named review threads and the corresponding resolution mutations;
- fails closed on head drift, reviewed-feedback drift, missing or forged validation evidence, commit drift, invalid signatures, and missing or ineligible target threads;
- makes the CI-independent contract mandatory in the repository registry schema and aligns the skill, workflow, script, and operator documentation.

The resolver performs no GitHub Actions, CodeQL, check-suite, status, mergeability, branch-protection, or readiness read. It also performs no polling, waiting, review request, Ready transition, merge, label, or generic comment mutation.

## Related Issues

Closes #644

Parent epic: #643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [ ] Manual testing performed

Validated with:

- `python3 -m unittest tests/secpal-resolve-fixed-threads-unit.py tests/secpal-pr-review-actions-unit.py tests/secpal-pr-review-unit.py` — 428 tests passed.
- `bash tests/secpal-pr-review-skill-policy.sh`
- `bash tests/secpal-pr-review-skill-integration.sh`
- `bash tests/secpal-pr-review-integration.sh`
- `bash tests/review-governance-suite.sh`
- `bash tests/reusable-workflow-policy.sh`
- `npm run lint:markdown`
- `./scripts/preflight.sh --reuse-tracked-only`
- `git diff --check`
- Pre-commit hooks for every changed file, including REUSE, Prettier, markdownlint, shellcheck, conflict checks, whitespace checks, and branch protection.

Regression coverage proves resolution succeeds when hosted checks are pending, failed, unavailable, or omitted and proves that no hosted-CI/readiness API call is made.

## TDD / Validate-First Evidence

- Failing proof before implementation: focused resolver tests demonstrated that a rehashed forged validation receipt, missing manual-gate evidence, commit-tree/parent/trailer drift, and missing or unsafe per-thread eligibility were not rejected by the previous resolver contract.
- Passing proof after implementation: the focused resolver suite now passes 63 tests, and the combined relevant Python suites pass all 428 tests.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Readiness

No known in-scope dependency or unresolved local check prevents review readiness. Hosted CI was intentionally not inspected: this PR makes fixed-thread resolution independent of hosted readiness, and draft PR creation does not authorize hosted-CI observation. The separately tracked frontend lifecycle refactor is outside this PR.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## Screenshots

Not applicable; this PR does not change frontend runtime code.
