### PR TITLE
docs: record CLA relicensing decision

### DIFF
--- a/.github/CLA_SETUP.md
+++ b/.github/CLA_SETUP.md
@@ -81,13 +81,24 @@ However, this requires manual configuration for each new repository.
 
 ## Active Repositories
 
-The following SecPal repositories are automatically covered by the organization-wide CLA:
+The organization-wide link is expected to cover every active SecPal repository:
 
+- `SecPal/.github` - Organization-wide governance and configuration
+- `SecPal/GuardGuide` - GuardGuide operations platform
+- `SecPal/android` - SecPal Android application
+- `SecPal/api` - SecPal API
 - `SecPal/contracts` - OpenAPI contracts repository
+- `SecPal/deployment` - Deployment and public governance
+- `SecPal/frontend` - SecPal frontend application
+- `SecPal/guardguide.de` - GuardGuide public website
+- `SecPal/secpal.app` - SecPal public website
 - All future SecPal repositories
+
+This inventory describes the expected scope; it does not replace the live-configuration verification required above.
 
 ## References
 
 - CLA Assistant: <https://github.com/cla-assistant/cla-assistant>
 - CLA Document: <https://github.com/SecPal/.github/blob/main/CLA.md>
+- Project Maintainer and CLA rights recipient: [`GOVERNANCE.md`](../GOVERNANCE.md)
 - CLA Assistant Service: <https://cla-assistant.io/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Log of notable changes to SecPal organization defaults (newest first).
 - confirmed that the existing non-exclusive contributor grants already cover
   plain-AGPL distribution and commercial licensing without changing contributor
   copyright ownership or the CLA text
-- designated the current Project Maintainer and CLA rights recipient in public
-  governance and documented a succession process that distinguishes legal
-  assignment from repository, team, account, and email administration
+- designated the current Project Maintainer through whom SecPal acts as the CLA
+  rights recipient in public governance and documented a succession process
+  that distinguishes legal assignment from repository, team, account, and email
+  administration
 - aligned the documented organization-wide CLA Assistant repository inventory
   with the active SecPal repositories while retaining separate live-configuration
   verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-16 - Confirm CLA And Commercial Relicensing Model
+
+**Changed:**
+
+- confirmed that the existing non-exclusive contributor grants already cover
+  plain-AGPL distribution and commercial licensing without changing contributor
+  copyright ownership or the CLA text
+- designated the current Project Maintainer and CLA rights recipient in public
+  governance and documented a succession process that distinguishes legal
+  assignment from repository, team, account, and email administration
+- aligned the documented organization-wide CLA Assistant repository inventory
+  with the active SecPal repositories while retaining separate live-configuration
+  verification
+
+---
+
 ## 2026-08-15 - Establish AI Licensing And Branding Invariants
 
 **Changed:**

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,6 +9,8 @@ SPDX-License-Identifier: CC0-1.0
 
 For the defined terms in [`CLA.md`](CLA.md), the current **Project Maintainer** is the individual publicly represented by the GitHub account [@aroviqen](https://github.com/aroviqen), GitHub user ID `266326653`. Under the CLA's definition, the current **CLA rights recipient** is SecPal acting through this Project Maintainer. CLA administration and legal correspondence use [legal@secpal.app](mailto:legal@secpal.app).
 
+This designation is effective as of 2026-08-16. It records the current administrator and rights recipient without changing contributor grants or their administration before that date.
+
 This is the public Project Maintainer designation referenced by the CLA. The `SecPal` GitHub organization, the `@SecPal/maintainers` team, the `SecPal Contributors` copyright convention, repository ownership, and control of an administrative account or email address do not independently replace the designated Project Maintainer or transfer the CLA rights granted to SecPal.
 
 The Project Maintainer is responsible for accepting contributions, administering contributor agreements, distributing contributions under the project's open source license, and granting commercial licenses within the rights contributors conveyed to SecPal.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# SecPal Project Governance
+
+## Project Maintainer And CLA Rights Recipient
+
+For the defined terms in [`CLA.md`](CLA.md), the current **Project Maintainer** and **CLA rights recipient** is the individual publicly represented by the GitHub account [@aroviqen](https://github.com/aroviqen), GitHub user ID `266326653`. CLA administration and legal correspondence use [legal@secpal.app](mailto:legal@secpal.app).
+
+This is the public governance designation referenced by the CLA. The `SecPal` GitHub organization, the `@SecPal/maintainers` team, the `SecPal Contributors` copyright convention, repository ownership, and control of an administrative account or email address do not independently replace or transfer the designated recipient's CLA rights.
+
+The Project Maintainer is responsible for accepting contributions, administering contributor agreements, distributing contributions under the project's open source license, and granting commercial licenses within the rights conveyed by contributors.
+
+## Succession
+
+Changing a GitHub username, CODEOWNERS entry, organization role, team membership, or contact address does not by itself assign CLA rights or designate a successor.
+
+Before a successor begins administering contributor agreements or granting commercial licenses, SecPal governance must:
+
+1. document the legal assignment or other lawful succession from the current rights recipient;
+2. update this document with the successor person or legal entity, an unambiguous public identifier, and the effective date; and
+3. align contributor-facing legal and administration documents with that designation before representing the successor as the CLA rights recipient.
+
+A later governance record documents the succession; it does not create an assignment merely by changing repository text. Existing contributor grants remain governed by the operative CLA and any valid assignment or legal succession.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,20 +7,20 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Project Maintainer And CLA Rights Recipient
 
-For the defined terms in [`CLA.md`](CLA.md), the current **Project Maintainer** and **CLA rights recipient** is the individual publicly represented by the GitHub account [@aroviqen](https://github.com/aroviqen), GitHub user ID `266326653`. CLA administration and legal correspondence use [legal@secpal.app](mailto:legal@secpal.app).
+For the defined terms in [`CLA.md`](CLA.md), the current **Project Maintainer** is the individual publicly represented by the GitHub account [@aroviqen](https://github.com/aroviqen), GitHub user ID `266326653`. Under the CLA's definition, the current **CLA rights recipient** is SecPal acting through this Project Maintainer. CLA administration and legal correspondence use [legal@secpal.app](mailto:legal@secpal.app).
 
-This is the public governance designation referenced by the CLA. The `SecPal` GitHub organization, the `@SecPal/maintainers` team, the `SecPal Contributors` copyright convention, repository ownership, and control of an administrative account or email address do not independently replace or transfer the designated recipient's CLA rights.
+This is the public Project Maintainer designation referenced by the CLA. The `SecPal` GitHub organization, the `@SecPal/maintainers` team, the `SecPal Contributors` copyright convention, repository ownership, and control of an administrative account or email address do not independently replace the designated Project Maintainer or transfer the CLA rights granted to SecPal.
 
-The Project Maintainer is responsible for accepting contributions, administering contributor agreements, distributing contributions under the project's open source license, and granting commercial licenses within the rights conveyed by contributors.
+The Project Maintainer is responsible for accepting contributions, administering contributor agreements, distributing contributions under the project's open source license, and granting commercial licenses within the rights contributors conveyed to SecPal.
 
 ## Succession
 
-Changing a GitHub username, CODEOWNERS entry, organization role, team membership, or contact address does not by itself assign CLA rights or designate a successor.
+Changing a GitHub username, CODEOWNERS entry, organization role, team membership, or contact address does not by itself transfer the CLA rights granted to SecPal or designate a successor Project Maintainer.
 
-Before a successor begins administering contributor agreements or granting commercial licenses, SecPal governance must:
+Before a successor Project Maintainer begins administering contributor agreements or granting commercial licenses, SecPal governance must:
 
-1. document the legal assignment or other lawful succession from the current rights recipient;
+1. document the successor's designation and any legal assignment or other lawful succession needed to preserve SecPal's CLA rights;
 2. update this document with the successor person or legal entity, an unambiguous public identifier, and the effective date; and
-3. align contributor-facing legal and administration documents with that designation before representing the successor as the CLA rights recipient.
+3. align contributor-facing legal and administration documents before representing the successor as Project Maintainer or a successor legal entity as the CLA rights recipient.
 
 A later governance record documents the succession; it does not create an assignment merely by changing repository text. Existing contributor grants remain governed by the operative CLA and any valid assignment or legal succession.

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ By contributing to SecPal projects, you agree to our [Contributor License Agreem
 - Grants us rights to distribute your contributions under **both** licensing models
 - Allows you to **retain copyright** ownership
 - Ensures your work can benefit both open source and commercial users
-- Defines SecPal and the Project Maintainer clearly enough for contributor license grants without turning the CLA into a copyright assignment; the current rights recipient and succession process are recorded in [GOVERNANCE.md](GOVERNANCE.md)
+- Defines SecPal and the Project Maintainer clearly enough for contributor license grants without turning the CLA into a copyright assignment; the current Project Maintainer through whom SecPal acts, and the succession process, are recorded in [GOVERNANCE.md](GOVERNANCE.md)
 
 **CLA Signing Process:**
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ By contributing to SecPal projects, you agree to our [Contributor License Agreem
 - Grants us rights to distribute your contributions under **both** licensing models
 - Allows you to **retain copyright** ownership
 - Ensures your work can benefit both open source and commercial users
-- Defines SecPal and the Project Maintainer clearly enough for contributor license grants without turning the CLA into a copyright assignment
+- Defines SecPal and the Project Maintainer clearly enough for contributor license grants without turning the CLA into a copyright assignment; the current rights recipient and succession process are recorded in [GOVERNANCE.md](GOVERNANCE.md)
 
 **CLA Signing Process:**
 

--- a/docs/cla-commercial-relicensing-review.md
+++ b/docs/cla-commercial-relicensing-review.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: CC0-1.0
 
 **Targeted governance update required; no CLA text change required.** The existing individual and corporate contributor grants already cover distribution under plain `AGPL-3.0-or-later` and the grant of commercial licenses. Removing `LicenseRef-SecPal-Attribution` from SecPal's public outbound license expression therefore does not change the contributor-rights model or require contributors to grant additional rights.
 
-The CLA already defines the recipient role but relies on public governance to identify its current holder. [`GOVERNANCE.md`](../GOVERNANCE.md) now makes that designation explicit and defines a succession process without amending the contributor grant.
+The CLA already defines the rights recipient as SecPal acting through the Project Maintainer but relies on public governance to identify the current Project Maintainer through whom SecPal acts. [`GOVERNANCE.md`](../GOVERNANCE.md) now makes that designation explicit and defines a succession process without amending the contributor grant.
 
 This decision is limited to the planned outbound-license simplification. It does not approve a copyright assignment, add an attribution obligation, change product branding, or migrate repository SPDX metadata.
 
@@ -41,7 +41,7 @@ The defined terms in [`CLA.md`](../CLA.md), [`licensing-policy.md`](licensing-po
 - `Project Maintainer` is the person or legal entity designated in public SecPal governance documentation to accept contributions, administer contributor agreements, and grant commercial licenses, including a legal successor or assignee of those rights. The current designee is the individual represented by GitHub account `@aroviqen`, GitHub user ID `266326653`.
 - `CLA rights recipient` is SecPal acting through the Project Maintainer until a successor legal entity is publicly designated in governance documentation.
 
-This designation remains coherent with the current administration paths: [`CLA_SETUP.md`](../.github/CLA_SETUP.md) links the organization-wide CLA service to the canonical CLA, and `legal@secpal.app` is the contact in the CLA for manual signatures, corporate-contributor changes, and legal questions. The governance record makes clear that changing account, team, repository, or email control does not transfer CLA rights. A later succession requires a legal assignment or other lawful succession and a public governance update before the successor is represented as the CLA rights recipient.
+This designation remains coherent with the current administration paths: [`CLA_SETUP.md`](../.github/CLA_SETUP.md) links the organization-wide CLA service to the canonical CLA, and `legal@secpal.app` is the contact in the CLA for manual signatures, corporate-contributor changes, and legal questions. The governance record makes clear that changing account, team, repository, or email control does not replace the Project Maintainer or transfer CLA rights. A later change to the Project Maintainer requires a documented public designation; any change to the CLA rights recipient also requires the legal assignment or other lawful succession needed to preserve the contributor grants.
 
 ## Attribution Dependency Review
 
@@ -65,8 +65,8 @@ Later migration work may rely on these conclusions:
 - The existing grant covers distribution under plain `AGPL-3.0-or-later`.
 - The existing grant separately covers commercial licensing.
 - Removing the public attribution addendum neither expands nor reduces contributor grants.
-- The Project Maintainer remains the administrator and CLA rights recipient for SecPal, subject to the documented public-succession mechanism.
-- The current rights recipient is explicitly designated in public governance; administrative account or team changes alone cannot transfer those rights.
+- The Project Maintainer remains the administrator through whom SecPal acts as the CLA rights recipient, subject to the documented public-succession mechanism.
+- The current Project Maintainer is explicitly designated in public governance; administrative account or team changes alone cannot replace that designation or transfer CLA rights.
 - No new attribution, branding, copyright-assignment, or contributor re-signing requirement follows from this decision.
 
 This is a governance and document-consistency decision for the migration. The external-counsel review tracked in [`legal-compliance.md`](legal-compliance.md) remains the path for a formal legal opinion.

--- a/docs/cla-commercial-relicensing-review.md
+++ b/docs/cla-commercial-relicensing-review.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# CLA And Commercial Relicensing Review
+
+**Decision date:** 2026-08-16
+
+**Tracking:** [SecPal/.github#651](https://github.com/SecPal/.github/issues/651), Gate 01 of [SecPal/.github#649](https://github.com/SecPal/.github/issues/649)
+
+## Decision
+
+**Targeted governance update required; no CLA text change required.** The existing individual and corporate contributor grants already cover distribution under plain `AGPL-3.0-or-later` and the grant of commercial licenses. Removing `LicenseRef-SecPal-Attribution` from SecPal's public outbound license expression therefore does not change the contributor-rights model or require contributors to grant additional rights.
+
+The CLA already defines the recipient role but relies on public governance to identify its current holder. [`GOVERNANCE.md`](../GOVERNANCE.md) now makes that designation explicit and defines a succession process without amending the contributor grant.
+
+This decision is limited to the planned outbound-license simplification. It does not approve a copyright assignment, add an attribution obligation, change product branding, or migrate repository SPDX metadata.
+
+## Basis
+
+The operative terms in [`CLA.md`](../CLA.md) establish the same rights model for individual and corporate contributors:
+
+- The agreement-wide Purpose confirms that contributors retain full copyright ownership. The individual agreement also expressly reserves all right, title, and interest except for the license granted to SecPal and downstream recipients.
+- Section 2 grants a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license. The grant includes reproduction, derivative works, public display and performance, sublicensing, and distribution.
+- Section 2 expressly authorizes distribution under `AGPL-3.0-or-later`.
+- Section 2 separately and expressly authorizes SecPal, acting through the Project Maintainer as the CLA rights recipient, to grant commercial licenses for contributions.
+- The patent grants and contributor representations do not depend on the outbound attribution addendum and remain unchanged.
+
+The grant is a license, not an assignment. Its express non-exclusive character and the reservation of contributor ownership rule out converting contributor copyright to SecPal ownership through this migration.
+
+Plain `AGPL-3.0-or-later` is already named in the CLA. The broader rights to sublicense and distribute, together with the separate express commercial-license authorization, do not depend on an outbound additional term. Removing that additional term narrows the conditions imposed on public recipients; it does not require a broader inbound grant from contributors.
+
+The current [SecPal attribution terms](../LICENSES/LicenseRef-SecPal-Attribution.txt) identify themselves as additional terms under AGPL sections 7(b) and 7(c). [AGPL section 7](https://www.gnu.org/licenses/agpl-3.0#section7) separately permits specified notice, attribution, origin, and modification-marking terms. That structure confirms that the addendum supplements the AGPL outbound terms rather than defining the CLA's inbound contributor grant.
+
+## Rights Recipient And Administration
+
+The defined terms in [`CLA.md`](../CLA.md), [`licensing-policy.md`](licensing-policy.md), and [`GOVERNANCE.md`](../GOVERNANCE.md) are aligned:
+
+- `SecPal` is the open source project maintained by the Project Maintainer.
+- `Project Maintainer` is the person or legal entity designated in public SecPal governance documentation to accept contributions, administer contributor agreements, and grant commercial licenses, including a legal successor or assignee of those rights. The current designee is the individual represented by GitHub account `@aroviqen`, GitHub user ID `266326653`.
+- `CLA rights recipient` is SecPal acting through the Project Maintainer until a successor legal entity is publicly designated in governance documentation.
+
+This designation remains coherent with the current administration paths: [`CLA_SETUP.md`](../.github/CLA_SETUP.md) links the organization-wide CLA service to the canonical CLA, and `legal@secpal.app` is the contact in the CLA for manual signatures, corporate-contributor changes, and legal questions. The governance record makes clear that changing account, team, repository, or email control does not transfer CLA rights. A later succession requires a legal assignment or other lawful succession and a public governance update before the successor is represented as the CLA rights recipient.
+
+## Attribution Dependency Review
+
+`CLA.md` contains no reference to `LicenseRef-SecPal-Attribution` and no clause that conditions the copyright or patent grants on that addendum. No CLA clause needs to be removed or amended for the outbound simplification.
+
+The active attribution-addendum references reviewed outside the CLA have these effects:
+
+- [`licensing-policy.md`](licensing-policy.md) currently defines the outbound SPDX and attribution policy. Updating those sections is Gate 02 work; its CLA-alignment section already describes the non-assignment, retained-copyright, AGPL-distribution, commercial-relicensing, and succession model correctly.
+- [`README.md`](../README.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md) contain outbound licensing and REUSE guidance that refers to the addendum. Those references do not define or limit the inbound CLA grant and are to be aligned by the ordered central-policy migration.
+- [`legal-compliance.md`](legal-compliance.md) does not define contributor grants or commercial-relicensing rights. It retains the broader requirement for external legal review before production launch.
+- [`CLA_SETUP.md`](../.github/CLA_SETUP.md) is operational guidance. It points to the canonical `CLA.md`, records that changing the CLA requires re-signing, and does not encode the attribution addendum.
+
+Because the operative CLA is unchanged, this decision does not itself trigger CLA Assistant re-signing. Later outbound SPDX or policy changes must not be represented as changes to already granted contributor rights.
+
+## Rights-Model Invariants For Later Gates
+
+Later migration work may rely on these conclusions:
+
+- Contributors retain copyright in their contributions.
+- SecPal receives a non-exclusive license, not a copyright assignment.
+- The existing grant covers distribution under plain `AGPL-3.0-or-later`.
+- The existing grant separately covers commercial licensing.
+- Removing the public attribution addendum neither expands nor reduces contributor grants.
+- The Project Maintainer remains the administrator and CLA rights recipient for SecPal, subject to the documented public-succession mechanism.
+- The current rights recipient is explicitly designated in public governance; administrative account or team changes alone cannot transfer those rights.
+- No new attribution, branding, copyright-assignment, or contributor re-signing requirement follows from this decision.
+
+This is a governance and document-consistency decision for the migration. The external-counsel review tracked in [`legal-compliance.md`](legal-compliance.md) remains the path for a formal legal opinion.

--- a/docs/legal-compliance.md
+++ b/docs/legal-compliance.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC0-1.0
 
 **Status:** Living document - Update when new requirements identified
 
-**Last Updated:** 2026-07-20
+**Last Updated:** 2026-08-16
 
 **Current architecture baseline:** [ADR-014](adr/20260720-tenant-identity-access-model-adr014.md) governs Tenant, global identity, Employee, access, encryption, erasure, and BWR file-export boundaries. Architecture-specific examples in this living document must conform to that accepted baseline.
 
@@ -445,6 +445,7 @@ If targeting alarm response market, additional requirements:
 
 ## Related
 
+- [CLA and commercial relicensing review](cla-commercial-relicensing-review.md)
 - Issue #46: Legal Review of CLA and Commercial Licenses
 - ADR-001: Event Sourcing (ensures BewachV §10 retention)
 - ADR-002: OpenTimestamp (provides tamper-proof evidence)

--- a/docs/licensing-policy.md
+++ b/docs/licensing-policy.md
@@ -15,7 +15,7 @@ This document is the central SecPal policy for contributor licensing, SPDX/REUSE
 
 These definitions keep the CLA model as a license grant rather than a copyright assignment: contributors retain copyright ownership and grant SecPal the rights needed for AGPL distribution and commercial relicensing.
 
-[`GOVERNANCE.md`](../GOVERNANCE.md) records the current Project Maintainer and CLA rights recipient and the required process for a later lawful succession. Administrative account, team, repository, or email control does not by itself transfer those rights.
+[`GOVERNANCE.md`](../GOVERNANCE.md) records the current Project Maintainer, through whom SecPal acts as the CLA rights recipient, and the required process for a later lawful succession. Administrative account, team, repository, or email control does not by itself replace that designation or transfer CLA rights.
 
 ## Standard SPDX Copyright Policy
 
@@ -88,7 +88,7 @@ Implementation notes:
 - The CLA is a contributor license agreement, not a copyright assignment.
 - Contributors retain copyright in their own work.
 - Contributors grant SecPal, acting through the Project Maintainer, the rights needed to distribute contributions under the AGPL and to grant commercial licenses.
-- The current Project Maintainer and CLA rights recipient is designated in [`GOVERNANCE.md`](../GOVERNANCE.md).
+- The current Project Maintainer, through whom SecPal acts as the CLA rights recipient, is designated in [`GOVERNANCE.md`](../GOVERNANCE.md).
 - If SecPal later forms or designates a successor legal entity, a legal assignment or other lawful succession must occur and SecPal governance documentation must identify that successor clearly before repository headers or contributor-facing legal text are updated to reflect it.
 
 See [`CLA.md`](../CLA.md) for the operative contributor agreement text and [`CONTRIBUTING.md`](../CONTRIBUTING.md) for day-to-day REUSE guidance.

--- a/docs/licensing-policy.md
+++ b/docs/licensing-policy.md
@@ -15,6 +15,8 @@ This document is the central SecPal policy for contributor licensing, SPDX/REUSE
 
 These definitions keep the CLA model as a license grant rather than a copyright assignment: contributors retain copyright ownership and grant SecPal the rights needed for AGPL distribution and commercial relicensing.
 
+[`GOVERNANCE.md`](../GOVERNANCE.md) records the current Project Maintainer and CLA rights recipient and the required process for a later lawful succession. Administrative account, team, repository, or email control does not by itself transfer those rights.
+
 ## Standard SPDX Copyright Policy
 
 Use project-based copyright notices for SecPal-owned material:
@@ -86,9 +88,12 @@ Implementation notes:
 - The CLA is a contributor license agreement, not a copyright assignment.
 - Contributors retain copyright in their own work.
 - Contributors grant SecPal, acting through the Project Maintainer, the rights needed to distribute contributions under the AGPL and to grant commercial licenses.
-- If SecPal later forms or designates a successor legal entity, SecPal governance documentation must identify that successor clearly before repository headers or contributor-facing legal text are updated to reflect it.
+- The current Project Maintainer and CLA rights recipient is designated in [`GOVERNANCE.md`](../GOVERNANCE.md).
+- If SecPal later forms or designates a successor legal entity, a legal assignment or other lawful succession must occur and SecPal governance documentation must identify that successor clearly before repository headers or contributor-facing legal text are updated to reflect it.
 
 See [`CLA.md`](../CLA.md) for the operative contributor agreement text and [`CONTRIBUTING.md`](../CONTRIBUTING.md) for day-to-day REUSE guidance.
+
+The Gate 01 review in [`cla-commercial-relicensing-review.md`](cla-commercial-relicensing-review.md) records why the existing CLA grant already covers distribution under plain `AGPL-3.0-or-later` and commercial relicensing without changing contributor rights or the CLA text.
 
 ## Implementation Tracking
 


### PR DESCRIPTION
## Problem and evidence

Gate 01 must establish whether simplifying the outbound license to plain `AGPL-3.0-or-later` preserves the existing contributor-rights and commercial-relicensing model.

The operative CLA already:

- reserves contributor copyright and describes a non-exclusive license grant;
- expressly authorizes AGPL distribution in both individual and corporate Section 2 grants; and
- separately authorizes commercial licensing in both grants.

The review found a narrower governance gap. The CLA definitions rely on public governance to identify the current Project Maintainer and CLA rights recipient, but no active governance document previously made that designation. The CLA Assistant setup was also internally inconsistent: it described organization-wide coverage while its active-repository inventory named only `SecPal/contracts` and future repositories.

Evidence:

- [`CLA.md` definitions and purpose](https://github.com/SecPal/.github/blob/verify-cla-relicensing/CLA.md#L15-L28)
- [individual copyright grant](https://github.com/SecPal/.github/blob/verify-cla-relicensing/CLA.md#L42-L60)
- [corporate copyright grant](https://github.com/SecPal/.github/blob/verify-cla-relicensing/CLA.md#L90-L110)
- [CLA administration and repository coverage](https://github.com/SecPal/.github/blob/verify-cla-relicensing/.github/CLA_SETUP.md#L47-L105)

## Change

- Record outcome 2: a targeted governance update is required, but no CLA text change is required.
- Add `GOVERNANCE.md` to designate the current Project Maintainer and CLA rights recipient and define a succession process that distinguishes legal assignment from account, team, repository, CODEOWNERS, and email administration.
- Add a durable clause-by-clause Gate 01 decision record covering copyright ownership, non-assignment, AGPL distribution, commercial licensing, attribution-addendum independence, administration, and succession.
- Cross-link the decision and governance designation from contributor-facing licensing and compliance documentation.
- Align the expected CLA Assistant inventory with all nine active SecPal repositories while retaining separate live-configuration verification.
- Record the governance decision in this repository's chronological changelog.

The operative `CLA.md` remains unchanged, so this change does not trigger contributor re-signing. It does not migrate SPDX metadata, introduce attribution or branding obligations, or start Gate 02.

## Validation

- `./node_modules/.bin/markdownlint --config .markdownlint.json GOVERNANCE.md README.md CHANGELOG.md .github/CLA_SETUP.md docs/cla-commercial-relicensing-review.md docs/licensing-policy.md docs/legal-compliance.md`
- `./node_modules/.bin/prettier --check GOVERNANCE.md README.md CHANGELOG.md .github/CLA_SETUP.md docs/cla-commercial-relicensing-review.md docs/licensing-policy.md docs/legal-compliance.md .context/issue-651-pr-body.md`
- `npm run lint:markdown`
- `reuse lint` — 257/257 files compliant
- `git diff --check`
- Compared the documented CLA repository inventory with all active, non-archived repositories in `SecPal`; no differences remained.
- Verified the commit signature successfully.

## TDD / Validate-First Evidence

- Failing proof before implementation: N/A
- Passing proof after implementation: N/A
- Validate-first exception reference: N/A
- No executable change reason: Documentation-only governance change; no executable behavior, automation, contract, or validation logic changed.

## Dependencies and readiness

- Gate 00, #650, is closed.
- No in-scope dependency or unresolved validation prevents review of this draft.
- The formal external-counsel review remains tracked in #46. This governance decision is not a formal legal opinion, and #46 remains the production/commercial-use legal-review path.
- Gate 02 must not begin until this PR is reviewed and merged and #651 is complete.

Closes #651.
