### PR TITLE
Establish licensing and branding invariants for AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -22,6 +22,13 @@ Prioritize findings that can change behavior or weaken a repository invariant.
   is safer and easier to validate.
 - Identify compatibility or rollout ordering risks when a shared contract has
   consumers outside the changed file.
+- Reject instruction metadata that adds or restores
+  `LicenseRef-SecPal-Attribution`; verify exact SPDX expressions while
+  preserving intentional CC0, MIT, Apache, third-party, generated-file, and
+  unrelated custom-license metadata.
+- For licensing changes on user-facing official SecPal product surfaces,
+  verify that `Powered by SecPal – A guard's best friend` remains intentional,
+  exact, and mandatory rather than weakened or made configurable.
 
 ## Finding Quality
 

--- a/.github/copilot-instructions.md.license
+++ b/.github/copilot-instructions.md.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: GitHub Workflow and Action Rules
 description: Applies focused security and validation criteria to GitHub automation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -37,6 +37,27 @@ including `.github/instructions/github-workflows.instructions.md`.
 - Hidden files, workflow definitions, templates, tests, and scripts are
   first-class source artifacts. Test governance and validator changes with
   meaningful positive and negative cases.
+
+## Licensing, REUSE, and Branding
+
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
+- Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
+- Use `SecPal Contributors` where the project copyright convention applies.
+  Preserve each file's first-publication year and extend its year range through
+  the current year when an edited file requires a copyright-year update.
+- Run the relevant REUSE or license validation after changing copyright or
+  license metadata.
+- On user-facing official SecPal product surfaces, preserve
+  `Powered by SecPal – A guard's best friend` where it is intentionally present.
+  A licensing change must not remove, weaken, parameterize, genericize, or make
+  that SecPal branding optional.
+- Do not add fork-oriented `Based on SecPal` guidance to AI instructions, and
+  do not introduce white-label or fork-branding configuration as part of a
+  licensing change.
 
 ## Validation and Review
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   alternate-license preservation, third-party metadata boundary, and official
   SecPal product-branding requirements explicit in the runtime and review
   instructions
-- changed AI-instruction license validation to require plain AGPL for the
-  migrated `.github` baseline, retain the API repository's intentional CC0,
-  preserve transitional CC0 compatibility for dependency-ordered sibling
-  migrations and deliberate focused-overlay licenses, and reject incomplete,
-  duplicate, conflicting, or obsolete expressions without disturbing unrelated
-  custom-license metadata
+- changed AI-instruction license validation to require plain AGPL for managed
+  baselines, retain the API repository's intentional CC0 and deliberate
+  focused-overlay licenses, and reject incomplete, duplicate, conflicting, or
+  obsolete expressions without disturbing unrelated custom-license metadata
 - aligned the Copilot profile's authoritative `.license` sidecar with its
   visible plain-AGPL metadata and the `SecPal Contributors` year convention
 - added Polyscope rollout regressions proving invalid attribution metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ Log of notable changes to SecPal organization defaults (newest first).
   alternate-license preservation, third-party metadata boundary, and official
   SecPal product-branding requirements explicit in the runtime and review
   instructions
-- changed AI-instruction license validation to require plain AGPL for managed
-  runtime and review baselines, retain the API repository's intentional CC0
-  baseline and deliberate focused-overlay licenses, and reject both incomplete
-  matches and the obsolete SecPal attribution expression without disturbing
-  unrelated custom-license metadata
+- changed AI-instruction license validation to require plain AGPL for the
+  migrated `.github` baseline, retain the API repository's intentional CC0,
+  preserve transitional CC0 compatibility for dependency-ordered sibling
+  migrations and deliberate focused-overlay licenses, and reject incomplete,
+  duplicate, conflicting, or obsolete expressions without disturbing unrelated
+  custom-license metadata
 - aligned the Copilot profile's authoritative `.license` sidecar with its
   visible plain-AGPL metadata and the `SecPal Contributors` year convention
 - added Polyscope rollout regressions proving invalid attribution metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-15 - Establish AI Licensing And Branding Invariants
+
+**Changed:**
+
+- made the plain-AGPL target, REUSE copyright and year handling, intentional
+  alternate-license preservation, third-party metadata boundary, and official
+  SecPal product-branding requirements explicit in the runtime and review
+  instructions
+- changed AI-instruction license validation to require plain AGPL for managed
+  runtime and review baselines, retain the API repository's intentional CC0
+  baseline and deliberate focused-overlay licenses, and reject both incomplete
+  matches and the obsolete SecPal attribution expression without disturbing
+  unrelated custom-license metadata
+- aligned the Copilot profile's authoritative `.license` sidecar with its
+  visible plain-AGPL metadata and the `SecPal Contributors` year convention
+- added Polyscope rollout regressions proving invalid attribution metadata
+  fails before side effects and valid repository instructions remain unchanged
+
+---
+
 ## 2026-08-11 - Decouple Fixed Review-Thread Resolution
 
 **Changed:**

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025-2026 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -44,7 +44,12 @@ The validator checks:
 
 - required `AGENTS.md` and `.github/copilot-instructions.md` files;
 - non-empty, readable UTF-8 Markdown with a top-level heading;
-- inline SPDX metadata or an allowed REUSE `.license` sidecar;
+- one complete policy-appropriate SPDX expression in inline metadata or a
+  REUSE `.license` sidecar for every runtime, review, and focused instruction
+  file: plain `AGPL-3.0-or-later` for managed runtime and review baselines,
+  except the intentionally `CC0-1.0` API baseline, with exact deliberate
+  `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT` expressions accepted
+  for focused overlays;
 - Markdown structure for runtime, review, and focused instruction files;
 - syntactically valid YAML overlay frontmatter with opening and closing
   delimiters plus non-empty string `name` and `applyTo` values;
@@ -97,6 +102,14 @@ Copilot review profile fails through the same canonical contract.
 `tests/validate-ai-instructions.sh` uses temporary repositories to prove that:
 
 - different valid runtime and review content passes;
+- managed runtime and review baselines require plain `AGPL-3.0-or-later`, the
+  API baseline requires its intentional `CC0-1.0`, and focused overlays retain
+  exact `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, and `MIT` support;
+- the obsolete expression
+  `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, duplicate identifiers,
+  and a wrong repository-baseline license fail;
+- API, GuardGuide, and `guardguide.de` fixtures exercise automatic repository
+  detection so GuardGuide remains AGPL and is not mistaken for the CC0 API;
 - missing, empty, malformed UTF-8, unlicensed, invalid Markdown, malformed
   frontmatter, and oversized instructions fail;
 - focused overlays are optional but structurally validated when present;
@@ -105,7 +118,8 @@ Copilot review profile fails through the same canonical contract.
 
 `tests/polyscope-rollout.sh` separately proves that rollout applies the
 canonical contract to managed roots and candidate worktrees before dependent
-writes, preserves an independent Copilot profile, and continues to manage the
+writes, rejects the obsolete SecPal attribution expression, preserves every
+repository instruction artifact byte-for-byte, and continues to manage the
 direct global Codex `AGENTS.md` symlink without introducing copied runtime
 sources or instruction modes.
 
@@ -253,9 +267,12 @@ instruction file into another merely to satisfy validation.
 
 ### REUSE failure
 
-Add an allowed inline SPDX header near the start of the file or a valid
-companion `.license` sidecar. The accepted instruction licenses are `CC0-1.0`
-and `AGPL-3.0-or-later`.
+Add one policy-appropriate inline SPDX header near the start of the file or a
+valid companion `.license` sidecar. Managed `AGENTS.md` and Copilot profiles
+require exactly `AGPL-3.0-or-later`, except for the API repository's intentional
+`CC0-1.0` baseline. Focused overlays may retain an intentional exact
+`AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT` expression. Longer
+expressions that merely begin with one of those identifiers are rejected.
 
 ### Markdown failure
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -108,8 +108,9 @@ Copilot review profile fails through the same canonical contract.
 - the obsolete expression
   `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, duplicate identifiers,
   and a wrong repository-baseline license fail;
-- API, GuardGuide, and `guardguide.de` fixtures exercise automatic repository
-  detection so GuardGuide remains AGPL and is not mistaken for the CC0 API;
+- API, frontend-with-Composer, GuardGuide, and `guardguide.de` fixtures exercise
+  automatic repository detection so only the exact `secpal/api` Composer
+  identity enables the CC0 baseline exception;
 - missing, empty, malformed UTF-8, unlicensed, invalid Markdown, malformed
   frontmatter, and oversized instructions fail;
 - focused overlays are optional but structurally validated when present;

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -48,10 +48,9 @@ The validator checks:
   metadata or REUSE `.license` sidecar for every runtime, review, and focused
   instruction file, while rejecting duplicate or conflicting declarations in
   either source: plain `AGPL-3.0-or-later` for the migrated `.github` baseline,
-  the intentionally `CC0-1.0` API baseline, transitional plain AGPL or CC0 for
-  other managed baselines until their dependency-ordered migrations complete,
-  and exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT`
-  expressions for focused overlays;
+  the intentionally `CC0-1.0` API baseline, plain `AGPL-3.0-or-later` for other
+  managed baselines, and exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`,
+  `CC0-1.0`, or `MIT` expressions for focused overlays;
 - Markdown structure for runtime, review, and focused instruction files;
 - syntactically valid YAML overlay frontmatter with opening and closing
   delimiters plus non-empty string `name` and `applyTo` values;
@@ -94,6 +93,13 @@ To validate another checked-out repository with this implementation:
 bash scripts/validate-ai-instructions.sh /path/to/repository
 ```
 
+Repository-path mode derives identity independently for each target and clears
+ambient `GITHUB_REPOSITORY`, `SECPAL_REPOSITORY_NAME`, and `REPO_TYPE` values
+before recursion. Without a path argument, canonical callers may supply trusted
+identity through `GITHUB_REPOSITORY` or `SECPAL_REPOSITORY_NAME`. The legacy
+`REPO_TYPE` hint remains available for local compatibility, but cannot select
+the API policy unless the repository has the exact `secpal/api` manifest.
+
 The compatibility entry point `validate-copilot-instructions.sh` always
 delegates to this canonical validator, including for repository-path arguments.
 It has no Copilot-only validation model, so a missing `AGENTS.md` or missing
@@ -104,16 +110,15 @@ Copilot review profile fails through the same canonical contract.
 `tests/validate-ai-instructions.sh` uses temporary repositories to prove that:
 
 - different valid runtime and review content passes;
-- the migrated `.github` runtime and review baseline requires plain
-  `AGPL-3.0-or-later`, the API baseline requires its intentional `CC0-1.0`,
-  other managed roots retain transitional plain-AGPL or CC0 compatibility, and
-  focused overlays retain exact `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`,
-  and `MIT` support;
+- managed runtime and review baselines require plain `AGPL-3.0-or-later`, the
+  API baseline requires its intentional `CC0-1.0`, and focused overlays retain
+  exact `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, and `MIT` support;
 - the obsolete expression
   `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, duplicate identifiers,
   and a wrong repository-baseline license fail;
 - API, frontend-with-Composer, GuardGuide, and `guardguide.de` fixtures exercise
-  trusted repository identity so candidate-controlled manifests cannot select
+  trusted repository identity, path-local fallback detection, and legacy type
+  hints so ambient identity and misleading manifest values cannot select
   another repository's licensing policy;
 - missing, empty, malformed UTF-8, unlicensed, invalid Markdown, malformed
   frontmatter, and oversized instructions fail;
@@ -274,10 +279,9 @@ instruction file into another merely to satisfy validation.
 
 Add one policy-appropriate inline SPDX header near the start of the file or a
 valid companion `.license` sidecar. When both sources declare a license, each
-must contain exactly one identical expression. The migrated `.github` baseline
-requires `AGPL-3.0-or-later`; the API requires its intentional `CC0-1.0`;
-other managed roots accept plain AGPL or transitional CC0 until their migrations
-complete. Focused overlays may retain an intentional exact
+must contain exactly one identical expression. Managed baselines require
+`AGPL-3.0-or-later`; the API requires its intentional `CC0-1.0`. Focused
+overlays may retain an intentional exact
 `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT` expression. Longer
 expressions that merely begin with one of those identifiers are rejected.
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -44,12 +44,14 @@ The validator checks:
 
 - required `AGENTS.md` and `.github/copilot-instructions.md` files;
 - non-empty, readable UTF-8 Markdown with a top-level heading;
-- one complete policy-appropriate SPDX expression in inline metadata or a
-  REUSE `.license` sidecar for every runtime, review, and focused instruction
-  file: plain `AGPL-3.0-or-later` for managed runtime and review baselines,
-  except the intentionally `CC0-1.0` API baseline, with exact deliberate
-  `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT` expressions accepted
-  for focused overlays;
+- one complete policy-appropriate SPDX expression in the authoritative inline
+  metadata or REUSE `.license` sidecar for every runtime, review, and focused
+  instruction file, while rejecting duplicate or conflicting declarations in
+  either source: plain `AGPL-3.0-or-later` for the migrated `.github` baseline,
+  the intentionally `CC0-1.0` API baseline, transitional plain AGPL or CC0 for
+  other managed baselines until their dependency-ordered migrations complete,
+  and exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT`
+  expressions for focused overlays;
 - Markdown structure for runtime, review, and focused instruction files;
 - syntactically valid YAML overlay frontmatter with opening and closing
   delimiters plus non-empty string `name` and `applyTo` values;
@@ -102,15 +104,17 @@ Copilot review profile fails through the same canonical contract.
 `tests/validate-ai-instructions.sh` uses temporary repositories to prove that:
 
 - different valid runtime and review content passes;
-- managed runtime and review baselines require plain `AGPL-3.0-or-later`, the
-  API baseline requires its intentional `CC0-1.0`, and focused overlays retain
-  exact `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, and `MIT` support;
+- the migrated `.github` runtime and review baseline requires plain
+  `AGPL-3.0-or-later`, the API baseline requires its intentional `CC0-1.0`,
+  other managed roots retain transitional plain-AGPL or CC0 compatibility, and
+  focused overlays retain exact `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`,
+  and `MIT` support;
 - the obsolete expression
   `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, duplicate identifiers,
   and a wrong repository-baseline license fail;
 - API, frontend-with-Composer, GuardGuide, and `guardguide.de` fixtures exercise
-  automatic repository detection so only the exact `secpal/api` Composer
-  identity enables the CC0 baseline exception;
+  trusted repository identity so candidate-controlled manifests cannot select
+  another repository's licensing policy;
 - missing, empty, malformed UTF-8, unlicensed, invalid Markdown, malformed
   frontmatter, and oversized instructions fail;
 - focused overlays are optional but structurally validated when present;
@@ -269,9 +273,11 @@ instruction file into another merely to satisfy validation.
 ### REUSE failure
 
 Add one policy-appropriate inline SPDX header near the start of the file or a
-valid companion `.license` sidecar. Managed `AGENTS.md` and Copilot profiles
-require exactly `AGPL-3.0-or-later`, except for the API repository's intentional
-`CC0-1.0` baseline. Focused overlays may retain an intentional exact
+valid companion `.license` sidecar. When both sources declare a license, each
+must contain exactly one identical expression. The migrated `.github` baseline
+requires `AGPL-3.0-or-later`; the API requires its intentional `CC0-1.0`;
+other managed roots accept plain AGPL or transitional CC0 until their migrations
+complete. Focused overlays may retain an intentional exact
 `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`, or `MIT` expression. Longer
 expressions that merely begin with one of those identifiers are rejected.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -253,9 +253,8 @@ and focused instruction overlays across all repositories.
    - Requires the complete repository-policy expression in inline SPDX
      metadata or a valid `.license` sidecar and rejects conflicting or duplicate
      declarations across both sources
-   - Requires plain `AGPL-3.0-or-later` for the migrated `.github` baseline,
-     preserves the API repository's intentional `CC0-1.0` baseline, and accepts
-     transitional plain AGPL or CC0 for other managed roots until migration
+   - Requires plain `AGPL-3.0-or-later` for managed baselines and preserves only
+     the API repository's intentional `CC0-1.0` baseline
    - Preserves exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`,
      or `MIT` expressions on focused overlays
    - Rejects the obsolete expression
@@ -338,7 +337,9 @@ See `.github/workflows/validate-ai-instructions.yml`
 Canonical GitHub and Polyscope callers supply trusted repository identity via
 `GITHUB_REPOSITORY` or `SECPAL_REPOSITORY_NAME`. Content-based detection remains
 a local compatibility fallback and does not select production policy when a
-trusted identity is available:
+trusted identity is available. Repository-path mode clears ambient identity and
+derives each target independently. The legacy `REPO_TYPE` hint cannot select
+the strict API policy without the exact `secpal/api` manifest:
 
 - **org**: `.github` repository (org-wide instructions)
 - **api**: SecPal API (has Composer package name `secpal/api`)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -336,7 +336,7 @@ See `.github/workflows/validate-ai-instructions.yml`
 The script automatically detects repository type:
 
 - **org**: `.github` repository (org-wide instructions)
-- **api**: Laravel API (has `artisan`, `composer.json`)
+- **api**: SecPal API (has Composer package name `secpal/api`)
 - **frontend**: React frontend or Android wrapper (has `package.json` with `vite`)
 - **website**: Astro landing page (has `astro.config.mjs`)
 - **contracts**: OpenAPI contracts (has `package.json` with `openapi` or `docs/openapi.yaml`)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -250,7 +250,14 @@ and focused instruction overlays across all repositories.
 2. **REUSE Compliance**
 
    - Validates `AGENTS.md` REUSE metadata
-   - Accepts allowed inline SPDX metadata or a valid `.license` sidecar
+   - Requires the complete repository-policy expression in inline SPDX
+     metadata or a valid `.license` sidecar
+   - Requires plain `AGPL-3.0-or-later` for managed runtime and review
+     baselines, except the API repository's intentional `CC0-1.0` baseline
+   - Preserves exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`,
+     or `MIT` expressions on focused overlays
+   - Rejects the obsolete expression
+     `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
 
 3. **Markdown Linting**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -251,9 +251,11 @@ and focused instruction overlays across all repositories.
 
    - Validates `AGENTS.md` REUSE metadata
    - Requires the complete repository-policy expression in inline SPDX
-     metadata or a valid `.license` sidecar
-   - Requires plain `AGPL-3.0-or-later` for managed runtime and review
-     baselines, except the API repository's intentional `CC0-1.0` baseline
+     metadata or a valid `.license` sidecar and rejects conflicting or duplicate
+     declarations across both sources
+   - Requires plain `AGPL-3.0-or-later` for the migrated `.github` baseline,
+     preserves the API repository's intentional `CC0-1.0` baseline, and accepts
+     transitional plain AGPL or CC0 for other managed roots until migration
    - Preserves exact deliberate `AGPL-3.0-or-later`, `Apache-2.0`, `CC0-1.0`,
      or `MIT` expressions on focused overlays
    - Rejects the obsolete expression
@@ -331,9 +333,12 @@ See `.github/workflows/validate-ai-instructions.yml`
 - `npm ci` in `SecPal/.github` (installs the pinned `markdownlint-cli` and `prettier` CLIs)
 - `ruby` (optional, only for the legacy YAML syntax check)
 
-**Repository Detection:**
+**Repository Identity:**
 
-The script automatically detects repository type:
+Canonical GitHub and Polyscope callers supply trusted repository identity via
+`GITHUB_REPOSITORY` or `SECPAL_REPOSITORY_NAME`. Content-based detection remains
+a local compatibility fallback and does not select production policy when a
+trusted identity is available:
 
 - **org**: `.github` repository (org-wide instructions)
 - **api**: SecPal API (has Composer package name `secpal/api`)

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3114,9 +3114,10 @@ def validate_instruction_root(
         validator_env.pop("REPO_TYPE", None)
         validator_env["SECPAL_REPOSITORY_NAME"] = repository_name
         result = subprocess.run(
-            [str(validator_path), str(resolved_root)],
+            [str(validator_path)],
             check=False,
             capture_output=True,
+            cwd=resolved_root,
             env=validator_env,
             text=True,
         )

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -669,10 +669,14 @@ def build_preview_url_template(preview_prefix: str | None) -> str:
     return "https://{{worktree}}.preview.secpal.dev"
 
 
-def build_workspace_instruction_validation_command() -> str:
+def build_workspace_instruction_validation_command(repo_name: str) -> str:
     """Return the synchronous guard used by Polyscope's native setup runner."""
     rollout_script = shlex.quote(str(ROLLOUT_SCRIPT_PATH))
-    return f"python3 {rollout_script} --validate-instruction-worktree \"$PWD\""
+    repository_name = shlex.quote(repo_name)
+    return (
+        f"python3 {rollout_script} --instruction-repository-name {repository_name} "
+        '--validate-instruction-worktree "$PWD"'
+    )
 
 
 def build_fail_closed_setup_command(commands: list[str]) -> str:
@@ -1600,7 +1604,7 @@ def cleanup_removed_api_preview_databases(
     clone_root: pathlib.Path,
     *,
     db_path: pathlib.Path | None = None,
-    validated_instruction_roots: set[pathlib.Path],
+    validated_instruction_roots: set[tuple[pathlib.Path, str]],
     registered_api_worktrees: list[pathlib.Path],
 ) -> list[str]:
     api_clone_root = clone_root / repo_state["api"]["id"]
@@ -3058,6 +3062,7 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
     for repo_name, settings in REPO_SETTINGS.items():
         spec = copy.deepcopy(settings)
         repo_path = workspace_root / repo_name
+        spec["repository_name"] = repo_name
         spec["path"] = repo_path
         spec["agent_instructions"] = repo_path / "AGENTS.md"
         spec["copilot_instructions"] = repo_path / settings["copilot_instructions"]
@@ -3079,7 +3084,7 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
         spec[NATIVE_SETUP_COMMANDS_KEY] = native_setup_commands
         spec["local_config"]["scripts"]["setup"] = [
             build_fail_closed_setup_command(
-                [build_workspace_instruction_validation_command(), *native_setup_commands]
+                [build_workspace_instruction_validation_command(repo_name), *native_setup_commands]
             )
         ]
         repo_specs[repo_name] = spec
@@ -3088,10 +3093,12 @@ def build_repo_specs(workspace_root: pathlib.Path) -> dict[str, dict[str, Any]]:
 
 def validate_instruction_root(
     root: pathlib.Path,
-    validated_instruction_roots: set[pathlib.Path],
+    validated_instruction_roots: set[tuple[pathlib.Path, str]],
+    repository_name: str,
 ) -> pathlib.Path:
     resolved_root = root.resolve()
-    if resolved_root in validated_instruction_roots:
+    validation_key = (resolved_root, repository_name)
+    if validation_key in validated_instruction_roots:
         return resolved_root
 
     validator_path = CANONICAL_AI_INSTRUCTIONS_VALIDATOR
@@ -3102,10 +3109,15 @@ def validate_instruction_root(
         )
 
     try:
+        validator_env = os.environ.copy()
+        validator_env.pop("GITHUB_REPOSITORY", None)
+        validator_env.pop("REPO_TYPE", None)
+        validator_env["SECPAL_REPOSITORY_NAME"] = repository_name
         result = subprocess.run(
             [str(validator_path), str(resolved_root)],
             check=False,
             capture_output=True,
+            env=validator_env,
             text=True,
         )
     except OSError as error:
@@ -3126,19 +3138,23 @@ def validate_instruction_root(
             f"(exit {result.returncode}):\n{details}"
         )
 
-    validated_instruction_roots.add(resolved_root)
+    validated_instruction_roots.add(validation_key)
     return resolved_root
 
 
 def require_repo_instruction_files(
     spec: dict[str, Any],
-    validated_instruction_roots: set[pathlib.Path] | None = None,
+    validated_instruction_roots: set[tuple[pathlib.Path, str]] | None = None,
 ) -> str:
     repo_path = pathlib.Path(spec["path"])
     resolved_repo_path = repo_path.resolve()
     if spec.get(CANONICAL_VALIDATION_SPEC_KEY) != resolved_repo_path:
         validation_cache = validated_instruction_roots if validated_instruction_roots is not None else set()
-        spec[CANONICAL_VALIDATION_SPEC_KEY] = validate_instruction_root(repo_path, validation_cache)
+        spec[CANONICAL_VALIDATION_SPEC_KEY] = validate_instruction_root(
+            repo_path,
+            validation_cache,
+            str(spec["repository_name"]),
+        )
 
     try:
         return pathlib.Path(spec["agent_instructions"]).read_text(encoding="utf-8")
@@ -3151,13 +3167,14 @@ def require_repo_instruction_files(
 
 def validate_repo_instruction_files(
     repo_specs: dict[str, dict[str, Any]],
-    validated_instruction_roots: set[pathlib.Path],
+    validated_instruction_roots: set[tuple[pathlib.Path, str]],
 ) -> None:
-    for spec in repo_specs.values():
+    for repo_name, spec in repo_specs.items():
         repo_path = pathlib.Path(spec["path"])
         spec[CANONICAL_VALIDATION_SPEC_KEY] = validate_instruction_root(
             repo_path,
             validated_instruction_roots,
+            repo_name,
         )
 
 
@@ -3489,7 +3506,7 @@ def is_provisionable_worktree(
     worktree_path: pathlib.Path,
     validation_commands: list[str],
     *,
-    validated_instruction_roots: set[pathlib.Path],
+    validated_instruction_roots: set[tuple[pathlib.Path, str]],
     log_skip_reason: bool = True,
 ) -> bool:
     def skip(reason: str) -> bool:
@@ -3511,7 +3528,7 @@ def is_provisionable_worktree(
         if not (android_project_dir / "settings.gradle").is_file():
             return skip("missing committed native Android Gradle project")
 
-    validate_instruction_root(worktree_path, validated_instruction_roots)
+    validate_instruction_root(worktree_path, validated_instruction_roots, repo_name)
 
     package_scripts = load_package_scripts(worktree_path)
     composer_scripts = load_composer_scripts(worktree_path)
@@ -4894,7 +4911,7 @@ def provision_worktrees(
     clone_root: pathlib.Path,
     *,
     db_path: pathlib.Path | None = None,
-    validated_instruction_roots: set[pathlib.Path] | None = None,
+    validated_instruction_roots: set[tuple[pathlib.Path, str]] | None = None,
 ) -> tuple[list[str], list[str], list[dict[str, str]]]:
     validation_cache = validated_instruction_roots if validated_instruction_roots is not None else set()
     resolved_db_path = db_path or default_polyscope_db_path()
@@ -5948,9 +5965,17 @@ def validate_direct_api_worktree_roots(
     worktree_path: pathlib.Path,
 ) -> tuple[pathlib.Path, pathlib.Path]:
     """Validate and resolve the exact source and target roots consumed by a direct mode."""
-    validated_instruction_roots: set[pathlib.Path] = set()
-    resolved_source_repo = validate_instruction_root(source_repo_path, validated_instruction_roots)
-    resolved_worktree = validate_instruction_root(worktree_path, validated_instruction_roots)
+    validated_instruction_roots: set[tuple[pathlib.Path, str]] = set()
+    resolved_source_repo = validate_instruction_root(
+        source_repo_path,
+        validated_instruction_roots,
+        "api",
+    )
+    resolved_worktree = validate_instruction_root(
+        worktree_path,
+        validated_instruction_roots,
+        "api",
+    )
     return resolved_source_repo, resolved_worktree
 
 
@@ -6019,8 +6044,17 @@ def dispatch_validation_only_direct_mode(args: argparse.Namespace) -> int | None
     requested_root = getattr(args, VALIDATION_ONLY_DIRECT_MODE)
     if requested_root is None:
         return None
+    if args.instruction_repository_name is None:
+        raise SystemExit(
+            "--instruction-repository-name is required with "
+            "--validate-instruction-worktree"
+        )
 
-    resolved_root = validate_instruction_root(requested_root, set())
+    resolved_root = validate_instruction_root(
+        requested_root,
+        set(),
+        args.instruction_repository_name,
+    )
     print(f"Canonical AI-instruction validation passed for {resolved_root}")
     return 0
 
@@ -6044,6 +6078,7 @@ def parse_args() -> argparse.Namespace:
             type=pathlib.Path,
         )
     parser.add_argument("--source-repo-path", type=pathlib.Path)
+    parser.add_argument("--instruction-repository-name")
     parser.add_argument("--shell-command")
     parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
     parser.add_argument("--db-path", type=pathlib.Path, default=default_polyscope_db_path())
@@ -6133,7 +6168,7 @@ def main() -> int:
 
 def run_rollout(args: argparse.Namespace) -> int:
     repo_specs = build_repo_specs(args.workspace_root)
-    validated_instruction_roots: set[pathlib.Path] = set()
+    validated_instruction_roots: set[tuple[pathlib.Path, str]] = set()
 
     try:
         validate_repo_instruction_files(repo_specs, validated_instruction_roots)

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -36,6 +36,28 @@ print_result() {
     FAILED_TESTS=$((FAILED_TESTS + 1))
 }
 
+composer_package_is() {
+    local manifest="$1"
+    local expected_name="$2"
+
+    python3 - "$manifest" "$expected_name" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+raise SystemExit(
+    0
+    if isinstance(manifest, dict) and manifest.get("name") == sys.argv[2]
+    else 1
+)
+PY
+}
+
 detect_repo_type() {
     if [ -n "${REPO_TYPE:-}" ]; then
         printf '%s\n' "$REPO_TYPE"
@@ -49,7 +71,8 @@ detect_repo_type() {
         || { [ -f package.json ] \
             && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"/]*/)?guardguide"' package.json; }; then
         printf '%s\n' guardguide
-    elif [ -f artisan ] || [ -f composer.json ]; then
+    elif [ -f composer.json ] \
+        && composer_package_is composer.json secpal/api; then
         printf '%s\n' api
     elif [ -f capacitor.config.ts ] || [ -d android/app/src ]; then
         printf '%s\n' android
@@ -200,8 +223,8 @@ has_complete_allowed_instruction_license() {
         metadata="$(head -n "$line_limit" "$file")"
     fi
 
-    identifier_count="$(printf '%s\n' "$metadata" \
-        | grep -cF 'SPDX-License''-Identifier:' || true)"
+    identifier_count="$(grep -cF 'SPDX-License''-Identifier:' "$file" \
+        || true)"
     allowed_count="$(printf '%s\n' "$metadata" \
         | grep -cE "($bare_pattern)|($html_pattern)" || true)"
 

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -92,21 +92,24 @@ detect_repo_type() {
             ;;
     esac
 
-    if [ -n "${REPO_TYPE:-}" ]; then
+    if [ -n "${REPO_TYPE:-}" ] \
+        && { [ "$REPO_TYPE" != "api" ] \
+            || { [ -f composer.json ] \
+                && composer_package_is composer.json secpal/api; }; }; then
         printf '%s\n' "$REPO_TYPE"
         return
     fi
 
-    if [ "$(basename "$PWD")" = "GuardGuide" ]; then
+    if [ -f composer.json ] \
+        && composer_package_is composer.json secpal/api; then
+        printf '%s\n' api
+    elif [ "$(basename "$PWD")" = "GuardGuide" ]; then
         printf '%s\n' guardguide
     elif { [ -f composer.json ] \
             && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"/]*/)?guardguide"' composer.json; } \
         || { [ -f package.json ] \
             && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"/]*/)?guardguide"' package.json; }; then
         printf '%s\n' guardguide
-    elif [ -f composer.json ] \
-        && composer_package_is composer.json secpal/api; then
-        printf '%s\n' api
     elif [ -f capacitor.config.ts ] || [ -d android/app/src ]; then
         printf '%s\n' android
     elif [ -f astro.config.mjs ]; then
@@ -117,6 +120,22 @@ detect_repo_type() {
         printf '%s\n' contracts
     else
         printf '%s\n' org
+    fi
+}
+
+instruction_baseline_policy() {
+    local repo_type="$1"
+    local repository_name="$2"
+
+    if [ "$repository_name" = "api" ]; then
+        printf '%s\n' api
+    elif [ -z "$repository_name" ] \
+        && [ "$repo_type" = "api" ] \
+        && [ -f composer.json ] \
+        && composer_package_is composer.json secpal/api; then
+        printf '%s\n' api
+    else
+        printf '%s\n' agpl
     fi
 }
 
@@ -218,22 +237,20 @@ instruction_license_pattern() {
     local file="$1"
     local repo_type="$2"
     local repository_name="$3"
+    local baseline_policy
+
+    baseline_policy="$(instruction_baseline_policy \
+        "$repo_type" "$repository_name")"
 
     case "$file" in
         .github/instructions/*.instructions.md)
             printf '%s\n' 'AGPL-3\.0-or-later|Apache-2\.0|CC0-1\.0|MIT'
             ;;
         *)
-            if [ "$repository_name" = "api" ] \
-                || { [ -z "$repository_name" ] \
-                    && [ "${REPO_TYPE:-}" = "api" ]; }; then
-                printf '%s\n' 'CC0-1\.0'
-            elif [ "$repository_name" = ".github" ] \
-                || { [ -z "$repository_name" ] && [ -n "${REPO_TYPE:-}" ]; }; then
-                printf '%s\n' 'AGPL-3\.0-or-later'
-            else
-                printf '%s\n' 'AGPL-3\.0-or-later|CC0-1\.0'
-            fi
+            case "$baseline_policy" in
+                api) printf '%s\n' 'CC0-1\.0' ;;
+                agpl) printf '%s\n' 'AGPL-3\.0-or-later' ;;
+            esac
             ;;
     esac
 }
@@ -242,22 +259,20 @@ instruction_license_description() {
     local file="$1"
     local repo_type="$2"
     local repository_name="$3"
+    local baseline_policy
+
+    baseline_policy="$(instruction_baseline_policy \
+        "$repo_type" "$repository_name")"
 
     case "$file" in
         .github/instructions/*.instructions.md)
             printf '%s\n' 'AGPL-3.0-or-later, Apache-2.0, CC0-1.0, or MIT'
             ;;
         *)
-            if [ "$repository_name" = "api" ] \
-                || { [ -z "$repository_name" ] \
-                    && [ "${REPO_TYPE:-}" = "api" ]; }; then
-                printf '%s\n' 'CC0-1.0'
-            elif [ "$repository_name" = ".github" ] \
-                || { [ -z "$repository_name" ] && [ -n "${REPO_TYPE:-}" ]; }; then
-                printf '%s\n' 'AGPL-3.0-or-later'
-            else
-                printf '%s\n' 'AGPL-3.0-or-later or transitional CC0-1.0'
-            fi
+            case "$baseline_policy" in
+                api) printf '%s\n' 'CC0-1.0' ;;
+                agpl) printf '%s\n' 'AGPL-3.0-or-later' ;;
+            esac
             ;;
     esac
 }
@@ -541,6 +556,7 @@ if [ "$#" -gt 0 ]; then
 
         (
             cd "$repo_path"
+            unset GITHUB_REPOSITORY SECPAL_REPOSITORY_NAME REPO_TYPE
             "$SCRIPT_DIR/validate-ai-instructions.sh"
         ) || overall_status=1
     done

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail
@@ -43,6 +43,11 @@ detect_repo_type() {
     fi
 
     if [ "$(basename "$PWD")" = "GuardGuide" ]; then
+        printf '%s\n' guardguide
+    elif { [ -f composer.json ] \
+            && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"/]*/)?guardguide"' composer.json; } \
+        || { [ -f package.json ] \
+            && grep -qiE '"name"[[:space:]]*:[[:space:]]*"([^"/]*/)?guardguide"' package.json; }; then
         printf '%s\n' guardguide
     elif [ -f artisan ] || [ -f composer.json ]; then
         printf '%s\n' api
@@ -140,10 +145,78 @@ PY
     fi
 }
 
+instruction_license_pattern() {
+    local file="$1"
+    local repo_type="$2"
+
+    case "$file" in
+        .github/instructions/*.instructions.md)
+            printf '%s\n' 'AGPL-3\.0-or-later|Apache-2\.0|CC0-1\.0|MIT'
+            ;;
+        *)
+            if [ "$repo_type" = "api" ]; then
+                printf '%s\n' 'CC0-1\.0'
+            else
+                printf '%s\n' 'AGPL-3\.0-or-later'
+            fi
+            ;;
+    esac
+}
+
+instruction_license_description() {
+    local file="$1"
+    local repo_type="$2"
+
+    case "$file" in
+        .github/instructions/*.instructions.md)
+            printf '%s\n' 'AGPL-3.0-or-later, Apache-2.0, CC0-1.0, or MIT'
+            ;;
+        *)
+            if [ "$repo_type" = "api" ]; then
+                printf '%s\n' 'CC0-1.0'
+            else
+                printf '%s\n' 'AGPL-3.0-or-later'
+            fi
+            ;;
+    esac
+}
+
+has_complete_allowed_instruction_license() {
+    local file="$1"
+    local line_limit="$2"
+    local expression_pattern="$3"
+    local bare_pattern
+    local html_pattern
+    local metadata
+    local identifier_count
+    local allowed_count
+
+    bare_pattern='^[[:space:]]*(#[[:space:]]*)?SPDX-License''-Identifier:[[:space:]]+('"$expression_pattern"')[[:space:]]*$'
+    html_pattern='^[[:space:]]*<!--[[:space:]]*SPDX-License''-Identifier:[[:space:]]+('"$expression_pattern"')[[:space:]]*-->[[:space:]]*$'
+
+    if [ "$line_limit" = "all" ]; then
+        metadata="$(<"$file")"
+    else
+        metadata="$(head -n "$line_limit" "$file")"
+    fi
+
+    identifier_count="$(printf '%s\n' "$metadata" \
+        | grep -cF 'SPDX-License''-Identifier:' || true)"
+    allowed_count="$(printf '%s\n' "$metadata" \
+        | grep -cE "($bare_pattern)|($html_pattern)" || true)"
+
+    [ "$identifier_count" -eq 1 ] && [ "$allowed_count" -eq 1 ]
+}
+
 test_reuse_license() {
     local file="$1"
     local label="$2"
-    local license_pattern='SPDX-License''-Identifier:[[:space:]]+(CC0-1.0|AGPL-3.0-or-later)'
+    local repo_type="$3"
+    local expression_pattern
+    local expected
+
+    expression_pattern="$(instruction_license_pattern "$file" "$repo_type")"
+    expected="$(instruction_license_description "$file" "$repo_type")"
 
     if [ ! -f "$file" ]; then
         print_result "$label has REUSE license" "FAIL" "Missing $file"
@@ -151,20 +224,21 @@ test_reuse_license() {
     fi
 
     if [ -f "$file.license" ]; then
-        if grep -qE "$license_pattern" "$file.license"; then
+        if has_complete_allowed_instruction_license \
+            "$file.license" all "$expression_pattern"; then
             print_result "$label has REUSE license" "PASS"
         else
             print_result "$label has REUSE license" "FAIL" \
-                "Sidecar .license exists but does not declare an allowed license"
+                "$label must declare exactly one complete permitted SPDX expression: $expected"
         fi
         return
     fi
 
-    if head -n 10 "$file" | grep -qE "$license_pattern"; then
+    if has_complete_allowed_instruction_license "$file" 10 "$expression_pattern"; then
         print_result "$label has REUSE license" "PASS"
     else
         print_result "$label has REUSE license" "FAIL" \
-            "Missing inline SPDX header or .license sidecar"
+            "$label must declare exactly one complete permitted SPDX expression: $expected"
     fi
 }
 
@@ -307,6 +381,7 @@ test_instruction_size_limit() {
 }
 
 main() {
+    local file
     local repo_type
 
     printf '%s\n' '========================================='
@@ -321,9 +396,12 @@ main() {
     test_readable_utf8_markdown AGENTS.md AGENTS.md
     test_readable_utf8_markdown \
         .github/copilot-instructions.md copilot-instructions.md
-    test_reuse_license AGENTS.md AGENTS.md
+    test_reuse_license AGENTS.md AGENTS.md "$repo_type"
     test_reuse_license \
-        .github/copilot-instructions.md copilot-instructions.md
+        .github/copilot-instructions.md copilot-instructions.md "$repo_type"
+    while IFS= read -r -d '' file; do
+        test_reuse_license "$file" "$file" "$repo_type"
+    done < <(find .github/instructions -type f -name '*.instructions.md' -print0 2>/dev/null)
     test_instruction_frontmatter
     test_markdown_lint
     test_instruction_size_limit AGENTS.md AGENTS.md "runtime discovery"

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -59,6 +59,39 @@ PY
 }
 
 detect_repo_type() {
+    local repository_name="${1:-}"
+
+    case "$repository_name" in
+        api)
+            printf '%s\n' api
+            return
+            ;;
+        GuardGuide)
+            printf '%s\n' guardguide
+            return
+            ;;
+        frontend)
+            printf '%s\n' frontend
+            return
+            ;;
+        android)
+            printf '%s\n' android
+            return
+            ;;
+        contracts)
+            printf '%s\n' contracts
+            return
+            ;;
+        guardguide.de|secpal.app)
+            printf '%s\n' website
+            return
+            ;;
+        .github)
+            printf '%s\n' org
+            return
+            ;;
+    esac
+
     if [ -n "${REPO_TYPE:-}" ]; then
         printf '%s\n' "$REPO_TYPE"
         return
@@ -84,6 +117,19 @@ detect_repo_type() {
         printf '%s\n' contracts
     else
         printf '%s\n' org
+    fi
+}
+
+trusted_repository_name() {
+    case "${GITHUB_REPOSITORY:-}" in
+        SecPal/*)
+            printf '%s\n' "${GITHUB_REPOSITORY#SecPal/}"
+            return
+            ;;
+    esac
+
+    if [ -n "${SECPAL_REPOSITORY_NAME:-}" ]; then
+        printf '%s\n' "$SECPAL_REPOSITORY_NAME"
     fi
 }
 
@@ -171,16 +217,22 @@ PY
 instruction_license_pattern() {
     local file="$1"
     local repo_type="$2"
+    local repository_name="$3"
 
     case "$file" in
         .github/instructions/*.instructions.md)
             printf '%s\n' 'AGPL-3\.0-or-later|Apache-2\.0|CC0-1\.0|MIT'
             ;;
         *)
-            if [ "$repo_type" = "api" ]; then
+            if [ "$repository_name" = "api" ] \
+                || { [ -z "$repository_name" ] \
+                    && [ "${REPO_TYPE:-}" = "api" ]; }; then
                 printf '%s\n' 'CC0-1\.0'
-            else
+            elif [ "$repository_name" = ".github" ] \
+                || { [ -z "$repository_name" ] && [ -n "${REPO_TYPE:-}" ]; }; then
                 printf '%s\n' 'AGPL-3\.0-or-later'
+            else
+                printf '%s\n' 'AGPL-3\.0-or-later|CC0-1\.0'
             fi
             ;;
     esac
@@ -189,22 +241,28 @@ instruction_license_pattern() {
 instruction_license_description() {
     local file="$1"
     local repo_type="$2"
+    local repository_name="$3"
 
     case "$file" in
         .github/instructions/*.instructions.md)
             printf '%s\n' 'AGPL-3.0-or-later, Apache-2.0, CC0-1.0, or MIT'
             ;;
         *)
-            if [ "$repo_type" = "api" ]; then
+            if [ "$repository_name" = "api" ] \
+                || { [ -z "$repository_name" ] \
+                    && [ "${REPO_TYPE:-}" = "api" ]; }; then
                 printf '%s\n' 'CC0-1.0'
-            else
+            elif [ "$repository_name" = ".github" ] \
+                || { [ -z "$repository_name" ] && [ -n "${REPO_TYPE:-}" ]; }; then
                 printf '%s\n' 'AGPL-3.0-or-later'
+            else
+                printf '%s\n' 'AGPL-3.0-or-later or transitional CC0-1.0'
             fi
             ;;
     esac
 }
 
-has_complete_allowed_instruction_license() {
+complete_allowed_instruction_license_expression() {
     local file="$1"
     local line_limit="$2"
     local expression_pattern="$3"
@@ -228,18 +286,30 @@ has_complete_allowed_instruction_license() {
     allowed_count="$(printf '%s\n' "$metadata" \
         | grep -cE "($bare_pattern)|($html_pattern)" || true)"
 
-    [ "$identifier_count" -eq 1 ] && [ "$allowed_count" -eq 1 ]
+    if [ "$identifier_count" -ne 1 ] || [ "$allowed_count" -ne 1 ]; then
+        return 1
+    fi
+
+    printf '%s\n' "$metadata" \
+        | grep -E "($bare_pattern)|($html_pattern)" \
+        | grep -oE "$expression_pattern"
 }
 
 test_reuse_license() {
     local file="$1"
     local label="$2"
     local repo_type="$3"
+    local repository_name="$4"
     local expression_pattern
     local expected
+    local inline_expression
+    local inline_identifier_count
+    local sidecar_expression
 
-    expression_pattern="$(instruction_license_pattern "$file" "$repo_type")"
-    expected="$(instruction_license_description "$file" "$repo_type")"
+    expression_pattern="$(instruction_license_pattern \
+        "$file" "$repo_type" "$repository_name")"
+    expected="$(instruction_license_description \
+        "$file" "$repo_type" "$repository_name")"
 
     if [ ! -f "$file" ]; then
         print_result "$label has REUSE license" "FAIL" "Missing $file"
@@ -247,8 +317,17 @@ test_reuse_license() {
     fi
 
     if [ -f "$file.license" ]; then
-        if has_complete_allowed_instruction_license \
-            "$file.license" all "$expression_pattern"; then
+        inline_identifier_count="$(grep -cF \
+            'SPDX-License''-Identifier:' "$file" || true)"
+        if ! sidecar_expression="$(complete_allowed_instruction_license_expression \
+            "$file.license" all "$expression_pattern")"; then
+            print_result "$label has REUSE license" "FAIL" \
+                "$label must declare exactly one complete permitted SPDX expression: $expected"
+        elif [ "$inline_identifier_count" -eq 0 ]; then
+            print_result "$label has REUSE license" "PASS"
+        elif inline_expression="$(complete_allowed_instruction_license_expression \
+            "$file" 10 "$expression_pattern")" \
+            && [ "$inline_expression" = "$sidecar_expression" ]; then
             print_result "$label has REUSE license" "PASS"
         else
             print_result "$label has REUSE license" "FAIL" \
@@ -257,7 +336,8 @@ test_reuse_license() {
         return
     fi
 
-    if has_complete_allowed_instruction_license "$file" 10 "$expression_pattern"; then
+    if complete_allowed_instruction_license_expression \
+        "$file" 10 "$expression_pattern" >/dev/null; then
         print_result "$label has REUSE license" "PASS"
     else
         print_result "$label has REUSE license" "FAIL" \
@@ -405,13 +485,15 @@ test_instruction_size_limit() {
 
 main() {
     local file
+    local repository_name
     local repo_type
 
     printf '%s\n' '========================================='
     printf '%s\n' 'SecPal AI Instructions Validation'
     printf '%s\n\n' '========================================='
 
-    repo_type="$(detect_repo_type)"
+    repository_name="$(trusted_repository_name)"
+    repo_type="$(detect_repo_type "$repository_name")"
     printf 'Repository Type: %s\n\n' "$repo_type"
 
     test_instruction_path_boundaries || return 1
@@ -419,11 +501,12 @@ main() {
     test_readable_utf8_markdown AGENTS.md AGENTS.md
     test_readable_utf8_markdown \
         .github/copilot-instructions.md copilot-instructions.md
-    test_reuse_license AGENTS.md AGENTS.md "$repo_type"
+    test_reuse_license AGENTS.md AGENTS.md "$repo_type" "$repository_name"
     test_reuse_license \
-        .github/copilot-instructions.md copilot-instructions.md "$repo_type"
+        .github/copilot-instructions.md copilot-instructions.md \
+        "$repo_type" "$repository_name"
     while IFS= read -r -d '' file; do
-        test_reuse_license "$file" "$file" "$repo_type"
+        test_reuse_license "$file" "$file" "$repo_type" "$repository_name"
     done < <(find .github/instructions -type f -name '*.instructions.md' -print0 2>/dev/null)
     test_instruction_frontmatter
     test_markdown_lint

--- a/tests/fixtures/validate-ai-instructions/wrong-ai-instructions-license-fixture.txt
+++ b/tests/fixtures/validate-ai-instructions/wrong-ai-instructions-license-fixture.txt
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -32,7 +32,9 @@ spec.loader.exec_module(module)
 
 
 def write_valid_instructions(root: pathlib.Path, repo_name: str | None = None) -> None:
-    license_expression = "CC0-1.0" if repo_name == "api" else "AGPL-3.0-or-later"
+    license_expression = (
+        "CC0-1.0" if repo_name in {"api", "frontend"} else "AGPL-3.0-or-later"
+    )
     root.joinpath(".github").mkdir(parents=True, exist_ok=True)
     root.joinpath(".markdownlint.json").write_text(repo_root.joinpath(".markdownlint.json").read_text())
     if repo_name == "api":
@@ -141,11 +143,13 @@ native_env = os.environ.copy()
 native_env["PATH"] = f"{native_fake_bin}:{native_env['PATH']}"
 native_env["NATIVE_SETUP_LOG"] = str(native_setup_log)
 native_env["POLYSCOPE_DB_PATH"] = str(workspace / "native-polyscope.db")
+native_env["GITHUB_REPOSITORY"] = "SecPal/.github"
 
 for repo_name, generated_spec in generated_specs.items():
     setup_commands = module.render_local_config(generated_spec).get("scripts", {}).get("setup", [])
     assert setup_commands, repo_name
     assert "--validate-instruction-worktree" in setup_commands[0], (repo_name, setup_commands)
+    assert f"--instruction-repository-name {repo_name}" in setup_commands[0], (repo_name, setup_commands)
 
     invalid_root = workspace / "native setup ; invalid roots" / repo_name
     write_valid_instructions(invalid_root, repo_name)

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -31,13 +31,17 @@ assert spec.loader is not None
 spec.loader.exec_module(module)
 
 
-def write_valid_instructions(root: pathlib.Path) -> None:
+def write_valid_instructions(root: pathlib.Path, repo_name: str | None = None) -> None:
+    license_expression = "CC0-1.0" if repo_name == "api" else "AGPL-3.0-or-later"
     root.joinpath(".github").mkdir(parents=True, exist_ok=True)
     root.joinpath(".markdownlint.json").write_text(repo_root.joinpath(".markdownlint.json").read_text())
+    if repo_name == "api":
+        root.joinpath("composer.json").write_text("{}\n")
     root.joinpath("AGENTS.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
-        "SPDX-License-" "Identifier: CC0-1.0\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+        "SPDX-License-"
+        f"Identifier: {license_expression}\n"
         "-->\n\n"
         "# Test Runtime Instructions\n\n"
         "## Scope and Safety\n\n"
@@ -45,8 +49,9 @@ def write_valid_instructions(root: pathlib.Path) -> None:
     )
     root.joinpath(".github", "copilot-instructions.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
-        "SPDX-License-" "Identifier: CC0-1.0\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+        "SPDX-License-"
+        f"Identifier: {license_expression}\n"
         "-->\n\n"
         "# Test Review Profile\n\n"
         "- Review the complete diff.\n"
@@ -75,7 +80,7 @@ def run_polyscope_setup(
 native_source_workspace = workspace / "native source roots"
 for repo_name in module.REPO_SETTINGS:
     source_root = native_source_workspace / repo_name
-    write_valid_instructions(source_root)
+    write_valid_instructions(source_root, repo_name)
     source_root.joinpath("package.json").write_text(
         json.dumps({"name": f"source-{repo_name}", "private": True}) + "\n"
     )
@@ -143,7 +148,7 @@ for repo_name, generated_spec in generated_specs.items():
     assert "--validate-instruction-worktree" in setup_commands[0], (repo_name, setup_commands)
 
     invalid_root = workspace / "native setup ; invalid roots" / repo_name
-    write_valid_instructions(invalid_root)
+    write_valid_instructions(invalid_root, repo_name)
     invalid_root.joinpath("AGENTS.md").write_text("# Missing SPDX metadata\n")
     invalid_root.joinpath("package.json").write_text(
         json.dumps({"name": f"invalid-{repo_name}", "private": True}) + "\n"
@@ -224,7 +229,7 @@ assert ordered_root.joinpath("failure-order.log").read_text().splitlines() == ["
 # repository after entering the single fail-closed boundary.
 for repo_name, generated_spec in generated_specs.items():
     valid_root = workspace / "native setup valid roots with spaces" / repo_name
-    write_valid_instructions(valid_root)
+    write_valid_instructions(valid_root, repo_name)
     valid_root.joinpath("package.json").write_text(
         json.dumps({"name": f"valid-{repo_name}", "private": True}) + "\n"
     )
@@ -239,10 +244,11 @@ for repo_name, generated_spec in generated_specs.items():
         )
         + "\n"
     )
-    valid_root.joinpath("composer.json").write_text(
-        json.dumps({"name": f"secpal/{repo_name.lower().replace('.', '-')}", "scripts": {}}) + "\n"
-    )
-    valid_root.joinpath("composer.lock").write_text("{}\n")
+    if repo_name in {"api", "GuardGuide"}:
+        valid_root.joinpath("composer.json").write_text(
+            json.dumps({"name": f"secpal/{repo_name.lower().replace('.', '-')}", "scripts": {}}) + "\n"
+        )
+        valid_root.joinpath("composer.lock").write_text("{}\n")
     valid_root.joinpath(".env.example").write_text(
         "APP_KEY=base64:test-key\nDB_CONNECTION=sqlite\nDB_DATABASE=database/database.sqlite\n"
     )
@@ -267,7 +273,7 @@ source_workspace = workspace / "source roots"
 repo_state: dict[str, dict[str, str]] = {}
 for index, repo_name in enumerate(module.REPO_SETTINGS, start=1):
     source_root = source_workspace / repo_name
-    write_valid_instructions(source_root)
+    write_valid_instructions(source_root, repo_name)
     repo_state[repo_name] = {
         "id": f"{index:08x}",
         "name": f"SecPal/{repo_name}",

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -32,9 +32,7 @@ spec.loader.exec_module(module)
 
 
 def write_valid_instructions(root: pathlib.Path, repo_name: str | None = None) -> None:
-    license_expression = (
-        "CC0-1.0" if repo_name in {"api", "frontend"} else "AGPL-3.0-or-later"
-    )
+    license_expression = "CC0-1.0" if repo_name == "api" else "AGPL-3.0-or-later"
     root.joinpath(".github").mkdir(parents=True, exist_ok=True)
     root.joinpath(".markdownlint.json").write_text(repo_root.joinpath(".markdownlint.json").read_text())
     if repo_name == "api":

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -36,7 +36,7 @@ def write_valid_instructions(root: pathlib.Path, repo_name: str | None = None) -
     root.joinpath(".github").mkdir(parents=True, exist_ok=True)
     root.joinpath(".markdownlint.json").write_text(repo_root.joinpath(".markdownlint.json").read_text())
     if repo_name == "api":
-        root.joinpath("composer.json").write_text("{}\n")
+        root.joinpath("composer.json").write_text('{"name":"secpal/api"}\n')
     root.joinpath("AGENTS.md").write_text(
         "<!--\n"
         "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -43,8 +43,14 @@ digest = hashlib.sha256()
 for path in sorted(root.rglob("*")):
     if not path.is_file():
         continue
-    if path.name not in {"AGENTS.md", "copilot-instructions.md"} \
-            and not path.name.endswith(".instructions.md"):
+    if path.name not in {
+        "AGENTS.md",
+        "AGENTS.md.license",
+        "copilot-instructions.md",
+        "copilot-instructions.md.license",
+    } and not path.name.endswith(
+        (".instructions.md", ".instructions.md.license")
+    ):
         continue
     digest.update(str(path.relative_to(root)).encode())
     digest.update(b"\0")
@@ -65,6 +71,25 @@ assert_no_generated_preflight_action() {
 
 workspace="$(mktemp -d "${TMPDIR:-/tmp}/polyscope-rollout.XXXXXX")"
 trap 'rm -rf "$workspace"' EXIT
+
+instruction_hash_fixture="$workspace/instruction-hash"
+mkdir -p "$instruction_hash_fixture/.github"
+printf '# Runtime instructions\n' >"$instruction_hash_fixture/AGENTS.md"
+printf '%s\n' 'SPDX-License''-Identifier: AGPL-3.0-or-later' \
+    >"$instruction_hash_fixture/AGENTS.md.license"
+instruction_hash_before_sidecar_change="$(
+    instruction_tree_sha256 "$instruction_hash_fixture"
+)"
+printf '%s\n' 'SPDX-License''-Identifier: MIT' \
+    >"$instruction_hash_fixture/AGENTS.md.license"
+instruction_hash_after_sidecar_change="$(
+    instruction_tree_sha256 "$instruction_hash_fixture"
+)"
+if [ "$instruction_hash_before_sidecar_change" \
+    = "$instruction_hash_after_sidecar_change" ]; then
+    echo "instruction tree hash must include REUSE sidecars" >&2
+    exit 1
+fi
 
 fake_setfacl="$workspace/fake-tools/setfacl"
 mkdir -p "$(dirname "$fake_setfacl")"
@@ -175,7 +200,7 @@ for repo_dir in workspace_root.iterdir():
     )
     (repo_dir / "AGENTS.md").write_text(agents_text.rstrip() + "\n")
 
-(workspace_root / "api" / "composer.json").write_text("{}\n")
+(workspace_root / "api" / "composer.json").write_text('{"name":"secpal/api"}\n')
 (workspace_root / "api" / "artisan").write_text("#!/usr/bin/env php\n")
 (workspace_root / "api" / "scripts").mkdir(parents=True, exist_ok=True)
 (workspace_root / "api" / "scripts" / "preflight.sh").write_text("#!/usr/bin/env bash\n")
@@ -273,7 +298,7 @@ seed_api_worktree_files() {
     local worktree_dir="$1"
 
     write_valid_worktree_instructions "$worktree_dir" CC0-1.0
-    printf '{}\n' > "$worktree_dir/composer.json"
+    printf '{"name":"secpal/api"}\n' > "$worktree_dir/composer.json"
     printf '#!/usr/bin/env php\n' > "$worktree_dir/artisan"
     chmod +x "$worktree_dir/artisan"
 }
@@ -989,7 +1014,7 @@ for executable in ("composer", "php", "psql"):
 def write_valid_instruction_root(root: pathlib.Path) -> None:
     (root / ".github").mkdir(parents=True)
     shutil.copy2(repo_root / ".markdownlint.json", root / ".markdownlint.json")
-    (root / "composer.json").write_text("{}\n")
+    (root / "composer.json").write_text('{"name":"secpal/api"}\n')
     (root / "AGENTS.md").write_text(
         "<!--\n"
         "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
@@ -1253,7 +1278,7 @@ release_first = fixture / "release-first"
 def write_valid_instruction_root(root: pathlib.Path) -> None:
     (root / ".github").mkdir(parents=True)
     shutil.copy2(repo_root / ".markdownlint.json", root / ".markdownlint.json")
-    (root / "composer.json").write_text("{}\n")
+    (root / "composer.json").write_text('{"name":"secpal/api"}\n')
     (root / "AGENTS.md").write_text(
         "<!--\n"
         "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
@@ -1292,7 +1317,7 @@ for instruction_name, instruction_title in (
 (physical_worktree / ".git" / "info").mkdir(parents=True)
 (physical_worktree / ".git" / "hooks").mkdir()
 for repository_root in (source_api, physical_worktree):
-    repository_root.joinpath("composer.json").write_text("{}\n")
+    repository_root.joinpath("composer.json").write_text('{"name":"secpal/api"}\n')
     repository_root.joinpath("artisan").write_text("#!/usr/bin/env php\n")
 fake_bin.mkdir(parents=True)
 race_state.mkdir()
@@ -2061,7 +2086,7 @@ fake_bin.mkdir()
 for instruction_root in (source_api, api_worktree):
     instruction_root.joinpath(".github").mkdir(exist_ok=True)
     shutil.copy2(repo_root / ".markdownlint.json", instruction_root / ".markdownlint.json")
-    instruction_root.joinpath("composer.json").write_text("{}\n")
+    instruction_root.joinpath("composer.json").write_text('{"name":"secpal/api"}\n')
     instruction_root.joinpath("AGENTS.md").write_text(
         "<!--\n"
         "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
@@ -5625,7 +5650,7 @@ EOF
 
 seed_api_worktree_files "$api_clone"
 write_valid_worktree_instructions "$broken_api_clone" CC0-1.0
-printf '{}\n' >"$broken_api_clone/composer.json"
+printf '{"name":"secpal/api"}\n' >"$broken_api_clone/composer.json"
 seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
 seed_node_worktree_files "$broken_android_clone" "android-feat"
 seed_node_worktree_files "$android_clone" "android-auto-hawk"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -1901,6 +1901,22 @@ resolved_fixture = module.validate_instruction_root(fixture, validated_roots, "f
 assert resolved_fixture == fixture.resolve()
 assert validated_roots == {(fixture.resolve(), "frontend")}
 
+misleading_guardguide_fixture = workspace / "GuardGuide instruction root"
+shutil.copytree(fixture, misleading_guardguide_fixture)
+(misleading_guardguide_fixture / "composer.json").write_text(
+    '{"name":"secpal/api"}\n'
+)
+resolved_guardguide_fixture = module.validate_instruction_root(
+    misleading_guardguide_fixture,
+    validated_roots,
+    "GuardGuide",
+)
+assert resolved_guardguide_fixture == misleading_guardguide_fixture.resolve()
+assert validated_roots == {
+    (fixture.resolve(), "frontend"),
+    (misleading_guardguide_fixture.resolve(), "GuardGuide"),
+}
+
 original_validator = module.CANONICAL_AI_INSTRUCTIONS_VALIDATOR
 missing_validator = workspace / "missing-validate-ai-instructions.sh"
 module.CANONICAL_AI_INSTRUCTIONS_VALIDATOR = missing_validator

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -523,6 +523,11 @@ SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->'
 
+legacy_header='<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->'
+
 create_repo "api" "$api_header
 
 # API Instructions
@@ -565,7 +570,7 @@ applyTo: '**/*.php'
 - Use vendor/bin/pint --dirty after changes.
 "
 
-create_repo "frontend" "$common_header
+create_repo "frontend" "$legacy_header
 
 # Frontend Instructions
 
@@ -1895,20 +1900,20 @@ fixture = workspace / "instruction root with shell $ characters"
     "# Review Profile\n"
 )
 
-validated_roots: set[pathlib.Path] = set()
-resolved_fixture = module.validate_instruction_root(fixture, validated_roots)
+validated_roots: set[tuple[pathlib.Path, str]] = set()
+resolved_fixture = module.validate_instruction_root(fixture, validated_roots, "frontend")
 assert resolved_fixture == fixture.resolve()
-assert validated_roots == {fixture.resolve()}
+assert validated_roots == {(fixture.resolve(), "frontend")}
 
 original_validator = module.CANONICAL_AI_INSTRUCTIONS_VALIDATOR
 missing_validator = workspace / "missing-validate-ai-instructions.sh"
 module.CANONICAL_AI_INSTRUCTIONS_VALIDATOR = missing_validator
-assert module.validate_instruction_root(fixture, validated_roots) == fixture.resolve()
+assert module.validate_instruction_root(fixture, validated_roots, "frontend") == fixture.resolve()
 
 uncached_fixture = workspace / "uncached instruction root"
 shutil.copytree(fixture, uncached_fixture)
 try:
-    module.validate_instruction_root(uncached_fixture, validated_roots)
+    module.validate_instruction_root(uncached_fixture, validated_roots, "frontend")
 except module.CanonicalInstructionValidationError as error:
     assert str(uncached_fixture) in str(error), error
     assert str(missing_validator) in str(error), error
@@ -1920,7 +1925,7 @@ nonexecutable_validator = workspace / "nonexecutable-validate-ai-instructions.sh
 nonexecutable_validator.write_text("#!/usr/bin/env bash\nexit 0\n")
 module.CANONICAL_AI_INSTRUCTIONS_VALIDATOR = nonexecutable_validator
 try:
-    module.validate_instruction_root(uncached_fixture, validated_roots)
+    module.validate_instruction_root(uncached_fixture, validated_roots, "frontend")
 except module.CanonicalInstructionValidationError as error:
     assert "missing or not executable" in str(error), error
 else:

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -32,6 +32,28 @@ print(digest.hexdigest())
 PY
 }
 
+instruction_tree_sha256() {
+    python3 - "$1" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+digest = hashlib.sha256()
+for path in sorted(root.rglob("*")):
+    if not path.is_file():
+        continue
+    if path.name not in {"AGENTS.md", "copilot-instructions.md"} \
+            and not path.name.endswith(".instructions.md"):
+        continue
+    digest.update(str(path.relative_to(root)).encode())
+    digest.update(b"\0")
+    digest.update(path.read_bytes())
+    digest.update(b"\0")
+print(digest.hexdigest())
+PY
+}
+
 assert_no_generated_preflight_action() {
     local config_path="$1"
 
@@ -76,7 +98,11 @@ create_repo() {
     cp "$REPO_ROOT/.markdownlint.json" "$repo_dir/.markdownlint.json"
     printf '%s' "$copilot_body" > "$repo_dir/.github/copilot-instructions.md"
     printf '%s' "$focus_body" > "$repo_dir/.github/instructions/$focus_filename"
+    sed -i '1a# SPDX-FileCopyrightText: 2026 SecPal Contributors\n# SPDX-License''-Identifier: AGPL-3.0-or-later' \
+        "$repo_dir/.github/instructions/$focus_filename"
     printf '%s' "---
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: Org Shared Rules
 applyTo: '**'
 ---
@@ -132,10 +158,12 @@ for repo_dir in workspace_root.iterdir():
         else:
             overlay_lines.append(f"- `.github/instructions/{overlay_path.name}`")
     overlays = "\n".join(overlay_lines)
+    license_expression = "CC0-1.0" if repo_dir.name == "api" else "AGPL-3.0-or-later"
     agents_text = (
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
-        "SPDX-License" + "-Identifier: AGPL-3.0-or-later\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+        "SPDX-License"
+        f"-Identifier: {license_expression}\n"
         "-->\n\n"
         f"# {repo_dir.name} Agent Instructions\n\n"
         "This file is the authoritative, provider-neutral runtime baseline for this repository.\n"
@@ -244,7 +272,7 @@ PY
 seed_api_worktree_files() {
     local worktree_dir="$1"
 
-    write_valid_worktree_instructions "$worktree_dir"
+    write_valid_worktree_instructions "$worktree_dir" CC0-1.0
     printf '{}\n' > "$worktree_dir/composer.json"
     printf '#!/usr/bin/env php\n' > "$worktree_dir/artisan"
     chmod +x "$worktree_dir/artisan"
@@ -254,38 +282,39 @@ seed_node_worktree_files() {
     local worktree_dir="$1"
     local package_name="$2"
 
-    write_valid_worktree_instructions "$worktree_dir"
+    write_valid_worktree_instructions "$worktree_dir" AGPL-3.0-or-later
     printf '{\n  "name": "%s",\n  "private": true,\n  "scripts": {\n    "build": "vite build"\n  }\n}\n' "$package_name" > "$worktree_dir/package.json"
     printf '{\n  "name": "%s",\n  "lockfileVersion": 3,\n  "requires": true,\n  "packages": {}\n}\n' "$package_name" > "$worktree_dir/package-lock.json"
 }
 
 write_valid_worktree_instructions() {
     local worktree_dir="$1"
+    local license_expression="$2"
 
     mkdir -p "$worktree_dir/.github"
     cp "$REPO_ROOT/.markdownlint.json" "$worktree_dir/.markdownlint.json"
-    cat >"$worktree_dir/AGENTS.md" <<'EOF'
-<!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
--->
-
-# Test Runtime Instructions
-
-## Scope and Safety
-
-- Preserve existing work.
-EOF
-    cat >"$worktree_dir/.github/copilot-instructions.md" <<'EOF'
-<!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
--->
-
-# Test Review Profile
-
-- Review the complete diff.
-EOF
+    printf '%s\n' \
+        '<!--' \
+        'SPDX-FileCopyrightText: 2026 SecPal Contributors' \
+        "SPDX-License""-Identifier: $license_expression" \
+        '-->' \
+        '' \
+        '# Test Runtime Instructions' \
+        '' \
+        '## Scope and Safety' \
+        '' \
+        '- Preserve existing work.' \
+        >"$worktree_dir/AGENTS.md"
+    printf '%s\n' \
+        '<!--' \
+        'SPDX-FileCopyrightText: 2026 SecPal Contributors' \
+        "SPDX-License""-Identifier: $license_expression" \
+        '-->' \
+        '' \
+        '# Test Review Profile' \
+        '' \
+        '- Review the complete diff.' \
+        >"$worktree_dir/.github/copilot-instructions.md"
 }
 
 assert_rollout_rejects_invalid_local_config() {
@@ -373,8 +402,8 @@ assert_rollout_rejects_instruction_contract() {
         no-heading)
             cat >"$instruction_path" <<'EOF'
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 This readable instruction file has no top-level heading.
@@ -387,8 +416,12 @@ EOF
         missing-spdx)
             sed '/SPDX-License''-Identifier:/d' "$saved_path" >"$instruction_path"
             ;;
-        invalid-spdx)
-            sed 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: MIT/' \
+        invalid-spdx-expression)
+            sed 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: Not-A-Valid-License/' \
+                "$saved_path" >"$instruction_path"
+            ;;
+        obsolete-attribution-spdx)
+            sed 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
                 "$saved_path" >"$instruction_path"
             ;;
         oversized)
@@ -456,11 +489,16 @@ EOF
 }
 
 common_header='<!--
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->'
 
-create_repo "api" "$common_header
+api_header='<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->'
+
+create_repo "api" "$api_header
 
 # API Instructions
 
@@ -580,6 +618,8 @@ applyTo: 'resources/js/**/*.tsx'
 "
 
 printf '%s' "---
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: Laravel PHP Rules
 applyTo: '**/*.php'
 ---
@@ -815,6 +855,8 @@ path = Path(sys.argv[1])
 path.write_text(path.read_text().replace("## Core Runtime Baseline\n\n", "", 1))
 PY
 
+instruction_tree_hash_before_rollout="$(instruction_tree_sha256 "$workspace_root")"
+
 db_path="$workspace/polyscope.db"
 repos_json="$workspace/repos.json"
 nginx_output="$workspace/preview.secpal.dev.conf"
@@ -891,9 +933,14 @@ assert_rollout_rejects_instruction_contract \
 assert_rollout_rejects_instruction_contract \
     "GuardGuide" "AGENTS.md" "markdown-invalid" 'instruction Markdown passes lint'
 assert_rollout_rejects_instruction_contract \
-    "GuardGuide" "AGENTS.md" "missing-spdx" 'Missing inline SPDX header or .license sidecar'
+    "GuardGuide" "AGENTS.md" "missing-spdx" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
 assert_rollout_rejects_instruction_contract \
-    "GuardGuide" "AGENTS.md" "invalid-spdx" 'Missing inline SPDX header or .license sidecar'
+    "GuardGuide" "AGENTS.md" "invalid-spdx-expression" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
+assert_rollout_rejects_instruction_contract \
+    "GuardGuide" "AGENTS.md" "obsolete-attribution-spdx" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
 assert_rollout_rejects_instruction_contract \
     "GuardGuide" "AGENTS.md" "oversized" 'bytes exceeds 32768 bytes'
 assert_rollout_rejects_instruction_contract \
@@ -942,9 +989,10 @@ for executable in ("composer", "php", "psql"):
 def write_valid_instruction_root(root: pathlib.Path) -> None:
     (root / ".github").mkdir(parents=True)
     shutil.copy2(repo_root / ".markdownlint.json", root / ".markdownlint.json")
+    (root / "composer.json").write_text("{}\n")
     (root / "AGENTS.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Runtime Instructions\n\n"
@@ -953,7 +1001,7 @@ def write_valid_instruction_root(root: pathlib.Path) -> None:
     )
     (root / ".github" / "copilot-instructions.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Review Profile\n\n"
@@ -981,7 +1029,7 @@ def invalidate_instruction(root: pathlib.Path, instruction_kind: str) -> str:
             "",
         )
     )
-    return "Missing inline SPDX header or .license sidecar"
+    return "copilot-instructions.md must declare exactly one complete permitted SPDX expression: CC0-1.0"
 
 
 def cli_arguments(
@@ -1205,9 +1253,10 @@ release_first = fixture / "release-first"
 def write_valid_instruction_root(root: pathlib.Path) -> None:
     (root / ".github").mkdir(parents=True)
     shutil.copy2(repo_root / ".markdownlint.json", root / ".markdownlint.json")
+    (root / "composer.json").write_text("{}\n")
     (root / "AGENTS.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Runtime Instructions\n\n"
@@ -1215,7 +1264,7 @@ def write_valid_instruction_root(root: pathlib.Path) -> None:
     )
     (root / ".github" / "copilot-instructions.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Review Profile\n\n"
@@ -1232,6 +1281,8 @@ for instruction_name, instruction_title in (
 ):
     source_api.joinpath(".github", "instructions", instruction_name).write_text(
         "---\n"
+        "# SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+        "# SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
         f"name: {instruction_title}\n"
         "applyTo: '**'\n"
         "---\n\n"
@@ -1692,6 +1743,17 @@ if [ "$frontend_copilot_hash_after_rollout" != "$frontend_copilot_hash_before_ro
     echo "rollout must not reconstruct or overwrite an independent Copilot profile" >&2
     exit 1
 fi
+instruction_tree_hash_after_rollout="$(instruction_tree_sha256 "$workspace_root")"
+if [ "$instruction_tree_hash_after_rollout" != "$instruction_tree_hash_before_rollout" ]; then
+    echo "rollout must not regenerate or synchronize repository AI instructions" >&2
+    exit 1
+fi
+if grep -R -qF \
+    'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution' \
+    "$workspace_root"/*/AGENTS.md "$workspace_root"/*/.github 2>/dev/null; then
+    echo "rollout must not reintroduce the obsolete SecPal attribution expression" >&2
+    exit 1
+fi
 grep -qF '## Independent Review Sentinel' "$frontend_copilot_path"
 
 # Provisionability requires both independent instruction files in each
@@ -1709,15 +1771,15 @@ fixture = workspace / "instruction-contract-worktree"
 (fixture / ".markdownlint.json").write_text('{"default": true}\n')
 (fixture / "AGENTS.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Runtime Instructions\n"
 )
 (fixture / ".github" / "copilot-instructions.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Review Profile\n"
 )
@@ -1754,7 +1816,7 @@ else:
 
 copilot_path = fixture / ".github" / "copilot-instructions.md"
 valid_copilot = copilot_path.read_text()
-copilot_path.write_text(valid_copilot.replace("SPDX-License" "-Identifier: CC0-1.0\n", ""))
+copilot_path.write_text(valid_copilot.replace("SPDX-License" "-Identifier: AGPL-3.0-or-later\n", ""))
 try:
     module.is_provisionable_worktree(
         "frontend",
@@ -1765,7 +1827,7 @@ try:
     )
 except module.CanonicalInstructionValidationError as error:
     assert str(fixture) in str(error), error
-    assert "Missing inline SPDX header or .license sidecar" in str(error), error
+    assert "copilot-instructions.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later" in str(error), error
 else:
     raise AssertionError("unlicensed Copilot instructions must fail canonical worktree validation")
 
@@ -1795,15 +1857,15 @@ fixture = workspace / "instruction root with shell $ characters"
 (fixture / ".markdownlint.json").write_text((repo_root / ".markdownlint.json").read_text())
 (fixture / "AGENTS.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Runtime Instructions\n"
 )
 (fixture / ".github" / "copilot-instructions.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Review Profile\n"
 )
@@ -1999,9 +2061,10 @@ fake_bin.mkdir()
 for instruction_root in (source_api, api_worktree):
     instruction_root.joinpath(".github").mkdir(exist_ok=True)
     shutil.copy2(repo_root / ".markdownlint.json", instruction_root / ".markdownlint.json")
+    instruction_root.joinpath("composer.json").write_text("{}\n")
     instruction_root.joinpath("AGENTS.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Runtime Instructions\n\n"
@@ -2009,7 +2072,7 @@ for instruction_root in (source_api, api_worktree):
     )
     instruction_root.joinpath(".github", "copilot-instructions.md").write_text(
         "<!--\n"
-        "SPDX-FileCopyrightText: 2026 SecPal\n"
+        "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
         "SPDX-License" "-Identifier: CC0-1.0\n"
         "-->\n\n"
         "# Test Review Profile\n\n"
@@ -3128,15 +3191,15 @@ repo_spec_frontend = workspace / "repo-spec-root" / "frontend"
 )
 (repo_spec_frontend / "AGENTS.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Frontend Runtime Instructions\n"
 )
 (repo_spec_frontend / ".github" / "copilot-instructions.md").write_text(
     "<!--\n"
-    "SPDX-FileCopyrightText: 2026 SecPal\n"
-    "SPDX-License" "-Identifier: CC0-1.0\n"
+    "SPDX-FileCopyrightText: 2026 SecPal Contributors\n"
+    "SPDX-License" "-Identifier: AGPL-3.0-or-later\n"
     "-->\n\n"
     "# Frontend Review Profile\n"
 )
@@ -5561,7 +5624,8 @@ CORS_ALLOWED_ORIGINS=https://app.secpal.dev
 EOF
 
 seed_api_worktree_files "$api_clone"
-write_valid_worktree_instructions "$broken_api_clone"
+write_valid_worktree_instructions "$broken_api_clone" CC0-1.0
+printf '{}\n' >"$broken_api_clone/composer.json"
 seed_node_worktree_files "$frontend_clone" "frontend-auto-hawk"
 seed_node_worktree_files "$broken_android_clone" "android-feat"
 seed_node_worktree_files "$android_clone" "android-auto-hawk"
@@ -5712,7 +5776,7 @@ assert_invalid_candidate_blocks_provisioning \
     "instruction Markdown passes lint"
 assert_invalid_candidate_blocks_provisioning \
     "invalid-copilot" ".github/copilot-instructions.md" "missing-spdx" \
-    "Missing inline SPDX header or .license sidecar"
+    "copilot-instructions.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later"
 
 replace_registered_worktrees \
     "api12345" "$api_clone" \
@@ -6191,7 +6255,7 @@ seed_api_worktree_files "$failing_api_alias_clone"
 seed_node_worktree_files "$failing_frontend_manifest_clone" "frontend-broken-ibis"
 seed_node_worktree_files "$failing_frontend_io_clone" "frontend-locked-oryx"
 seed_api_worktree_files "$guardguide_clone"
-seed_node_worktree_files "$guardguide_clone" "guardguide-steady-otter"
+seed_node_worktree_files "$guardguide_clone" "guardguide"
 cp "$workspace_root/api/.env" "$failing_api_clone/.env"
 mkdir -p "$home_dir/.polyscope/clones/api12345/$failing_api_alias_workspace"
 printf '{\n  "packages": []\n}\n' > "$guardguide_clone/composer.lock"

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -523,11 +523,6 @@ SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->'
 
-legacy_header='<!--
-SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: CC0-1.0
--->'
-
 create_repo "api" "$api_header
 
 # API Instructions
@@ -570,7 +565,7 @@ applyTo: '**/*.php'
 - Use vendor/bin/pint --dirty after changes.
 "
 
-create_repo "frontend" "$legacy_header
+create_repo "frontend" "$common_header
 
 # Frontend Instructions
 
@@ -1865,8 +1860,9 @@ assert not (fixture / "polyscope.local.json").exists()
 assert not (fixture / ".polyscope-secpal-provisioned.json").exists()
 PY
 
-# Canonical validation uses argv-safe paths, caches each resolved root after a
-# real successful run, and fails closed when its validator cannot execute.
+# Canonical validation uses a resolved working directory with trusted repository
+# identity, caches each root after a real successful run, and fails closed when
+# its validator cannot execute.
 python3 -B - <<'PY' "$PYTHON_SCRIPT" "$workspace" "$REPO_ROOT"
 import importlib.util
 import pathlib

--- a/tests/secpal-pr-review-skill-policy.sh
+++ b/tests/secpal-pr-review-skill-policy.sh
@@ -63,6 +63,57 @@ protected_content_matches() {
     "$(normalize_documented_action_pins <<<"$accepted_content")"
 }
 
+normalize_agents_license_branding_overlay() {
+  local text
+
+  text="$(cat)"
+  python3 - "$text" <<'PY'
+import sys
+
+text = sys.argv[1]
+section = """## Licensing, REUSE, and Branding
+
+- Use `AGPL-3.0-or-later` for SecPal-owned material intentionally covered by
+  the AGPL. Never add or restore `LicenseRef-SecPal-Attribution` after the
+  licensing rollout.
+- Preserve deliberately different licenses, including `CC0-1.0`, `MIT`,
+  `Apache-2.0`, third-party and generated-file licenses, and unrelated custom
+  license references. Do not rewrite third-party copyright or license metadata.
+- Use `SecPal Contributors` where the project copyright convention applies.
+  Preserve each file's first-publication year and extend its year range through
+  the current year when an edited file requires a copyright-year update.
+- Run the relevant REUSE or license validation after changing copyright or
+  license metadata.
+- On user-facing official SecPal product surfaces, preserve
+  `Powered by SecPal – A guard's best friend` where it is intentionally present.
+  A licensing change must not remove, weaken, parameterize, genericize, or make
+  that SecPal branding optional.
+- Do not add fork-oriented `Based on SecPal` guidance to AI instructions, and
+  do not introduce white-label or fork-branding configuration as part of a
+  licensing change."""
+overlay = section + "\n\n"
+copyright_line = "SPDX-FileCopyrightText: 2026 SecPal Contributors"
+
+if text.count(overlay) != 1 or text.count(copyright_line) != 1:
+    raise SystemExit(1)
+
+text = text.replace(overlay, "", 1)
+text = text.replace(
+    copyright_line,
+    "SPDX-FileCopyrightText: 2026 SecPal",
+    1,
+)
+sys.stdout.write(text)
+PY
+}
+
+if sed \
+  "s/that SecPal branding optional/that SecPal branding configurable/" \
+  "$REPO_ROOT/AGENTS.md" \
+  | normalize_agents_license_branding_overlay >/dev/null; then
+  fail 'modified licensing and branding instruction overlay was accepted'
+fi
+
 protected_mode_matches() {
   local accepted_mode="$1"
   local path="$2"
@@ -403,6 +454,10 @@ for path in "${protected_paths[@]}"; do
   accepted_content="$(git -C "$REPO_ROOT" show "$P21_BASELINE:$relative_path")" \
     || fail "accepted protected-file baseline is unavailable: $relative_path"
   current_content="$(<"$path")"
+  if [ "$relative_path" = "AGENTS.md" ]; then
+    current_content="$(normalize_agents_license_branding_overlay <<<"$current_content")" \
+      || fail 'canonical licensing and branding instruction overlay changed'
+  fi
   protected_content_matches "$accepted_content" "$current_content" \
     || fail 'existing review governance or instruction routing changed'
 done

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -197,23 +197,20 @@ assert_fails_with "$late_duplicate_agents_license_repo" \
 
 api_license_repo="$workspace/allowed-api-cc0"
 copy_valid_repo "$valid_repo" "$api_license_repo"
+printf '{"name":"secpal/api"}\n' >"$api_license_repo/composer.json"
 sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
     "$api_license_repo/AGENTS.md" \
     "$api_license_repo/.github/copilot-instructions.md"
 assert_passes "$api_license_repo" "$workspace/allowed-api-cc0.output" api
 
-legacy_frontend_license_repo="$workspace/allowed-legacy-frontend-cc0"
+legacy_frontend_license_repo="$workspace/rejected-legacy-frontend-cc0"
 copy_valid_repo "$valid_repo" "$legacy_frontend_license_repo"
 sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
     "$legacy_frontend_license_repo/AGENTS.md" \
     "$legacy_frontend_license_repo/.github/copilot-instructions.md"
-legacy_frontend_output="$workspace/allowed-legacy-frontend-cc0.output"
-(
-    cd "$legacy_frontend_license_repo"
-    SECPAL_REPOSITORY_NAME=frontend bash "$VALIDATOR"
-) >"$legacy_frontend_output" 2>&1
-grep -qF 'Repository Type: frontend' "$legacy_frontend_output"
-grep -qF 'All tests passed' "$legacy_frontend_output"
+assert_fails_with "$legacy_frontend_license_repo" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later' \
+    frontend
 
 wrong_org_root_license_repo="$workspace/wrong-org-root-license"
 copy_valid_repo "$valid_repo" "$wrong_org_root_license_repo"
@@ -224,8 +221,24 @@ assert_fails_with "$wrong_org_root_license_repo" \
 
 wrong_api_root_license_repo="$workspace/wrong-api-root-license"
 copy_valid_repo "$valid_repo" "$wrong_api_root_license_repo"
-assert_fails_with "$wrong_api_root_license_repo" \
-    'AGENTS.md must declare exactly one complete permitted SPDX expression: CC0-1.0' api
+printf '{"name":"secpal/api"}\n' \
+    >"$wrong_api_root_license_repo/composer.json"
+wrong_api_root_output="$workspace/wrong-api-root-license.output"
+set +e
+(
+    cd "$wrong_api_root_license_repo"
+    SECPAL_REPOSITORY_NAME=api bash "$VALIDATOR"
+) >"$wrong_api_root_output" 2>&1
+wrong_api_root_status=$?
+set -e
+if [ "$wrong_api_root_status" -eq 0 ]; then
+    sed -n '1,240p' "$wrong_api_root_output" >&2
+    echo "trusted API identity must require the CC0 baseline" >&2
+    exit 1
+fi
+grep -qF \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: CC0-1.0' \
+    "$wrong_api_root_output"
 
 for allowed_license in CC0-1.0 MIT Apache-2.0; do
     allowed_license_slug="${allowed_license//./-}"
@@ -283,13 +296,32 @@ sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier
     "$detected_api_repo/AGENTS.md" \
     "$detected_api_repo/.github/copilot-instructions.md"
 detected_api_output="$workspace/detected-api.output"
-SECPAL_REPOSITORY_NAME=api \
-    bash "$VALIDATOR" "$detected_api_repo" >"$detected_api_output" 2>&1
+(
+    cd "$detected_api_repo"
+    SECPAL_REPOSITORY_NAME=api bash "$VALIDATOR"
+) >"$detected_api_output" 2>&1
 grep -qF 'Repository Type: api' "$detected_api_output"
+
+ambient_github_api_output="$workspace/ambient-github-api.output"
+GITHUB_REPOSITORY=SecPal/.github \
+    bash "$VALIDATOR" "$detected_api_repo" >"$ambient_github_api_output" 2>&1
+grep -qF 'Repository Type: api' "$ambient_github_api_output"
+grep -qF 'All tests passed' "$ambient_github_api_output"
+
+api_named_guardguide_repo="$workspace/api-path-heuristic/GuardGuide"
+copy_valid_repo "$detected_api_repo" "$api_named_guardguide_repo"
+api_named_guardguide_output="$workspace/api-named-guardguide.output"
+bash "$VALIDATOR" "$api_named_guardguide_repo" \
+    >"$api_named_guardguide_output" 2>&1
+grep -qF 'Repository Type: api' "$api_named_guardguide_output"
+grep -qF 'All tests passed' "$api_named_guardguide_output"
 
 untrusted_api_manifest_repo="$workspace/untrusted-api-manifest"
 copy_valid_repo "$valid_repo" "$untrusted_api_manifest_repo"
 printf '{"name":"secpal/api"}\n' >"$untrusted_api_manifest_repo/composer.json"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
+    "$untrusted_api_manifest_repo/AGENTS.md" \
+    "$untrusted_api_manifest_repo/.github/copilot-instructions.md"
 untrusted_api_manifest_output="$workspace/untrusted-api-manifest.output"
 bash "$VALIDATOR" "$untrusted_api_manifest_repo" \
     >"$untrusted_api_manifest_output" 2>&1
@@ -303,11 +335,26 @@ printf '{"name":"secpal/api"}\n' \
 printf '{"name":"secpal/frontend","devDependencies":{"vite":"latest"}}\n' \
     >"$frontend_with_composer_repo/package.json"
 frontend_with_composer_output="$workspace/frontend-with-composer.output"
-GITHUB_REPOSITORY=SecPal/frontend \
-    bash "$VALIDATOR" "$frontend_with_composer_repo" \
-    >"$frontend_with_composer_output" 2>&1
+(
+    cd "$frontend_with_composer_repo"
+    GITHUB_REPOSITORY=SecPal/frontend bash "$VALIDATOR"
+) >"$frontend_with_composer_output" 2>&1
 grep -qF 'Repository Type: frontend' "$frontend_with_composer_output"
 grep -qF 'All tests passed' "$frontend_with_composer_output"
+
+non_api_override_repo="$workspace/non-api-override"
+copy_valid_repo "$valid_repo" "$non_api_override_repo"
+printf '{"name":"example/vite-plugin","extra":{"name":"secpal/api"}}\n' \
+    >"$non_api_override_repo/composer.json"
+printf '{"name":"secpal/frontend","devDependencies":{"vite":"latest"}}\n' \
+    >"$non_api_override_repo/package.json"
+non_api_override_output="$workspace/non-api-override.output"
+(
+    cd "$non_api_override_repo"
+    REPO_TYPE=api bash "$VALIDATOR"
+) >"$non_api_override_output" 2>&1
+grep -qF 'Repository Type: frontend' "$non_api_override_output"
+grep -qF 'All tests passed' "$non_api_override_output"
 
 detected_guardguide_repo="$workspace/detected-guardguide"
 copy_valid_repo "$valid_repo" "$detected_guardguide_repo"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -160,6 +160,18 @@ sed -i \
 assert_fails_with "$obsolete_copilot_license_repo" \
     'copilot-instructions.md has REUSE license'
 
+obsolete_inline_with_valid_sidecar_repo="$workspace/obsolete-inline-with-valid-sidecar"
+copy_valid_repo "$valid_repo" "$obsolete_inline_with_valid_sidecar_repo"
+printf '%s\n' \
+    'SPDX-FileCopyrightText: 2026 SecPal Contributors' \
+    'SPDX-License''-Identifier: AGPL-3.0-or-later' \
+    >"$obsolete_inline_with_valid_sidecar_repo/.github/copilot-instructions.md.license"
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
+    "$obsolete_inline_with_valid_sidecar_repo/.github/copilot-instructions.md"
+assert_fails_with "$obsolete_inline_with_valid_sidecar_repo" \
+    'copilot-instructions.md has REUSE license'
+
 obsolete_overlay_license_repo="$workspace/obsolete-overlay-license"
 copy_valid_repo "$valid_repo" "$obsolete_overlay_license_repo"
 sed -i \
@@ -189,6 +201,19 @@ sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier
     "$api_license_repo/AGENTS.md" \
     "$api_license_repo/.github/copilot-instructions.md"
 assert_passes "$api_license_repo" "$workspace/allowed-api-cc0.output" api
+
+legacy_frontend_license_repo="$workspace/allowed-legacy-frontend-cc0"
+copy_valid_repo "$valid_repo" "$legacy_frontend_license_repo"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
+    "$legacy_frontend_license_repo/AGENTS.md" \
+    "$legacy_frontend_license_repo/.github/copilot-instructions.md"
+legacy_frontend_output="$workspace/allowed-legacy-frontend-cc0.output"
+(
+    cd "$legacy_frontend_license_repo"
+    SECPAL_REPOSITORY_NAME=frontend bash "$VALIDATOR"
+) >"$legacy_frontend_output" 2>&1
+grep -qF 'Repository Type: frontend' "$legacy_frontend_output"
+grep -qF 'All tests passed' "$legacy_frontend_output"
 
 wrong_org_root_license_repo="$workspace/wrong-org-root-license"
 copy_valid_repo "$valid_repo" "$wrong_org_root_license_repo"
@@ -258,33 +283,31 @@ sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier
     "$detected_api_repo/AGENTS.md" \
     "$detected_api_repo/.github/copilot-instructions.md"
 detected_api_output="$workspace/detected-api.output"
-bash "$VALIDATOR" "$detected_api_repo" >"$detected_api_output" 2>&1
+SECPAL_REPOSITORY_NAME=api \
+    bash "$VALIDATOR" "$detected_api_repo" >"$detected_api_output" 2>&1
 grep -qF 'Repository Type: api' "$detected_api_output"
+
+untrusted_api_manifest_repo="$workspace/untrusted-api-manifest"
+copy_valid_repo "$valid_repo" "$untrusted_api_manifest_repo"
+printf '{"name":"secpal/api"}\n' >"$untrusted_api_manifest_repo/composer.json"
+untrusted_api_manifest_output="$workspace/untrusted-api-manifest.output"
+bash "$VALIDATOR" "$untrusted_api_manifest_repo" \
+    >"$untrusted_api_manifest_output" 2>&1
+grep -qF 'Repository Type: api' "$untrusted_api_manifest_output"
+grep -qF 'All tests passed' "$untrusted_api_manifest_output"
 
 frontend_with_composer_repo="$workspace/frontend-with-composer"
 copy_valid_repo "$valid_repo" "$frontend_with_composer_repo"
-printf '{"name":"example/vite-plugin","extra":{"name":"secpal/api"}}\n' \
+printf '{"name":"secpal/api"}\n' \
     >"$frontend_with_composer_repo/composer.json"
 printf '{"name":"secpal/frontend","devDependencies":{"vite":"latest"}}\n' \
     >"$frontend_with_composer_repo/package.json"
-sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
-    "$frontend_with_composer_repo/AGENTS.md" \
-    "$frontend_with_composer_repo/.github/copilot-instructions.md"
 frontend_with_composer_output="$workspace/frontend-with-composer.output"
-set +e
-bash "$VALIDATOR" "$frontend_with_composer_repo" \
+GITHUB_REPOSITORY=SecPal/frontend \
+    bash "$VALIDATOR" "$frontend_with_composer_repo" \
     >"$frontend_with_composer_output" 2>&1
-frontend_with_composer_status=$?
-set -e
-if [ "$frontend_with_composer_status" -eq 0 ]; then
-    sed -n '1,240p' "$frontend_with_composer_output" >&2
-    echo "a non-API composer.json must not enable the API CC0 exception" >&2
-    exit 1
-fi
 grep -qF 'Repository Type: frontend' "$frontend_with_composer_output"
-grep -qF \
-    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later' \
-    "$frontend_with_composer_output"
+grep -qF 'All tests passed' "$frontend_with_composer_output"
 
 detected_guardguide_repo="$workspace/detected-guardguide"
 copy_valid_repo "$valid_repo" "$detected_guardguide_repo"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -175,6 +175,14 @@ sed -i \
     "$duplicate_agents_license_repo/AGENTS.md"
 assert_fails_with "$duplicate_agents_license_repo" 'AGENTS.md has REUSE license'
 
+late_duplicate_agents_license_repo="$workspace/late-duplicate-agents-license"
+copy_valid_repo "$valid_repo" "$late_duplicate_agents_license_repo"
+printf '%s\n' \
+    '<!-- SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->' \
+    >>"$late_duplicate_agents_license_repo/AGENTS.md"
+assert_fails_with "$late_duplicate_agents_license_repo" \
+    'AGENTS.md has REUSE license'
+
 api_license_repo="$workspace/allowed-api-cc0"
 copy_valid_repo "$valid_repo" "$api_license_repo"
 sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
@@ -252,6 +260,31 @@ sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier
 detected_api_output="$workspace/detected-api.output"
 bash "$VALIDATOR" "$detected_api_repo" >"$detected_api_output" 2>&1
 grep -qF 'Repository Type: api' "$detected_api_output"
+
+frontend_with_composer_repo="$workspace/frontend-with-composer"
+copy_valid_repo "$valid_repo" "$frontend_with_composer_repo"
+printf '{"name":"example/vite-plugin","extra":{"name":"secpal/api"}}\n' \
+    >"$frontend_with_composer_repo/composer.json"
+printf '{"name":"secpal/frontend","devDependencies":{"vite":"latest"}}\n' \
+    >"$frontend_with_composer_repo/package.json"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
+    "$frontend_with_composer_repo/AGENTS.md" \
+    "$frontend_with_composer_repo/.github/copilot-instructions.md"
+frontend_with_composer_output="$workspace/frontend-with-composer.output"
+set +e
+bash "$VALIDATOR" "$frontend_with_composer_repo" \
+    >"$frontend_with_composer_output" 2>&1
+frontend_with_composer_status=$?
+set -e
+if [ "$frontend_with_composer_status" -eq 0 ]; then
+    sed -n '1,240p' "$frontend_with_composer_output" >&2
+    echo "a non-API composer.json must not enable the API CC0 exception" >&2
+    exit 1
+fi
+grep -qF 'Repository Type: frontend' "$frontend_with_composer_output"
+grep -qF \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later' \
+    "$frontend_with_composer_output"
 
 detected_guardguide_repo="$workspace/detected-guardguide"
 copy_valid_repo "$valid_repo" "$detected_guardguide_repo"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -26,8 +26,8 @@ write_valid_repo() {
 
     cat >"$target_dir/AGENTS.md" <<'EOF'
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Repository Runtime Instructions
@@ -44,8 +44,8 @@ EOF
 
     cat >"$target_dir/.github/copilot-instructions.md" <<'EOF'
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Code Review Profile
@@ -61,8 +61,8 @@ EOF
 
     cat >"$target_dir/.github/instructions/example.instructions.md" <<'EOF'
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: Example Workflow Rules
 description: Applies focused checks to workflow files.
 applyTo: ".github/workflows/**/*.yml"
@@ -85,18 +85,20 @@ copy_valid_repo() {
 run_validator() {
     local repo_dir="$1"
     local output_file="$2"
+    local repo_type="${3:-org}"
 
     (
         cd "$repo_dir"
-        REPO_TYPE=org bash "$VALIDATOR"
+        REPO_TYPE="$repo_type" bash "$VALIDATOR"
     ) >"$output_file" 2>&1
 }
 
 assert_passes() {
     local repo_dir="$1"
     local output_file="$2"
+    local repo_type="${3:-org}"
 
-    if ! run_validator "$repo_dir" "$output_file"; then
+    if ! run_validator "$repo_dir" "$output_file" "$repo_type"; then
         sed -n '1,240p' "$output_file" >&2
         echo "validator unexpectedly rejected $repo_dir" >&2
         exit 1
@@ -106,13 +108,14 @@ assert_passes() {
 assert_fails_with() {
     local repo_dir="$1"
     local expected="$2"
+    local repo_type="${3:-org}"
     local output_file
     local exit_code
 
     output_file="$workspace/$(basename "$repo_dir").output"
 
     set +e
-    run_validator "$repo_dir" "$output_file"
+    run_validator "$repo_dir" "$output_file" "$repo_type"
     exit_code=$?
     set -e
 
@@ -142,6 +145,87 @@ grep -qF 'instruction Markdown passes lint' "$valid_output"
 grep -qF 'instruction overlays include valid frontmatter' "$valid_output"
 grep -qF 'AGENTS.md stays under runtime discovery size limit' "$valid_output"
 
+obsolete_agents_license_repo="$workspace/obsolete-agents-license"
+copy_valid_repo "$valid_repo" "$obsolete_agents_license_repo"
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
+    "$obsolete_agents_license_repo/AGENTS.md"
+assert_fails_with "$obsolete_agents_license_repo" 'AGENTS.md has REUSE license'
+
+obsolete_copilot_license_repo="$workspace/obsolete-copilot-license"
+copy_valid_repo "$valid_repo" "$obsolete_copilot_license_repo"
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
+    "$obsolete_copilot_license_repo/.github/copilot-instructions.md"
+assert_fails_with "$obsolete_copilot_license_repo" \
+    'copilot-instructions.md has REUSE license'
+
+obsolete_overlay_license_repo="$workspace/obsolete-overlay-license"
+copy_valid_repo "$valid_repo" "$obsolete_overlay_license_repo"
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
+    "$obsolete_overlay_license_repo/.github/instructions/example.instructions.md"
+assert_fails_with "$obsolete_overlay_license_repo" \
+    '.github/instructions/example.instructions.md has REUSE license'
+
+duplicate_agents_license_repo="$workspace/duplicate-agents-license"
+copy_valid_repo "$valid_repo" "$duplicate_agents_license_repo"
+sed -i \
+    '/SPDX-License''-Identifier: AGPL-3.0-or-later/aSPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution' \
+    "$duplicate_agents_license_repo/AGENTS.md"
+assert_fails_with "$duplicate_agents_license_repo" 'AGENTS.md has REUSE license'
+
+api_license_repo="$workspace/allowed-api-cc0"
+copy_valid_repo "$valid_repo" "$api_license_repo"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
+    "$api_license_repo/AGENTS.md" \
+    "$api_license_repo/.github/copilot-instructions.md"
+assert_passes "$api_license_repo" "$workspace/allowed-api-cc0.output" api
+
+wrong_org_root_license_repo="$workspace/wrong-org-root-license"
+copy_valid_repo "$valid_repo" "$wrong_org_root_license_repo"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: MIT/' \
+    "$wrong_org_root_license_repo/AGENTS.md"
+assert_fails_with "$wrong_org_root_license_repo" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
+
+wrong_api_root_license_repo="$workspace/wrong-api-root-license"
+copy_valid_repo "$valid_repo" "$wrong_api_root_license_repo"
+assert_fails_with "$wrong_api_root_license_repo" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: CC0-1.0' api
+
+for allowed_license in CC0-1.0 MIT Apache-2.0; do
+    allowed_license_slug="${allowed_license//./-}"
+    allowed_license_repo="$workspace/allowed-$allowed_license_slug"
+    allowed_license_output="$workspace/allowed-$allowed_license_slug.output"
+    copy_valid_repo "$valid_repo" "$allowed_license_repo"
+    sed -i \
+        "s/SPDX-License""-Identifier: AGPL-3.0-or-later/SPDX-License""-Identifier: $allowed_license/" \
+        "$allowed_license_repo/.github/instructions/example.instructions.md"
+    assert_passes "$allowed_license_repo" "$allowed_license_output"
+done
+
+html_comment_repo="$workspace/html-comment-license"
+copy_valid_repo "$valid_repo" "$html_comment_repo"
+html_license_identifier='SPDX-License'"-Identifier: AGPL-3.0-or-later"
+printf -v html_header_sed \
+    '1,4c<!-- SPDX-FileCopyrightText: 2026 SecPal Contributors -->\\\n<!-- %s -->' \
+    "$html_license_identifier"
+sed -i "$html_header_sed" \
+    "$html_comment_repo/AGENTS.md" \
+    "$html_comment_repo/.github/copilot-instructions.md"
+assert_passes "$html_comment_repo" "$workspace/html-comment-license.output"
+
+unrelated_custom_license_repo="$workspace/unrelated-custom-license"
+copy_valid_repo "$valid_repo" "$unrelated_custom_license_repo"
+mkdir -p "$unrelated_custom_license_repo/vendor"
+printf '%s\n' \
+    'SPDX-FileCopyrightText: 2026 Example Vendor' \
+    'SPDX-License''-Identifier: LicenseRef-Example-''Vendor' \
+    >"$unrelated_custom_license_repo/vendor/example.txt.license"
+assert_passes "$unrelated_custom_license_repo" \
+    "$workspace/unrelated-custom-license.output"
+
 # The positive fixture deliberately has different runtime and review content,
 # no mirror declaration, no copied overlay body, and none of the former policy
 # keywords. Its success is the behavioral contract for independent layers.
@@ -158,6 +242,35 @@ fi
 path_argument_output="$workspace/path-argument.output"
 bash "$VALIDATOR" "$valid_repo" >"$path_argument_output" 2>&1
 grep -qF 'Repository Type: org' "$path_argument_output"
+
+detected_api_repo="$workspace/detected-api"
+copy_valid_repo "$valid_repo" "$detected_api_repo"
+printf '{"name":"secpal/api"}\n' >"$detected_api_repo/composer.json"
+sed -i 's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: CC0-1.0/' \
+    "$detected_api_repo/AGENTS.md" \
+    "$detected_api_repo/.github/copilot-instructions.md"
+detected_api_output="$workspace/detected-api.output"
+bash "$VALIDATOR" "$detected_api_repo" >"$detected_api_output" 2>&1
+grep -qF 'Repository Type: api' "$detected_api_output"
+
+detected_guardguide_repo="$workspace/detected-guardguide"
+copy_valid_repo "$valid_repo" "$detected_guardguide_repo"
+printf '{"name":"secpal/guardguide"}\n' \
+    >"$detected_guardguide_repo/composer.json"
+detected_guardguide_output="$workspace/detected-guardguide.output"
+bash "$VALIDATOR" "$detected_guardguide_repo" \
+    >"$detected_guardguide_output" 2>&1
+grep -qF 'Repository Type: guardguide' "$detected_guardguide_output"
+
+detected_website_repo="$workspace/detected-guardguide-website"
+copy_valid_repo "$valid_repo" "$detected_website_repo"
+printf '{"name":"secpal/guardguide.de"}\n' \
+    >"$detected_website_repo/package.json"
+printf 'export default {};\n' >"$detected_website_repo/astro.config.mjs"
+detected_website_output="$workspace/detected-guardguide-website.output"
+bash "$VALIDATOR" "$detected_website_repo" \
+    >"$detected_website_output" 2>&1
+grep -qF 'Repository Type: website' "$detected_website_output"
 
 symlinked_agents_repo="$workspace/symlinked-agents"
 symlinked_agents_target="$workspace/external-AGENTS.md"
@@ -226,7 +339,7 @@ copy_valid_repo "$valid_repo" "$wrong_sidecar_repo"
 cp "$FIXTURES_DIR/wrong-ai-instructions-license-fixture.txt" \
     "$wrong_sidecar_repo/.github/copilot-instructions.md.license"
 assert_fails_with "$wrong_sidecar_repo" \
-    'Sidecar .license exists but does not declare an allowed license'
+    'copilot-instructions.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
 
 malformed_markdown_repo="$workspace/malformed-markdown"
 copy_valid_repo "$valid_repo" "$malformed_markdown_repo"
@@ -240,6 +353,13 @@ sed -i '/^applyTo:/d' \
     "$malformed_frontmatter_repo/.github/instructions/example.instructions.md"
 assert_fails_with "$malformed_frontmatter_repo" \
     'instruction overlays include valid frontmatter'
+
+missing_overlay_license_repo="$workspace/missing-overlay-license"
+copy_valid_repo "$valid_repo" "$missing_overlay_license_repo"
+sed -i '/SPDX-License''-Identifier:/d' \
+    "$missing_overlay_license_repo/.github/instructions/example.instructions.md"
+assert_fails_with "$missing_overlay_license_repo" \
+    '.github/instructions/example.instructions.md has REUSE license'
 
 empty_frontmatter_name_repo="$workspace/empty-frontmatter-name"
 copy_valid_repo "$valid_repo" "$empty_frontmatter_name_repo"

--- a/tests/validate-copilot-instructions.sh
+++ b/tests/validate-copilot-instructions.sh
@@ -20,8 +20,8 @@ write_valid_repo() {
 
     cat >"$target_dir/AGENTS.md" <<'EOF'
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Repository Runtime Instructions
@@ -33,8 +33,8 @@ EOF
 
     cat >"$target_dir/.github/copilot-instructions.md" <<'EOF'
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Code Review Profile
@@ -107,9 +107,10 @@ copy_repo "$valid_repo" "$missing_copilot_repo"
 rm "$missing_copilot_repo/.github/copilot-instructions.md"
 assert_wrapper_fails_with "$missing_copilot_repo" 'Missing: .github/copilot-instructions.md'
 
-invalid_license_repo="$workspace/invalid-inline-license"
+invalid_license_repo="$workspace/obsolete-attribution-license"
 copy_repo "$valid_repo" "$invalid_license_repo"
-sed -i 's/SPDX-License''-Identifier: CC0-1.0/SPDX-License''-Identifier: MIT/' \
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
     "$invalid_license_repo/.github/copilot-instructions.md"
 assert_wrapper_fails_with "$invalid_license_repo" 'copilot-instructions.md has REUSE license'
 


### PR DESCRIPTION
## Problem

Gate 00 requires the target licensing model and official-product branding invariants to be present in runtime instructions before repository migrations begin.

The repository had three concrete gaps:

- `scripts/validate-ai-instructions.sh` accepted an allowed SPDX prefix instead of requiring the complete policy expression, so the obsolete `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` expression could pass.
- `.github/copilot-instructions.md.license` declared `CC0-1.0` while the instruction file declared plain AGPL.
- Polyscope rollout tests did not prove that synchronization leaves repository instruction trees unchanged or that the obsolete attribution expression cannot be regenerated.

## Change

- Define the canonical AGPL, REUSE, copyright-year, third-party metadata, and SecPal product-branding invariants in the runtime and review instructions.
- Require complete repository-policy SPDX expressions: plain `AGPL-3.0-or-later` for managed runtime and review baselines, with the intentional `CC0-1.0` API baseline and deliberately different focused-overlay licenses preserved.
- Reject duplicate identifiers, invalid expressions, and the obsolete SecPal attribution expression with precise diagnostics.
- Keep GuardGuide detection distinct from API and `guardguide.de` detection.
- Align the Copilot REUSE sidecar with the visible plain-AGPL metadata and `SecPal Contributors` convention.
- Add rollout regressions that preserve instruction artifacts byte-for-byte and prevent obsolete licensing metadata from being reintroduced.
- Document the validator contract and record the governance change in this repository's changelog.

## Validation

All local checks passed:

- `bash scripts/validate-ai-instructions.sh`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- `bash tests/polyscope-rollout.sh`
- `shellcheck scripts/validate-ai-instructions.sh tests/validate-ai-instructions.sh tests/validate-copilot-instructions.sh tests/polyscope-rollout.sh tests/polyscope-package-1-closure.sh`
- repository-pinned Markdownlint for all changed Markdown instruction and documentation files
- `reuse lint`
- `pre-commit run`
- `git diff --check`

## Readiness and scope

There is no unresolved in-scope dependency or failing local check. This pull request establishes the `.github` governance and validation contract. Updating instruction artifacts in `frontend`, `android`, `deployment`, and other sibling repositories remains a dependency-ordered follow-up in their own repository workspaces; those repositories are intentionally not modified here.

Relates to #650 and SecPal/.github#649.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/secpal-pr-review-skill-policy.sh` failed with `policy failure: existing review governance or instruction routing changed` when the canonical licensing and branding block was added to `AGENTS.md`.
- Passing proof after implementation: `bash tests/secpal-pr-review-skill-policy.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A