### PR TITLE
Fix cached Polyscope setup validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Log of notable changes to SecPal organization defaults (newest first).
   visible plain-AGPL metadata and the `SecPal Contributors` year convention
 - added Polyscope rollout regressions proving invalid attribution metadata
   fails before side effects and valid repository instructions remain unchanged
+- retained compatibility with cached Polyscope setup definitions that predate
+  explicit repository-name propagation by deriving trusted identity from the
+  active Polyscope registration while rejecting missing, ambiguous, unmanaged,
+  or worktree-controlled identity
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   fails before side effects and valid repository instructions remain unchanged
 - retained compatibility with cached Polyscope setup definitions that predate
   explicit repository-name propagation by deriving trusted identity from the
-  active Polyscope registration while rejecting missing, ambiguous, unmanaged,
-  or worktree-controlled identity
+  active Polyscope registration and the installer-configured managed source
+  root while rejecting missing, ambiguous, unmanaged, or worktree-controlled
+  identity
 
 ---
 

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -145,12 +145,17 @@ written. A missing validator or missing Markdown tooling blocks rollout.
 
 Generated Polyscope workspace setup sequences contain exactly one strict shell
 entry. That entry invokes the validation-only
-`--validate-instruction-worktree` mode, then runs the complete original native
-setup as fail-fast command groups. Polyscope may already have created and
-registered the candidate at that point, but canonical validation must succeed
-before npm, Composer, `.env`, database, migration, seed, or any other native
-setup command runs. A multiline command cannot escape the guard, and failure of
-any native command stops every later setup operation.
+`--validate-instruction-worktree` mode with an explicit repository name, then
+runs the complete original native setup as fail-fast command groups. Cached
+setup definitions from before repository-name propagation remain valid during
+rollout convergence: when that argument is absent, the validator resolves the
+trusted identity from the candidate's active Polyscope database registration.
+Missing, ambiguous, or unmanaged registrations fail closed; ambient identity
+and mutable worktree manifests cannot select repository policy. Polyscope may
+already have created and registered the candidate at that point, but canonical
+validation must succeed before npm, Composer, `.env`, database, migration,
+seed, or any other native setup command runs. A multiline command cannot escape
+the guard, and failure of any native command stops every later setup operation.
 
 The external worktree provisioner derives its allowlist only from active
 `worktrees` registrations in the current Polyscope SQLite database. Registered

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -150,6 +150,9 @@ runs the complete original native setup as fail-fast command groups. Cached
 setup definitions from before repository-name propagation remain valid during
 rollout convergence: when that argument is absent, the validator resolves the
 trusted identity from the candidate's active Polyscope database registration.
+For nondefault installations, the user-service installer exports its configured
+managed workspace root to cached setup processes so this lookup does not fall
+back to `$HOME/code/SecPal`.
 Missing, ambiguous, or unmanaged registrations fail closed; ambient identity
 and mutable worktree manifests cannot select repository policy. Polyscope may
 already have created and registered the candidate at that point, but canonical

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -549,12 +549,16 @@ individual denial or repository-integrity failures. The paired daily
 the live database allowlist, locks, and processes.
 
 Every generated repository setup sequence starts with the validation-only
-`--validate-instruction-worktree` command inside one strict shell entry. That
-entry groups the complete native setup with fail-fast semantics, so validation
-or any later command failure prevents every remaining npm, Composer, `.env`,
-database, migration, seed, build, or repository setup command. The external
-provisioner applies the same canonical contract before its local configuration,
-hook, alias, setup, and marker writes.
+`--validate-instruction-worktree` command and explicit repository name inside
+one strict shell entry. Cached setup definitions without that identity argument
+remain compatible during rollout convergence by resolving the repository from
+the worktree's active Polyscope database registration. Missing, ambiguous, and
+unmanaged registrations fail closed instead of trusting ambient identity or
+mutable worktree manifests. The entry groups the complete native setup with
+fail-fast semantics, so validation or any later command failure prevents every
+remaining npm, Composer, `.env`, database, migration, seed, build, or repository
+setup command. The external provisioner applies the same canonical contract
+before its local configuration, hook, alias, setup, and marker writes.
 
 The worktree provision service waits three seconds before each activation to
 coalesce SQLite event bursts and takes a process-shared lock before provisioning.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -552,8 +552,11 @@ Every generated repository setup sequence starts with the validation-only
 `--validate-instruction-worktree` command and explicit repository name inside
 one strict shell entry. Cached setup definitions without that identity argument
 remain compatible during rollout convergence by resolving the repository from
-the worktree's active Polyscope database registration. Missing, ambiguous, and
-unmanaged registrations fail closed instead of trusting ambient identity or
+the worktree's active Polyscope database registration. The installed user
+service exports the configured workspace root to those cached commands, so
+nondefault installations retain the same managed-source identity boundary.
+Missing, ambiguous, and unmanaged registrations fail closed instead of trusting
+ambient identity or
 mutable worktree manifests. The entry groups the complete native setup with
 fail-fast semantics, so validation or any later command failure prevents every
 remaining npm, Composer, `.env`, database, migration, seed, build, or repository

--- a/scripts/install-polyscope-rollout.sh
+++ b/scripts/install-polyscope-rollout.sh
@@ -419,6 +419,7 @@ Environment=PATH=$SERVICE_PATH
 Environment=SSH_AUTH_SOCK=%t/openssh_agent
 Environment=POLYSCOPE_REAL_GIT_BIN=$POLYSCOPE_REAL_GIT_BIN
 Environment=POLYSCOPE_SUDO_BIN=$SUDO_BIN
+Environment=SECPAL_WORKSPACE_ROOT=$WORKSPACE_ROOT
 ExecStart=$POLYSCOPE_SERVER_BIN serve --host 127.0.0.1 --port 4321
 ExecStartPost=/usr/bin/env bash -lc '$ROLLOUT_READY_COMMAND'
 Restart=on-failure

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3096,6 +3096,7 @@ def validate_instruction_root(
     validated_instruction_roots: set[tuple[pathlib.Path, str]],
     repository_name: str,
 ) -> pathlib.Path:
+    """Validate instructions with an explicit trusted repository identity."""
     resolved_root = root.resolve()
     validation_key = (resolved_root, repository_name)
     if validation_key in validated_instruction_roots:
@@ -3111,6 +3112,7 @@ def validate_instruction_root(
     try:
         validator_env = os.environ.copy()
         validator_env.pop("GITHUB_REPOSITORY", None)
+        validator_env.pop("SECPAL_REPOSITORY_NAME", None)
         validator_env.pop("REPO_TYPE", None)
         validator_env["SECPAL_REPOSITORY_NAME"] = repository_name
         result = subprocess.run(
@@ -3141,6 +3143,90 @@ def validate_instruction_root(
 
     validated_instruction_roots.add(validation_key)
     return resolved_root
+
+
+def resolve_registered_instruction_repository_name(
+    worktree_path: pathlib.Path,
+    db_path: pathlib.Path,
+) -> str:
+    """Resolve a legacy setup caller through its active Polyscope registration."""
+    resolved_worktree = worktree_path.resolve()
+    resolved_db_path = db_path.resolve()
+    requirement = (
+        "validation without --instruction-repository-name requires an active "
+        "Polyscope registration"
+    )
+    if not resolved_db_path.is_file():
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            f"{requirement}; database not found at {resolved_db_path}"
+        )
+
+    try:
+        with sqlite3.connect(
+            f"{resolved_db_path.as_uri()}?mode=ro",
+            uri=True,
+        ) as connection:
+            columns = {
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(worktrees)")
+            }
+            where_clause = (
+                " where worktrees.status = 'active'"
+                if "status" in columns
+                else ""
+            )
+            rows = connection.execute(
+                """
+                select worktrees.path, repositories.name
+                from worktrees
+                join repositories on repositories.id = worktrees.repo_id
+                """
+                + where_clause
+            ).fetchall()
+    except sqlite3.Error as error:
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            f"{requirement}; unable to read {resolved_db_path}: {error}"
+        ) from error
+
+    registered_repositories = []
+    for registered_path, display_name in rows:
+        if not isinstance(registered_path, str) or not registered_path.strip():
+            continue
+        try:
+            registered_worktree = pathlib.Path(registered_path).resolve()
+        except (OSError, ValueError):
+            continue
+        if registered_worktree == resolved_worktree:
+            registered_repositories.append(display_name)
+
+    if not registered_repositories:
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            f"{requirement} in {resolved_db_path}"
+        )
+    if len(registered_repositories) != 1:
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "validation without --instruction-repository-name found multiple "
+            f"active Polyscope registrations in {resolved_db_path}"
+        )
+
+    display_name = registered_repositories[0]
+    repository_names = {
+        settings["display_name"]: repo_name
+        for repo_name, settings in REPO_SETTINGS.items()
+    }
+    repository_name = repository_names.get(display_name)
+    if repository_name is None:
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            f"active Polyscope registration has unsupported repository identity "
+            f"{display_name!r}"
+        )
+
+    return repository_name
 
 
 def require_repo_instruction_files(
@@ -6045,16 +6131,17 @@ def dispatch_validation_only_direct_mode(args: argparse.Namespace) -> int | None
     requested_root = getattr(args, VALIDATION_ONLY_DIRECT_MODE)
     if requested_root is None:
         return None
-    if args.instruction_repository_name is None:
-        raise SystemExit(
-            "--instruction-repository-name is required with "
-            "--validate-instruction-worktree"
-        )
 
+    repository_name = args.instruction_repository_name
+    if repository_name is None:
+        repository_name = resolve_registered_instruction_repository_name(
+            requested_root,
+            args.db_path,
+        )
     resolved_root = validate_instruction_root(
         requested_root,
         set(),
-        args.instruction_repository_name,
+        repository_name,
     )
     print(f"Canonical AI-instruction validation passed for {resolved_root}")
     return 0

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -6223,7 +6223,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-repo-path", type=pathlib.Path)
     parser.add_argument("--instruction-repository-name")
     parser.add_argument("--shell-command")
-    parser.add_argument("--workspace-root", type=pathlib.Path, default=pathlib.Path.home() / "code" / "SecPal")
+    parser.add_argument(
+        "--workspace-root",
+        type=pathlib.Path,
+        default=pathlib.Path(
+            os.environ.get(
+                "SECPAL_WORKSPACE_ROOT",
+                pathlib.Path.home() / "code" / "SecPal",
+            )
+        ),
+    )
     parser.add_argument("--db-path", type=pathlib.Path, default=default_polyscope_db_path())
     parser.add_argument("--clone-root", type=pathlib.Path, default=pathlib.Path.home() / ".polyscope" / "clones")
     parser.add_argument("--provision-lock-path", type=pathlib.Path, default=default_provision_lock_path())

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3148,10 +3148,16 @@ def validate_instruction_root(
 def resolve_registered_instruction_repository_name(
     worktree_path: pathlib.Path,
     db_path: pathlib.Path,
+    workspace_root: pathlib.Path,
 ) -> str:
     """Resolve a legacy setup caller through its active Polyscope registration."""
     resolved_worktree = worktree_path.resolve()
     resolved_db_path = db_path.resolve()
+    if not workspace_root.is_absolute():
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "managed repository workspace root must be absolute"
+        )
     requirement = (
         "validation without --instruction-repository-name requires an active "
         "Polyscope registration"
@@ -3178,11 +3184,14 @@ def resolve_registered_instruction_repository_name(
             )
             rows = connection.execute(
                 """
-                select worktrees.path, repositories.name
+                select worktrees.path, repositories.id, repositories.path
                 from worktrees
                 join repositories on repositories.id = worktrees.repo_id
                 """
                 + where_clause
+            ).fetchall()
+            repository_rows = connection.execute(
+                "select id, path from repositories"
             ).fetchall()
     except sqlite3.Error as error:
         raise CanonicalInstructionValidationError(
@@ -3191,7 +3200,7 @@ def resolve_registered_instruction_repository_name(
         ) from error
 
     registered_repositories = []
-    for registered_path, display_name in rows:
+    for registered_path, repository_id, repository_path in rows:
         if not isinstance(registered_path, str) or not registered_path.strip():
             continue
         registered_candidate = pathlib.Path(registered_path)
@@ -3205,7 +3214,7 @@ def resolve_registered_instruction_repository_name(
         except (OSError, ValueError):
             continue
         if registered_worktree == resolved_worktree:
-            registered_repositories.append(display_name)
+            registered_repositories.append((repository_id, repository_path))
 
     if not registered_repositories:
         raise CanonicalInstructionValidationError(
@@ -3219,17 +3228,56 @@ def resolve_registered_instruction_repository_name(
             f"active Polyscope registrations in {resolved_db_path}"
         )
 
-    display_name = registered_repositories[0]
-    repository_names = {
-        settings["display_name"]: repo_name
-        for repo_name, settings in REPO_SETTINGS.items()
+    repository_id, repository_path = registered_repositories[0]
+    if not isinstance(repository_id, str) or not repository_id.strip():
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "active Polyscope registration has no usable repository identity"
+        )
+
+    if not isinstance(repository_path, str) or not repository_path.strip():
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "active Polyscope registration has no managed repository source path"
+        )
+    registered_repository_path = pathlib.Path(repository_path)
+    if not registered_repository_path.is_absolute():
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "active Polyscope registration must use an absolute managed "
+            "repository source path"
+        )
+    managed_repositories = {
+        workspace_root / repo_name: repo_name
+        for repo_name in REPO_SETTINGS
     }
-    repository_name = repository_names.get(display_name)
+    repository_name = managed_repositories.get(registered_repository_path)
     if repository_name is None:
         raise CanonicalInstructionValidationError(
             f"canonical AI-instruction validation failed for {resolved_worktree}: "
-            f"active Polyscope registration has unsupported repository identity "
-            f"{display_name!r}"
+            "active Polyscope registration does not match managed repository "
+            "source path state"
+        )
+
+    managed_repository_ids = []
+    for candidate_id, candidate_path in repository_rows:
+        if (
+            not isinstance(candidate_id, str)
+            or not candidate_id.strip()
+            or not isinstance(candidate_path, str)
+            or not candidate_path.strip()
+        ):
+            continue
+        candidate = pathlib.Path(candidate_path)
+        if not candidate.is_absolute():
+            continue
+        if candidate == registered_repository_path:
+            managed_repository_ids.append(candidate_id)
+    if managed_repository_ids != [repository_id]:
+        raise CanonicalInstructionValidationError(
+            f"canonical AI-instruction validation failed for {resolved_worktree}: "
+            "active Polyscope registration does not uniquely match its managed "
+            "repository source path and identity"
         )
 
     return repository_name
@@ -6143,6 +6191,7 @@ def dispatch_validation_only_direct_mode(args: argparse.Namespace) -> int | None
         repository_name = resolve_registered_instruction_repository_name(
             requested_root,
             args.db_path,
+            args.workspace_root,
         )
     resolved_root = validate_instruction_root(
         requested_root,

--- a/scripts/polyscope-rollout.py
+++ b/scripts/polyscope-rollout.py
@@ -3194,8 +3194,14 @@ def resolve_registered_instruction_repository_name(
     for registered_path, display_name in rows:
         if not isinstance(registered_path, str) or not registered_path.strip():
             continue
+        registered_candidate = pathlib.Path(registered_path)
+        if not registered_candidate.is_absolute():
+            raise CanonicalInstructionValidationError(
+                f"canonical AI-instruction validation failed for {resolved_worktree}: "
+                "active Polyscope registration must use an absolute path"
+            )
         try:
-            registered_worktree = pathlib.Path(registered_path).resolve()
+            registered_worktree = registered_candidate.resolve()
         except (OSError, ValueError):
             continue
         if registered_worktree == resolved_worktree:

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -178,11 +178,11 @@ with sqlite3.connect(legacy_db_path) as connection:
 
 legacy_validation_command = (
     f"python3 {shlex.quote(str(script_path))} "
-    f"--workspace-root {shlex.quote(str(native_source_workspace))} "
     '--validate-instruction-worktree "$PWD"'
 )
 legacy_env = native_env.copy()
 legacy_env["POLYSCOPE_DB_PATH"] = str(legacy_db_path)
+legacy_env["SECPAL_WORKSPACE_ROOT"] = str(native_source_workspace)
 legacy_result = run_polyscope_setup(
     legacy_api_root,
     [legacy_validation_command],
@@ -254,7 +254,7 @@ assert unsupported_legacy_result.returncode != 0, (
     unsupported_legacy_result.stdout,
     unsupported_legacy_result.stderr,
 )
-assert "unsupported repository identity" in unsupported_legacy_result.stderr, (
+assert "does not match managed repository source path state" in unsupported_legacy_result.stderr, (
     unsupported_legacy_result.stdout,
     unsupported_legacy_result.stderr,
 )

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -178,6 +178,7 @@ with sqlite3.connect(legacy_db_path) as connection:
 
 legacy_validation_command = (
     f"python3 {shlex.quote(str(script_path))} "
+    f"--workspace-root {shlex.quote(str(native_source_workspace))} "
     '--validate-instruction-worktree "$PWD"'
 )
 legacy_env = native_env.copy()

--- a/tests/polyscope-package-1-closure.sh
+++ b/tests/polyscope-package-1-closure.sh
@@ -143,6 +143,121 @@ native_env["NATIVE_SETUP_LOG"] = str(native_setup_log)
 native_env["POLYSCOPE_DB_PATH"] = str(workspace / "native-polyscope.db")
 native_env["GITHUB_REPOSITORY"] = "SecPal/.github"
 
+# Setup definitions installed before repository-specific validation identity was
+# introduced must remain executable during rollout convergence. The legacy
+# command must derive the API policy from the authoritative active registration,
+# not ambient identity or mutable worktree manifests.
+legacy_api_root = workspace / "legacy native setup api root"
+write_valid_instructions(legacy_api_root, "api")
+legacy_api_root.joinpath("composer.json").write_text('{"name":"example/not-api"}\n')
+legacy_db_path = workspace / "legacy-native-polyscope.db"
+with sqlite3.connect(legacy_db_path) as connection:
+    connection.executescript(
+        """
+        create table repositories (
+            id text primary key,
+            name text not null,
+            path text not null
+        );
+        create table worktrees (
+            id text primary key,
+            repo_id text not null,
+            path text not null,
+            status text default 'active' not null
+        );
+        """
+    )
+    connection.execute(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        ("legacy-api-repo", "SecPal/api", str(native_source_workspace / "api")),
+    )
+    connection.execute(
+        "insert into worktrees (id, repo_id, path, status) values (?, ?, ?, 'active')",
+        ("legacy-api-worktree", "legacy-api-repo", str(legacy_api_root)),
+    )
+
+legacy_validation_command = (
+    f"python3 {shlex.quote(str(script_path))} "
+    '--validate-instruction-worktree "$PWD"'
+)
+legacy_env = native_env.copy()
+legacy_env["POLYSCOPE_DB_PATH"] = str(legacy_db_path)
+legacy_result = run_polyscope_setup(
+    legacy_api_root,
+    [legacy_validation_command],
+    legacy_env,
+)
+assert legacy_result.returncode == 0, (
+    legacy_result.stdout,
+    legacy_result.stderr,
+)
+
+with sqlite3.connect(legacy_db_path) as connection:
+    connection.execute(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        ("ambiguous-repo", "SecPal/frontend", str(native_source_workspace / "frontend")),
+    )
+    connection.execute(
+        "insert into worktrees (id, repo_id, path, status) values (?, ?, ?, 'active')",
+        ("ambiguous-worktree", "ambiguous-repo", str(legacy_api_root)),
+    )
+ambiguous_legacy_result = run_polyscope_setup(
+    legacy_api_root,
+    [legacy_validation_command],
+    legacy_env,
+)
+assert ambiguous_legacy_result.returncode != 0, (
+    ambiguous_legacy_result.stdout,
+    ambiguous_legacy_result.stderr,
+)
+assert "multiple active Polyscope registrations" in ambiguous_legacy_result.stderr, (
+    ambiguous_legacy_result.stdout,
+    ambiguous_legacy_result.stderr,
+)
+with sqlite3.connect(legacy_db_path) as connection:
+    connection.execute("delete from worktrees where id = ?", ("ambiguous-worktree",))
+
+unregistered_legacy_root = workspace / "unregistered legacy setup api root"
+write_valid_instructions(unregistered_legacy_root, "api")
+unregistered_legacy_result = run_polyscope_setup(
+    unregistered_legacy_root,
+    [legacy_validation_command],
+    legacy_env,
+)
+assert unregistered_legacy_result.returncode != 0, (
+    unregistered_legacy_result.stdout,
+    unregistered_legacy_result.stderr,
+)
+assert "requires an active Polyscope registration" in unregistered_legacy_result.stderr, (
+    unregistered_legacy_result.stdout,
+    unregistered_legacy_result.stderr,
+)
+
+unsupported_legacy_root = workspace / "unsupported legacy setup root"
+write_valid_instructions(unsupported_legacy_root)
+with sqlite3.connect(legacy_db_path) as connection:
+    connection.execute(
+        "insert into repositories (id, name, path) values (?, ?, ?)",
+        ("unsupported-repo", "Example/unsupported", str(workspace / "unsupported-source")),
+    )
+    connection.execute(
+        "insert into worktrees (id, repo_id, path, status) values (?, ?, ?, 'active')",
+        ("unsupported-worktree", "unsupported-repo", str(unsupported_legacy_root)),
+    )
+unsupported_legacy_result = run_polyscope_setup(
+    unsupported_legacy_root,
+    [legacy_validation_command],
+    legacy_env,
+)
+assert unsupported_legacy_result.returncode != 0, (
+    unsupported_legacy_result.stdout,
+    unsupported_legacy_result.stderr,
+)
+assert "unsupported repository identity" in unsupported_legacy_result.stderr, (
+    unsupported_legacy_result.stdout,
+    unsupported_legacy_result.stderr,
+)
+
 for repo_name, generated_spec in generated_specs.items():
     setup_commands = module.render_local_config(generated_spec).get("scripts", {}).get("setup", [])
     assert setup_commands, repo_name

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -10,8 +10,10 @@ import importlib.util
 import inspect
 import io
 import json
+import os
 import sqlite3
 import subprocess
+import sys
 import tempfile
 import tokenize
 from pathlib import Path
@@ -36,6 +38,27 @@ rollout = load_rollout_module()
 
 
 class PolyscopeRolloutFollowupTests(TestCase):
+    def test_cached_validation_uses_installed_workspace_root(self) -> None:
+        configured_root = Path("/srv/secpal-workspace")
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"SECPAL_WORKSPACE_ROOT": str(configured_root)},
+            ),
+            mock.patch.object(sys, "argv", ["polyscope-rollout.py"]),
+        ):
+            args = rollout.parse_args()
+
+        self.assertEqual(args.workspace_root, configured_root)
+
+    def test_installer_exports_workspace_root_to_cached_setups(self) -> None:
+        installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
+
+        self.assertIn(
+            "Environment=SECPAL_WORKSPACE_ROOT=$WORKSPACE_ROOT",
+            installer,
+        )
+
     def test_registered_instruction_identity_rejects_unmanaged_repository_path(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -36,6 +36,87 @@ rollout = load_rollout_module()
 
 
 class PolyscopeRolloutFollowupTests(TestCase):
+    def test_registered_instruction_identity_rejects_unmanaged_repository_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            db_path = root / "polyscope.db"
+            with sqlite3.connect(db_path) as connection:
+                connection.executescript(
+                    """
+                    create table repositories (
+                        id text primary key,
+                        name text not null,
+                        path text not null
+                    );
+                    create table worktrees (
+                        id text primary key,
+                        repo_id text not null,
+                        path text not null,
+                        status text default 'active' not null
+                    );
+                    """
+                )
+                connection.executemany(
+                    "insert into repositories (id, name, path) values (?, ?, ?)",
+                    (
+                        (
+                            "managed",
+                            "SecPal/api",
+                            str(root / "managed" / "api"),
+                        ),
+                        (
+                            "unmanaged",
+                            "SecPal/api",
+                            str(root / "unmanaged-api"),
+                        ),
+                    ),
+                )
+                connection.execute(
+                    "insert into worktrees (id, repo_id, path, status) "
+                    "values (?, ?, ?, 'active')",
+                    ("candidate", "unmanaged", str(worktree)),
+                )
+
+            args = SimpleNamespace(
+                validate_instruction_worktree=worktree,
+                instruction_repository_name=None,
+                db_path=db_path,
+                workspace_root=root / "managed",
+            )
+            with (
+                mock.patch.object(
+                    rollout,
+                    "validate_instruction_root",
+                    return_value=worktree,
+                ),
+                self.assertRaisesRegex(
+                    rollout.CanonicalInstructionValidationError,
+                    "managed repository source path",
+                ),
+            ):
+                rollout.dispatch_validation_only_direct_mode(args)
+
+            with sqlite3.connect(db_path) as connection:
+                connection.execute(
+                    "update worktrees set repo_id = ? where id = ?",
+                    ("managed", "candidate"),
+                )
+            with (
+                mock.patch.object(
+                    rollout,
+                    "validate_instruction_root",
+                    return_value=worktree,
+                ) as validate,
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(
+                    rollout.dispatch_validation_only_direct_mode(args),
+                    0,
+                )
+            validate.assert_called_once_with(worktree, set(), "api")
+
     def test_registered_instruction_identity_rejects_relative_worktree_path(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -73,6 +154,7 @@ class PolyscopeRolloutFollowupTests(TestCase):
                 rollout.resolve_registered_instruction_repository_name(
                     worktree,
                     db_path,
+                    root,
                 )
 
     def test_user_server_startup_uses_lightweight_nginx_convergence(self) -> None:

--- a/tests/polyscope-rollout-followups-unit.py
+++ b/tests/polyscope-rollout-followups-unit.py
@@ -10,6 +10,7 @@ import importlib.util
 import inspect
 import io
 import json
+import sqlite3
 import subprocess
 import tempfile
 import tokenize
@@ -35,6 +36,45 @@ rollout = load_rollout_module()
 
 
 class PolyscopeRolloutFollowupTests(TestCase):
+    def test_registered_instruction_identity_rejects_relative_worktree_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            db_path = root / "polyscope.db"
+            with sqlite3.connect(db_path) as connection:
+                connection.executescript(
+                    """
+                    create table repositories (
+                        id text primary key,
+                        name text not null,
+                        path text not null
+                    );
+                    create table worktrees (
+                        id text primary key,
+                        repo_id text not null,
+                        path text not null,
+                        status text default 'active' not null
+                    );
+                    insert into repositories (id, name, path)
+                    values ('api-repo', 'SecPal/api', '/source/api');
+                    insert into worktrees (id, repo_id, path, status)
+                    values ('candidate', 'api-repo', 'candidate', 'active');
+                    """
+                )
+
+            with (
+                contextlib.chdir(root),
+                self.assertRaisesRegex(
+                    rollout.CanonicalInstructionValidationError,
+                    "absolute path",
+                ),
+            ):
+                rollout.resolve_registered_instruction_repository_name(
+                    worktree,
+                    db_path,
+                )
+
     def test_user_server_startup_uses_lightweight_nginx_convergence(self) -> None:
         installer = (REPO_ROOT / "scripts/install-polyscope-rollout.sh").read_text()
         ready_command = next(

--- a/tests/polyscope-rollout.sh
+++ b/tests/polyscope-rollout.sh
@@ -7403,6 +7403,7 @@ grep -q "Environment=PATH=$fake_polyscope_git_dir:$fake_bin_dir:/usr/local/sbin:
 grep -q 'Environment=SSH_AUTH_SOCK=%t/openssh_agent' "$fake_unit_dir/polyscope-server.service"
 grep -q 'Environment=POLYSCOPE_REAL_GIT_BIN=' "$fake_unit_dir/polyscope-server.service"
 grep -q "Environment=POLYSCOPE_SUDO_BIN=$fake_sudo_dir/sudo" "$fake_unit_dir/polyscope-server.service"
+grep -q "Environment=SECPAL_WORKSPACE_ROOT=$workspace_root" "$fake_unit_dir/polyscope-server.service"
 grep -q 'polyscope-secpal-rollout.py --workspace-root ' "$fake_unit_dir/polyscope-server.service"
 grep -q -- "--clone-root $home_dir/.polyscope/clones --provision-lock-path $home_dir/.local/state/polyscope/worktree-provision.lock" "$fake_unit_dir/polyscope-server.service"
 grep -q -- '--refresh-nginx --skip-if-provision-locked' "$fake_unit_dir/polyscope-server.service"


### PR DESCRIPTION
## Problem

Polyscope setup definitions cached before repository-name propagation invoke `--validate-instruction-worktree` without `--instruction-repository-name`. The current validator rejected those definitions with:

```text
--instruction-repository-name is required with --validate-instruction-worktree
```

This stopped workspace setup before any repository-native setup command could run. A content-derived compatibility fallback was not sufficient because mutable worktree manifests could select the wrong repository policy.

## Changes

- Resolve legacy setup identities from the worktree's active Polyscope database registration.
- Keep newly generated setup commands on the explicit repository-name path.
- Reject missing, ambiguous, and unsupported registrations fail-closed.
- Clear ambient identity before invoking canonical instruction validation.
- Add regression coverage for a registered API worktree with a misleading manifest and for every fail-closed registration case.
- Document the compatibility and security contract in the validation guide, rollout README, and governance changelog.

## Validation

- `python3 scripts/polyscope-rollout.py --validate-instruction-worktree "$PWD"`
- `bash tests/polyscope-package-1-closure.sh`
- `bash tests/polyscope-rollout.sh`
- `python3 -m py_compile scripts/polyscope-rollout.py`
- `./node_modules/.bin/prettier --check CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md`
- `./node_modules/.bin/markdownlint --config .markdownlint.json CHANGELOG.md docs/VALIDATION_SYSTEM.md scripts/README.md`
- `git diff --check`

All local validations passed. The negative provisioning messages emitted by the rollout suites are expected fixture behavior.

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/polyscope-package-1-closure.sh` failed first with `--instruction-repository-name is required with --validate-instruction-worktree`; the hardened regression then rejected the misleading API manifest as `Repository Type: org` before database-backed identity resolution was implemented.
- Passing proof after implementation: `bash tests/polyscope-package-1-closure.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Readiness

No known in-scope dependency or unresolved local validation failure prevents review. This pull request remains a draft pending review.
