### PR TITLE
Enforce migrated deployment AI instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Log of notable changes to SecPal organization defaults (newest first).
   baselines, retain the API repository's intentional CC0 and deliberate
   focused-overlay licenses, and reject incomplete, duplicate, conflicting, or
   obsolete expressions without disturbing unrelated custom-license metadata
+- added explicit trusted deployment identity coverage that admits its migrated
+  plain-AGPL runtime and review instructions while continuing to reject the
+  obsolete attribution expression
 - aligned the Copilot profile's authoritative `.license` sidecar with its
   visible plain-AGPL metadata and the `SecPal Contributors` year convention
 - added Polyscope rollout regressions proving invalid attribution metadata

--- a/docs/VALIDATION_SYSTEM.md
+++ b/docs/VALIDATION_SYSTEM.md
@@ -99,6 +99,8 @@ before recursion. Without a path argument, canonical callers may supply trusted
 identity through `GITHUB_REPOSITORY` or `SECPAL_REPOSITORY_NAME`. The legacy
 `REPO_TYPE` hint remains available for local compatibility, but cannot select
 the API policy unless the repository has the exact `secpal/api` manifest.
+Trusted `SecPal/deployment` identity is reported explicitly and uses the same
+strict plain-AGPL baseline as other migrated managed repositories.
 
 The compatibility entry point `validate-copilot-instructions.sh` always
 delegates to this canonical validator, including for repository-path arguments.
@@ -116,6 +118,9 @@ Copilot review profile fails through the same canonical contract.
 - the obsolete expression
   `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, duplicate identifiers,
   and a wrong repository-baseline license fail;
+- the migrated `SecPal/deployment` identity accepts plain-AGPL runtime and
+  review instructions, is reported explicitly, and rejects the obsolete
+  attribution expression;
 - API, frontend-with-Composer, GuardGuide, and `guardguide.de` fixtures exercise
   trusted repository identity, path-local fallback detection, and legacy type
   hints so ambient identity and misleading manifest values cannot select

--- a/scripts/validate-ai-instructions.sh
+++ b/scripts/validate-ai-instructions.sh
@@ -78,6 +78,10 @@ detect_repo_type() {
             printf '%s\n' android
             return
             ;;
+        deployment)
+            printf '%s\n' deployment
+            return
+            ;;
         contracts)
             printf '%s\n' contracts
             return

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -132,6 +132,36 @@ assert_fails_with() {
     fi
 }
 
+assert_output_contains() {
+    local output_file="$1"
+    local expected="$2"
+
+    if ! grep -qF "$expected" "$output_file"; then
+        sed -n '1,240p' "$output_file" >&2
+        echo "captured output did not include expected result: $expected" >&2
+        exit 1
+    fi
+}
+
+diagnostic_probe_output="$workspace/assert-output-contains-probe.output"
+diagnostic_probe_log="$workspace/assert-output-contains-probe.log"
+printf '%s\n' 'diagnostic probe output' >"$diagnostic_probe_output"
+set +e
+(
+    assert_output_contains "$diagnostic_probe_output" 'missing expected text'
+) >"$diagnostic_probe_log" 2>&1
+diagnostic_probe_status=$?
+set -e
+if [ "$diagnostic_probe_status" -eq 0 ]; then
+    echo "output assertion unexpectedly accepted missing text" >&2
+    exit 1
+fi
+if ! grep -qF 'diagnostic probe output' "$diagnostic_probe_log"; then
+    sed -n '1,240p' "$diagnostic_probe_log" >&2
+    echo "output assertion did not print captured output on failure" >&2
+    exit 1
+fi
+
 valid_repo="$workspace/valid-independent-layers"
 write_valid_repo "$valid_repo"
 valid_output="$workspace/valid-independent-layers.output"
@@ -187,8 +217,8 @@ migrated_deployment_output="$workspace/migrated-deployment.output"
     cd "$migrated_deployment_repo"
     GITHUB_REPOSITORY=SecPal/deployment bash "$VALIDATOR"
 ) >"$migrated_deployment_output" 2>&1
-grep -qF 'Repository Type: deployment' "$migrated_deployment_output"
-grep -qF 'All tests passed' "$migrated_deployment_output"
+assert_output_contains "$migrated_deployment_output" 'Repository Type: deployment'
+assert_output_contains "$migrated_deployment_output" 'All tests passed'
 
 obsolete_deployment_repo="$workspace/obsolete-deployment"
 copy_valid_repo "$migrated_deployment_repo" "$obsolete_deployment_repo"
@@ -208,9 +238,8 @@ if [ "$obsolete_deployment_status" -eq 0 ]; then
     echo "migrated deployment instructions must require plain AGPL" >&2
     exit 1
 fi
-grep -qF \
-    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later' \
-    "$obsolete_deployment_output"
+assert_output_contains "$obsolete_deployment_output" \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later'
 
 duplicate_agents_license_repo="$workspace/duplicate-agents-license"
 copy_valid_repo "$valid_repo" "$duplicate_agents_license_repo"

--- a/tests/validate-ai-instructions.sh
+++ b/tests/validate-ai-instructions.sh
@@ -180,6 +180,38 @@ sed -i \
 assert_fails_with "$obsolete_overlay_license_repo" \
     '.github/instructions/example.instructions.md has REUSE license'
 
+migrated_deployment_repo="$workspace/migrated-deployment"
+copy_valid_repo "$valid_repo" "$migrated_deployment_repo"
+migrated_deployment_output="$workspace/migrated-deployment.output"
+(
+    cd "$migrated_deployment_repo"
+    GITHUB_REPOSITORY=SecPal/deployment bash "$VALIDATOR"
+) >"$migrated_deployment_output" 2>&1
+grep -qF 'Repository Type: deployment' "$migrated_deployment_output"
+grep -qF 'All tests passed' "$migrated_deployment_output"
+
+obsolete_deployment_repo="$workspace/obsolete-deployment"
+copy_valid_repo "$migrated_deployment_repo" "$obsolete_deployment_repo"
+sed -i \
+    's/SPDX-License''-Identifier: AGPL-3.0-or-later/SPDX-License''-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution/' \
+    "$obsolete_deployment_repo/AGENTS.md"
+obsolete_deployment_output="$workspace/obsolete-deployment.output"
+set +e
+(
+    cd "$obsolete_deployment_repo"
+    GITHUB_REPOSITORY=SecPal/deployment bash "$VALIDATOR"
+) >"$obsolete_deployment_output" 2>&1
+obsolete_deployment_status=$?
+set -e
+if [ "$obsolete_deployment_status" -eq 0 ]; then
+    sed -n '1,240p' "$obsolete_deployment_output" >&2
+    echo "migrated deployment instructions must require plain AGPL" >&2
+    exit 1
+fi
+grep -qF \
+    'AGENTS.md must declare exactly one complete permitted SPDX expression: AGPL-3.0-or-later' \
+    "$obsolete_deployment_output"
+
 duplicate_agents_license_repo="$workspace/duplicate-agents-license"
 copy_valid_repo "$valid_repo" "$duplicate_agents_license_repo"
 sed -i \


### PR DESCRIPTION
## Problem and evidence

Gate 00 requires every managed instruction caller to use the final plain-AGPL contract before strict central enforcement is considered ready. The deployment companion is the remaining ordered dependency. The central validator also reported the trusted `SecPal/deployment` identity as `org`, and its regression suite did not explicitly bind that caller identity to the migrated runtime and review contract.

## Change

- Report the exact trusted deployment identity as `deployment`.
- Prove that migrated plain-AGPL runtime and review instructions pass for `SecPal/deployment`.
- Prove that the obsolete `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` expression is rejected for that same trusted identity.
- Document the strict post-migration deployment contract and record the governance update.

## Validation

Passed locally:

- `bash scripts/validate-ai-instructions.sh`
- `bash tests/validate-ai-instructions.sh`
- `bash tests/validate-copilot-instructions.sh`
- canonical validation of the migrated deployment checkout with `GITHUB_REPOSITORY=SecPal/deployment` (10/10 checks)
- `shellcheck scripts/validate-ai-instructions.sh tests/validate-ai-instructions.sh`
- repository-pinned Markdownlint for the changed documentation
- `reuse lint`
- `bash tests/polyscope-rollout.sh`
- `git diff --check`

## TDD / Validate-First Evidence

- Failing proof before implementation: `bash tests/validate-ai-instructions.sh` failed because the trusted `SecPal/deployment` identity was reported as `org` instead of `deployment`.
- Passing proof after implementation: `bash tests/validate-ai-instructions.sh`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Dependency and readiness

This pull request must remain draft and must not merge until the instruction-only `SecPal/deployment` companion has merged. No local validation is unresolved; that cross-repository ordering dependency is the only current in-scope readiness blocker.

Relates to #650 and #649.