### PR TITLE
Implement read-only SecPal work-graph resolution

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -77,6 +77,30 @@ jobs:
       - name: Run fake-GitHub and temporary-HOME integration tests
         run: bash tests/secpal-pr-review-skill-integration.sh
 
+  work-graph-resolver:
+    name: Work-Graph Resolver
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.x"
+
+      # markdown-it provides the standards-compliant Markdown parsing the
+      # structural acceptance-criteria check depends on.
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run pure resolver and acceptance-criteria tests
+        run: python3 -m unittest tests/secpal-work-graph-unit.py
+
+      - name: Run fake-GitHub adapter and command tests
+        run: python3 -m unittest tests/secpal-work-graph-adapter.py
+
   prettier:
     name: Check Code Formatting
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Log of notable changes to SecPal organization defaults (newest first).
 
 ---
 
+## 2026-08-19 - Implement Read-Only SecPal Work-Graph Resolution
+
+**Added:**
+
+- `scripts/secpal-work-graph.py` with `show`, `validate`, `ready`, `next`, and
+  `validate-issue`, resolving GitHub-native hierarchy, dependencies, sibling
+  order, state, closure reason, and closing pull-request relationships into the
+  machine-derived states defined by `docs/work-graph-contract.md`
+- `scripts/secpal_work_graph/` holding the GitHub read boundary, the immutable
+  normalized snapshot, the pure state resolver, structural acceptance-criteria
+  detection, and deterministic rendering, so JSON and human output derive from
+  one resolved model
+- a `Work-Graph Resolver` job in `.github/workflows/quality.yml` running the
+  hermetic resolver, acceptance-criteria, fake-GitHub adapter, and command tests
+
+**Changed:**
+
+- `markdown-it` is now an explicit dev dependency, providing the
+  standards-compliant Markdown parsing that structural acceptance-criteria
+  detection requires
+
+---
+
 ## 2026-08-19 - Define The Canonical SecPal Work-Graph Contract
 
 **Added:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "js-yaml": "^5.2.1",
+        "markdown-it": "14.3.0",
         "markdownlint-cli": "0.49.1",
         "prettier": "3.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "js-yaml": "^5.2.1",
+    "markdown-it": "14.3.0",
     "markdownlint-cli": "0.49.1",
     "prettier": "3.5.3"
   }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,6 +97,38 @@ See [Finite SecPal PR review workflow](../docs/secpal-pr-review-workflow.md) for
 explicit invocation, state limits, classification, guarded action ordering,
 registry decisions, recovery, and post-merge rollout prerequisites.
 
+## Work Graph
+
+### `secpal-work-graph.py`
+
+Read-only resolution of the GitHub-native SecPal work graph. Semantics:
+[docs/work-graph-contract.md](../docs/work-graph-contract.md) — the tool derives
+its results from that contract and defines none of its own.
+
+```bash
+scripts/secpal-work-graph.py show          SecPal/.github#665
+scripts/secpal-work-graph.py validate      SecPal/.github#665
+scripts/secpal-work-graph.py ready         SecPal/.github#665
+scripts/secpal-work-graph.py next          SecPal/.github#665 --executor <login>
+scripts/secpal-work-graph.py validate-issue SecPal/.github#669
+```
+
+A scope root or issue is given as `owner/repo#number`, as an issue URL, or as a
+bare number together with `--repo owner/repo`. Output is deterministic JSON by
+default; `--format text` renders the same resolved model for humans.
+
+Options: `--gh` (path to the `gh` executable), `--timeout` (per-request seconds),
+`--max-nodes` (issues read per invocation). `next` resolves its executor identity
+from `--executor`, and otherwise from the authenticated `gh` identity.
+
+Exit codes: `0` success, `1` structural findings reported (`validate`) or issue
+not `READY` (`validate-issue`), `2` invalid input, `3` GitHub or parser failure.
+
+Requirements: an authenticated `gh` CLI, Python 3, and `npm ci` so the
+`markdown-it` parser used for structural acceptance-criteria detection is
+present. The tool reads through `gh api graphql` only, performs no mutation, and
+persists no state.
+
 ## Validation Scripts
 
 ### `check-domains.sh`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,8 +121,10 @@ Options: `--gh` (path to the `gh` executable), `--timeout` (per-request seconds)
 `--max-nodes` (issues read per invocation). `next` resolves its executor identity
 from `--executor`, and otherwise from the authenticated `gh` identity.
 
-Exit codes: `0` success, `1` structural findings reported (`validate`) or issue
-not `READY` (`validate-issue`), `2` invalid input, `3` GitHub or parser failure.
+Exit codes: `0` success, `1` structural findings reported (`validate`), issue not
+`READY` (`validate-issue`), or `NEXT` inputs not fully observable (`next`), `2`
+invalid input, `3` GitHub or parser failure. Both canonical `NEXT` no-selection
+results are ordinary answers and exit `0`.
 
 Requirements: an authenticated `gh` CLI, Python 3, and `npm ci` so the
 `markdown-it` parser used for structural acceptance-criteria detection is

--- a/scripts/secpal-work-graph.py
+++ b/scripts/secpal-work-graph.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Read-only SecPal work-graph resolution.
+
+Semantics: docs/work-graph-contract.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from secpal_work_graph.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secpal_work_graph/__init__.py
+++ b/scripts/secpal_work_graph/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Read-only resolver for the SecPal work graph.
+
+Semantics: docs/work-graph-contract.md.
+"""

--- a/scripts/secpal_work_graph/acceptance_criteria.py
+++ b/scripts/secpal_work_graph/acceptance_criteria.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import string
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
@@ -34,6 +35,14 @@ class MarkdownParserUnavailable(RuntimeError):
     """
 
 
+@dataclass(frozen=True)
+class StructuralBody:
+    """Markdown syntax facts consumed by the work-graph normalizer."""
+
+    has_acceptance_criteria: bool
+    relationship_mirrors: tuple[str, ...]
+
+
 def qualifies(heading_text: str) -> bool:
     """Apply the five normalization steps of section 4.1 to a heading's text."""
     value = heading_text.strip()
@@ -44,16 +53,16 @@ def qualifies(heading_text: str) -> bool:
     return value.translate(_ASCII_LOWER) == CANONICAL_HEADING
 
 
-def detect(
+def parse(
     bodies: Sequence[str | None],
     *,
     node_executable: str = "node",
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
-) -> list[bool]:
-    """Return, per body, whether it structurally carries acceptance criteria."""
+) -> list[StructuralBody]:
+    """Parse structural body facts through the shared Markdown bridge."""
     if not bodies:
         return []
-    detected: list[bool] = []
+    detected: list[StructuralBody] = []
     for start in range(0, len(bodies), DETECTION_BATCH_SIZE):
         batch = bodies[start : start + DETECTION_BATCH_SIZE]
         payload = json.dumps([body or "" for body in batch])
@@ -77,8 +86,27 @@ def detect(
             raise MarkdownParserUnavailable(f"unreadable Markdown parser output: {error}") from error
         if not isinstance(parsed, list) or len(parsed) != len(batch):
             raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
-        detected.extend(
-            any(qualifies(heading["text"]) and heading["hasContent"] for heading in headings)
-            for headings in parsed
-        )
+        for item in parsed:
+            headings = item.get("headings") if isinstance(item, dict) else None
+            mirrors = item.get("relationshipMirrors") if isinstance(item, dict) else None
+            if (
+                not isinstance(headings, list)
+                or any(
+                    not isinstance(heading, dict)
+                    or not isinstance(heading.get("text"), str)
+                    or not isinstance(heading.get("hasContent"), bool)
+                    for heading in headings
+                )
+                or not isinstance(mirrors, list)
+                or any(not isinstance(mirror, str) for mirror in mirrors)
+            ):
+                raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
+            detected.append(
+                StructuralBody(
+                    has_acceptance_criteria=any(
+                        qualifies(heading["text"]) and heading["hasContent"] for heading in headings
+                    ),
+                    relationship_mirrors=tuple(sorted(set(mirrors))),
+                )
+            )
     return detected

--- a/scripts/secpal_work_graph/acceptance_criteria.py
+++ b/scripts/secpal_work_graph/acceptance_criteria.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Structural acceptance-criteria detection.
+
+Implements the "structurally complete" definition of
+docs/work-graph-contract.md section 4.1. The Markdown primitive is provided by
+the repository's `markdown-it` parser; only the canonical normalization
+procedure is applied here.
+"""
+
+from __future__ import annotations
+
+import json
+import string
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+CANONICAL_HEADING = "acceptance criteria"
+DECORATIVE_PREFIX = "✅"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+_BRIDGE = Path(__file__).resolve().parent / "markdown_headings.mjs"
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+_ASCII_LOWER = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+class MarkdownParserUnavailable(RuntimeError):
+    """The maintained Markdown parser could not be used.
+
+    Detection fails closed: it is never replaced by a textual approximation.
+    """
+
+
+def qualifies(heading_text: str) -> bool:
+    """Apply the five normalization steps of section 4.1 to a heading's text."""
+    value = heading_text.strip()
+    if value.startswith(DECORATIVE_PREFIX):
+        value = value[len(DECORATIVE_PREFIX) :].strip()
+    if value.endswith(":"):
+        value = value[:-1].rstrip()
+    return value.translate(_ASCII_LOWER) == CANONICAL_HEADING
+
+
+def detect(
+    bodies: Sequence[str | None],
+    *,
+    node_executable: str = "node",
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[bool]:
+    """Return, per body, whether it structurally carries acceptance criteria."""
+    if not bodies:
+        return []
+    payload = json.dumps([body or "" for body in bodies])
+    try:
+        completed = subprocess.run(
+            [node_executable, str(_BRIDGE)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+            cwd=str(_REPOSITORY_ROOT),
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise MarkdownParserUnavailable(f"cannot run the Markdown parser: {error}") from error
+    if completed.returncode != 0:
+        raise MarkdownParserUnavailable(completed.stderr.strip() or "Markdown parsing failed")
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise MarkdownParserUnavailable(f"unreadable Markdown parser output: {error}") from error
+    if not isinstance(parsed, list) or len(parsed) != len(bodies):
+        raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
+    return [
+        any(qualifies(heading["text"]) and heading["hasContent"] for heading in headings)
+        for headings in parsed
+    ]
+
+
+def has_acceptance_criteria(body: str | None, **options) -> bool:
+    """Convenience wrapper around :func:`detect` for a single body."""
+    return detect([body], **options)[0]

--- a/scripts/secpal_work_graph/acceptance_criteria.py
+++ b/scripts/secpal_work_graph/acceptance_criteria.py
@@ -20,6 +20,7 @@ from typing import Sequence
 CANONICAL_HEADING = "acceptance criteria"
 DECORATIVE_PREFIX = "✅"
 DEFAULT_TIMEOUT_SECONDS = 30
+DETECTION_BATCH_SIZE = 100
 
 _BRIDGE = Path(__file__).resolve().parent / "markdown_headings.mjs"
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -52,28 +53,32 @@ def detect(
     """Return, per body, whether it structurally carries acceptance criteria."""
     if not bodies:
         return []
-    payload = json.dumps([body or "" for body in bodies])
-    try:
-        completed = subprocess.run(
-            [node_executable, str(_BRIDGE)],
-            input=payload,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=timeout,
-            cwd=str(_REPOSITORY_ROOT),
+    detected: list[bool] = []
+    for start in range(0, len(bodies), DETECTION_BATCH_SIZE):
+        batch = bodies[start : start + DETECTION_BATCH_SIZE]
+        payload = json.dumps([body or "" for body in batch])
+        try:
+            completed = subprocess.run(
+                [node_executable, str(_BRIDGE)],
+                input=payload,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+                cwd=str(_REPOSITORY_ROOT),
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise MarkdownParserUnavailable(f"cannot run the Markdown parser: {error}") from error
+        if completed.returncode != 0:
+            raise MarkdownParserUnavailable(completed.stderr.strip() or "Markdown parsing failed")
+        try:
+            parsed = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise MarkdownParserUnavailable(f"unreadable Markdown parser output: {error}") from error
+        if not isinstance(parsed, list) or len(parsed) != len(batch):
+            raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
+        detected.extend(
+            any(qualifies(heading["text"]) and heading["hasContent"] for heading in headings)
+            for headings in parsed
         )
-    except (OSError, subprocess.SubprocessError) as error:
-        raise MarkdownParserUnavailable(f"cannot run the Markdown parser: {error}") from error
-    if completed.returncode != 0:
-        raise MarkdownParserUnavailable(completed.stderr.strip() or "Markdown parsing failed")
-    try:
-        parsed = json.loads(completed.stdout)
-    except json.JSONDecodeError as error:
-        raise MarkdownParserUnavailable(f"unreadable Markdown parser output: {error}") from error
-    if not isinstance(parsed, list) or len(parsed) != len(bodies):
-        raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
-    return [
-        any(qualifies(heading["text"]) and heading["hasContent"] for heading in headings)
-        for headings in parsed
-    ]
+    return detected

--- a/scripts/secpal_work_graph/acceptance_criteria.py
+++ b/scripts/secpal_work_graph/acceptance_criteria.py
@@ -77,8 +77,3 @@ def detect(
         any(qualifies(heading["text"]) and heading["hasContent"] for heading in headings)
         for headings in parsed
     ]
-
-
-def has_acceptance_criteria(body: str | None, **options) -> bool:
-    """Convenience wrapper around :func:`detect` for a single body."""
-    return detect([body], **options)[0]

--- a/scripts/secpal_work_graph/cli.py
+++ b/scripts/secpal_work_graph/cli.py
@@ -99,9 +99,11 @@ def _node_json(resolution: resolver.Resolution, key: str) -> dict[str, Any]:
         "state": node.state,
         "state_reason": node.state_reason,
         "parent": node.parent,
+        "parent_observable": node.parent_observable,
         "children": list(node.children),
         "blocked_by": list(node.blocked_by),
         "priority_labels": list(node.priority_labels),
+        "priority_labels_observable": node.priority_labels_observable,
         "has_acceptance_criteria": node.has_acceptance_criteria,
         "path": list(state.path),
         "depth": state.depth,
@@ -162,8 +164,13 @@ def build_document(command: str, resolution: resolver.Resolution, *, executor: s
         document["executor"] = executor
         document["selected"] = _node_json(resolution, result.selected) if result.selected else None
         document["no_selection_reason"] = result.no_selection_reason
+        document["incomplete_reason"] = result.incomplete_reason
         document["candidates"] = list(result.candidates)
         document["ready"] = list(resolution.ready_leaves())
+        if result.incomplete_reason is not None:
+            # Not a canonical no-selection result: the declared inputs were not
+            # fully observable, so no canonical `NEXT` exists for this scope.
+            document["status"] = "incomplete_inputs"
         if result.no_selection_reason == resolver.NO_READY_LEAF:
             document["not_ready_leaves"] = _not_ready_leaves(resolution)
     elif command == "validate-issue":
@@ -194,6 +201,8 @@ def _render_text(document: Mapping[str, Any]) -> str:
     elif command == "next":
         if document["selected"]:
             lines.append(f"  NEXT {document['selected']['key']} {document['selected']['title']}")
+        elif document["incomplete_reason"]:
+            lines.append(f"  no canonical NEXT: {document['incomplete_reason']}")
         else:
             lines.append(f"  no selection: {document['no_selection_reason']}")
         for entry in document.get("not_ready_leaves", []):
@@ -239,6 +248,10 @@ def _exit_code(command: str, document: Mapping[str, Any]) -> int:
         return EXIT_REPORTED if document["findings"] else EXIT_OK
     if command == "validate-issue":
         return EXIT_OK if document["issue"]["ready"] else EXIT_REPORTED
+    if command == "next":
+        # Both canonical no-selection reasons are ordinary answers; incomplete
+        # inputs are not.
+        return EXIT_REPORTED if document["incomplete_reason"] else EXIT_OK
     return EXIT_OK
 
 

--- a/scripts/secpal_work_graph/cli.py
+++ b/scripts/secpal_work_graph/cli.py
@@ -132,12 +132,9 @@ def _envelope(command: str, resolution: resolver.Resolution) -> dict[str, Any]:
 
 def _not_ready_leaves(resolution: resolver.Resolution) -> list[dict[str, Any]]:
     return [
-        {"key": key, "reasons": list(resolution.states[key].reasons)}
-        for key in resolution.order
-        if key in resolution.states
-        and resolution.states[key].leaf
-        and resolution.states[key].open
-        and not resolution.states[key].ready
+        {"key": state.key, "reasons": list(state.reasons)}
+        for state in resolution.resolved_states()
+        if state.leaf and state.open and not state.ready
     ]
 
 
@@ -154,7 +151,7 @@ def build_document(command: str, resolution: resolver.Resolution, *, executor: s
             }
             for key in resolution.ancestors
         ]
-        document["nodes"] = [_node_json(resolution, key) for key in resolution.order if key in resolution.states]
+        document["nodes"] = [_node_json(resolution, state.key) for state in resolution.resolved_states()]
     elif command == "validate":
         document["finding_count"] = len(resolution.findings)
     elif command == "ready":

--- a/scripts/secpal_work_graph/cli.py
+++ b/scripts/secpal_work_graph/cli.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Deterministic rendering and command surface of the work-graph resolver.
+
+Every command derives its result from one resolved model, so the JSON and the
+human-readable rendering can never disagree. Semantics:
+docs/work-graph-contract.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Mapping, Sequence
+
+from . import github, resolver
+from .acceptance_criteria import MarkdownParserUnavailable
+from .model import Snapshot
+
+SCHEMA = "secpal-work-graph/v1"
+CONTRACT = "docs/work-graph-contract.md"
+
+EXIT_OK = 0
+EXIT_REPORTED = 1
+EXIT_USAGE = 2
+EXIT_GITHUB = 3
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="secpal-work-graph",
+        description=(
+            "Read-only resolution of the GitHub-native SecPal work graph. "
+            f"Semantics: {CONTRACT}."
+        ),
+    )
+    parser.add_argument("--repo", help="Default owner/repo for bare issue numbers.")
+    parser.add_argument(
+        "--format", choices=("json", "text"), default="json", help="Output format (default: json)."
+    )
+    parser.add_argument("--gh", default="gh", help="Path to the gh executable.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=github.DEFAULT_TIMEOUT_SECONDS,
+        help="Per-request timeout in seconds.",
+    )
+    parser.add_argument(
+        "--max-nodes",
+        type=int,
+        default=github.DEFAULT_MAX_NODES,
+        help="Maximum number of issues read in one invocation.",
+    )
+
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name, help_text in (
+        ("show", "Print the normalized graph for a scope root."),
+        ("validate", "Report machine-derivable structural findings for a scope root."),
+        ("ready", "List every READY delivery leaf under a scope root."),
+    ):
+        subparser = commands.add_parser(name, help=help_text)
+        subparser.add_argument("root", help="Scope root as owner/repo#number, #number, or issue URL.")
+
+    next_parser = commands.add_parser("next", help="Select the next leaf for one executor.")
+    next_parser.add_argument("root", help="Scope root as owner/repo#number, #number, or issue URL.")
+    next_parser.add_argument(
+        "--executor",
+        help=(
+            "Executor identity for claim filtering. Defaults to the authenticated "
+            "gh identity, which resolves the invocation-context input."
+        ),
+    )
+
+    issue_parser = commands.add_parser(
+        "validate-issue", help="Explain the resolved state of a single issue."
+    )
+    issue_parser.add_argument("issue", help="Issue as owner/repo#number, #number, or issue URL.")
+    return parser
+
+
+def _claim_json(claims) -> list[dict[str, str]]:
+    return [
+        {"executor": claim.executor, "pull_request": claim.pull_request, "url": claim.url}
+        for claim in claims
+    ]
+
+
+def _node_json(resolution: resolver.Resolution, key: str) -> dict[str, Any]:
+    node = resolution.snapshot.nodes[key]
+    state = resolution.states[key]
+    return {
+        "key": key,
+        "repository": node.repository,
+        "number": node.number,
+        "title": node.title,
+        "url": node.url,
+        "state": node.state,
+        "state_reason": node.state_reason,
+        "parent": node.parent,
+        "children": list(node.children),
+        "blocked_by": list(node.blocked_by),
+        "priority_labels": list(node.priority_labels),
+        "has_acceptance_criteria": node.has_acceptance_criteria,
+        "path": list(state.path),
+        "depth": state.depth,
+        "leaf": state.leaf,
+        "open": state.open,
+        "done": state.done,
+        "blocked": state.blocked,
+        "ready": state.ready,
+        "active": state.active,
+        "malformed": state.malformed,
+        "reasons": list(state.reasons),
+        "priority_rank": state.priority_rank,
+        "claims": _claim_json(state.claims),
+    }
+
+
+def _envelope(command: str, resolution: resolver.Resolution) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "semantics": CONTRACT,
+        "command": command,
+        "status": "resolved",
+        "scope_root": resolution.scope_root,
+        "complete": resolution.complete,
+        "findings": [finding.as_json() for finding in resolution.findings],
+    }
+
+
+def _not_ready_leaves(resolution: resolver.Resolution) -> list[dict[str, Any]]:
+    return [
+        {"key": key, "reasons": list(resolution.states[key].reasons)}
+        for key in resolution.order
+        if key in resolution.states
+        and resolution.states[key].leaf
+        and resolution.states[key].open
+        and not resolution.states[key].ready
+    ]
+
+
+def build_document(command: str, resolution: resolver.Resolution, *, executor: str | None) -> dict[str, Any]:
+    """Derive one command's machine output from the resolved model."""
+    document = _envelope(command, resolution)
+
+    if command == "show":
+        document["ancestors"] = [
+            {
+                "key": key,
+                "state": resolution.snapshot.require(key).state,
+                "resolved": resolution.snapshot.require(key).resolved,
+            }
+            for key in resolution.ancestors
+        ]
+        document["nodes"] = [_node_json(resolution, key) for key in resolution.order if key in resolution.states]
+    elif command == "validate":
+        document["finding_count"] = len(resolution.findings)
+    elif command == "ready":
+        document["ready"] = [_node_json(resolution, key) for key in resolution.ready_leaves()]
+        document["not_ready_leaves"] = _not_ready_leaves(resolution)
+    elif command == "next":
+        result = resolution.select_next(executor or "")
+        document["executor"] = executor
+        document["selected"] = _node_json(resolution, result.selected) if result.selected else None
+        document["no_selection_reason"] = result.no_selection_reason
+        document["candidates"] = list(result.candidates)
+        document["ready"] = list(resolution.ready_leaves())
+        if result.no_selection_reason == resolver.NO_READY_LEAF:
+            document["not_ready_leaves"] = _not_ready_leaves(resolution)
+    elif command == "validate-issue":
+        key = resolution.scope_root
+        document["issue"] = _node_json(resolution, key)
+        document["findings"] = [
+            finding.as_json() for finding in resolution.findings if finding.node == key
+        ]
+    return document
+
+
+def _render_text(document: Mapping[str, Any]) -> str:
+    lines = [f"{document['command']} {document['scope_root']}  (semantics: {CONTRACT})"]
+    command = document["command"]
+
+    if command == "show":
+        for ancestor in document["ancestors"]:
+            lines.append(f"  ancestor {ancestor['key']} [{ancestor['state']}]")
+        for node in document["nodes"]:
+            marker = "READY" if node["ready"] else ",".join(node["reasons"]) or node["state"]
+            path = ".".join(str(position) for position in node["path"]) or "-"
+            lines.append(f"  {path:<10} {node['key']:<28} {marker}")
+    elif command == "ready":
+        for node in document["ready"]:
+            lines.append(f"  READY {node['key']} {node['title']}")
+        for entry in document["not_ready_leaves"]:
+            lines.append(f"  ---   {entry['key']} {','.join(entry['reasons'])}")
+    elif command == "next":
+        if document["selected"]:
+            lines.append(f"  NEXT {document['selected']['key']} {document['selected']['title']}")
+        else:
+            lines.append(f"  no selection: {document['no_selection_reason']}")
+        for entry in document.get("not_ready_leaves", []):
+            lines.append(f"  ---  {entry['key']} {','.join(entry['reasons'])}")
+    elif command == "validate-issue":
+        issue = document["issue"]
+        predicates = [name for name in ("open", "done", "blocked", "ready", "active", "malformed") if issue[name]]
+        lines.append(f"  {issue['key']} {' '.join(predicates) or 'none'}")
+        if issue["reasons"]:
+            lines.append(f"  not ready: {', '.join(issue['reasons'])}")
+
+    if document["findings"]:
+        lines.append("  findings:")
+        for finding in document["findings"]:
+            detail = f" ({finding['detail']})" if finding["detail"] else ""
+            lines.append(f"    {finding['code']} {finding['node']}{detail}")
+    elif command == "validate":
+        lines.append("  no structural findings")
+    if not document["complete"]:
+        lines.append("  incomplete: required graph data could not be resolved")
+    return "\n".join(lines)
+
+
+def _emit(document: Mapping[str, Any], output_format: str, stream) -> None:
+    if output_format == "json":
+        print(json.dumps(document, indent=2, sort_keys=True), file=stream)
+    else:
+        print(_render_text(document), file=stream)
+
+
+def _failure(command: str, code: str, message: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "semantics": CONTRACT,
+        "command": command,
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+
+
+def _exit_code(command: str, document: Mapping[str, Any]) -> int:
+    if command == "validate":
+        return EXIT_REPORTED if document["findings"] else EXIT_OK
+    if command == "validate-issue":
+        return EXIT_OK if document["issue"]["ready"] else EXIT_REPORTED
+    return EXIT_OK
+
+
+def main(argv: Sequence[str] | None = None, *, stdout=None, stderr=None) -> int:
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    command = arguments.command
+    reference = getattr(arguments, "root", None) or arguments.issue
+
+    try:
+        scope_root = github.resolve_reference(reference, default_repository=arguments.repo)
+    except ValueError as error:
+        _emit(_failure(command, "invalid_reference", str(error)), arguments.format, stderr)
+        return EXIT_USAGE
+
+    adapter = github.GitHubReadAdapter(
+        gh_executable=arguments.gh, timeout=arguments.timeout, max_nodes=arguments.max_nodes
+    )
+    try:
+        executor = getattr(arguments, "executor", None)
+        if command == "next" and not executor:
+            executor = adapter.viewer_login()
+        snapshot: Snapshot = github.load_snapshot(adapter, scope_root)
+    except github.GitHubError as error:
+        _emit(_failure(command, "github_unavailable", str(error)), arguments.format, stderr)
+        return EXIT_GITHUB
+    except MarkdownParserUnavailable as error:
+        _emit(_failure(command, "markdown_parser_unavailable", str(error)), arguments.format, stderr)
+        return EXIT_GITHUB
+
+    try:
+        resolution = resolver.resolve(snapshot, scope_root)
+    except resolver.ScopeRootUnresolved as error:
+        _emit(_failure(command, "unresolved_scope_root", str(error)), arguments.format, stderr)
+        return EXIT_GITHUB
+
+    document = build_document(command, resolution, executor=executor)
+    _emit(document, arguments.format, stdout)
+    return _exit_code(command, document)

--- a/scripts/secpal_work_graph/cli.py
+++ b/scripts/secpal_work_graph/cli.py
@@ -136,7 +136,7 @@ def _not_ready_leaves(resolution: resolver.Resolution) -> list[dict[str, Any]]:
     return [
         {"key": state.key, "reasons": list(state.reasons)}
         for state in resolution.resolved_states()
-        if state.leaf and state.open and not state.ready
+        if state.leaf and not state.ready
     ]
 
 

--- a/scripts/secpal_work_graph/cli.py
+++ b/scripts/secpal_work_graph/cli.py
@@ -276,7 +276,10 @@ def main(argv: Sequence[str] | None = None, *, stdout=None, stderr=None) -> int:
         executor = getattr(arguments, "executor", None)
         if command == "next" and not executor:
             executor = adapter.viewer_login()
-        snapshot: Snapshot = github.load_snapshot(adapter, scope_root)
+        # GitHub may canonicalize the requested repository spelling, so the
+        # resolver runs against the identity it returned, not the one typed.
+        snapshot: Snapshot
+        snapshot, scope_root = github.load_snapshot(adapter, scope_root)
     except github.GitHubError as error:
         _emit(_failure(command, "github_unavailable", str(error)), arguments.format, stderr)
         return EXIT_GITHUB

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -115,10 +115,11 @@ PAGE_QUERIES: Mapping[str, str] = {
     ),
 }
 
-# Relationship inputs a canonical predicate enumerates. If one of them is
-# unreadable, even partially, section 3.5 forbids treating the readable part as
-# the complete list, so the whole node stays unresolved. Observability is
-# all-or-nothing per connection.
+# Relationship inputs that a scope traversal consumes. If one is unreadable,
+# even partially, section 3.5 forbids treating the readable part as the complete
+# list, so the scope node stays unresolved. Dependency traversal consumes only
+# `blockedBy` for cycle detection; ancestors consume neither connection.
+# Observability is all-or-nothing per consumed connection.
 #
 # `parent` is handled separately because it is a single field: an unreadable
 # parent is recorded as unobservable containment rather than an unresolved node,
@@ -247,10 +248,14 @@ def _paginate(
         raise ConnectionUnreadable(connection, "unresolved")
     collected = _connection_nodes(issue.get(connection))
     page_info = (issue.get(connection) or {}).get("pageInfo") or {}
+    seen_cursors: set[str] = set()
     while page_info.get("hasNextPage"):
         cursor = page_info.get("endCursor")
         if not cursor:
             raise GitHubError(f"{connection} reported another page without a cursor")
+        if cursor in seen_cursors:
+            raise GitHubError(f"{connection} repeated pagination cursor {cursor!r}")
+        seen_cursors.add(cursor)
         response = adapter.query(PAGE_QUERIES[connection], {**variables, "cursor": cursor})
         page_errors = response.errors_touching(connection)
         if page_errors:
@@ -295,7 +300,9 @@ class Fetched:
     body: str | None
 
 
-def _fetch(adapter: GitHubReadAdapter, key: str) -> Fetched:
+def _fetch(
+    adapter: GitHubReadAdapter, key: str, *, required_connections: Iterable[str]
+) -> Fetched:
     """Fetch one issue, or return an unresolved node under the requested key."""
     repository, number = parse_node_key(key)
     owner, name = repository.split("/", 1)
@@ -314,7 +321,7 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> Fetched:
             connection: _references(
                 _paginate(adapter, connection, issue, variables, response.errors_touching(connection))
             )
-            for connection in REQUIRED_CONNECTIONS
+            for connection in required_connections
         }
     except ConnectionUnreadable as unreadable:
         return Fetched(key, unresolved_node(key, unreadable.reason), None)
@@ -354,8 +361,8 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> Fetched:
         state_reason=str(state_reason).lower() if state_reason else None,
         parent=_reference(issue.get("parent")),
         parent_observable=not response.errors_touching("parent"),
-        children=relationships["subIssues"],
-        blocked_by=relationships["blockedBy"],
+        children=relationships.get("subIssues", ()),
+        blocked_by=relationships.get("blockedBy", ()),
         blocking_count=int((issue.get("blocking") or {}).get("totalCount") or 0),
         priority_labels=tuple(sorted(label for label in labels if label in PRIORITY_RANKS)),
         priority_labels_observable=priority_labels_observable,
@@ -369,6 +376,14 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> Fetched:
 SCOPE = "scope"
 ANCESTOR = "ancestor"
 DEPENDENCY = "dependency"
+
+
+def _required_connections(mode: str) -> tuple[str, ...]:
+    if mode == SCOPE:
+        return REQUIRED_CONNECTIONS
+    if mode == DEPENDENCY:
+        return ("blockedBy",)
+    return ()
 
 
 def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot, str]:
@@ -403,7 +418,7 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
                     f"graph exceeds the configured budget of {adapter.max_nodes} issues; "
                     "narrow the scope root"
                 )
-            result = _fetch(adapter, requested)
+            result = _fetch(adapter, requested, required_connections=_required_connections(mode))
             key, node = result.canonical_key, result.node
             if key != requested:
                 canonical[requested] = key
@@ -458,7 +473,7 @@ def resolve_reference(reference: str, *, default_repository: str | None = None) 
         if (
             parsed.hostname == "github.com"
             and len(parts) == 4
-            and parts[2] in {"issues", "pull"}
+            and parts[2] == "issues"
             and parts[3].isdigit()
         ):
             return _canonical(f"{parts[0]}/{parts[1]}", parts[3], reference)

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections import deque
 from dataclasses import dataclass, replace
 from typing import Any, Iterable, Mapping
+from urllib.parse import urlparse
 
 from . import acceptance_criteria
 from .model import (
@@ -386,10 +388,10 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
     bodies: dict[str, str] = {}
     canonical: dict[str, str] = {}
     expanded: set[tuple[str, str]] = set()
-    pending: list[tuple[str, str]] = [(scope_root, SCOPE)]
+    pending: deque[tuple[str, str]] = deque([(scope_root, SCOPE)])
 
     while pending:
-        requested, mode = pending.pop(0)
+        requested, mode = pending.popleft()
         key = canonical.get(requested, requested)
         if (key, mode) in expanded:
             continue
@@ -451,9 +453,15 @@ def resolve_reference(reference: str, *, default_repository: str | None = None) 
     """
     value = reference.strip()
     if value.startswith("http://") or value.startswith("https://"):
-        parts = [part for part in value.split("/") if part]
-        if len(parts) >= 5 and parts[-2] in {"issues", "pull"} and parts[-1].isdigit():
-            return _canonical(f"{parts[-4]}/{parts[-3]}", parts[-1], reference)
+        parsed = urlparse(value)
+        parts = [part for part in parsed.path.split("/") if part]
+        if (
+            parsed.hostname == "github.com"
+            and len(parts) == 4
+            and parts[2] in {"issues", "pull"}
+            and parts[3].isdigit()
+        ):
+            return _canonical(f"{parts[0]}/{parts[1]}", parts[3], reference)
         raise ValueError(f"not a GitHub issue URL: {reference}")
     if "#" in value:
         repository, _, number = value.rpartition("#")

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -73,7 +73,6 @@ ISSUE_QUERY = f"""query WorkGraphIssue($owner: String!, $name: String!, $number:
           number
           url
           state
-          isDraft
           author {{ login }}
           repository {{ nameWithOwner }}
         }}
@@ -98,7 +97,7 @@ def _page_query(
 }}"""
 
 
-_CLAIM_SELECTION = "number url state isDraft author { login } repository { nameWithOwner }"
+_CLAIM_SELECTION = "number url state author { login } repository { nameWithOwner }"
 
 # Each paginated connection, keyed by the field name used in the issue query.
 PAGE_QUERIES: Mapping[str, str] = {
@@ -114,10 +113,12 @@ PAGE_QUERIES: Mapping[str, str] = {
     ),
 }
 
-# Connections whose absence means the native relationship data is unreadable.
-# Section 3.5 forbids treating that as "no relationship"; claims are the single
-# exception the contract allows (section 4.2).
-REQUIRED_CONNECTIONS = ("labels", "subIssues", "blockedBy", "blocking")
+# Connections whose absence means data a canonical predicate reads is
+# unreadable. Section 3.5 forbids treating that as "no relationship". Claims are
+# the exception section 4.2 allows, and `blocking` is excluded on purpose: it
+# feeds only the advisory section 3.2 limit finding, so letting it gate `READY`
+# would make a derived value depend on an input section 1.2 never declares.
+REQUIRED_CONNECTIONS = ("labels", "subIssues", "blockedBy")
 
 VIEWER_QUERY = "query WorkGraphViewer { viewer { login } }"
 
@@ -368,20 +369,35 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
 
 
 def resolve_reference(reference: str, *, default_repository: str | None = None) -> str:
-    """Normalize a user-supplied issue reference to a canonical identity."""
+    """Normalize a user-supplied issue reference to a canonical identity.
+
+    Every accepted form is validated here, so an unusable reference is invalid
+    input rather than a failure deeper in the read boundary.
+    """
     value = reference.strip()
     if value.startswith("http://") or value.startswith("https://"):
         parts = [part for part in value.split("/") if part]
-        if len(parts) >= 5 and parts[-2] in {"issues", "pull"}:
-            return node_key(f"{parts[-4]}/{parts[-3]}", int(parts[-1]))
+        if len(parts) >= 5 and parts[-2] in {"issues", "pull"} and parts[-1].isdigit():
+            return _canonical(f"{parts[-4]}/{parts[-3]}", parts[-1], reference)
         raise ValueError(f"not a GitHub issue URL: {reference}")
     if "#" in value:
         repository, _, number = value.rpartition("#")
         if repository:
-            return node_key(repository, int(number))
+            return _canonical(repository, number, reference)
         value = number
     if not value.isdigit():
         raise ValueError(f"not an issue reference: {reference}")
     if not default_repository:
         raise ValueError(f"{reference} needs a repository; use owner/repo#number or --repo")
-    return node_key(default_repository, int(value))
+    return _canonical(default_repository, value, reference)
+
+
+def _canonical(repository: str, number: str, reference: str) -> str:
+    if not number.isdigit():
+        raise ValueError(f"not an issue number in {reference}")
+    key = node_key(repository, int(number))
+    try:
+        parse_node_key(key)
+    except ValueError as error:
+        raise ValueError(f"{reference} is not repository-qualified as owner/repo#number") from error
+    return key

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -284,15 +284,28 @@ def _unresolved_reason(errors: Iterable[Mapping[str, Any]]) -> str:
     return next((str(error.get("type")) for error in errors if error.get("type")), "unresolved")
 
 
-def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
-    """Fetch one issue. Returns the raw node and its body, or an unresolved node."""
+@dataclass(frozen=True)
+class Fetched:
+    """One issue read, under the identity GitHub itself returned for it."""
+
+    canonical_key: str
+    node: Node
+    body: str | None
+
+
+def _fetch(adapter: GitHubReadAdapter, key: str) -> Fetched:
+    """Fetch one issue, or return an unresolved node under the requested key."""
     repository, number = parse_node_key(key)
     owner, name = repository.split("/", 1)
     variables = {"owner": owner, "name": name, "number": number}
     response = adapter.query(ISSUE_QUERY, variables)
     issue = ((response.data or {}).get("repository") or {}).get("issue")
     if not issue:
-        return unresolved_node(key, _unresolved_reason(response.errors)), None
+        return Fetched(key, unresolved_node(key, _unresolved_reason(response.errors)), None)
+    if int(issue.get("number", number)) != number:
+        # GitHub canonicalizes a repository spelling, never an issue number, so
+        # a different number means the answer does not belong to this lookup.
+        raise GitHubError(f"{key} resolved to issue number {issue.get('number')}")
 
     try:
         relationships = {
@@ -302,7 +315,7 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
             for connection in REQUIRED_CONNECTIONS
         }
     except ConnectionUnreadable as unreadable:
-        return unresolved_node(key, unreadable.reason), None
+        return Fetched(key, unresolved_node(key, unreadable.reason), None)
 
     # Selection metadata and claims degrade on their own instead of taking the
     # node down with them, because section 1.2 keeps them out of `READY`.
@@ -315,13 +328,19 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
     except ConnectionUnreadable:
         labels, priority_labels_observable = set(), False
 
-    claims_errors = response.errors_touching("closedByPullRequestsReferences")
-    claims_observable = not claims_errors and issue.get("closedByPullRequestsReferences") is not None
-    claims = (
-        _claims(_paginate(adapter, "closedByPullRequestsReferences", issue, variables))
-        if claims_observable
-        else ()
-    )
+    try:
+        claims = _claims(
+            _paginate(
+                adapter,
+                "closedByPullRequestsReferences",
+                issue,
+                variables,
+                response.errors_touching("closedByPullRequestsReferences"),
+            )
+        )
+        claims_observable = True
+    except ConnectionUnreadable:
+        claims, claims_observable = (), False
 
     state_reason = issue.get("stateReason")
     node = Node(
@@ -342,7 +361,7 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
         claims_observable=claims_observable,
         mirror_relationships=mirror_relationships(issue.get("body")),
     )
-    return node, issue.get("body") or ""
+    return Fetched(node.key, node, issue.get("body") or "")
 
 
 SCOPE = "scope"
@@ -350,7 +369,7 @@ ANCESTOR = "ancestor"
 DEPENDENCY = "dependency"
 
 
-def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
+def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot, str]:
     """Collect one immutable snapshot for ``scope_root``.
 
     Traversal reads exactly what the canonical predicates need: the scope root's
@@ -358,17 +377,22 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
     targets section 3.5 needs to detect unsatisfied edges and cycles. Ancestors
     contribute their own containment chain only, because section 3.2 never
     inherits dependencies and siblings above the scope root are out of scope.
+
+    Returns the snapshot together with the canonical scope root, because GitHub
+    accepts repository spellings it then canonicalizes. Every node is keyed by
+    the identity GitHub returned, so one issue is never two graph nodes.
     """
     fetched: dict[str, Node] = {}
     bodies: dict[str, str] = {}
+    canonical: dict[str, str] = {}
     expanded: set[tuple[str, str]] = set()
     pending: list[tuple[str, str]] = [(scope_root, SCOPE)]
 
     while pending:
-        key, mode = pending.pop(0)
+        requested, mode = pending.pop(0)
+        key = canonical.get(requested, requested)
         if (key, mode) in expanded:
             continue
-        expanded.add((key, mode))
 
         node = fetched.get(key)
         if node is None:
@@ -377,18 +401,26 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
                     f"graph exceeds the configured budget of {adapter.max_nodes} issues; "
                     "narrow the scope root"
                 )
-            node, body = _fetch(adapter, key)
+            result = _fetch(adapter, requested)
+            key, node = result.canonical_key, result.node
+            if key != requested:
+                canonical[requested] = key
+            if (key, mode) in expanded:
+                continue
             fetched[key] = node
-            if body is None:
-                if key == scope_root:
+            if result.body is None:
+                expanded.add((key, mode))
+                if requested == scope_root:
                     raise GitHubError(
                         f"cannot resolve the scope root {scope_root}: {node.unresolved_reason}"
                     )
                 continue
-            bodies[key] = body
+            bodies[key] = result.body
         elif not node.resolved:
+            expanded.add((key, mode))
             continue
 
+        expanded.add((key, mode))
         if mode == SCOPE:
             pending.extend((child, SCOPE) for child in node.children)
             pending.extend((target, DEPENDENCY) for target in node.blocked_by)
@@ -402,12 +434,13 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
 
     ordered_bodies = list(bodies)
     detected = dict(zip(ordered_bodies, acceptance_criteria.detect([bodies[key] for key in ordered_bodies])))
-    return Snapshot(
+    snapshot = Snapshot(
         {
             key: (replace(node, has_acceptance_criteria=detected[key]) if key in detected else node)
             for key, node in fetched.items()
         }
     )
+    return snapshot, canonical.get(scope_root, scope_root)
 
 
 def resolve_reference(reference: str, *, default_repository: str | None = None) -> str:

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""The single GitHub read boundary of the work-graph resolver.
+
+Every fact the resolver consumes is read here through `gh api graphql`, using
+GitHub's native hierarchy, dependency, state, ordering, and closing-relationship
+data. Nothing in this module mutates GitHub or persists state, and no
+human-readable `gh` output is parsed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, replace
+from typing import Any, Iterable, Mapping
+
+from . import acceptance_criteria
+from .model import (
+    CLOSED,
+    Claim,
+    Node,
+    OPEN,
+    PRIORITY_RANKS,
+    Snapshot,
+    mirror_relationships,
+    node_key,
+    parse_node_key,
+    unresolved_node,
+)
+
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_MAX_NODES = 1000
+SUB_ISSUE_PAGE_SIZE = 100
+DEPENDENCY_PAGE_SIZE = 50
+LABEL_PAGE_SIZE = 100
+CLAIM_PAGE_SIZE = 50
+
+# GraphQL error types that describe one unreadable node rather than an
+# operational failure of the invocation.
+UNRESOLVED_ERROR_TYPES = frozenset({"NOT_FOUND", "FORBIDDEN"})
+
+_REFERENCE_FIELDS = "number repository { nameWithOwner }"
+
+ISSUE_QUERY = f"""query WorkGraphIssue($owner: String!, $name: String!, $number: Int!) {{
+  repository(owner: $owner, name: $name) {{
+    issue(number: $number) {{
+      number
+      title
+      url
+      state
+      stateReason
+      body
+      repository {{ nameWithOwner }}
+      parent {{ {_REFERENCE_FIELDS} }}
+      labels(first: {LABEL_PAGE_SIZE}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{ name }}
+      }}
+      subIssues(first: {SUB_ISSUE_PAGE_SIZE}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{ {_REFERENCE_FIELDS} }}
+      }}
+      blockedBy(first: {DEPENDENCY_PAGE_SIZE}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{ {_REFERENCE_FIELDS} }}
+      }}
+      blocking(first: 1) {{ totalCount }}
+      closedByPullRequestsReferences(first: {CLAIM_PAGE_SIZE}, includeClosedPrs: false) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          number
+          url
+          state
+          isDraft
+          author {{ login }}
+          repository {{ nameWithOwner }}
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+
+def _page_query(
+    operation: str, connection: str, page_size: int, selection: str, extra_arguments: str = ""
+) -> str:
+    return f"""query {operation}($owner: String!, $name: String!, $number: Int!, $cursor: String!) {{
+  repository(owner: $owner, name: $name) {{
+    issue(number: $number) {{
+      {connection}(first: {page_size}, after: $cursor{extra_arguments}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{ {selection} }}
+      }}
+    }}
+  }}
+}}"""
+
+
+_CLAIM_SELECTION = "number url state isDraft author { login } repository { nameWithOwner }"
+
+# Each paginated connection, keyed by the field name used in the issue query.
+PAGE_QUERIES: Mapping[str, str] = {
+    "subIssues": _page_query("WorkGraphSubIssues", "subIssues", SUB_ISSUE_PAGE_SIZE, _REFERENCE_FIELDS),
+    "blockedBy": _page_query("WorkGraphBlockedBy", "blockedBy", DEPENDENCY_PAGE_SIZE, _REFERENCE_FIELDS),
+    "labels": _page_query("WorkGraphLabels", "labels", LABEL_PAGE_SIZE, "name"),
+    "closedByPullRequestsReferences": _page_query(
+        "WorkGraphClaims",
+        "closedByPullRequestsReferences",
+        CLAIM_PAGE_SIZE,
+        _CLAIM_SELECTION,
+        ", includeClosedPrs: false",
+    ),
+}
+
+# Connections whose absence means the native relationship data is unreadable.
+# Section 3.5 forbids treating that as "no relationship"; claims are the single
+# exception the contract allows (section 4.2).
+REQUIRED_CONNECTIONS = ("labels", "subIssues", "blockedBy", "blocking")
+
+VIEWER_QUERY = "query WorkGraphViewer { viewer { login } }"
+
+
+class GitHubError(RuntimeError):
+    """An operational GitHub failure. It is never converted into absent data."""
+
+
+@dataclass(frozen=True)
+class GraphQLResponse:
+    data: Mapping[str, Any] | None
+    errors: tuple[Mapping[str, Any], ...]
+
+    def errors_under(self, *path_tail: str) -> tuple[Mapping[str, Any], ...]:
+        return tuple(error for error in self.errors if tuple(error.get("path") or ())[-1:] == path_tail)
+
+
+@dataclass
+class GitHubReadAdapter:
+    """Runs read-only GraphQL documents through the `gh` CLI."""
+
+    gh_executable: str = "gh"
+    timeout: float = DEFAULT_TIMEOUT_SECONDS
+    max_nodes: int = DEFAULT_MAX_NODES
+    environment: Mapping[str, str] | None = None
+
+    def query(self, document: str, variables: Mapping[str, Any]) -> GraphQLResponse:
+        payload = json.dumps({"query": document, "variables": dict(variables)})
+        try:
+            completed = subprocess.run(
+                [self.gh_executable, "api", "graphql", "--input", "-"],
+                input=payload,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.timeout,
+                env=dict(self.environment) if self.environment is not None else None,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise GitHubError(f"cannot run {self.gh_executable}: {error}") from error
+
+        if not completed.stdout.strip():
+            raise GitHubError(
+                f"gh produced no response (exit {completed.returncode}): {completed.stderr.strip()}"
+            )
+        try:
+            body = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise GitHubError(f"unreadable gh response: {error}") from error
+        if not isinstance(body, dict):
+            raise GitHubError("unreadable gh response: expected a JSON object")
+
+        errors = tuple(body.get("errors") or ())
+        fatal = [error for error in errors if error.get("type") not in UNRESOLVED_ERROR_TYPES]
+        if fatal:
+            raise GitHubError("; ".join(str(error.get("message", error)) for error in fatal))
+        return GraphQLResponse(body.get("data"), errors)
+
+    def viewer_login(self) -> str:
+        """Resolve the invocation-context executor identity from `gh` authentication."""
+        response = self.query(VIEWER_QUERY, {})
+        login = ((response.data or {}).get("viewer") or {}).get("login")
+        if not login:
+            raise GitHubError("cannot resolve the authenticated GitHub identity")
+        return str(login)
+
+
+def _reference(payload: Mapping[str, Any] | None) -> str | None:
+    if not payload:
+        return None
+    repository = (payload.get("repository") or {}).get("nameWithOwner")
+    number = payload.get("number")
+    if not repository or number is None:
+        return None
+    return node_key(str(repository), int(number))
+
+
+def _connection_nodes(payload: Mapping[str, Any] | None) -> list[Mapping[str, Any]]:
+    if not payload:
+        return []
+    return [entry for entry in (payload.get("nodes") or []) if entry]
+
+
+def _paginate(
+    adapter: GitHubReadAdapter,
+    connection: str,
+    issue: Mapping[str, Any],
+    variables: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    """Consume every remaining page of one connection."""
+    collected = _connection_nodes(issue.get(connection))
+    page_info = (issue.get(connection) or {}).get("pageInfo") or {}
+    while page_info.get("hasNextPage"):
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            raise GitHubError(f"{connection} reported another page without a cursor")
+        response = adapter.query(PAGE_QUERIES[connection], {**variables, "cursor": cursor})
+        nested = ((response.data or {}).get("repository") or {}).get("issue") or {}
+        payload = nested.get(connection)
+        if payload is None:
+            # A page that cannot be read is not an empty page.
+            raise GitHubError(f"{connection} page after {cursor} could not be read")
+        collected.extend(_connection_nodes(payload))
+        page_info = payload.get("pageInfo") or {}
+    return collected
+
+
+def _claims(entries: Iterable[Mapping[str, Any]]) -> tuple[Claim, ...]:
+    """Section 4.2: an open primary delivery pull request with a named author."""
+    claims = []
+    for entry in entries:
+        if str(entry.get("state", "")).upper() != "OPEN":
+            continue
+        login = (entry.get("author") or {}).get("login")
+        if not login:
+            continue
+        repository = (entry.get("repository") or {}).get("nameWithOwner")
+        number = entry.get("number")
+        if not repository or number is None:
+            continue
+        claims.append(Claim(str(login), node_key(str(repository), int(number)), str(entry.get("url") or "")))
+    return tuple(sorted(claims))
+
+
+def _unresolved_reason(errors: Iterable[Mapping[str, Any]]) -> str:
+    return next((str(error.get("type")) for error in errors if error.get("type")), "unresolved")
+
+
+def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
+    """Fetch one issue. Returns the raw node and its body, or an unresolved node."""
+    repository, number = parse_node_key(key)
+    owner, name = repository.split("/", 1)
+    variables = {"owner": owner, "name": name, "number": number}
+    response = adapter.query(ISSUE_QUERY, variables)
+    issue = ((response.data or {}).get("repository") or {}).get("issue")
+    if not issue:
+        return unresolved_node(key, _unresolved_reason(response.errors)), None
+    if any(issue.get(connection) is None for connection in REQUIRED_CONNECTIONS):
+        return unresolved_node(key, _unresolved_reason(response.errors)), None
+
+    claims_errors = response.errors_under("closedByPullRequestsReferences")
+    claims_observable = not claims_errors and issue.get("closedByPullRequestsReferences") is not None
+
+    labels = {str(entry.get("name")) for entry in _paginate(adapter, "labels", issue, variables)}
+    children = tuple(
+        reference
+        for reference in (
+            _reference(entry) for entry in _paginate(adapter, "subIssues", issue, variables)
+        )
+        if reference
+    )
+    blocked_by = tuple(
+        reference
+        for reference in (
+            _reference(entry) for entry in _paginate(adapter, "blockedBy", issue, variables)
+        )
+        if reference
+    )
+    claims = (
+        _claims(_paginate(adapter, "closedByPullRequestsReferences", issue, variables))
+        if claims_observable
+        else ()
+    )
+
+    state_reason = issue.get("stateReason")
+    node = Node(
+        repository=str((issue.get("repository") or {}).get("nameWithOwner") or repository),
+        number=int(issue.get("number", number)),
+        title=str(issue.get("title") or ""),
+        url=str(issue.get("url") or ""),
+        state=OPEN if str(issue.get("state", "")).upper() == "OPEN" else CLOSED,
+        state_reason=str(state_reason).lower() if state_reason else None,
+        parent=_reference(issue.get("parent")),
+        children=children,
+        blocked_by=blocked_by,
+        blocking_count=int((issue.get("blocking") or {}).get("totalCount") or 0),
+        priority_labels=tuple(sorted(label for label in labels if label in PRIORITY_RANKS)),
+        claims=claims,
+        claims_observable=claims_observable,
+        mirror_relationships=mirror_relationships(issue.get("body")),
+    )
+    return node, issue.get("body") or ""
+
+
+SCOPE = "scope"
+ANCESTOR = "ancestor"
+DEPENDENCY = "dependency"
+
+
+def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> Snapshot:
+    """Collect one immutable snapshot for ``scope_root``.
+
+    Traversal reads exactly what the canonical predicates need: the scope root's
+    subtree, the ancestors section 4.1 evaluates, and the transitive dependency
+    targets section 3.5 needs to detect unsatisfied edges and cycles. Ancestors
+    contribute their own containment chain only, because section 3.2 never
+    inherits dependencies and siblings above the scope root are out of scope.
+    """
+    fetched: dict[str, Node] = {}
+    bodies: dict[str, str] = {}
+    expanded: set[tuple[str, str]] = set()
+    pending: list[tuple[str, str]] = [(scope_root, SCOPE)]
+
+    while pending:
+        key, mode = pending.pop(0)
+        if (key, mode) in expanded:
+            continue
+        expanded.add((key, mode))
+
+        node = fetched.get(key)
+        if node is None:
+            if len(fetched) >= adapter.max_nodes:
+                raise GitHubError(
+                    f"graph exceeds the configured budget of {adapter.max_nodes} issues; "
+                    "narrow the scope root"
+                )
+            node, body = _fetch(adapter, key)
+            fetched[key] = node
+            if body is None:
+                if key == scope_root:
+                    raise GitHubError(
+                        f"cannot resolve the scope root {scope_root}: {node.unresolved_reason}"
+                    )
+                continue
+            bodies[key] = body
+        elif not node.resolved:
+            continue
+
+        if mode == SCOPE:
+            pending.extend((child, SCOPE) for child in node.children)
+            pending.extend((target, DEPENDENCY) for target in node.blocked_by)
+            if node.parent:
+                pending.append((node.parent, ANCESTOR))
+        elif mode == ANCESTOR:
+            if node.parent:
+                pending.append((node.parent, ANCESTOR))
+        else:
+            pending.extend((target, DEPENDENCY) for target in node.blocked_by)
+
+    ordered_bodies = list(bodies)
+    detected = dict(zip(ordered_bodies, acceptance_criteria.detect([bodies[key] for key in ordered_bodies])))
+    return Snapshot(
+        {
+            key: (replace(node, has_acceptance_criteria=detected[key]) if key in detected else node)
+            for key, node in fetched.items()
+        }
+    )
+
+
+def resolve_reference(reference: str, *, default_repository: str | None = None) -> str:
+    """Normalize a user-supplied issue reference to a canonical identity."""
+    value = reference.strip()
+    if value.startswith("http://") or value.startswith("https://"):
+        parts = [part for part in value.split("/") if part]
+        if len(parts) >= 5 and parts[-2] in {"issues", "pull"}:
+            return node_key(f"{parts[-4]}/{parts[-3]}", int(parts[-1]))
+        raise ValueError(f"not a GitHub issue URL: {reference}")
+    if "#" in value:
+        repository, _, number = value.rpartition("#")
+        if repository:
+            return node_key(repository, int(number))
+        value = number
+    if not value.isdigit():
+        raise ValueError(f"not an issue reference: {reference}")
+    if not default_repository:
+        raise ValueError(f"{reference} needs a repository; use owner/repo#number or --repo")
+    return node_key(default_repository, int(value))

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -113,12 +113,19 @@ PAGE_QUERIES: Mapping[str, str] = {
     ),
 }
 
-# Connections whose absence means data a canonical predicate reads is
-# unreadable. Section 3.5 forbids treating that as "no relationship". Claims are
-# the exception section 4.2 allows, and `blocking` is excluded on purpose: it
-# feeds only the advisory section 3.2 limit finding, so letting it gate `READY`
-# would make a derived value depend on an input section 1.2 never declares.
-REQUIRED_CONNECTIONS = ("labels", "subIssues", "blockedBy")
+# Relationship inputs a canonical predicate enumerates. If one of them is
+# unreadable, even partially, section 3.5 forbids treating the readable part as
+# the complete list, so the whole node stays unresolved. Observability is
+# all-or-nothing per connection.
+#
+# `parent` is handled separately because it is a single field: an unreadable
+# parent is recorded as unobservable containment rather than an unresolved node,
+# which is what keeps it distinct from a genuinely absent parent.
+#
+# Deliberately excluded: `labels` are selection metadata that section 1.2 keeps
+# out of `READY`, claims are the exception section 4.2 allows, and `blocking`
+# feeds only the advisory section 3.2 limit finding.
+REQUIRED_CONNECTIONS = ("subIssues", "blockedBy")
 
 VIEWER_QUERY = "query WorkGraphViewer { viewer { login } }"
 
@@ -132,8 +139,13 @@ class GraphQLResponse:
     data: Mapping[str, Any] | None
     errors: tuple[Mapping[str, Any], ...]
 
-    def errors_under(self, *path_tail: str) -> tuple[Mapping[str, Any], ...]:
-        return tuple(error for error in self.errors if tuple(error.get("path") or ())[-1:] == path_tail)
+    def errors_touching(self, field: str) -> tuple[Mapping[str, Any], ...]:
+        """Errors anywhere under ``field``, including nested and per-node paths."""
+        return tuple(
+            error
+            for error in self.errors
+            if field in [str(segment) for segment in (error.get("path") or ())]
+        )
 
 
 @dataclass
@@ -196,10 +208,23 @@ def _reference(payload: Mapping[str, Any] | None) -> str | None:
     return node_key(str(repository), int(number))
 
 
+def _references(entries: Iterable[Mapping[str, Any]]) -> tuple[str, ...]:
+    return tuple(reference for reference in (_reference(entry) for entry in entries) if reference)
+
+
 def _connection_nodes(payload: Mapping[str, Any] | None) -> list[Mapping[str, Any]]:
     if not payload:
         return []
     return [entry for entry in (payload.get("nodes") or []) if entry]
+
+
+class ConnectionUnreadable(Exception):
+    """One connection could not be read completely, so its list is unknown."""
+
+    def __init__(self, connection: str, reason: str) -> None:
+        super().__init__(f"{connection} could not be read completely")
+        self.connection = connection
+        self.reason = reason
 
 
 def _paginate(
@@ -207,8 +232,17 @@ def _paginate(
     connection: str,
     issue: Mapping[str, Any],
     variables: Mapping[str, Any],
+    errors: tuple[Mapping[str, Any], ...] = (),
 ) -> list[Mapping[str, Any]]:
-    """Consume every remaining page of one connection."""
+    """Consume every remaining page of one connection, or report it unreadable.
+
+    A payload carrying some nodes plus an access error underneath it is a
+    partial read, never a complete short list.
+    """
+    if errors:
+        raise ConnectionUnreadable(connection, _unresolved_reason(errors))
+    if issue.get(connection) is None:
+        raise ConnectionUnreadable(connection, "unresolved")
     collected = _connection_nodes(issue.get(connection))
     page_info = (issue.get(connection) or {}).get("pageInfo") or {}
     while page_info.get("hasNextPage"):
@@ -216,11 +250,14 @@ def _paginate(
         if not cursor:
             raise GitHubError(f"{connection} reported another page without a cursor")
         response = adapter.query(PAGE_QUERIES[connection], {**variables, "cursor": cursor})
+        page_errors = response.errors_touching(connection)
+        if page_errors:
+            raise ConnectionUnreadable(connection, _unresolved_reason(page_errors))
         nested = ((response.data or {}).get("repository") or {}).get("issue") or {}
         payload = nested.get(connection)
         if payload is None:
             # A page that cannot be read is not an empty page.
-            raise GitHubError(f"{connection} page after {cursor} could not be read")
+            raise ConnectionUnreadable(connection, "unresolved")
         collected.extend(_connection_nodes(payload))
         page_info = payload.get("pageInfo") or {}
     return collected
@@ -256,27 +293,30 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
     issue = ((response.data or {}).get("repository") or {}).get("issue")
     if not issue:
         return unresolved_node(key, _unresolved_reason(response.errors)), None
-    if any(issue.get(connection) is None for connection in REQUIRED_CONNECTIONS):
-        return unresolved_node(key, _unresolved_reason(response.errors)), None
 
-    claims_errors = response.errors_under("closedByPullRequestsReferences")
+    try:
+        relationships = {
+            connection: _references(
+                _paginate(adapter, connection, issue, variables, response.errors_touching(connection))
+            )
+            for connection in REQUIRED_CONNECTIONS
+        }
+    except ConnectionUnreadable as unreadable:
+        return unresolved_node(key, unreadable.reason), None
+
+    # Selection metadata and claims degrade on their own instead of taking the
+    # node down with them, because section 1.2 keeps them out of `READY`.
+    try:
+        labels = {
+            str(entry.get("name"))
+            for entry in _paginate(adapter, "labels", issue, variables, response.errors_touching("labels"))
+        }
+        priority_labels_observable = True
+    except ConnectionUnreadable:
+        labels, priority_labels_observable = set(), False
+
+    claims_errors = response.errors_touching("closedByPullRequestsReferences")
     claims_observable = not claims_errors and issue.get("closedByPullRequestsReferences") is not None
-
-    labels = {str(entry.get("name")) for entry in _paginate(adapter, "labels", issue, variables)}
-    children = tuple(
-        reference
-        for reference in (
-            _reference(entry) for entry in _paginate(adapter, "subIssues", issue, variables)
-        )
-        if reference
-    )
-    blocked_by = tuple(
-        reference
-        for reference in (
-            _reference(entry) for entry in _paginate(adapter, "blockedBy", issue, variables)
-        )
-        if reference
-    )
     claims = (
         _claims(_paginate(adapter, "closedByPullRequestsReferences", issue, variables))
         if claims_observable
@@ -292,10 +332,12 @@ def _fetch(adapter: GitHubReadAdapter, key: str) -> tuple[Node, str | None]:
         state=OPEN if str(issue.get("state", "")).upper() == "OPEN" else CLOSED,
         state_reason=str(state_reason).lower() if state_reason else None,
         parent=_reference(issue.get("parent")),
-        children=children,
-        blocked_by=blocked_by,
+        parent_observable=not response.errors_touching("parent"),
+        children=relationships["subIssues"],
+        blocked_by=relationships["blockedBy"],
         blocking_count=int((issue.get("blocking") or {}).get("totalCount") or 0),
         priority_labels=tuple(sorted(label for label in labels if label in PRIORITY_RANKS)),
+        priority_labels_observable=priority_labels_observable,
         claims=claims,
         claims_observable=claims_observable,
         mirror_relationships=mirror_relationships(issue.get("body")),

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -26,7 +26,6 @@ from .model import (
     OPEN,
     PRIORITY_RANKS,
     Snapshot,
-    mirror_relationships,
     node_key,
     parse_node_key,
     unresolved_node,
@@ -316,6 +315,7 @@ def _fetch(
         # a different number means the answer does not belong to this lookup.
         raise GitHubError(f"{key} resolved to issue number {issue.get('number')}")
 
+    required_connections = tuple(required_connections)
     try:
         relationships = {
             connection: _references(
@@ -362,13 +362,14 @@ def _fetch(
         parent=_reference(issue.get("parent")),
         parent_observable=not response.errors_touching("parent"),
         children=relationships.get("subIssues", ()),
+        children_observable="subIssues" in required_connections,
         blocked_by=relationships.get("blockedBy", ()),
+        dependencies_observable="blockedBy" in required_connections,
         blocking_count=int((issue.get("blocking") or {}).get("totalCount") or 0),
         priority_labels=tuple(sorted(label for label in labels if label in PRIORITY_RANKS)),
         priority_labels_observable=priority_labels_observable,
         claims=claims,
         claims_observable=claims_observable,
-        mirror_relationships=mirror_relationships(issue.get("body")),
     )
     return Fetched(node.key, node, issue.get("body") or "")
 
@@ -384,6 +385,37 @@ def _required_connections(mode: str) -> tuple[str, ...]:
     if mode == DEPENDENCY:
         return ("blockedBy",)
     return ()
+
+
+def _needs_upgrade(node: Node, mode: str) -> bool:
+    required = _required_connections(mode)
+    return (
+        ("subIssues" in required and not node.children_observable)
+        or ("blockedBy" in required and not node.dependencies_observable)
+    )
+
+
+def _merge_node(existing: Node, upgraded: Node) -> Node:
+    """Increase known node facts without turning an earlier fact into absence."""
+    return replace(
+        upgraded,
+        parent=existing.parent if existing.parent_observable and not upgraded.parent_observable else upgraded.parent,
+        parent_observable=existing.parent_observable or upgraded.parent_observable,
+        children=upgraded.children if upgraded.children_observable else existing.children,
+        children_observable=existing.children_observable or upgraded.children_observable,
+        blocked_by=upgraded.blocked_by if upgraded.dependencies_observable else existing.blocked_by,
+        dependencies_observable=existing.dependencies_observable or upgraded.dependencies_observable,
+        priority_labels=(
+            upgraded.priority_labels
+            if upgraded.priority_labels_observable
+            else existing.priority_labels
+        ),
+        priority_labels_observable=(
+            existing.priority_labels_observable or upgraded.priority_labels_observable
+        ),
+        claims=upgraded.claims if upgraded.claims_observable else existing.claims,
+        claims_observable=existing.claims_observable or upgraded.claims_observable,
+    )
 
 
 def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot, str]:
@@ -411,9 +443,9 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
         if (key, mode) in expanded:
             continue
 
-        node = fetched.get(key)
-        if node is None:
-            if len(fetched) >= adapter.max_nodes:
+        cached = fetched.get(key)
+        if cached is None or (cached.resolved and _needs_upgrade(cached, mode)):
+            if cached is None and len(fetched) >= adapter.max_nodes:
                 raise GitHubError(
                     f"graph exceeds the configured budget of {adapter.max_nodes} issues; "
                     "narrow the scope root"
@@ -424,7 +456,8 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
                 canonical[requested] = key
             if (key, mode) in expanded:
                 continue
-            fetched[key] = node
+            fetched[key] = node if cached is None else _merge_node(cached, node)
+            node = fetched[key]
             if result.body is None:
                 expanded.add((key, mode))
                 if requested == scope_root:
@@ -433,9 +466,11 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
                     )
                 continue
             bodies[key] = result.body
-        elif not node.resolved:
+        elif not cached.resolved:
             expanded.add((key, mode))
             continue
+        else:
+            node = cached
 
         expanded.add((key, mode))
         if mode == SCOPE:
@@ -450,10 +485,20 @@ def load_snapshot(adapter: GitHubReadAdapter, scope_root: str) -> tuple[Snapshot
             pending.extend((target, DEPENDENCY) for target in node.blocked_by)
 
     ordered_bodies = list(bodies)
-    detected = dict(zip(ordered_bodies, acceptance_criteria.detect([bodies[key] for key in ordered_bodies])))
+    structural = dict(
+        zip(ordered_bodies, acceptance_criteria.parse([bodies[key] for key in ordered_bodies]))
+    )
     snapshot = Snapshot(
         {
-            key: (replace(node, has_acceptance_criteria=detected[key]) if key in detected else node)
+            key: (
+                replace(
+                    node,
+                    has_acceptance_criteria=structural[key].has_acceptance_criteria,
+                    mirror_relationships=structural[key].relationship_mirrors,
+                )
+                if key in structural
+                else node
+            )
             for key, node in fetched.items()
         }
     )

--- a/scripts/secpal_work_graph/markdown_headings.mjs
+++ b/scripts/secpal_work_graph/markdown_headings.mjs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: MIT
+
+// Structural heading extraction for the SecPal work-graph resolver.
+//
+// Reads a JSON array of issue bodies on stdin and writes a JSON array of
+// per-body heading records. It reports only what a standards-compliant parser
+// sees; the canonical normalization procedure of docs/work-graph-contract.md
+// section 4.1 is applied by the caller.
+//
+// A record is emitted for every real ATX heading at the document's top level,
+// which excludes headings inside fenced or indented code and inside any
+// container block such as a blockquote or a list item.
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const MarkdownIt = require("markdown-it");
+
+const parser = new MarkdownIt();
+
+function textContent(inlineToken) {
+  if (!inlineToken || !inlineToken.children) {
+    return inlineToken ? inlineToken.content : "";
+  }
+  return inlineToken.children
+    .map((child) => {
+      if (child.type === "text" || child.type === "code_inline") {
+        return child.content;
+      }
+      if (child.type === "softbreak" || child.type === "hardbreak") {
+        return " ";
+      }
+      return "";
+    })
+    .join("");
+}
+
+function hasContent(tokens, start) {
+  for (let index = start; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.type === "heading_open" && token.level === 0) {
+      return false;
+    }
+    if (token.type === "hr") {
+      return true;
+    }
+    if (
+      (token.type === "inline" ||
+        token.type === "fence" ||
+        token.type === "code_block" ||
+        token.type === "html_block") &&
+      token.content.trim() !== ""
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function headings(body) {
+  const tokens = parser.parse(body ?? "", {});
+  const records = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    // level 0 keeps the heading at the document's top level, and a `#` markup
+    // keeps it an ATX heading rather than a setext one.
+    if (token.type !== "heading_open" || token.level !== 0 || !token.markup.startsWith("#")) {
+      continue;
+    }
+    records.push({
+      text: textContent(tokens[index + 1]),
+      hasContent: hasContent(tokens, index + 3),
+    });
+  }
+  return records;
+}
+
+const chunks = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk);
+}
+const bodies = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+process.stdout.write(JSON.stringify(bodies.map(headings)));

--- a/scripts/secpal_work_graph/markdown_headings.mjs
+++ b/scripts/secpal_work_graph/markdown_headings.mjs
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: MIT
 
-// Structural heading extraction for the SecPal work-graph resolver.
+// Structural Markdown extraction for the SecPal work-graph resolver.
 //
 // Reads a JSON array of issue bodies on stdin and writes a JSON array of
-// per-body heading records. It reports only what a standards-compliant parser
+// per-body structural facts. It reports only what a standards-compliant parser
 // sees; the canonical normalization procedure of docs/work-graph-contract.md
 // section 4.1 is applied by the caller.
 //
-// A record is emitted for every real ATX heading at the document's top level,
-// which excludes headings inside fenced or indented code and inside any
+// Heading records are emitted only for real ATX headings at the document's top
+// level, excluding headings inside fenced or indented code and inside any
 // container block such as a blockquote or a list item.
 
 import { createRequire } from "node:module";
@@ -19,21 +19,20 @@ const MarkdownIt = require("markdown-it");
 
 const parser = new MarkdownIt();
 
-function textContent(inlineToken) {
-  if (!inlineToken || !inlineToken.children) {
-    return inlineToken ? inlineToken.content : "";
+const mirrorPattern =
+  /^[ \t]*(?:\*\*|__)?(parent|order|blocked by|blocks|depends on)(?:\*\*|__)?[ \t]*:/gim;
+
+function textContent(token) {
+  if (!token) {
+    return "";
   }
-  return inlineToken.children
-    .map((child) => {
-      if (child.type === "text" || child.type === "code_inline") {
-        return child.content;
-      }
-      if (child.type === "softbreak" || child.type === "hardbreak") {
-        return " ";
-      }
-      return "";
-    })
-    .join("");
+  if (token.children) {
+    return token.children.map(textContent).join("");
+  }
+  if (token.type === "softbreak" || token.type === "hardbreak") {
+    return " ";
+  }
+  return token.content || "";
 }
 
 function hasContent(tokens, start) {
@@ -58,8 +57,7 @@ function hasContent(tokens, start) {
   return false;
 }
 
-function headings(body) {
-  const tokens = parser.parse(body ?? "", {});
+function headings(tokens) {
   const records = [];
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
@@ -76,9 +74,29 @@ function headings(body) {
   return records;
 }
 
+function relationshipMirrors(tokens) {
+  const mirrors = new Set();
+  for (let index = 1; index < tokens.length; index += 1) {
+    const previous = tokens[index - 1];
+    const token = tokens[index];
+    if (token.type !== "inline" || previous.type !== "paragraph_open" || previous.level !== 0) {
+      continue;
+    }
+    for (const match of token.content.matchAll(mirrorPattern)) {
+      mirrors.add(match[1].toLowerCase());
+    }
+  }
+  return [...mirrors].sort();
+}
+
+function bodyFacts(body) {
+  const tokens = parser.parse(body ?? "", {});
+  return { headings: headings(tokens), relationshipMirrors: relationshipMirrors(tokens) };
+}
+
 const chunks = [];
 for await (const chunk of process.stdin) {
   chunks.push(chunk);
 }
 const bodies = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-process.stdout.write(JSON.stringify(bodies.map(headings)));
+process.stdout.write(JSON.stringify(bodies.map(bodyFacts)));

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -60,7 +60,32 @@ def mirror_relationships(body: str | None) -> tuple[str, ...]:
     """Return the lowercased mirror relationship keywords present in a body."""
     if not body:
         return ()
-    return tuple(sorted({match.group(1).lower() for match in _MIRROR_PATTERN.finditer(body)}))
+    return tuple(
+        sorted(
+            {
+                match.group(1).lower()
+                for match in _MIRROR_PATTERN.finditer("\n".join(_semantic_lines(body)))
+            }
+        )
+    )
+
+
+def _semantic_lines(body: str) -> Iterable[str]:
+    """Yield body lines excluding Markdown containers that are examples, not metadata."""
+    fenced = False
+    fence = None
+    for line in body.splitlines():
+        fence_match = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if not fenced:
+                fenced, fence = True, marker[0]
+            elif marker[0] == fence:
+                fenced, fence = False, None
+            continue
+        if fenced or line.startswith(("    ", "\t", ">")):
+            continue
+        yield line
 
 
 @dataclass(frozen=True, order=True)

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -35,14 +35,6 @@ MAX_DEPENDENCIES_PER_TYPE = 50
 
 _REFERENCE = re.compile(r"^(?P<repository>[^/\s]+/[^/#\s]+)#(?P<number>\d+)$")
 
-# Bootstrap mirrors named by section 1. They are reported for migration and
-# never read as graph state, so a textual scan is the whole of their handling.
-_MIRROR_PATTERN = re.compile(
-    r"^[ \t]*(?:[-*+][ \t]+)?(?:\*\*|__)?(parent|order|blocked by|blocks|depends on)(?:\*\*|__)?[ \t]*:",
-    re.IGNORECASE | re.MULTILINE,
-)
-
-
 def node_key(repository: str, number: int) -> str:
     """Return the canonical repository-qualified identity of an issue."""
     return f"{repository}#{number}"
@@ -54,42 +46,6 @@ def parse_node_key(reference: str) -> tuple[str, int]:
     if match is None:
         raise ValueError(f"not a repository-qualified issue identity: {reference!r}")
     return match.group("repository"), int(match.group("number"))
-
-
-def mirror_relationships(body: str | None) -> tuple[str, ...]:
-    """Return the lowercased mirror relationship keywords present in a body."""
-    if not body:
-        return ()
-    return tuple(
-        sorted(
-            {
-                match.group(1).lower()
-                for match in _MIRROR_PATTERN.finditer("\n".join(_semantic_lines(body)))
-            }
-        )
-    )
-
-
-def _semantic_lines(body: str) -> Iterable[str]:
-    """Yield body lines excluding Markdown containers that are examples, not metadata."""
-    fence: tuple[str, int] | None = None
-    for line in body.splitlines():
-        if fence is None:
-            opening = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
-            if opening:
-                marker = opening.group(1)
-                fence = marker[0], len(marker)
-                continue
-        else:
-            closing = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$", line)
-            if closing:
-                marker = closing.group(1)
-                if marker[0] == fence[0] and len(marker) >= fence[1]:
-                    fence = None
-            continue
-        if line.startswith(("    ", "\t", ">")):
-            continue
-        yield line
 
 
 @dataclass(frozen=True, order=True)
@@ -123,7 +79,14 @@ class Node:
     # collapsed into `parent is None`.
     parent_observable: bool = True
     children: tuple[str, ...] = ()
+    # False when this invocation has not yet read native sub-issues for this
+    # node. A later scope traversal upgrades the one canonical node instead of
+    # treating this unknown input as an empty child list.
+    children_observable: bool = True
     blocked_by: tuple[str, ...] = ()
+    # False when this invocation has not yet read native dependencies for this
+    # node. Dependency and scope traversal upgrade this fact monotonically.
+    dependencies_observable: bool = True
     blocking_count: int = 0
     priority_labels: tuple[str, ...] = ()
     # False when the priority labels could not be read. Section 1.2 keeps them

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -72,18 +72,22 @@ def mirror_relationships(body: str | None) -> tuple[str, ...]:
 
 def _semantic_lines(body: str) -> Iterable[str]:
     """Yield body lines excluding Markdown containers that are examples, not metadata."""
-    fenced = False
-    fence = None
+    fence: tuple[str, int] | None = None
     for line in body.splitlines():
-        fence_match = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
-        if fence_match:
-            marker = fence_match.group(1)
-            if not fenced:
-                fenced, fence = True, marker[0]
-            elif marker[0] == fence:
-                fenced, fence = False, None
+        if fence is None:
+            opening = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
+            if opening:
+                marker = opening.group(1)
+                fence = marker[0], len(marker)
+                continue
+        else:
+            closing = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$", line)
+            if closing:
+                marker = closing.group(1)
+                if marker[0] == fence[0] and len(marker) >= fence[1]:
+                    fence = None
             continue
-        if fenced or line.startswith(("    ", "\t", ">")):
+        if line.startswith(("    ", "\t", ">")):
             continue
         yield line
 

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -89,10 +89,17 @@ class Node:
     state: str = OPEN
     state_reason: str | None = None
     parent: str | None = None
+    # False when the native parent field itself could not be read. Section 3.5
+    # makes that different from a genuinely absent parent, so the two are never
+    # collapsed into `parent is None`.
+    parent_observable: bool = True
     children: tuple[str, ...] = ()
     blocked_by: tuple[str, ...] = ()
     blocking_count: int = 0
     priority_labels: tuple[str, ...] = ()
+    # False when the priority labels could not be read. Section 1.2 keeps them
+    # out of `READY`, so this only suspends `NEXT` ranking.
+    priority_labels_observable: bool = True
     has_acceptance_criteria: bool = False
     claims: tuple[Claim, ...] = ()
     claims_observable: bool = True

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -76,8 +76,10 @@ class Claim:
 class Node:
     """One normalized issue.
 
-    Only fields the canonical contract consumes, or that are required to explain
-    a structural finding, belong here.
+    A field belongs here only when a canonical predicate consumes it, when it is
+    required to explain a structural finding, or when it identifies the node for
+    a reader. `title` and `url` are identification only and are never read by the
+    resolver.
     """
 
     repository: str

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Immutable normalized work-graph snapshot.
+
+Semantics: docs/work-graph-contract.md. This module only declares the inputs the
+contract consumes; it derives nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Iterable, Mapping
+
+OPEN = "open"
+CLOSED = "closed"
+COMPLETED = "completed"
+
+# Section 4.3 recognizes exactly these label names, by exact name.
+PRIORITY_RANKS: Mapping[str, int] = MappingProxyType(
+    {
+        "priority: blocker": 3,
+        "priority: high": 2,
+        "priority: medium": 1,
+    }
+)
+UNRECOGNIZED_PRIORITY_RANK = 0
+
+# Native GitHub limits named by sections 2.2 and 3.2.
+MAX_SUB_ISSUES_PER_PARENT = 100
+MAX_NESTING_DEPTH = 8
+MAX_DEPENDENCIES_PER_TYPE = 50
+
+_REFERENCE = re.compile(r"^(?P<repository>[^/\s]+/[^/#\s]+)#(?P<number>\d+)$")
+
+# Bootstrap mirrors named by section 1. They are reported for migration and
+# never read as graph state, so a textual scan is the whole of their handling.
+_MIRROR_PATTERN = re.compile(
+    r"^[ \t]*(?:[-*+][ \t]+)?(?:\*\*|__)?(parent|order|blocked by|blocks|depends on)(?:\*\*|__)?[ \t]*:",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def node_key(repository: str, number: int) -> str:
+    """Return the canonical repository-qualified identity of an issue."""
+    return f"{repository}#{number}"
+
+
+def parse_node_key(reference: str) -> tuple[str, int]:
+    """Split a canonical ``owner/repo#number`` identity."""
+    match = _REFERENCE.match(reference.strip())
+    if match is None:
+        raise ValueError(f"not a repository-qualified issue identity: {reference!r}")
+    return match.group("repository"), int(match.group("number"))
+
+
+def mirror_relationships(body: str | None) -> tuple[str, ...]:
+    """Return the lowercased mirror relationship keywords present in a body."""
+    if not body:
+        return ()
+    return tuple(sorted({match.group(1).lower() for match in _MIRROR_PATTERN.finditer(body)}))
+
+
+@dataclass(frozen=True, order=True)
+class Claim:
+    """A valid execution claim as defined by section 4.2."""
+
+    executor: str
+    pull_request: str
+    url: str = ""
+
+
+@dataclass(frozen=True)
+class Node:
+    """One normalized issue.
+
+    Only fields the canonical contract consumes, or that are required to explain
+    a structural finding, belong here.
+    """
+
+    repository: str
+    number: int
+    title: str = ""
+    url: str = ""
+    state: str = OPEN
+    state_reason: str | None = None
+    parent: str | None = None
+    children: tuple[str, ...] = ()
+    blocked_by: tuple[str, ...] = ()
+    blocking_count: int = 0
+    priority_labels: tuple[str, ...] = ()
+    has_acceptance_criteria: bool = False
+    claims: tuple[Claim, ...] = ()
+    claims_observable: bool = True
+    resolved: bool = True
+    unresolved_reason: str | None = None
+    mirror_relationships: tuple[str, ...] = ()
+
+    @property
+    def key(self) -> str:
+        return node_key(self.repository, self.number)
+
+    @property
+    def is_open(self) -> bool:
+        return self.resolved and self.state == OPEN
+
+    @property
+    def is_done(self) -> bool:
+        """Section 4.1 `DONE`: closed with the native closure reason `completed`."""
+        return self.resolved and self.state == CLOSED and self.state_reason == COMPLETED
+
+    @property
+    def priority_rank(self) -> int:
+        return max(
+            (PRIORITY_RANKS[label] for label in self.priority_labels if label in PRIORITY_RANKS),
+            default=UNRECOGNIZED_PRIORITY_RANK,
+        )
+
+
+def unresolved_node(key: str, reason: str) -> Node:
+    """Return a placeholder for an issue that was requested but not resolvable."""
+    repository, number = parse_node_key(key)
+    return Node(repository=repository, number=number, resolved=False, unresolved_reason=reason)
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """One invocation's collected GitHub data, treated as immutable."""
+
+    nodes: Mapping[str, Node] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "nodes", MappingProxyType(dict(self.nodes)))
+
+    def get(self, key: str) -> Node | None:
+        return self.nodes.get(key)
+
+    def require(self, key: str) -> Node:
+        """Return the node for ``key``, or an unresolved placeholder."""
+        node = self.nodes.get(key)
+        if node is None:
+            return unresolved_node(key, "not_in_snapshot")
+        return node
+
+
+def build_snapshot(nodes: Iterable[Node]) -> Snapshot:
+    return Snapshot({node.key: node for node in nodes})
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    """A machine-derivable structural fact about the graph."""
+
+    code: str
+    node: str = ""
+    detail: str = ""
+
+    def as_json(self) -> dict[str, str]:
+        return {"code": self.code, "node": self.node, "detail": self.detail}

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -146,9 +146,13 @@ class Resolution:
     def complete(self) -> bool:
         return not any(finding.code in INCOMPLETE_FINDINGS for finding in self.findings)
 
+    def resolved_states(self) -> tuple[NodeState, ...]:
+        """Subtree states in traversal order, skipping nodes that stayed unresolved."""
+        return tuple(self.states[key] for key in self.order if key in self.states)
+
     def ready_leaves(self) -> tuple[str, ...]:
         """Section 4.2 executable leaf set, in section 4.3 selection order."""
-        ready = [self.states[key] for key in self.order if self.states[key].ready]
+        ready = [state for state in self.resolved_states() if state.ready]
         return tuple(state.key for state in sorted(ready, key=lambda state: state.selection_key))
 
     def select_next(self, executor: str) -> NextResult:
@@ -187,12 +191,21 @@ def _ancestor_chain(snapshot: Snapshot, key: str) -> tuple[tuple[str, ...], str 
     return tuple(reversed(upward)), None
 
 
-def _dependency_cycles(snapshot: Snapshot) -> tuple[frozenset[str], tuple[tuple[str, ...], ...]]:
-    """Return the nodes tainted by a dependency cycle and the cycles themselves.
+@dataclass(frozen=True)
+class DependencyCycles:
+    """Section 3.5 cycle facts.
 
-    Section 3.5 removes both cycle members and everything depending on them from
-    `READY`, so the taint is propagated along reverse dependency edges.
+    `members` are the nodes that participate in a cycle, which is what section
+    4.1 makes `BLOCKED`. `tainted` additionally holds the nodes that depend on a
+    member, which section 3.5 keeps out of `READY` without making them `BLOCKED`.
     """
+
+    members: frozenset[str]
+    tainted: frozenset[str]
+    cycles: tuple[tuple[str, ...], ...]
+
+
+def _dependency_cycles(snapshot: Snapshot) -> DependencyCycles:
     index: dict[str, int] = {}
     low: dict[str, int] = {}
     on_stack: dict[str, bool] = {}
@@ -254,7 +267,7 @@ def _dependency_cycles(snapshot: Snapshot) -> tuple[frozenset[str], tuple[tuple[
             if dependent not in tainted:
                 tainted.add(dependent)
                 queue.append(dependent)
-    return frozenset(tainted), tuple(sorted(components))
+    return DependencyCycles(frozenset(members), frozenset(tainted), tuple(sorted(components)))
 
 
 def _subtree(snapshot: Snapshot, root: str) -> tuple[tuple[str, ...], dict[str, tuple[int, ...]]]:
@@ -285,7 +298,7 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
 
     order, paths = _subtree(snapshot, scope_root)
     root_ancestors, _ = _ancestor_chain(snapshot, scope_root)
-    tainted_by_cycle, cycles = _dependency_cycles(snapshot)
+    cycles = _dependency_cycles(snapshot)
 
     states: dict[str, NodeState] = {}
     findings: list[Finding] = []
@@ -301,16 +314,11 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
                 )
             )
             continue
-        state, node_findings = _derive(
-            snapshot,
-            node,
-            path=paths[key],
-            tainted_by_cycle=tainted_by_cycle,
-        )
+        state, node_findings = _derive(snapshot, node, path=paths[key], cycles=cycles)
         states[key] = state
         findings.extend(node_findings)
 
-    for cycle in cycles:
+    for cycle in cycles.cycles:
         if any(member in states for member in cycle):
             findings.append(Finding(FINDING_DEPENDENCY_CYCLE, cycle[0], ", ".join(cycle)))
 
@@ -347,7 +355,7 @@ def _derive(
     node: Node,
     *,
     path: tuple[int, ...],
-    tainted_by_cycle: frozenset[str],
+    cycles: DependencyCycles,
 ) -> tuple[NodeState, list[Finding]]:
     findings: list[Finding] = []
     reasons: set[str] = set()
@@ -391,7 +399,7 @@ def _derive(
             findings.append(Finding(FINDING_UNRESOLVED_DEPENDENCY, node.key, target_key))
         elif not target.is_done:
             reasons.add(REASON_UNSATISFIED_DEPENDENCY)
-    if node.key in tainted_by_cycle:
+    if node.key in cycles.tainted:
         reasons.add(REASON_DEPENDENCY_CYCLE)
 
     if not node.has_acceptance_criteria:
@@ -412,15 +420,13 @@ def _derive(
     if not node.claims_observable:
         findings.append(Finding(FINDING_CLAIMS_UNOBSERVABLE, node.key))
 
-    # Section 4.1 `BLOCKED`: an open node with an unsatisfied, unresolvable, or
-    # cyclic dependency. Malformed containment is deliberately not `BLOCKED`.
-    blocked = is_open and bool(
-        reasons
-        & {
-            REASON_UNSATISFIED_DEPENDENCY,
-            REASON_UNRESOLVED_DEPENDENCY,
-            REASON_DEPENDENCY_CYCLE,
-        }
+    # Section 4.1 `BLOCKED`: an open node with an unsatisfied or unresolvable
+    # dependency, or one that itself participates in a dependency cycle. Merely
+    # depending on a cycle member is not participation, and malformed
+    # containment is deliberately not `BLOCKED` either.
+    blocked = is_open and (
+        bool(reasons & {REASON_UNSATISFIED_DEPENDENCY, REASON_UNRESOLVED_DEPENDENCY})
+        or node.key in cycles.members
     )
     ready = not reasons
     claims = tuple(sorted(node.claims)) if node.claims_observable else ()

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -33,6 +33,7 @@ REASON_UNSATISFIED_DEPENDENCY = "unsatisfied_dependency"
 REASON_UNRESOLVED_DEPENDENCY = "unresolved_dependency"
 REASON_DEPENDENCY_CYCLE = "dependency_cycle"
 REASON_CONTAINMENT_CYCLE = "containment_cycle"
+REASON_CONTAINMENT_INCONSISTENT = "containment_inconsistent"
 REASON_UNRESOLVED_ANCESTOR = "unresolved_ancestor"
 REASON_CLOSED_ANCESTOR = "closed_ancestor"
 REASON_MISSING_ACCEPTANCE_CRITERIA = "missing_acceptance_criteria"
@@ -41,6 +42,7 @@ REASON_ORDER = (
     REASON_CLOSED,
     REASON_NOT_LEAF,
     REASON_CONTAINMENT_CYCLE,
+    REASON_CONTAINMENT_INCONSISTENT,
     REASON_UNRESOLVED_ANCESTOR,
     REASON_CLOSED_ANCESTOR,
     REASON_DEPENDENCY_CYCLE,
@@ -50,9 +52,12 @@ REASON_ORDER = (
 )
 
 # Section 3.5 fail-closed containment conditions, as distinct from `BLOCKED`.
-MALFORMED_REASONS = frozenset({REASON_CONTAINMENT_CYCLE, REASON_UNRESOLVED_ANCESTOR})
+MALFORMED_REASONS = frozenset(
+    {REASON_CONTAINMENT_CYCLE, REASON_CONTAINMENT_INCONSISTENT, REASON_UNRESOLVED_ANCESTOR}
+)
 
 FINDING_CONTAINMENT_CYCLE = "containment_cycle"
+FINDING_CONTAINMENT_INCONSISTENT = "containment_inconsistent"
 FINDING_UNRESOLVED_ANCESTOR = "unresolved_ancestor"
 FINDING_CLOSED_ANCESTOR = "closed_ancestor"
 FINDING_DEPENDENCY_CYCLE = "dependency_cycle"
@@ -71,14 +76,27 @@ FINDING_CLAIMS_UNOBSERVABLE = "claims_unobservable"
 INCOMPLETE_FINDINGS = frozenset(
     {
         FINDING_CONTAINMENT_CYCLE,
+        FINDING_CONTAINMENT_INCONSISTENT,
         FINDING_UNRESOLVED_ANCESTOR,
         FINDING_UNRESOLVED_DEPENDENCY,
         FINDING_UNRESOLVED_SUB_ISSUE,
     }
 )
 
+# Findings that leave the set of possible `READY` candidates, or their path
+# order, unknown. A leaf that merely fails closed on its own inputs is not one
+# of these: that is a complete answer about that leaf, and section 3.1 keeps it
+# from affecting a sibling.
+CANDIDATE_SCOPE_FINDINGS = frozenset({FINDING_UNRESOLVED_SUB_ISSUE, FINDING_CONTAINMENT_INCONSISTENT})
+
 NO_READY_LEAF = "no_ready_leaf"
 ALL_CANDIDATES_CLAIMED = "all_candidates_claimed"
+
+# `NEXT` is undecidable rather than empty when its declared inputs are unknown.
+# These are not canonical no-selection reasons: section 4.3 defines those two
+# only for a complete input set.
+INCOMPLETE_CANDIDATE_SCOPE = "incomplete_candidate_scope"
+INCOMPLETE_SELECTION_METADATA = "incomplete_selection_metadata"
 
 
 class ScopeRootUnresolved(Exception):
@@ -123,6 +141,7 @@ class NodeState:
     malformed: bool
     reasons: tuple[str, ...]
     priority_rank: int
+    priority_observable: bool
     claims: tuple[Claim, ...]
 
     @property
@@ -133,11 +152,17 @@ class NodeState:
 
 @dataclass(frozen=True)
 class NextResult:
-    """Section 4.3 result: exactly one leaf, or a canonical no-selection reason."""
+    """Section 4.3 result.
+
+    Exactly one of three shapes: a selected leaf, a canonical no-selection
+    reason, or an incompleteness reason meaning the declared inputs were not
+    fully observable and no canonical answer exists.
+    """
 
     selected: str | None
     no_selection_reason: str | None
     candidates: tuple[str, ...]
+    incomplete_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -162,7 +187,18 @@ class Resolution:
         ready = [state for state in self.resolved_states() if state.ready]
         return tuple(state.key for state in sorted(ready, key=lambda state: state.selection_key))
 
+    def next_inputs_incomplete(self) -> str | None:
+        """Return why `NEXT` is undecidable here, or None when it is decidable."""
+        if any(finding.code in CANDIDATE_SCOPE_FINDINGS for finding in self.findings):
+            return INCOMPLETE_CANDIDATE_SCOPE
+        if any(not self.states[key].priority_observable for key in self.ready_leaves()):
+            return INCOMPLETE_SELECTION_METADATA
+        return None
+
     def select_next(self, executor: str) -> NextResult:
+        incomplete = self.next_inputs_incomplete()
+        if incomplete is not None:
+            return NextResult(None, None, (), incomplete)
         executable = self.ready_leaves()
         candidates = tuple(
             key for key in executable if not _claimed_by_another(self.states[key].claims, executor)
@@ -185,7 +221,13 @@ def _ancestor_chain(snapshot: Snapshot, key: str) -> tuple[tuple[str, ...], str 
     seen = {key}
     upward: list[str] = []
     current = snapshot.get(key)
-    while current is not None and current.parent is not None:
+    while current is not None:
+        if not current.parent_observable:
+            # An inaccessible parent is not an absent parent, so the chain ends
+            # unresolved rather than at a root.
+            return tuple(reversed(upward)), REASON_UNRESOLVED_ANCESTOR
+        if current.parent is None:
+            break
         parent_key = current.parent
         if parent_key in seen:
             return tuple(reversed(upward)), REASON_CONTAINMENT_CYCLE
@@ -277,10 +319,21 @@ def _dependency_cycles(snapshot: Snapshot) -> DependencyCycles:
     return DependencyCycles(frozenset(members), frozenset(tainted), tuple(sorted(components)))
 
 
-def _subtree(snapshot: Snapshot, root: str) -> tuple[tuple[str, ...], dict[str, tuple[int, ...]]]:
+@dataclass(frozen=True)
+class Subtree:
+    order: tuple[str, ...]
+    paths: Mapping[str, tuple[int, ...]]
+    # Children a parent listed whose own native parent does not confirm the edge.
+    # One invocation reads issues through several requests, so the two views can
+    # disagree; neither is preferred over the other.
+    inconsistent: Mapping[str, str]
+
+
+def _subtree(snapshot: Snapshot, root: str) -> Subtree:
     """Walk native containment downwards, recording the section 4.3 path vector."""
     order: list[str] = []
     paths: dict[str, tuple[int, ...]] = {}
+    inconsistent: dict[str, str] = {}
     stack: list[tuple[str, tuple[int, ...]]] = [(root, ())]
     while stack:
         key, path = stack.pop()
@@ -292,9 +345,12 @@ def _subtree(snapshot: Snapshot, root: str) -> tuple[tuple[str, ...], dict[str, 
         if node is None or not node.resolved:
             continue
         for position, child in reversed(list(enumerate(node.children))):
+            child_node = snapshot.get(child)
+            if child_node is not None and child_node.resolved and child_node.parent != key:
+                inconsistent[child] = key
             if child not in paths:
                 stack.append((child, path + (position,)))
-    return tuple(order), paths
+    return Subtree(tuple(order), paths, inconsistent)
 
 
 def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
@@ -303,7 +359,8 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
     if root_node is None or not root_node.resolved:
         raise ScopeRootUnresolved(scope_root)
 
-    order, paths = _subtree(snapshot, scope_root)
+    subtree = _subtree(snapshot, scope_root)
+    order = subtree.order
     root_ancestors, _ = _ancestor_chain(snapshot, scope_root)
     cycles = _dependency_cycles(snapshot)
 
@@ -321,7 +378,13 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
                 )
             )
             continue
-        state, node_findings = _derive(snapshot, node, path=paths[key], cycles=cycles)
+        state, node_findings = _derive(
+            snapshot,
+            node,
+            path=subtree.paths[key],
+            cycles=cycles,
+            listing_parent=subtree.inconsistent.get(key),
+        )
         states[key] = state
         findings.extend(node_findings)
 
@@ -363,6 +426,7 @@ def _derive(
     *,
     path: tuple[int, ...],
     cycles: DependencyCycles,
+    listing_parent: str | None = None,
 ) -> tuple[NodeState, list[Finding]]:
     findings: list[Finding] = []
     reasons: set[str] = set()
@@ -373,6 +437,10 @@ def _derive(
         reasons.add(REASON_CLOSED)
     if not is_leaf:
         reasons.add(REASON_NOT_LEAF)
+
+    if listing_parent is not None:
+        reasons.add(REASON_CONTAINMENT_INCONSISTENT)
+        findings.append(Finding(FINDING_CONTAINMENT_INCONSISTENT, node.key, listing_parent))
 
     # Section 4.1 reads every ancestor up to the graph root, not just the ones
     # inside the requested scope.
@@ -451,6 +519,7 @@ def _derive(
         malformed=bool(reasons & MALFORMED_REASONS),
         reasons=tuple(reason for reason in REASON_ORDER if reason in reasons),
         priority_rank=node.priority_rank,
+        priority_observable=node.priority_labels_observable,
         claims=claims,
     )
     return state, findings

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import total_ordering
-from types import MappingProxyType
+from types import MappingProxyType, NotImplementedType
 from typing import Iterable, Mapping
 
 from .model import (
@@ -121,7 +121,9 @@ class SelectionKey:
     def _ordering(self) -> tuple[int, tuple[int, ...], str, int]:
         return (-self.priority_rank, self.path, self.repository, self.number)
 
-    def __lt__(self, other: "SelectionKey") -> bool:
+    def __lt__(self, other: object) -> bool | NotImplementedType:
+        if not isinstance(other, SelectionKey):
+            return NotImplemented
         return self._ordering() < other._ordering()
 
 
@@ -210,7 +212,7 @@ class Resolution:
 
 
 def _claimed_by_another(claims: Iterable[Claim], executor: str) -> bool:
-    return any(claim.executor != executor for claim in claims)
+    return any(claim.executor.casefold() != executor.casefold() for claim in claims)
 
 
 def _ancestor_chain(snapshot: Snapshot, key: str) -> tuple[tuple[str, ...], str | None]:
@@ -252,6 +254,14 @@ class DependencyCycles:
     members: frozenset[str]
     tainted: frozenset[str]
     cycles: tuple[tuple[str, ...], ...]
+
+
+def _dependents(snapshot: Snapshot) -> Mapping[str, tuple[str, ...]]:
+    dependents: dict[str, list[str]] = {}
+    for key, node in snapshot.nodes.items():
+        for target in node.blocked_by:
+            dependents.setdefault(target, []).append(key)
+    return MappingProxyType({key: tuple(value) for key, value in dependents.items()})
 
 
 def _dependency_cycles(snapshot: Snapshot) -> DependencyCycles:
@@ -303,10 +313,7 @@ def _dependency_cycles(snapshot: Snapshot) -> DependencyCycles:
                     components.append(tuple(sorted(component)))
 
     members = {member for component in components for member in component}
-    dependents: dict[str, list[str]] = {}
-    for key, node in snapshot.nodes.items():
-        for target in node.blocked_by:
-            dependents.setdefault(target, []).append(key)
+    dependents = _dependents(snapshot)
 
     tainted = set(members)
     queue = list(members)
@@ -344,6 +351,10 @@ def _subtree(snapshot: Snapshot, root: str) -> Subtree:
         node = snapshot.get(key)
         if node is None or not node.resolved:
             continue
+        if key in inconsistent:
+            # The child itself stays visible with its malformed containment
+            # finding, but its descendants are outside a provable scope.
+            continue
         for position, child in reversed(list(enumerate(node.children))):
             child_node = snapshot.get(child)
             if child_node is not None and child_node.resolved and child_node.parent != key:
@@ -351,6 +362,24 @@ def _subtree(snapshot: Snapshot, root: str) -> Subtree:
             if child not in paths:
                 stack.append((child, path + (position,)))
     return Subtree(tuple(order), paths, inconsistent)
+
+
+def _cycle_reaches_scope(
+    cycle: tuple[str, ...], dependents: Mapping[str, Iterable[str]], scope_keys: Iterable[str]
+) -> bool:
+    """Return whether one cycle can block a node in the requested scope."""
+    scope = set(scope_keys)
+    pending = list(cycle)
+    reached = set(cycle)
+    while pending:
+        key = pending.pop()
+        if key in scope:
+            return True
+        for dependent in dependents.get(key, ()):
+            if dependent not in reached:
+                reached.add(dependent)
+                pending.append(dependent)
+    return False
 
 
 def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
@@ -363,6 +392,7 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
     order = subtree.order
     root_ancestors, _ = _ancestor_chain(snapshot, scope_root)
     cycles = _dependency_cycles(snapshot)
+    dependents = _dependents(snapshot)
 
     states: dict[str, NodeState] = {}
     findings: list[Finding] = []
@@ -389,7 +419,7 @@ def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
         findings.extend(node_findings)
 
     for cycle in cycles.cycles:
-        if any(member in states for member in cycle):
+        if _cycle_reaches_scope(cycle, dependents, states):
             findings.append(Finding(FINDING_DEPENDENCY_CYCLE, cycle[0], ", ".join(cycle)))
 
     findings.extend(_multiple_parent_findings(snapshot, order))

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -1,0 +1,443 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Pure derivation of work-graph state from an immutable snapshot.
+
+Every predicate here implements docs/work-graph-contract.md sections 3 and 4 and
+reads nothing beyond the inputs section 1.2 declares. No GitHub access happens in
+this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Iterable, Mapping
+
+from .model import (
+    MAX_DEPENDENCIES_PER_TYPE,
+    MAX_NESTING_DEPTH,
+    MAX_SUB_ISSUES_PER_PARENT,
+    Claim,
+    Finding,
+    Node,
+    Snapshot,
+)
+
+# Reasons a node is not `READY`. They are the `READY` conditions of section 4.1
+# themselves, which is what section 4.2 requires an empty executable set to report.
+REASON_CLOSED = "closed"
+REASON_NOT_LEAF = "not_a_leaf"
+REASON_UNSATISFIED_DEPENDENCY = "unsatisfied_dependency"
+REASON_UNRESOLVED_DEPENDENCY = "unresolved_dependency"
+REASON_DEPENDENCY_CYCLE = "dependency_cycle"
+REASON_CONTAINMENT_CYCLE = "containment_cycle"
+REASON_UNRESOLVED_ANCESTOR = "unresolved_ancestor"
+REASON_CLOSED_ANCESTOR = "closed_ancestor"
+REASON_MISSING_ACCEPTANCE_CRITERIA = "missing_acceptance_criteria"
+
+REASON_ORDER = (
+    REASON_CLOSED,
+    REASON_NOT_LEAF,
+    REASON_CONTAINMENT_CYCLE,
+    REASON_UNRESOLVED_ANCESTOR,
+    REASON_CLOSED_ANCESTOR,
+    REASON_DEPENDENCY_CYCLE,
+    REASON_UNRESOLVED_DEPENDENCY,
+    REASON_UNSATISFIED_DEPENDENCY,
+    REASON_MISSING_ACCEPTANCE_CRITERIA,
+)
+
+# Section 3.5 fail-closed containment conditions, as distinct from `BLOCKED`.
+MALFORMED_REASONS = frozenset({REASON_CONTAINMENT_CYCLE, REASON_UNRESOLVED_ANCESTOR})
+
+FINDING_CONTAINMENT_CYCLE = "containment_cycle"
+FINDING_UNRESOLVED_ANCESTOR = "unresolved_ancestor"
+FINDING_CLOSED_ANCESTOR = "closed_ancestor"
+FINDING_DEPENDENCY_CYCLE = "dependency_cycle"
+FINDING_UNRESOLVED_DEPENDENCY = "unresolved_dependency"
+FINDING_UNRESOLVED_SUB_ISSUE = "unresolved_sub_issue"
+FINDING_MISSING_ACCEPTANCE_CRITERIA = "missing_acceptance_criteria"
+FINDING_SUB_ISSUE_LIMIT = "sub_issue_limit_exceeded"
+FINDING_NESTING_DEPTH = "nesting_depth_exceeded"
+FINDING_DEPENDENCY_LIMIT = "dependency_limit_exceeded"
+FINDING_DEPENDENCY_LIMIT_BLOCKING = "blocking_limit_exceeded"
+FINDING_MULTIPLE_PARENTS = "multiple_parents"
+FINDING_MIRROR_RELATIONSHIP = "body_relationship_mirror"
+FINDING_CLAIMS_UNOBSERVABLE = "claims_unobservable"
+
+# Findings that mean required graph data could not be resolved.
+INCOMPLETE_FINDINGS = frozenset(
+    {
+        FINDING_CONTAINMENT_CYCLE,
+        FINDING_UNRESOLVED_ANCESTOR,
+        FINDING_UNRESOLVED_DEPENDENCY,
+        FINDING_UNRESOLVED_SUB_ISSUE,
+    }
+)
+
+NO_READY_LEAF = "no_ready_leaf"
+ALL_CANDIDATES_CLAIMED = "all_candidates_claimed"
+
+
+class ScopeRootUnresolved(Exception):
+    """The requested scope root itself could not be resolved."""
+
+
+@dataclass(frozen=True)
+class SelectionKey:
+    """The four ordering keys of section 4.3, highest priority first."""
+
+    priority_rank: int
+    path: tuple[int, ...]
+    repository: str
+    number: int
+
+    def _ordering(self) -> tuple[int, tuple[int, ...], str, int]:
+        return (-self.priority_rank, self.path, self.repository, self.number)
+
+    def __lt__(self, other: "SelectionKey") -> bool:
+        return self._ordering() < other._ordering()
+
+
+@dataclass(frozen=True)
+class NodeState:
+    """Derived state for one node inside the resolved scope."""
+
+    key: str
+    path: tuple[int, ...]
+    depth: int
+    leaf: bool
+    open: bool
+    done: bool
+    blocked: bool
+    ready: bool
+    active: bool
+    malformed: bool
+    reasons: tuple[str, ...]
+    priority_rank: int
+    claims: tuple[Claim, ...]
+
+    @property
+    def selection_key(self) -> SelectionKey:
+        repository, _, number = self.key.rpartition("#")
+        return SelectionKey(self.priority_rank, self.path, repository, int(number))
+
+
+@dataclass(frozen=True)
+class NextResult:
+    """Section 4.3 result: exactly one leaf, or a canonical no-selection reason."""
+
+    selected: str | None
+    no_selection_reason: str | None
+    candidates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Resolution:
+    snapshot: Snapshot
+    scope_root: str
+    ancestors: tuple[str, ...]
+    order: tuple[str, ...]
+    states: Mapping[str, NodeState]
+    findings: tuple[Finding, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not any(finding.code in INCOMPLETE_FINDINGS for finding in self.findings)
+
+    def ready_leaves(self) -> tuple[str, ...]:
+        """Section 4.2 executable leaf set, in section 4.3 selection order."""
+        ready = [self.states[key] for key in self.order if self.states[key].ready]
+        return tuple(state.key for state in sorted(ready, key=lambda state: state.selection_key))
+
+    def select_next(self, executor: str) -> NextResult:
+        executable = self.ready_leaves()
+        candidates = tuple(
+            key for key in executable if not _claimed_by_another(self.states[key].claims, executor)
+        )
+        if candidates:
+            return NextResult(candidates[0], None, candidates)
+        reason = ALL_CANDIDATES_CLAIMED if executable else NO_READY_LEAF
+        return NextResult(None, reason, ())
+
+
+def _claimed_by_another(claims: Iterable[Claim], executor: str) -> bool:
+    return any(claim.executor != executor for claim in claims)
+
+
+def _ancestor_chain(snapshot: Snapshot, key: str) -> tuple[tuple[str, ...], str | None]:
+    """Walk native containment upwards; return the chain and any fail-closed reason.
+
+    The chain is ordered from the graph root down to the node's parent.
+    """
+    seen = {key}
+    upward: list[str] = []
+    current = snapshot.get(key)
+    while current is not None and current.parent is not None:
+        parent_key = current.parent
+        if parent_key in seen:
+            return tuple(reversed(upward)), REASON_CONTAINMENT_CYCLE
+        parent = snapshot.get(parent_key)
+        upward.append(parent_key)
+        if parent is None or not parent.resolved:
+            return tuple(reversed(upward)), REASON_UNRESOLVED_ANCESTOR
+        seen.add(parent_key)
+        current = parent
+    return tuple(reversed(upward)), None
+
+
+def _dependency_cycles(snapshot: Snapshot) -> tuple[frozenset[str], tuple[tuple[str, ...], ...]]:
+    """Return the nodes tainted by a dependency cycle and the cycles themselves.
+
+    Section 3.5 removes both cycle members and everything depending on them from
+    `READY`, so the taint is propagated along reverse dependency edges.
+    """
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    stack: list[str] = []
+    components: list[tuple[str, ...]] = []
+    counter = 0
+
+    def edges(key: str) -> tuple[str, ...]:
+        node = snapshot.get(key)
+        return node.blocked_by if node is not None else ()
+
+    for start in snapshot.nodes:
+        if start in index:
+            continue
+        work: list[tuple[str, int]] = [(start, 0)]
+        while work:
+            key, child_position = work[-1]
+            if child_position == 0:
+                index[key] = low[key] = counter
+                counter += 1
+                stack.append(key)
+                on_stack[key] = True
+            neighbours = edges(key)
+            if child_position < len(neighbours):
+                work[-1] = (key, child_position + 1)
+                target = neighbours[child_position]
+                if target not in index:
+                    if snapshot.get(target) is not None:
+                        work.append((target, 0))
+                elif on_stack.get(target):
+                    low[key] = min(low[key], index[target])
+                continue
+            work.pop()
+            if work:
+                parent_key = work[-1][0]
+                low[parent_key] = min(low[parent_key], low[key])
+            if low[key] == index[key]:
+                component: list[str] = []
+                while True:
+                    member = stack.pop()
+                    on_stack[member] = False
+                    component.append(member)
+                    if member == key:
+                        break
+                if len(component) > 1 or key in edges(key):
+                    components.append(tuple(sorted(component)))
+
+    members = {member for component in components for member in component}
+    dependents: dict[str, list[str]] = {}
+    for key, node in snapshot.nodes.items():
+        for target in node.blocked_by:
+            dependents.setdefault(target, []).append(key)
+
+    tainted = set(members)
+    queue = list(members)
+    while queue:
+        key = queue.pop()
+        for dependent in dependents.get(key, ()):
+            if dependent not in tainted:
+                tainted.add(dependent)
+                queue.append(dependent)
+    return frozenset(tainted), tuple(sorted(components))
+
+
+def _subtree(snapshot: Snapshot, root: str) -> tuple[tuple[str, ...], dict[str, tuple[int, ...]]]:
+    """Walk native containment downwards, recording the section 4.3 path vector."""
+    order: list[str] = []
+    paths: dict[str, tuple[int, ...]] = {}
+    stack: list[tuple[str, tuple[int, ...]]] = [(root, ())]
+    while stack:
+        key, path = stack.pop()
+        if key in paths:
+            continue
+        paths[key] = path
+        order.append(key)
+        node = snapshot.get(key)
+        if node is None or not node.resolved:
+            continue
+        for position, child in reversed(list(enumerate(node.children))):
+            if child not in paths:
+                stack.append((child, path + (position,)))
+    return tuple(order), paths
+
+
+def resolve(snapshot: Snapshot, scope_root: str) -> Resolution:
+    """Derive every contract state for the subtree of ``scope_root``."""
+    root_node = snapshot.get(scope_root)
+    if root_node is None or not root_node.resolved:
+        raise ScopeRootUnresolved(scope_root)
+
+    order, paths = _subtree(snapshot, scope_root)
+    root_ancestors, _ = _ancestor_chain(snapshot, scope_root)
+    tainted_by_cycle, cycles = _dependency_cycles(snapshot)
+
+    states: dict[str, NodeState] = {}
+    findings: list[Finding] = []
+
+    for key in order:
+        node = snapshot.get(key)
+        if node is None or not node.resolved:
+            findings.append(
+                Finding(
+                    FINDING_UNRESOLVED_SUB_ISSUE,
+                    key,
+                    node.unresolved_reason if node is not None else "not_in_snapshot",
+                )
+            )
+            continue
+        state, node_findings = _derive(
+            snapshot,
+            node,
+            path=paths[key],
+            tainted_by_cycle=tainted_by_cycle,
+        )
+        states[key] = state
+        findings.extend(node_findings)
+
+    for cycle in cycles:
+        if any(member in states for member in cycle):
+            findings.append(Finding(FINDING_DEPENDENCY_CYCLE, cycle[0], ", ".join(cycle)))
+
+    findings.extend(_multiple_parent_findings(snapshot, order))
+
+    return Resolution(
+        snapshot=snapshot,
+        scope_root=scope_root,
+        ancestors=root_ancestors,
+        order=order,
+        states=MappingProxyType(states),
+        findings=tuple(sorted(set(findings))),
+    )
+
+
+def _multiple_parent_findings(snapshot: Snapshot, order: Iterable[str]) -> list[Finding]:
+    """Section 3.1 forbids more than one parent; report it if the data shows one."""
+    claimed: dict[str, list[str]] = {}
+    for key in order:
+        node = snapshot.get(key)
+        if node is None or not node.resolved:
+            continue
+        for child in node.children:
+            claimed.setdefault(child, []).append(key)
+    return [
+        Finding(FINDING_MULTIPLE_PARENTS, child, ", ".join(sorted(parents)))
+        for child, parents in claimed.items()
+        if len(parents) > 1
+    ]
+
+
+def _derive(
+    snapshot: Snapshot,
+    node: Node,
+    *,
+    path: tuple[int, ...],
+    tainted_by_cycle: frozenset[str],
+) -> tuple[NodeState, list[Finding]]:
+    findings: list[Finding] = []
+    reasons: set[str] = set()
+
+    is_open = node.is_open
+    is_leaf = not node.children
+    if not is_open:
+        reasons.add(REASON_CLOSED)
+    if not is_leaf:
+        reasons.add(REASON_NOT_LEAF)
+
+    # Section 4.1 reads every ancestor up to the graph root, not just the ones
+    # inside the requested scope.
+    own_ancestors, containment_problem = _ancestor_chain(snapshot, node.key)
+    if containment_problem is not None:
+        reasons.add(containment_problem)
+        code = (
+            FINDING_CONTAINMENT_CYCLE
+            if containment_problem == REASON_CONTAINMENT_CYCLE
+            else FINDING_UNRESOLVED_ANCESTOR
+        )
+        detail = own_ancestors[0] if own_ancestors else ""
+        findings.append(Finding(code, node.key, detail))
+
+    for ancestor_key in own_ancestors:
+        ancestor = snapshot.get(ancestor_key)
+        if ancestor is not None and ancestor.resolved and not ancestor.is_open:
+            reasons.add(REASON_CLOSED_ANCESTOR)
+            if is_open:
+                findings.append(Finding(FINDING_CLOSED_ANCESTOR, node.key, ancestor_key))
+
+    depth = len(own_ancestors)
+    if depth > MAX_NESTING_DEPTH:
+        findings.append(Finding(FINDING_NESTING_DEPTH, node.key, str(depth)))
+
+    # Dependencies. Section 3.2: satisfied only by closure reason `completed`.
+    for target_key in node.blocked_by:
+        target = snapshot.get(target_key)
+        if target is None or not target.resolved:
+            reasons.add(REASON_UNRESOLVED_DEPENDENCY)
+            findings.append(Finding(FINDING_UNRESOLVED_DEPENDENCY, node.key, target_key))
+        elif not target.is_done:
+            reasons.add(REASON_UNSATISFIED_DEPENDENCY)
+    if node.key in tainted_by_cycle:
+        reasons.add(REASON_DEPENDENCY_CYCLE)
+
+    if not node.has_acceptance_criteria:
+        reasons.add(REASON_MISSING_ACCEPTANCE_CRITERIA)
+        if is_open and is_leaf:
+            findings.append(Finding(FINDING_MISSING_ACCEPTANCE_CRITERIA, node.key))
+
+    if len(node.children) > MAX_SUB_ISSUES_PER_PARENT:
+        findings.append(Finding(FINDING_SUB_ISSUE_LIMIT, node.key, str(len(node.children))))
+    if len(node.blocked_by) > MAX_DEPENDENCIES_PER_TYPE:
+        findings.append(Finding(FINDING_DEPENDENCY_LIMIT, node.key, str(len(node.blocked_by))))
+    if node.blocking_count > MAX_DEPENDENCIES_PER_TYPE:
+        findings.append(Finding(FINDING_DEPENDENCY_LIMIT_BLOCKING, node.key, str(node.blocking_count)))
+    if node.mirror_relationships:
+        findings.append(
+            Finding(FINDING_MIRROR_RELATIONSHIP, node.key, ", ".join(node.mirror_relationships))
+        )
+    if not node.claims_observable:
+        findings.append(Finding(FINDING_CLAIMS_UNOBSERVABLE, node.key))
+
+    # Section 4.1 `BLOCKED`: an open node with an unsatisfied, unresolvable, or
+    # cyclic dependency. Malformed containment is deliberately not `BLOCKED`.
+    blocked = is_open and bool(
+        reasons
+        & {
+            REASON_UNSATISFIED_DEPENDENCY,
+            REASON_UNRESOLVED_DEPENDENCY,
+            REASON_DEPENDENCY_CYCLE,
+        }
+    )
+    ready = not reasons
+    claims = tuple(sorted(node.claims)) if node.claims_observable else ()
+
+    state = NodeState(
+        key=node.key,
+        path=path,
+        depth=depth,
+        leaf=is_leaf,
+        open=is_open,
+        done=node.is_done,
+        blocked=blocked,
+        ready=ready,
+        active=ready and bool(claims),
+        malformed=bool(reasons & MALFORMED_REASONS),
+        reasons=tuple(reason for reason in REASON_ORDER if reason in reasons),
+        priority_rank=node.priority_rank,
+        claims=claims,
+    )
+    return state, findings

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -361,7 +361,29 @@ def _subtree(snapshot: Snapshot, root: str) -> Subtree:
                 inconsistent[child] = key
             if child not in paths:
                 stack.append((child, path + (position,)))
-    return Subtree(tuple(order), paths, inconsistent)
+
+    # A conflicting listing can be discovered after the matching parent has
+    # already expanded the child. Keep the malformed child visible, but remove
+    # every descendant whose membership and path therefore remain unprovable.
+    excluded: set[str] = set()
+    pending: list[str] = []
+    for key in inconsistent:
+        node = snapshot.get(key)
+        if node is not None and node.resolved:
+            pending.extend(node.children)
+    while pending:
+        key = pending.pop()
+        if key == root or key in excluded:
+            continue
+        excluded.add(key)
+        node = snapshot.get(key)
+        if node is not None and node.resolved:
+            pending.extend(node.children)
+
+    filtered_order = tuple(key for key in order if key not in excluded)
+    filtered_paths = {key: path for key, path in paths.items() if key not in excluded}
+    filtered_inconsistent = {key: parent for key, parent in inconsistent.items() if key not in excluded}
+    return Subtree(filtered_order, filtered_paths, filtered_inconsistent)
 
 
 def _cycle_reaches_scope(

--- a/scripts/secpal_work_graph/resolver.py
+++ b/scripts/secpal_work_graph/resolver.py
@@ -11,6 +11,7 @@ this module.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import total_ordering
 from types import MappingProxyType
 from typing import Iterable, Mapping
 
@@ -84,9 +85,15 @@ class ScopeRootUnresolved(Exception):
     """The requested scope root itself could not be resolved."""
 
 
+@total_ordering
 @dataclass(frozen=True)
 class SelectionKey:
-    """The four ordering keys of section 4.3, highest priority first."""
+    """The four ordering keys of section 4.3, highest priority first.
+
+    Priority ranks descending while the remaining keys ascend, so the ordering
+    cannot come from the dataclass field order and is derived from `__lt__` and
+    the dataclass equality instead.
+    """
 
     priority_rank: int
     path: tuple[int, ...]

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -128,7 +128,6 @@ def issue_payload(
                                 "number": pull_number,
                                 "url": f"https://github.com/{repository}/pull/{pull_number}",
                                 "state": pull_state,
-                                "isDraft": False,
                                 "author": ({"login": login} if login else None),
                                 "repository": {"nameWithOwner": repository},
                             }
@@ -189,6 +188,17 @@ class AdapterTestCase(TestCase):
             for line in self.log_path.read_text(encoding="utf-8").splitlines()
             if line
         ]
+
+    def run_command(self, script, *arguments):
+        """Drive the real CLI against the fake gh, which it inherits from the environment."""
+        self.script_path.write_text(json.dumps(script), encoding="utf-8")
+        os.environ["FAKE_GH_SCRIPT"] = str(self.script_path)
+        os.environ["FAKE_GH_LOG"] = str(self.log_path)
+        self.addCleanup(os.environ.pop, "FAKE_GH_SCRIPT", None)
+        self.addCleanup(os.environ.pop, "FAKE_GH_LOG", None)
+        stdout, stderr = io.StringIO(), io.StringIO()
+        code = cli.main(["--gh", str(self.gh_path), *arguments], stdout=stdout, stderr=stderr)
+        return code, stdout.getvalue(), stderr.getvalue()
 
 
 class SnapshotLoadingTests(AdapterTestCase):
@@ -354,6 +364,26 @@ class FailureTests(AdapterTestCase):
         self.assertFalse(missing.resolved)
         self.assertEqual(missing.unresolved_reason, "NOT_FOUND")
 
+    def test_an_unreadable_sub_issue_reports_incompleteness_instead_of_failing(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#2", f"{REPO}#404")
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+            "WorkGraphIssue:SecPal/.github#404:": {
+                "data": {"repository": {"issue": None}},
+                "errors": [{"type": "NOT_FOUND", "path": ["repository", "issue"]}],
+            },
+        }
+        code, output, _ = self.run_command(script, "ready", f"{REPO}#1")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual([node["key"] for node in document["ready"]], [f"{REPO}#2"])
+        self.assertFalse(document["complete"])
+        self.assertIn(
+            "unresolved_sub_issue", {finding["code"] for finding in document["findings"]}
+        )
+
     def test_operational_failures_are_raised_instead_of_becoming_absence(self):
         cases = {
             "unparseable output": {"__raw": "not json at all", "__exit": 0},
@@ -408,20 +438,11 @@ class CommandTests(AdapterTestCase):
         "WorkGraphIssue:SecPal/.github#4:": issue_payload(4),
     }
 
-    def run_command(self, *arguments):
-        self.script_path.write_text(json.dumps(self.SCRIPT), encoding="utf-8")
-        os.environ["FAKE_GH_SCRIPT"] = str(self.script_path)
-        os.environ["FAKE_GH_LOG"] = str(self.log_path)
-        self.addCleanup(os.environ.pop, "FAKE_GH_SCRIPT", None)
-        self.addCleanup(os.environ.pop, "FAKE_GH_LOG", None)
-        stdout, stderr = io.StringIO(), io.StringIO()
-        code = cli.main(
-            ["--gh", str(self.gh_path), *arguments], stdout=stdout, stderr=stderr
-        )
-        return code, stdout.getvalue(), stderr.getvalue()
+    def command(self, *arguments):
+        return self.run_command(self.SCRIPT, *arguments)
 
     def test_show_renders_the_normalized_subtree(self):
-        code, output, _ = self.run_command("show", f"{REPO}#1")
+        code, output, _ = self.command("show", f"{REPO}#1")
         document = json.loads(output)
         self.assertEqual(code, 0)
         self.assertEqual([node["key"] for node in document["nodes"]], [f"{REPO}#{n}" for n in (1, 2, 3)])
@@ -429,7 +450,7 @@ class CommandTests(AdapterTestCase):
         self.assertTrue(document["complete"])
 
     def test_ready_returns_only_the_executable_leaf(self):
-        code, output, _ = self.run_command("ready", f"{REPO}#1")
+        code, output, _ = self.command("ready", f"{REPO}#1")
         document = json.loads(output)
         self.assertEqual(code, 0)
         self.assertEqual([node["key"] for node in document["ready"]], [f"{REPO}#2"])
@@ -444,7 +465,7 @@ class CommandTests(AdapterTestCase):
         )
 
     def test_next_selects_one_leaf_for_the_given_executor(self):
-        code, output, _ = self.run_command("next", f"{REPO}#1", "--executor", "alice")
+        code, output, _ = self.command("next", f"{REPO}#1", "--executor", "alice")
         document = json.loads(output)
         self.assertEqual(code, 0)
         self.assertEqual(document["selected"]["key"], f"{REPO}#2")
@@ -452,7 +473,7 @@ class CommandTests(AdapterTestCase):
         self.assertEqual(document["executor"], "alice")
 
     def test_validate_reports_structural_findings_only(self):
-        code, output, _ = self.run_command("validate", f"{REPO}#1")
+        code, output, _ = self.command("validate", f"{REPO}#1")
         document = json.loads(output)
         self.assertEqual(code, 1)
         self.assertEqual(
@@ -461,8 +482,8 @@ class CommandTests(AdapterTestCase):
         )
 
     def test_validate_issue_explains_one_issue(self):
-        ready_code, ready_output, _ = self.run_command("validate-issue", f"{REPO}#2")
-        blocked_code, blocked_output, _ = self.run_command("validate-issue", f"{REPO}#3")
+        ready_code, ready_output, _ = self.command("validate-issue", f"{REPO}#2")
+        blocked_code, blocked_output, _ = self.command("validate-issue", f"{REPO}#3")
         self.assertEqual(ready_code, 0)
         self.assertTrue(json.loads(ready_output)["issue"]["ready"])
         self.assertEqual(blocked_code, 1)
@@ -474,31 +495,44 @@ class CommandTests(AdapterTestCase):
         )
 
     def test_machine_output_is_deterministic_and_text_uses_the_same_model(self):
-        first = self.run_command("show", f"{REPO}#1")[1]
-        second = self.run_command("show", f"{REPO}#1")[1]
+        first = self.command("show", f"{REPO}#1")[1]
+        second = self.command("show", f"{REPO}#1")[1]
         self.assertEqual(first, second)
-        text = self.run_command("--format", "text", "ready", f"{REPO}#1")[1]
+        text = self.command("--format", "text", "ready", f"{REPO}#1")[1]
         self.assertIn(f"READY {REPO}#2", text)
         self.assertIn(f"{REPO}#3", text)
 
     def test_invalid_references_are_rejected_without_contacting_github(self):
-        code, _, stderr = self.run_command("show", "not-an-issue")
-        self.assertEqual(code, 2)
-        self.assertEqual(json.loads(stderr)["error"]["code"], "invalid_reference")
+        for reference in ("not-an-issue", "foo#1", "12", "https://example.com/x", "SecPal/.github#x"):
+            with self.subTest(reference=reference):
+                code, _, stderr = self.command("show", reference)
+                self.assertEqual(code, 2)
+                self.assertEqual(json.loads(stderr)["error"]["code"], "invalid_reference")
         self.assertEqual(self.calls(), [])
+
+    def test_a_bare_number_resolves_against_an_explicit_repository(self):
+        code, output, _ = self.command("--repo", REPO, "validate-issue", "2")
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(output)["issue"]["key"], f"{REPO}#2")
 
 
 class SubprocessSafetyTests(TestCase):
-    def test_the_adapter_never_uses_a_shell(self):
+    def test_github_access_is_bounded_and_never_shelled_out(self):
+        # Structural evidence for the stated invariant that the read boundary
+        # runs gh as an argument vector, never through a shell.
         source = (ROOT / "scripts/secpal_work_graph/github.py").read_text(encoding="utf-8")
         self.assertNotIn("shell=True", source)
-        self.assertIn("timeout=", source)
+        self.assertGreater(github.GitHubReadAdapter().timeout, 0)
 
-    def test_the_entrypoint_compiles(self):
-        subprocess.run(
-            [sys.executable, "-m", "py_compile", str(ROOT / "scripts/secpal-work-graph.py")],
+    def test_the_entrypoint_runs(self):
+        completed = subprocess.run(
+            [sys.executable, str(ROOT / "scripts/secpal-work-graph.py"), "--help"],
+            capture_output=True,
+            text=True,
             check=True,
         )
+        for command in ("show", "validate", "ready", "next", "validate-issue"):
+            self.assertIn(command, completed.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -313,6 +313,101 @@ class SnapshotLoadingTests(AdapterTestCase):
         self.assertEqual(sorted(documents), [1, 2, 3])
 
 
+def with_error(payload, kind, *path_tail):
+    """Attach a field-level GraphQL access error to an otherwise readable issue."""
+    document = json.loads(json.dumps(payload))
+    document.setdefault("errors", []).append(
+        {"type": kind, "path": ["repository", "issue", *path_tail], "message": "not accessible"}
+    )
+    return document
+
+
+class RequiredInputObservabilityTests(AdapterTestCase):
+    """Section 3.5: an inaccessible native input never becomes absent data."""
+
+    def test_an_unobservable_parent_is_not_reported_as_a_root(self):
+        cases = {
+            "forbidden": with_error(issue_payload(1), "FORBIDDEN", "parent"),
+            "not found": with_error(issue_payload(1), "NOT_FOUND", "parent"),
+            "nested path": with_error(issue_payload(1), "FORBIDDEN", "parent", "repository"),
+        }
+        for label, payload in cases.items():
+            with self.subTest(case=label):
+                snapshot = github.load_snapshot(
+                    self.adapter({"WorkGraphIssue:SecPal/.github#1:": payload}), f"{REPO}#1"
+                )
+                node = snapshot.nodes[f"{REPO}#1"]
+                self.assertIsNone(node.parent)
+                self.assertFalse(node.parent_observable)
+                state = resolver.resolve(snapshot, f"{REPO}#1").states[f"{REPO}#1"]
+                self.assertFalse(state.ready)
+                self.assertTrue(state.malformed)
+
+    def test_a_null_parent_without_an_access_error_is_a_legitimate_root(self):
+        snapshot = github.load_snapshot(
+            self.adapter({"WorkGraphIssue:SecPal/.github#1:": issue_payload(1)}), f"{REPO}#1"
+        )
+        node = snapshot.nodes[f"{REPO}#1"]
+        self.assertIsNone(node.parent)
+        self.assertTrue(node.parent_observable)
+        self.assertTrue(resolver.resolve(snapshot, f"{REPO}#1").states[f"{REPO}#1"].ready)
+
+    def test_partially_readable_relationship_data_is_not_a_complete_list(self):
+        # A payload carrying usable nodes plus an access error underneath the
+        # connection must never be normalized into a shorter complete list.
+        for connection, kind in (("subIssues", "FORBIDDEN"), ("blockedBy", "NOT_FOUND")):
+            with self.subTest(connection=connection, error=kind):
+                base = issue_payload(
+                    2, parent=f"{REPO}#1", sub_issues=(f"{REPO}#5",), blocked_by=(f"{REPO}#6",)
+                )
+                script = {
+                    "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                        1, sub_issues=(f"{REPO}#2", f"{REPO}#3")
+                    ),
+                    "WorkGraphIssue:SecPal/.github#2:": with_error(base, kind, connection, "nodes", "1"),
+                    "WorkGraphIssue:SecPal/.github#3:": issue_payload(3, parent=f"{REPO}#1"),
+                    "WorkGraphIssue:SecPal/.github#5:": issue_payload(5, parent=f"{REPO}#2"),
+                    "WorkGraphIssue:SecPal/.github#6:": issue_payload(6),
+                }
+                snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+                unreadable = snapshot.nodes[f"{REPO}#2"]
+                self.assertFalse(unreadable.resolved)
+                self.assertEqual(unreadable.unresolved_reason, kind)
+                resolution = resolver.resolve(snapshot, f"{REPO}#1")
+                self.assertFalse(resolution.complete)
+                self.assertIsNone(resolution.select_next("alice").selected)
+
+    def test_a_partial_follow_up_page_is_not_a_successful_page(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#2",), sub_cursor="SUB1"
+            ),
+            "WorkGraphSubIssues:SecPal/.github#1:SUB1": with_error(
+                page("subIssues", (f"{REPO}#3",)), "FORBIDDEN", "subIssues", "nodes", "0"
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(3, parent=f"{REPO}#1"),
+        }
+        # Every referenced issue is readable, so only the partial page can fail this.
+        with self.assertRaises(github.GitHubError):
+            github.load_snapshot(self.adapter(script), f"{REPO}#1")
+
+    def test_unreadable_labels_leave_the_node_resolvable(self):
+        # Selection metadata is not an input to READY, so it must not make the
+        # whole node unresolved.
+        snapshot = github.load_snapshot(
+            self.adapter(
+                {"WorkGraphIssue:SecPal/.github#1:": with_error(issue_payload(1), "FORBIDDEN", "labels")}
+            ),
+            f"{REPO}#1",
+        )
+        node = snapshot.nodes[f"{REPO}#1"]
+        self.assertTrue(node.resolved)
+        self.assertFalse(node.priority_labels_observable)
+        self.assertEqual(node.priority_labels, ())
+        self.assertTrue(resolver.resolve(snapshot, f"{REPO}#1").states[f"{REPO}#1"].ready)
+
+
 class ClaimObservationTests(AdapterTestCase):
     def test_only_open_pull_requests_with_a_named_author_are_claims(self):
         script = {
@@ -471,6 +566,30 @@ class CommandTests(AdapterTestCase):
         self.assertEqual(document["selected"]["key"], f"{REPO}#2")
         self.assertIsNone(document["no_selection_reason"])
         self.assertEqual(document["executor"], "alice")
+
+    def test_next_reports_incomplete_inputs_instead_of_a_canonical_answer(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#404", f"{REPO}#2")
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+            "WorkGraphIssue:SecPal/.github#404:": {
+                "data": {"repository": {"issue": None}},
+                "errors": [{"type": "NOT_FOUND", "path": ["repository", "issue"]}],
+            },
+        }
+        code, output, _ = self.run_command(script, "next", f"{REPO}#1", "--executor", "alice")
+        document = json.loads(output)
+        self.assertEqual(code, 1)
+        self.assertEqual(document["status"], "incomplete_inputs")
+        self.assertIsNone(document["selected"])
+        self.assertIsNone(document["no_selection_reason"])
+        self.assertEqual(document["incomplete_reason"], "incomplete_candidate_scope")
+        # The known sibling is still truthfully READY on the `ready` surface.
+        self.assertEqual(document["ready"], [f"{REPO}#2"])
+        ready_code, ready_output, _ = self.run_command(script, "ready", f"{REPO}#1")
+        self.assertEqual(ready_code, 0)
+        self.assertEqual([node["key"] for node in json.loads(ready_output)["ready"]], [f"{REPO}#2"])
 
     def test_validate_reports_structural_findings_only(self):
         code, output, _ = self.command("validate", f"{REPO}#1")

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -201,6 +201,41 @@ class AdapterTestCase(TestCase):
 
 
 class SnapshotLoadingTests(AdapterTestCase):
+    def test_snapshot_upgrades_a_dependency_read_when_it_becomes_scope(self):
+        dependency_first = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#3",), blocked_by=(f"{REPO}#2",)
+            ),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(
+                3, parent=f"{REPO}#1", sub_issues=(f"{REPO}#2",)
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(
+                2, parent=f"{REPO}#3", sub_issues=(f"{REPO}#4",)
+            ),
+            "WorkGraphIssue:SecPal/.github#4:": issue_payload(4, parent=f"{REPO}#2"),
+        }
+        snapshot, root = github.load_snapshot(self.adapter(dependency_first), f"{REPO}#1")
+        resolution = resolver.resolve(snapshot, root)
+        self.assertEqual(snapshot.nodes[f"{REPO}#2"].children, (f"{REPO}#4",))
+        self.assertFalse(resolution.states[f"{REPO}#2"].leaf)
+        self.assertTrue(resolution.states[f"{REPO}#4"].ready)
+        numbers = [json.loads(call["body"])["variables"]["number"] for call in self.calls()]
+        self.assertEqual(numbers.count(2), 2)
+
+        scope_first = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#2",), blocked_by=(f"{REPO}#2",)
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(
+                2, parent=f"{REPO}#1", sub_issues=(f"{REPO}#3",)
+            ),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(3, parent=f"{REPO}#2"),
+        }
+        self.log_path.write_text("", encoding="utf-8")
+        github.load_snapshot(self.adapter(scope_first), f"{REPO}#1")
+        numbers = [json.loads(call["body"])["variables"]["number"] for call in self.calls()]
+        self.assertEqual(numbers.count(2), 1)
+
     def test_native_relationships_become_a_normalized_snapshot(self):
         script = {
             "WorkGraphIssue:SecPal/.github#1:": issue_payload(
@@ -684,6 +719,23 @@ class CommandTests(AdapterTestCase):
         ready_code, ready_output, _ = self.run_command(script, "ready", f"{REPO}#1")
         self.assertEqual(ready_code, 0)
         self.assertEqual([node["key"] for node in json.loads(ready_output)["ready"]], [f"{REPO}#2"])
+
+    def test_all_closed_leaves_explain_an_empty_executable_set(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(1, sub_issues=(f"{REPO}#2",)),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(
+                2, parent=f"{REPO}#1", state="CLOSED", state_reason="COMPLETED"
+            ),
+        }
+        code, output, _ = self.run_command(script, "next", f"{REPO}#1", "--executor", "alice")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual(document["no_selection_reason"], resolver.NO_READY_LEAF)
+        self.assertEqual(document["not_ready_leaves"], [{"key": f"{REPO}#2", "reasons": ["closed"]}])
+        _, text, _ = self.run_command(
+            script, "--format", "text", "next", f"{REPO}#1", "--executor", "alice"
+        )
+        self.assertIn(f"---  {REPO}#2 closed", text)
 
     def test_validate_reports_structural_findings_only(self):
         code, output, _ = self.command("validate", f"{REPO}#1")

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -685,7 +685,14 @@ class CommandTests(AdapterTestCase):
         self.assertIn(f"{REPO}#3", text)
 
     def test_invalid_references_are_rejected_without_contacting_github(self):
-        for reference in ("not-an-issue", "foo#1", "12", "https://example.com/x", "SecPal/.github#x"):
+        for reference in (
+            "not-an-issue",
+            "foo#1",
+            "12",
+            "https://example.com/x",
+            "https://gitlab.com/acme/project/issues/5",
+            "SecPal/.github#x",
+        ):
             with self.subTest(reference=reference):
                 code, _, stderr = self.command("show", reference)
                 self.assertEqual(code, 2)

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -140,23 +140,22 @@ def issue_payload(
     }
 
 
+def page_payload(connection, payload):
+    return {"data": {"repository": {"issue": {connection: payload}}}}
+
+
 def page(connection, nodes, *, cursor=None):
     def reference(value):
         repository, _, number = value.rpartition("#")
         return {"number": int(number), "repository": {"nameWithOwner": repository}}
 
-    return {
-        "data": {
-            "repository": {
-                "issue": {
-                    connection: {
-                        "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
-                        "nodes": [reference(value) for value in nodes],
-                    }
-                }
-            }
-        }
-    }
+    return page_payload(
+        connection,
+        {
+            "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+            "nodes": [reference(value) for value in nodes],
+        },
+    )
 
 
 class AdapterTestCase(TestCase):
@@ -224,7 +223,7 @@ class SnapshotLoadingTests(AdapterTestCase):
                 3, state="CLOSED", state_reason="COMPLETED"
             ),
         }
-        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#1")
 
         root = snapshot.nodes[f"{REPO}#1"]
         self.assertEqual(root.children, (f"{OTHER_REPO}#7", f"{REPO}#2"))
@@ -274,7 +273,7 @@ class SnapshotLoadingTests(AdapterTestCase):
             "WorkGraphIssue:SecPal/.github#4:": issue_payload(4),
             "WorkGraphIssue:SecPal/.github#5:": issue_payload(5),
         }
-        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#1")
         root = snapshot.nodes[f"{REPO}#1"]
         self.assertEqual(root.children, (f"{REPO}#2", f"{REPO}#3"))
         self.assertEqual(root.blocked_by, (f"{REPO}#4", f"{REPO}#5"))
@@ -291,7 +290,7 @@ class SnapshotLoadingTests(AdapterTestCase):
             ),
             "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
         }
-        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#2")
+        snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#2")
         self.assertIn(f"{REPO}#1", snapshot.nodes)
         self.assertNotIn(f"{REPO}#9", snapshot.nodes)
         state = resolver.resolve(snapshot, f"{REPO}#2").states[f"{REPO}#2"]
@@ -333,7 +332,7 @@ class RequiredInputObservabilityTests(AdapterTestCase):
         }
         for label, payload in cases.items():
             with self.subTest(case=label):
-                snapshot = github.load_snapshot(
+                snapshot, _ = github.load_snapshot(
                     self.adapter({"WorkGraphIssue:SecPal/.github#1:": payload}), f"{REPO}#1"
                 )
                 node = snapshot.nodes[f"{REPO}#1"]
@@ -344,7 +343,7 @@ class RequiredInputObservabilityTests(AdapterTestCase):
                 self.assertTrue(state.malformed)
 
     def test_a_null_parent_without_an_access_error_is_a_legitimate_root(self):
-        snapshot = github.load_snapshot(
+        snapshot, _ = github.load_snapshot(
             self.adapter({"WorkGraphIssue:SecPal/.github#1:": issue_payload(1)}), f"{REPO}#1"
         )
         node = snapshot.nodes[f"{REPO}#1"]
@@ -369,7 +368,7 @@ class RequiredInputObservabilityTests(AdapterTestCase):
                     "WorkGraphIssue:SecPal/.github#5:": issue_payload(5, parent=f"{REPO}#2"),
                     "WorkGraphIssue:SecPal/.github#6:": issue_payload(6),
                 }
-                snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+                snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#1")
                 unreadable = snapshot.nodes[f"{REPO}#2"]
                 self.assertFalse(unreadable.resolved)
                 self.assertEqual(unreadable.unresolved_reason, kind)
@@ -395,7 +394,7 @@ class RequiredInputObservabilityTests(AdapterTestCase):
     def test_unreadable_labels_leave_the_node_resolvable(self):
         # Selection metadata is not an input to READY, so it must not make the
         # whole node unresolved.
-        snapshot = github.load_snapshot(
+        snapshot, _ = github.load_snapshot(
             self.adapter(
                 {"WorkGraphIssue:SecPal/.github#1:": with_error(issue_payload(1), "FORBIDDEN", "labels")}
             ),
@@ -416,7 +415,7 @@ class ClaimObservationTests(AdapterTestCase):
                 claims=((10, "OPEN", "alice"), (11, "CLOSED", "bob"), (12, "OPEN", None)),
             )
         }
-        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#1")
         node = snapshot.nodes[f"{REPO}#1"]
         self.assertEqual(node.claims, (model.Claim("alice", f"{REPO}#10", node.claims[0].url),))
         self.assertTrue(node.claims_observable)
@@ -431,12 +430,76 @@ class ClaimObservationTests(AdapterTestCase):
                 "message": "Resource not accessible",
             }
         ]
-        snapshot = github.load_snapshot(
+        snapshot, _ = github.load_snapshot(
             self.adapter({"WorkGraphIssue:SecPal/.github#1:": payload}), f"{REPO}#1"
         )
         node = snapshot.nodes[f"{REPO}#1"]
         self.assertFalse(node.claims_observable)
         self.assertEqual(node.claims, ())
+
+    def test_an_unreadable_claim_page_degrades_exactly_like_an_unreadable_first_page(self):
+        # Claim observability is all-or-nothing per invocation, so a readable
+        # first page plus an unreadable continuation is not a complete claim set.
+        first = issue_payload(1, claims=((10, "OPEN", "alice"),))
+        connection = first["data"]["repository"]["issue"]["closedByPullRequestsReferences"]
+        connection["pageInfo"] = {"hasNextPage": True, "endCursor": "CLAIM1"}
+        continuation = with_error(
+            page_payload(
+                "closedByPullRequestsReferences",
+                {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": []},
+            ),
+            "FORBIDDEN",
+            "closedByPullRequestsReferences",
+            "nodes",
+            "0",
+        )
+        snapshot, root = github.load_snapshot(
+            self.adapter(
+                {
+                    "WorkGraphIssue:SecPal/.github#1:": first,
+                    "WorkGraphClaims:SecPal/.github#1:CLAIM1": continuation,
+                }
+            ),
+            f"{REPO}#1",
+        )
+        node = snapshot.nodes[f"{REPO}#1"]
+        self.assertFalse(node.claims_observable)
+        self.assertEqual(node.claims, ())
+        state = resolver.resolve(snapshot, root).states[f"{REPO}#1"]
+        self.assertTrue(state.ready)
+        self.assertFalse(state.active)
+
+
+class CanonicalIdentityTests(AdapterTestCase):
+    """One issue has exactly one identity: the one GitHub returns."""
+
+    CANONICAL = {
+        "WorkGraphIssue:SecPal/.github#1:": issue_payload(1, sub_issues=(f"{REPO}#2",)),
+        "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+    }
+
+    def test_a_reference_github_canonicalizes_resolves_to_the_canonical_identity(self):
+        # GitHub accepts `secpal/.github` and answers with `SecPal/.github`. The
+        # requested spelling is an input reference, never a second graph node.
+        variant = dict(self.CANONICAL)
+        variant["WorkGraphIssue:secpal/.github#1:"] = variant.pop(
+            "WorkGraphIssue:SecPal/.github#1:"
+        )
+        code, output, _ = self.run_command(variant, "ready", "secpal/.github#1")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual(document["scope_root"], f"{REPO}#1")
+        self.assertEqual([node["key"] for node in document["ready"]], [f"{REPO}#2"])
+        self.assertTrue(document["complete"])
+        self.assertEqual(document["findings"], [])
+
+        canonical = self.run_command(self.CANONICAL, "ready", f"{REPO}#1")
+        self.assertEqual((code, output), canonical[:2])
+
+    def test_an_incoherent_issue_number_is_a_read_boundary_failure(self):
+        script = {"WorkGraphIssue:SecPal/.github#1:": issue_payload(7)}
+        with self.assertRaises(github.GitHubError):
+            github.load_snapshot(self.adapter(script), f"{REPO}#1")
 
 
 class FailureTests(AdapterTestCase):
@@ -454,7 +517,7 @@ class FailureTests(AdapterTestCase):
                 ],
             },
         }
-        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        snapshot, _ = github.load_snapshot(self.adapter(script), f"{REPO}#1")
         missing = snapshot.nodes[f"{REPO}#404"]
         self.assertFalse(missing.resolved)
         self.assertEqual(missing.unresolved_reason, "NOT_FOUND")

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -278,6 +278,23 @@ class SnapshotLoadingTests(AdapterTestCase):
         self.assertEqual(root.children, (f"{REPO}#2", f"{REPO}#3"))
         self.assertEqual(root.blocked_by, (f"{REPO}#4", f"{REPO}#5"))
 
+    def test_pagination_rejects_a_repeated_cursor(self):
+        class RepeatingCursorAdapter:
+            calls = 0
+
+            def query(self, document, variables):
+                self.calls += 1
+                if self.calls > 1:
+                    raise AssertionError("pagination requested the repeated cursor again")
+                payload = page("subIssues", (), cursor="SAME")
+                return github.GraphQLResponse(payload["data"], ())
+
+        adapter = RepeatingCursorAdapter()
+        issue = issue_payload(1, sub_cursor="SAME")["data"]["repository"]["issue"]
+        with self.assertRaisesRegex(github.GitHubError, "cursor"):
+            github._paginate(adapter, "subIssues", issue, {"owner": "SecPal", "name": ".github", "number": 1})
+        self.assertEqual(adapter.calls, 1)
+
     def test_ancestors_are_read_without_pulling_in_sibling_scopes(self):
         # The fake gh fails on any unscripted request, so the absence of a
         # request for #9 is asserted by the run completing at all.
@@ -375,6 +392,20 @@ class RequiredInputObservabilityTests(AdapterTestCase):
                 resolution = resolver.resolve(snapshot, f"{REPO}#1")
                 self.assertFalse(resolution.complete)
                 self.assertIsNone(resolution.select_next("alice").selected)
+
+    def test_dependency_reads_do_not_require_irrelevant_sub_issues(self):
+        dependency = with_error(
+            issue_payload(2, state="CLOSED", state_reason="COMPLETED"),
+            "FORBIDDEN",
+            "subIssues",
+        )
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(1, blocked_by=(f"{REPO}#2",)),
+            "WorkGraphIssue:SecPal/.github#2:": dependency,
+        }
+        snapshot, root = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        self.assertTrue(snapshot.nodes[f"{REPO}#2"].is_done)
+        self.assertTrue(resolver.resolve(snapshot, root).states[f"{REPO}#1"].ready)
 
     def test_a_partial_follow_up_page_is_not_a_successful_page(self):
         script = {
@@ -691,6 +722,7 @@ class CommandTests(AdapterTestCase):
             "12",
             "https://example.com/x",
             "https://gitlab.com/acme/project/issues/5",
+            "https://github.com/SecPal/.github/pull/5",
             "SecPal/.github#x",
         ):
             with self.subTest(reference=reference):

--- a/tests/secpal-work-graph-adapter.py
+++ b/tests/secpal-work-graph-adapter.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""GitHub read-adapter evidence for the work-graph resolver.
+
+These cases drive the real subprocess boundary against a controlled fake `gh`
+executable, so they prove argument construction, pagination, failure handling,
+and read-only operation. Graph semantics are proven separately from synthetic
+snapshots in tests/secpal-work-graph-unit.py.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from secpal_work_graph import cli, github, model, resolver  # noqa: E402
+
+REPO = "SecPal/.github"
+OTHER_REPO = "SecPal/api"
+
+FAKE_GH = '''#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+argv = sys.argv[1:]
+body = sys.stdin.read()
+with open(os.environ["FAKE_GH_LOG"], "a", encoding="utf-8") as log:
+    log.write(json.dumps({"argv": argv, "body": body}) + "\\n")
+
+script = json.loads(open(os.environ["FAKE_GH_SCRIPT"], encoding="utf-8").read())
+request = json.loads(body)
+operation = re.search(r"query\\s+(\\w+)", request["query"]).group(1)
+variables = request.get("variables", {})
+key = "{}:{}/{}#{}:{}".format(
+    operation,
+    variables.get("owner", ""),
+    variables.get("name", ""),
+    variables.get("number", ""),
+    variables.get("cursor") or "",
+)
+if key not in script:
+    sys.stderr.write("fake gh: unexpected request " + key + "\\n")
+    sys.exit(9)
+response = script[key]
+if response.get("__raw") is not None:
+    sys.stdout.write(response["__raw"])
+    sys.exit(response.get("__exit", 0))
+sys.stdout.write(json.dumps(response))
+sys.exit(1 if response.get("errors") else 0)
+'''
+
+
+def issue_payload(
+    number,
+    *,
+    repository=REPO,
+    state="OPEN",
+    state_reason=None,
+    body="## Acceptance Criteria\n\n- proven\n",
+    parent=None,
+    sub_issues=(),
+    blocked_by=(),
+    labels=(),
+    blocking=0,
+    claims=(),
+    sub_cursor=None,
+    dependency_cursor=None,
+):
+    owner, name = repository.split("/")
+
+    def reference(value):
+        target_repository, _, target_number = value.rpartition("#")
+        target_owner, target_name = target_repository.split("/")
+        return {
+            "number": int(target_number),
+            "repository": {"nameWithOwner": f"{target_owner}/{target_name}"},
+        }
+
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    "number": number,
+                    "title": f"Issue {number}",
+                    "url": f"https://github.com/{owner}/{name}/issues/{number}",
+                    "state": state,
+                    "stateReason": state_reason,
+                    "body": body,
+                    "repository": {"nameWithOwner": repository},
+                    "parent": reference(parent) if parent else None,
+                    "labels": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [{"name": label} for label in labels],
+                    },
+                    "subIssues": {
+                        "pageInfo": {
+                            "hasNextPage": sub_cursor is not None,
+                            "endCursor": sub_cursor,
+                        },
+                        "nodes": [reference(value) for value in sub_issues],
+                    },
+                    "blockedBy": {
+                        "pageInfo": {
+                            "hasNextPage": dependency_cursor is not None,
+                            "endCursor": dependency_cursor,
+                        },
+                        "nodes": [reference(value) for value in blocked_by],
+                    },
+                    "blocking": {"totalCount": blocking},
+                    "closedByPullRequestsReferences": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [
+                            {
+                                "number": pull_number,
+                                "url": f"https://github.com/{repository}/pull/{pull_number}",
+                                "state": pull_state,
+                                "isDraft": False,
+                                "author": ({"login": login} if login else None),
+                                "repository": {"nameWithOwner": repository},
+                            }
+                            for pull_number, pull_state, login in claims
+                        ],
+                    },
+                }
+            }
+        }
+    }
+
+
+def page(connection, nodes, *, cursor=None):
+    def reference(value):
+        repository, _, number = value.rpartition("#")
+        return {"number": int(number), "repository": {"nameWithOwner": repository}}
+
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    connection: {
+                        "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                        "nodes": [reference(value) for value in nodes],
+                    }
+                }
+            }
+        }
+    }
+
+
+class AdapterTestCase(TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        base = Path(self.directory.name)
+        self.script_path = base / "script.json"
+        self.log_path = base / "calls.jsonl"
+        binary_directory = base / "bin"
+        binary_directory.mkdir()
+        self.gh_path = binary_directory / "gh"
+        self.gh_path.write_text(FAKE_GH, encoding="utf-8")
+        self.gh_path.chmod(self.gh_path.stat().st_mode | stat.S_IXUSR)
+        self.log_path.write_text("", encoding="utf-8")
+
+    def adapter(self, script, **options):
+        self.script_path.write_text(json.dumps(script), encoding="utf-8")
+        environment = dict(os.environ)
+        environment["FAKE_GH_SCRIPT"] = str(self.script_path)
+        environment["FAKE_GH_LOG"] = str(self.log_path)
+        return github.GitHubReadAdapter(
+            gh_executable=str(self.gh_path), environment=environment, **options
+        )
+
+    def calls(self):
+        return [
+            json.loads(line)
+            for line in self.log_path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+
+class SnapshotLoadingTests(AdapterTestCase):
+    def test_native_relationships_become_a_normalized_snapshot(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{OTHER_REPO}#7", f"{REPO}#2"), blocking=3
+            ),
+            "WorkGraphIssue:SecPal/api#7:": issue_payload(
+                7,
+                repository=OTHER_REPO,
+                parent=f"{REPO}#1",
+                labels=("priority: high", "area: api"),
+                claims=((11, "OPEN", "bob"),),
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(
+                2,
+                parent=f"{REPO}#1",
+                blocked_by=(f"{REPO}#3",),
+                body="Parent: #1\n\nNo criteria here.\n",
+            ),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(
+                3, state="CLOSED", state_reason="COMPLETED"
+            ),
+        }
+        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+
+        root = snapshot.nodes[f"{REPO}#1"]
+        self.assertEqual(root.children, (f"{OTHER_REPO}#7", f"{REPO}#2"))
+        self.assertEqual(root.blocking_count, 3)
+        self.assertTrue(root.has_acceptance_criteria)
+
+        cross_repository = snapshot.nodes[f"{OTHER_REPO}#7"]
+        self.assertEqual(cross_repository.parent, f"{REPO}#1")
+        self.assertEqual(cross_repository.priority_labels, ("priority: high",))
+        self.assertEqual(
+            cross_repository.claims,
+            (model.Claim("bob", f"{OTHER_REPO}#11", f"https://github.com/{OTHER_REPO}/pull/11"),),
+        )
+
+        leaf = snapshot.nodes[f"{REPO}#2"]
+        self.assertEqual(leaf.blocked_by, (f"{REPO}#3",))
+        self.assertFalse(leaf.has_acceptance_criteria)
+        self.assertEqual(leaf.mirror_relationships, ("parent",))
+
+        dependency = snapshot.nodes[f"{REPO}#3"]
+        self.assertTrue(dependency.is_done)
+
+    def test_every_call_is_a_read_only_graphql_query(self):
+        script = {"WorkGraphIssue:SecPal/.github#1:": issue_payload(1)}
+        github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        calls = self.calls()
+        self.assertTrue(calls)
+        for call in calls:
+            self.assertEqual(call["argv"], ["api", "graphql", "--input", "-"])
+            document = json.loads(call["body"])["query"]
+            self.assertTrue(document.lstrip().startswith("query "))
+            self.assertNotIn("mutation", document)
+
+    def test_pagination_is_consumed_completely(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1,
+                sub_issues=(f"{REPO}#2",),
+                blocked_by=(f"{REPO}#4",),
+                sub_cursor="SUB1",
+                dependency_cursor="DEP1",
+            ),
+            "WorkGraphSubIssues:SecPal/.github#1:SUB1": page("subIssues", (f"{REPO}#3",)),
+            "WorkGraphBlockedBy:SecPal/.github#1:DEP1": page("blockedBy", (f"{REPO}#5",)),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(3, parent=f"{REPO}#1"),
+            "WorkGraphIssue:SecPal/.github#4:": issue_payload(4),
+            "WorkGraphIssue:SecPal/.github#5:": issue_payload(5),
+        }
+        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        root = snapshot.nodes[f"{REPO}#1"]
+        self.assertEqual(root.children, (f"{REPO}#2", f"{REPO}#3"))
+        self.assertEqual(root.blocked_by, (f"{REPO}#4", f"{REPO}#5"))
+
+    def test_ancestors_are_read_without_pulling_in_sibling_scopes(self):
+        # The fake gh fails on any unscripted request, so the absence of a
+        # request for #9 is asserted by the run completing at all.
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1,
+                state="CLOSED",
+                state_reason="COMPLETED",
+                sub_issues=(f"{REPO}#2", f"{REPO}#9"),
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+        }
+        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#2")
+        self.assertIn(f"{REPO}#1", snapshot.nodes)
+        self.assertNotIn(f"{REPO}#9", snapshot.nodes)
+        state = resolver.resolve(snapshot, f"{REPO}#2").states[f"{REPO}#2"]
+        self.assertFalse(state.ready)
+        self.assertEqual(state.reasons, (resolver.REASON_CLOSED_ANCESTOR,))
+
+    def test_each_issue_is_fetched_once_per_invocation(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1, sub_issues=(f"{REPO}#2", f"{REPO}#3")
+            ),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(
+                2, parent=f"{REPO}#1", blocked_by=(f"{REPO}#3",)
+            ),
+            "WorkGraphIssue:SecPal/.github#3:": issue_payload(3, parent=f"{REPO}#1"),
+        }
+        github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        documents = [json.loads(call["body"])["variables"]["number"] for call in self.calls()]
+        self.assertEqual(sorted(documents), [1, 2, 3])
+
+
+class ClaimObservationTests(AdapterTestCase):
+    def test_only_open_pull_requests_with_a_named_author_are_claims(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+                1,
+                claims=((10, "OPEN", "alice"), (11, "CLOSED", "bob"), (12, "OPEN", None)),
+            )
+        }
+        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        node = snapshot.nodes[f"{REPO}#1"]
+        self.assertEqual(node.claims, (model.Claim("alice", f"{REPO}#10", node.claims[0].url),))
+        self.assertTrue(node.claims_observable)
+
+    def test_inaccessible_claim_data_is_reported_rather_than_assumed_absent(self):
+        payload = issue_payload(1)
+        payload["data"]["repository"]["issue"]["closedByPullRequestsReferences"] = None
+        payload["errors"] = [
+            {
+                "type": "FORBIDDEN",
+                "path": ["repository", "issue", "closedByPullRequestsReferences"],
+                "message": "Resource not accessible",
+            }
+        ]
+        snapshot = github.load_snapshot(
+            self.adapter({"WorkGraphIssue:SecPal/.github#1:": payload}), f"{REPO}#1"
+        )
+        node = snapshot.nodes[f"{REPO}#1"]
+        self.assertFalse(node.claims_observable)
+        self.assertEqual(node.claims, ())
+
+
+class FailureTests(AdapterTestCase):
+    def test_missing_issue_becomes_an_unresolved_node(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(1, blocked_by=(f"{REPO}#404",)),
+            "WorkGraphIssue:SecPal/.github#404:": {
+                "data": {"repository": {"issue": None}},
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "path": ["repository", "issue"],
+                        "message": "Could not resolve to an Issue",
+                    }
+                ],
+            },
+        }
+        snapshot = github.load_snapshot(self.adapter(script), f"{REPO}#1")
+        missing = snapshot.nodes[f"{REPO}#404"]
+        self.assertFalse(missing.resolved)
+        self.assertEqual(missing.unresolved_reason, "NOT_FOUND")
+
+    def test_operational_failures_are_raised_instead_of_becoming_absence(self):
+        cases = {
+            "unparseable output": {"__raw": "not json at all", "__exit": 0},
+            "transport failure": {"__raw": "", "__exit": 1},
+            "server error": {
+                "data": None,
+                "errors": [{"type": "INTERNAL", "message": "something failed"}],
+            },
+        }
+        for label, response in cases.items():
+            with self.subTest(case=label):
+                adapter = self.adapter({"WorkGraphIssue:SecPal/.github#1:": response})
+                with self.assertRaises(github.GitHubError):
+                    github.load_snapshot(adapter, f"{REPO}#1")
+
+    def test_unresolvable_scope_root_is_raised(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": {
+                "data": {"repository": {"issue": None}},
+                "errors": [{"type": "NOT_FOUND", "path": ["repository", "issue"]}],
+            }
+        }
+        with self.assertRaises(github.GitHubError):
+            github.load_snapshot(self.adapter(script), f"{REPO}#1")
+
+    def test_the_node_budget_fails_closed(self):
+        script = {
+            "WorkGraphIssue:SecPal/.github#1:": issue_payload(1, sub_issues=(f"{REPO}#2",)),
+            "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+        }
+        with self.assertRaises(github.GitHubError):
+            github.load_snapshot(self.adapter(script, max_nodes=1), f"{REPO}#1")
+
+
+class ExecutorIdentityTests(AdapterTestCase):
+    def test_authenticated_identity_resolves_the_invocation_context(self):
+        script = {"WorkGraphViewer:/#:": {"data": {"viewer": {"login": "carol"}}}}
+        self.assertEqual(self.adapter(script).viewer_login(), "carol")
+
+
+class CommandTests(AdapterTestCase):
+    """The five commands #669 requires, rendered from one resolved model."""
+
+    SCRIPT = {
+        "WorkGraphIssue:SecPal/.github#1:": issue_payload(
+            1, sub_issues=(f"{REPO}#2", f"{REPO}#3")
+        ),
+        "WorkGraphIssue:SecPal/.github#2:": issue_payload(2, parent=f"{REPO}#1"),
+        "WorkGraphIssue:SecPal/.github#3:": issue_payload(
+            3, parent=f"{REPO}#1", blocked_by=(f"{REPO}#4",), body="No criteria.\n"
+        ),
+        "WorkGraphIssue:SecPal/.github#4:": issue_payload(4),
+    }
+
+    def run_command(self, *arguments):
+        self.script_path.write_text(json.dumps(self.SCRIPT), encoding="utf-8")
+        os.environ["FAKE_GH_SCRIPT"] = str(self.script_path)
+        os.environ["FAKE_GH_LOG"] = str(self.log_path)
+        self.addCleanup(os.environ.pop, "FAKE_GH_SCRIPT", None)
+        self.addCleanup(os.environ.pop, "FAKE_GH_LOG", None)
+        stdout, stderr = io.StringIO(), io.StringIO()
+        code = cli.main(
+            ["--gh", str(self.gh_path), *arguments], stdout=stdout, stderr=stderr
+        )
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_show_renders_the_normalized_subtree(self):
+        code, output, _ = self.run_command("show", f"{REPO}#1")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual([node["key"] for node in document["nodes"]], [f"{REPO}#{n}" for n in (1, 2, 3)])
+        self.assertEqual(document["nodes"][1]["path"], [0])
+        self.assertTrue(document["complete"])
+
+    def test_ready_returns_only_the_executable_leaf(self):
+        code, output, _ = self.run_command("ready", f"{REPO}#1")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual([node["key"] for node in document["ready"]], [f"{REPO}#2"])
+        self.assertEqual(
+            document["not_ready_leaves"],
+            [
+                {
+                    "key": f"{REPO}#3",
+                    "reasons": ["unsatisfied_dependency", "missing_acceptance_criteria"],
+                }
+            ],
+        )
+
+    def test_next_selects_one_leaf_for_the_given_executor(self):
+        code, output, _ = self.run_command("next", f"{REPO}#1", "--executor", "alice")
+        document = json.loads(output)
+        self.assertEqual(code, 0)
+        self.assertEqual(document["selected"]["key"], f"{REPO}#2")
+        self.assertIsNone(document["no_selection_reason"])
+        self.assertEqual(document["executor"], "alice")
+
+    def test_validate_reports_structural_findings_only(self):
+        code, output, _ = self.run_command("validate", f"{REPO}#1")
+        document = json.loads(output)
+        self.assertEqual(code, 1)
+        self.assertEqual(
+            {finding["code"] for finding in document["findings"]},
+            {"missing_acceptance_criteria"},
+        )
+
+    def test_validate_issue_explains_one_issue(self):
+        ready_code, ready_output, _ = self.run_command("validate-issue", f"{REPO}#2")
+        blocked_code, blocked_output, _ = self.run_command("validate-issue", f"{REPO}#3")
+        self.assertEqual(ready_code, 0)
+        self.assertTrue(json.loads(ready_output)["issue"]["ready"])
+        self.assertEqual(blocked_code, 1)
+        blocked = json.loads(blocked_output)["issue"]
+        self.assertTrue(blocked["blocked"])
+        self.assertFalse(blocked["malformed"])
+        self.assertEqual(
+            blocked["reasons"], ["unsatisfied_dependency", "missing_acceptance_criteria"]
+        )
+
+    def test_machine_output_is_deterministic_and_text_uses_the_same_model(self):
+        first = self.run_command("show", f"{REPO}#1")[1]
+        second = self.run_command("show", f"{REPO}#1")[1]
+        self.assertEqual(first, second)
+        text = self.run_command("--format", "text", "ready", f"{REPO}#1")[1]
+        self.assertIn(f"READY {REPO}#2", text)
+        self.assertIn(f"{REPO}#3", text)
+
+    def test_invalid_references_are_rejected_without_contacting_github(self):
+        code, _, stderr = self.run_command("show", "not-an-issue")
+        self.assertEqual(code, 2)
+        self.assertEqual(json.loads(stderr)["error"]["code"], "invalid_reference")
+        self.assertEqual(self.calls(), [])
+
+
+class SubprocessSafetyTests(TestCase):
+    def test_the_adapter_never_uses_a_shell(self):
+        source = (ROOT / "scripts/secpal_work_graph/github.py").read_text(encoding="utf-8")
+        self.assertNotIn("shell=True", source)
+        self.assertIn("timeout=", source)
+
+    def test_the_entrypoint_compiles(self):
+        subprocess.run(
+            [sys.executable, "-m", "py_compile", str(ROOT / "scripts/secpal-work-graph.py")],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Pure resolver and acceptance-criteria evidence for the work-graph resolver.
+
+Semantics under test: docs/work-graph-contract.md. These cases prove the
+machine-derivable rules of sections 1, 3, and 4 from synthetic snapshots, so no
+GitHub access happens here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase, main
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from secpal_work_graph import acceptance_criteria, model, resolver  # noqa: E402
+from secpal_work_graph.model import Claim, Node, build_snapshot  # noqa: E402
+
+REPO = "SecPal/.github"
+OTHER_REPO = "SecPal/api"
+
+
+def leaf(number: int, *, repository: str = REPO, **overrides) -> Node:
+    """Build a node that is `READY` unless an override says otherwise."""
+    fields = {
+        "repository": repository,
+        "number": number,
+        "has_acceptance_criteria": True,
+    }
+    fields.update(overrides)
+    return Node(**fields)
+
+
+def epic(number: int, children: tuple[str, ...], *, repository: str = REPO, **overrides) -> Node:
+    return leaf(number, repository=repository, children=children, **overrides)
+
+
+def key(number: int, repository: str = REPO) -> str:
+    return model.node_key(repository, number)
+
+
+def closed(reason: str = model.COMPLETED) -> dict[str, object]:
+    return {"state": model.CLOSED, "state_reason": reason}
+
+
+class ReadyPredicateTests(TestCase):
+    """Section 4.1 `READY` and its blocking reasons."""
+
+    def resolve_leaf(self, *nodes: Node, root: str | None = None) -> resolver.Resolution:
+        snapshot = build_snapshot(nodes)
+        return resolver.resolve(snapshot, root or nodes[0].key)
+
+    def test_standalone_root_leaf_is_ready(self):
+        resolution = self.resolve_leaf(leaf(1))
+        state = resolution.states[key(1)]
+        self.assertTrue(state.ready)
+        self.assertFalse(state.blocked)
+        self.assertFalse(state.malformed)
+        self.assertEqual(state.reasons, ())
+        self.assertEqual(resolution.ready_leaves(), (key(1),))
+
+    def test_nested_leaf_is_ready_and_its_epic_is_not(self):
+        resolution = self.resolve_leaf(
+            epic(1, (key(2),)),
+            leaf(2, parent=key(1)),
+        )
+        self.assertFalse(resolution.states[key(1)].ready)
+        self.assertIn(resolver.REASON_NOT_LEAF, resolution.states[key(1)].reasons)
+        self.assertTrue(resolution.states[key(2)].ready)
+        self.assertEqual(resolution.ready_leaves(), (key(2),))
+
+    def test_ready_conditions_each_remove_the_leaf(self):
+        cases = {
+            resolver.REASON_CLOSED: leaf(2, parent=key(1), **closed()),
+            resolver.REASON_MISSING_ACCEPTANCE_CRITERIA: leaf(2, parent=key(1), has_acceptance_criteria=False),
+            resolver.REASON_NOT_LEAF: leaf(2, parent=key(1), children=(key(9),)),
+        }
+        for reason, node in cases.items():
+            with self.subTest(reason=reason):
+                resolution = self.resolve_leaf(epic(1, (key(2),)), node, leaf(9, parent=key(2)), root=key(1))
+                state = resolution.states[key(2)]
+                self.assertFalse(state.ready)
+                self.assertIn(reason, state.reasons)
+
+    def test_closed_ancestor_makes_open_leaf_unexecutable(self):
+        resolution = self.resolve_leaf(
+            epic(1, (key(2),), **closed()),
+            leaf(2, parent=key(1)),
+            root=key(1),
+        )
+        state = resolution.states[key(2)]
+        self.assertFalse(state.ready)
+        self.assertEqual(state.reasons, (resolver.REASON_CLOSED_ANCESTOR,))
+        self.assertIn(
+            model.Finding(resolver.FINDING_CLOSED_ANCESTOR, key(2), key(1)),
+            resolution.findings,
+        )
+
+    def test_closed_ancestor_above_the_scope_root_still_applies(self):
+        resolution = self.resolve_leaf(
+            epic(1, (key(2),), **closed()),
+            epic(2, (key(3),), parent=key(1)),
+            leaf(3, parent=key(2)),
+            root=key(2),
+        )
+        self.assertEqual(resolution.ancestors, (key(1),))
+        self.assertFalse(resolution.states[key(3)].ready)
+        self.assertIn(resolver.REASON_CLOSED_ANCESTOR, resolution.states[key(3)].reasons)
+
+    def test_unresolved_ancestor_fails_closed_and_is_not_a_root_leaf(self):
+        resolution = self.resolve_leaf(leaf(2, parent=key(1)))
+        state = resolution.states[key(2)]
+        self.assertFalse(state.ready)
+        self.assertTrue(state.malformed)
+        self.assertEqual(state.reasons, (resolver.REASON_UNRESOLVED_ANCESTOR,))
+        self.assertFalse(resolution.complete)
+
+    def test_containment_cycle_fails_closed_without_becoming_blocked(self):
+        resolution = self.resolve_leaf(
+            epic(1, (key(2),), parent=key(2)),
+            leaf(2, parent=key(1), children=(key(1),)),
+            root=key(1),
+        )
+        state = resolution.states[key(1)]
+        self.assertFalse(state.ready)
+        self.assertTrue(state.malformed)
+        self.assertFalse(state.blocked)
+        self.assertIn(resolver.REASON_CONTAINMENT_CYCLE, state.reasons)
+        self.assertIn(
+            resolver.FINDING_CONTAINMENT_CYCLE,
+            {finding.code for finding in resolution.findings},
+        )
+
+
+class DependencyTests(TestCase):
+    """Sections 3.2 and 3.5 dependency semantics."""
+
+    def test_satisfaction_follows_the_closure_reason_rule(self):
+        cases = {
+            "open": ({}, False),
+            "completed": (closed(), True),
+            "not_planned": (closed("not_planned"), False),
+            "duplicate": (closed("duplicate"), False),
+        }
+        for label, (target_state, satisfied) in cases.items():
+            with self.subTest(target=label):
+                snapshot = build_snapshot(
+                    [
+                        leaf(1, blocked_by=(key(2),)),
+                        leaf(2, **target_state),
+                    ]
+                )
+                state = resolver.resolve(snapshot, key(1)).states[key(1)]
+                self.assertEqual(state.ready, satisfied)
+                self.assertEqual(state.blocked, not satisfied)
+                if not satisfied:
+                    self.assertIn(resolver.REASON_UNSATISFIED_DEPENDENCY, state.reasons)
+
+    def test_cross_repository_dependency_is_honoured(self):
+        snapshot = build_snapshot(
+            [
+                leaf(1, blocked_by=(key(7, OTHER_REPO),)),
+                leaf(7, repository=OTHER_REPO),
+            ]
+        )
+        state = resolver.resolve(snapshot, key(1)).states[key(1)]
+        self.assertTrue(state.blocked)
+        self.assertIn(resolver.REASON_UNSATISFIED_DEPENDENCY, state.reasons)
+
+    def test_missing_dependency_target_blocks_and_is_reported(self):
+        snapshot = build_snapshot([leaf(1, blocked_by=(key(404),))])
+        resolution = resolver.resolve(snapshot, key(1))
+        state = resolution.states[key(1)]
+        self.assertFalse(state.ready)
+        self.assertTrue(state.blocked)
+        self.assertIn(resolver.REASON_UNRESOLVED_DEPENDENCY, state.reasons)
+        self.assertIn(
+            resolver.FINDING_UNRESOLVED_DEPENDENCY,
+            {finding.code for finding in resolution.findings},
+        )
+        self.assertFalse(resolution.complete)
+
+    def test_dependency_cycle_blocks_members_and_their_dependents(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(3), key(4))),
+                leaf(2, parent=key(1), blocked_by=(key(3),)),
+                leaf(3, parent=key(1), blocked_by=(key(2),)),
+                leaf(4, parent=key(1), blocked_by=(key(2),)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        for number in (2, 3, 4):
+            with self.subTest(node=number):
+                state = resolution.states[key(number)]
+                self.assertFalse(state.ready)
+                self.assertIn(resolver.REASON_DEPENDENCY_CYCLE, state.reasons)
+        self.assertTrue(resolution.states[key(2)].blocked)
+        self.assertIn(
+            resolver.FINDING_DEPENDENCY_CYCLE,
+            {finding.code for finding in resolution.findings},
+        )
+
+    def test_dependencies_are_never_inherited_through_containment(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2),), blocked_by=(key(3),)),
+                leaf(2, parent=key(1)),
+                leaf(3),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertTrue(resolution.states[key(1)].blocked)
+        self.assertTrue(resolution.states[key(2)].ready)
+
+
+class NativeLimitTests(TestCase):
+    """Sections 2.2 and 3.2 native limits are validation constraints."""
+
+    def test_limits_are_reported_as_structural_findings(self):
+        children = tuple(key(number) for number in range(100, 100 + model.MAX_SUB_ISSUES_PER_PARENT + 1))
+        dependencies = tuple(key(number) for number in range(500, 500 + model.MAX_DEPENDENCIES_PER_TYPE + 1))
+        nodes = [epic(1, children, blocked_by=dependencies, blocking_count=model.MAX_DEPENDENCIES_PER_TYPE + 1)]
+        nodes.extend(leaf(number, parent=key(1)) for number in range(100, 100 + model.MAX_SUB_ISSUES_PER_PARENT + 1))
+        nodes.extend(leaf(number, **closed()) for number in range(500, 500 + model.MAX_DEPENDENCIES_PER_TYPE + 1))
+        resolution = resolver.resolve(build_snapshot(nodes), key(1))
+        codes = {finding.code for finding in resolution.findings}
+        self.assertIn(resolver.FINDING_SUB_ISSUE_LIMIT, codes)
+        self.assertIn(resolver.FINDING_DEPENDENCY_LIMIT, codes)
+        self.assertIn(resolver.FINDING_DEPENDENCY_LIMIT_BLOCKING, codes)
+
+    def test_nesting_beyond_the_native_depth_is_reported(self):
+        depth = model.MAX_NESTING_DEPTH + 1
+        nodes = [epic(0, (key(1),))]
+        nodes.extend(epic(number, (key(number + 1),), parent=key(number - 1)) for number in range(1, depth))
+        nodes.append(leaf(depth, parent=key(depth - 1)))
+        resolution = resolver.resolve(build_snapshot(nodes), key(0))
+        self.assertIn(
+            model.Finding(resolver.FINDING_NESTING_DEPTH, key(depth), str(depth)),
+            resolution.findings,
+        )
+        self.assertTrue(resolution.states[key(depth)].ready)
+
+
+class MirrorTests(TestCase):
+    """Section 1: a Markdown mirror never becomes graph state."""
+
+    def test_body_relationships_are_reported_but_change_nothing(self):
+        snapshot = build_snapshot([leaf(1, mirror_relationships=("blocked by", "parent"))])
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertTrue(resolution.states[key(1)].ready)
+        self.assertIn(
+            model.Finding(resolver.FINDING_MIRROR_RELATIONSHIP, key(1), "blocked by, parent"),
+            resolution.findings,
+        )
+
+    def test_mirror_detection_recognizes_bootstrap_lines_only(self):
+        body = "Parent: #1\n- Blocked by: #2\n**Order:** 3\nParenthetical: no\n"
+        self.assertEqual(model.mirror_relationships(body), ("blocked by", "order", "parent"))
+        self.assertEqual(model.mirror_relationships("no relationships here"), ())
+
+
+class DoneTests(TestCase):
+    """Section 4.1 `DONE` is native state, not proof of correct delivery."""
+
+    def test_done_reports_native_closure_without_judging_it(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(3))),
+                leaf(2, parent=key(1), has_acceptance_criteria=False, **closed()),
+                leaf(3, parent=key(1), **closed("not_planned")),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertTrue(resolution.states[key(2)].done)
+        self.assertFalse(resolution.states[key(3)].done)
+        for number in (2, 3):
+            self.assertFalse(resolution.states[key(number)].blocked)
+
+
+class ClaimTests(TestCase):
+    """Section 4.2 execution claims."""
+
+    def test_claim_on_a_ready_leaf_makes_it_active(self):
+        snapshot = build_snapshot([leaf(1, claims=(Claim("alice", f"{REPO}#10"),))])
+        self.assertTrue(resolver.resolve(snapshot, key(1)).states[key(1)].active)
+
+    def test_claim_on_a_non_ready_leaf_does_not_make_it_active(self):
+        snapshot = build_snapshot(
+            [leaf(1, has_acceptance_criteria=False, claims=(Claim("alice", f"{REPO}#10"),))]
+        )
+        state = resolver.resolve(snapshot, key(1)).states[key(1)]
+        self.assertFalse(state.active)
+        self.assertFalse(state.ready)
+
+    def test_unobservable_claims_leave_the_leaf_available_and_are_reported(self):
+        snapshot = build_snapshot([leaf(1, claims_observable=False)])
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertTrue(resolution.states[key(1)].ready)
+        self.assertFalse(resolution.states[key(1)].active)
+        self.assertIn(
+            model.Finding(resolver.FINDING_CLAIMS_UNOBSERVABLE, key(1)),
+            resolution.findings,
+        )
+        self.assertEqual(
+            resolution.select_next("alice").selected,
+            key(1),
+        )
+
+
+class NextSelectionTests(TestCase):
+    """Section 4.3 deterministic `NEXT`."""
+
+    def parallel_epic(self, *leaves: Node) -> resolver.Resolution:
+        children = tuple(node.key for node in leaves)
+        snapshot = build_snapshot([epic(1, children), *leaves])
+        return resolver.resolve(snapshot, key(1))
+
+    def test_parallelism_is_preserved_and_sibling_order_only_biases_selection(self):
+        resolution = self.parallel_epic(leaf(5, parent=key(1)), leaf(4, parent=key(1)))
+        self.assertEqual(resolution.ready_leaves(), (key(5), key(4)))
+        self.assertEqual(resolution.select_next("alice").selected, key(5))
+
+    def test_priority_rank_outranks_sibling_order(self):
+        resolution = self.parallel_epic(
+            leaf(5, parent=key(1)),
+            leaf(4, parent=key(1), priority_labels=("priority: high",)),
+        )
+        self.assertEqual(resolution.select_next("alice").selected, key(4))
+
+    def test_highest_recognized_label_wins_and_unknown_labels_rank_lowest(self):
+        resolution = self.parallel_epic(
+            leaf(5, parent=key(1), priority_labels=("priority: urgent",)),
+            leaf(4, parent=key(1), priority_labels=("priority: medium", "priority: blocker")),
+        )
+        self.assertEqual(resolution.select_next("alice").selected, key(4))
+        self.assertEqual(resolution.states[key(5)].priority_rank, model.UNRECOGNIZED_PRIORITY_RANK)
+
+    def test_ties_break_by_repository_then_issue_number(self):
+        # Distinct leaves under one root always differ in path order, so the last
+        # two keys of section 4.3 are proven on the ordering function itself.
+        same_path = (0,)
+        ordered = [
+            resolver.SelectionKey(priority_rank=2, path=same_path, repository=REPO, number=8),
+            resolver.SelectionKey(priority_rank=1, path=same_path, repository=REPO, number=3),
+            resolver.SelectionKey(priority_rank=1, path=same_path, repository=REPO, number=8),
+            resolver.SelectionKey(priority_rank=1, path=same_path, repository=OTHER_REPO, number=3),
+            resolver.SelectionKey(priority_rank=1, path=(0, 0), repository=REPO, number=1),
+        ]
+        self.assertEqual(sorted(ordered), ordered)
+
+    def test_path_order_compares_vectors_lexicographically(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(5))),
+                epic(2, (key(3),), parent=key(1)),
+                leaf(3, parent=key(2)),
+                leaf(5, parent=key(1)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertEqual(resolution.states[key(3)].path, (0, 0))
+        self.assertEqual(resolution.states[key(5)].path, (1,))
+        self.assertEqual(resolution.select_next("alice").selected, key(3))
+
+    def test_foreign_claims_are_excluded_and_own_claims_are_not(self):
+        resolution = self.parallel_epic(
+            leaf(5, parent=key(1), claims=(Claim("bob", f"{REPO}#10"),)),
+            leaf(4, parent=key(1), claims=(Claim("alice", f"{REPO}#11"),)),
+        )
+        result = resolution.select_next("alice")
+        self.assertEqual(result.selected, key(4))
+        self.assertEqual(result.candidates, (key(4),))
+
+    def test_no_ready_leaf_and_all_candidates_claimed_are_distinct(self):
+        blocked = self.parallel_epic(leaf(5, parent=key(1), has_acceptance_criteria=False))
+        empty = blocked.select_next("alice")
+        self.assertIsNone(empty.selected)
+        self.assertEqual(empty.no_selection_reason, resolver.NO_READY_LEAF)
+
+        claimed = self.parallel_epic(leaf(5, parent=key(1), claims=(Claim("bob", f"{REPO}#10"),)))
+        result = claimed.select_next("alice")
+        self.assertIsNone(result.selected)
+        self.assertEqual(result.no_selection_reason, resolver.ALL_CANDIDATES_CLAIMED)
+
+    def test_cross_repository_containment_keeps_native_order(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(7, OTHER_REPO), key(2))),
+                leaf(7, repository=OTHER_REPO, parent=key(1)),
+                leaf(2, parent=key(1)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertEqual(resolution.ready_leaves(), (key(7, OTHER_REPO), key(2)))
+
+
+class AcceptanceCriteriaTests(TestCase):
+    """Section 4.1 structural acceptance-criteria detection."""
+
+    ACCEPTED = {
+        "canonical heading": "## Acceptance Criteria\n\n- one\n",
+        "approved decoration": "### ✅ Acceptance Criteria\n\n- one\n",
+        "trailing colon and case": "## acceptance criteria:\n\ntext\n",
+        "upper case deep heading": "#### ACCEPTANCE CRITERIA\n\ntext\n",
+        "emphasis inside heading": "## **Acceptance Criteria**\n\ntext\n",
+        "fenced block as content": "## Acceptance Criteria\n\n```\ncode\n```\n",
+        "heading after other sections": "# Goal\n\ntext\n\n## Acceptance Criteria\n\n- one\n",
+    }
+
+    REJECTED = {
+        "fenced code": "```markdown\n## Acceptance Criteria\n\n- one\n```\n",
+        "indented code": "    ## Acceptance Criteria\n\n    - one\n",
+        "blockquote": "> ## Acceptance Criteria\n>\n> - one\n",
+        "bold text": "**Acceptance Criteria**\n\n- one\n",
+        "prose mention": "This issue has acceptance criteria below.\n",
+        "unapproved decoration": "## \U0001f3af Acceptance Criteria\n\n- one\n",
+        "parenthetical suffix": "## Acceptance Criteria (draft)\n\n- one\n",
+        "different words": "## Criteria\n\n- one\n",
+        "empty section": "## Acceptance Criteria\n\n## Non-Goals\n\n- one\n",
+        "empty body": "",
+        "setext heading": "Acceptance Criteria\n===\n\n- one\n",
+    }
+
+    def test_structural_detection_matches_the_canonical_procedure(self):
+        for label, body in self.ACCEPTED.items():
+            with self.subTest(accepted=label):
+                self.assertTrue(acceptance_criteria.has_acceptance_criteria(body))
+        for label, body in self.REJECTED.items():
+            with self.subTest(rejected=label):
+                self.assertFalse(acceptance_criteria.has_acceptance_criteria(body))
+
+    def test_batch_detection_preserves_input_order(self):
+        bodies = ["## Acceptance Criteria\n\ntext\n", "nothing", "## acceptance criteria:\n\ntext\n"]
+        self.assertEqual(acceptance_criteria.detect(bodies), [True, False, True])
+
+    def test_detection_failure_is_raised_rather_than_defaulted(self):
+        with self.assertRaises(acceptance_criteria.MarkdownParserUnavailable):
+            acceptance_criteria.detect(["text"], node_executable="definitely-not-node")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -11,9 +11,12 @@ GitHub access happens here.
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 from unittest import TestCase, main
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -185,6 +188,20 @@ class MalformedContainmentTests(TestCase):
                 self.assertNotIn(key(2), resolution.ready_leaves())
                 self.assertIsNone(resolution.select_next("alice").selected)
 
+    def test_an_inconsistent_containment_edge_does_not_admit_its_descendants(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2),)),
+                epic(2, (key(3),), parent=key(8)),
+                leaf(3, parent=key(2)),
+                leaf(8),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertIn(resolver.REASON_CONTAINMENT_INCONSISTENT, resolution.states[key(2)].reasons)
+        self.assertNotIn(key(3), resolution.states)
+        self.assertFalse(resolution.complete)
+
 
 class SelectionInputTests(TestCase):
     """Sections 1.1 and 1.2: selection metadata is an input to `NEXT` only."""
@@ -336,6 +353,20 @@ class DependencyTests(TestCase):
         self.assertFalse(state.blocked)
         self.assertEqual(state.reasons, (resolver.REASON_DEPENDENCY_CYCLE,))
 
+    def test_a_cycle_outside_the_scope_is_reported_when_it_taints_a_scope_node(self):
+        snapshot = build_snapshot(
+            [
+                leaf(1, blocked_by=(key(2),)),
+                leaf(2, blocked_by=(key(3),), **closed()),
+                leaf(3, blocked_by=(key(2),), **closed()),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertIn(
+            model.Finding(resolver.FINDING_DEPENDENCY_CYCLE, key(2), f"{key(2)}, {key(3)}"),
+            resolution.findings,
+        )
+
     def test_dependencies_are_never_inherited_through_containment(self):
         snapshot = build_snapshot(
             [
@@ -393,6 +424,10 @@ class MirrorTests(TestCase):
         body = "Parent: #1\n- Blocked by: #2\n**Order:** 3\nParenthetical: no\n"
         self.assertEqual(model.mirror_relationships(body), ("blocked by", "order", "parent"))
         self.assertEqual(model.mirror_relationships("no relationships here"), ())
+
+    def test_mirror_detection_ignores_code_examples(self):
+        body = "```markdown\nParent: #1\n```\n\n    Blocked by: #2\n"
+        self.assertEqual(model.mirror_relationships(body), ())
 
 
 class DoneTests(TestCase):
@@ -484,6 +519,10 @@ class NextSelectionTests(TestCase):
         ]
         self.assertEqual(sorted(ordered), ordered)
 
+    def test_selection_key_returns_not_implemented_for_other_types(self):
+        selection_key = resolver.SelectionKey(1, (), REPO, 1)
+        self.assertIs(selection_key.__lt__(object()), NotImplemented)
+
     def test_path_order_compares_vectors_lexicographically(self):
         snapshot = build_snapshot(
             [
@@ -506,6 +545,12 @@ class NextSelectionTests(TestCase):
         result = resolution.select_next("alice")
         self.assertEqual(result.selected, key(4))
         self.assertEqual(result.candidates, (key(4),))
+
+    def test_claim_logins_compare_case_insensitively(self):
+        resolution = self.parallel_epic(
+            leaf(5, parent=key(1), claims=(Claim("Alice", f"{REPO}#10"),)),
+        )
+        self.assertEqual(resolution.select_next("alice").selected, key(5))
 
     def test_no_ready_leaf_and_all_candidates_claimed_are_distinct(self):
         # Both are ordinary answers over a complete input set, so neither is an
@@ -571,6 +616,20 @@ class AcceptanceCriteriaTests(TestCase):
     def test_detection_failure_is_raised_rather_than_defaulted(self):
         with self.assertRaises(acceptance_criteria.MarkdownParserUnavailable):
             acceptance_criteria.detect(["text"], node_executable="definitely-not-node")
+
+    def test_detection_uses_bounded_parser_batches_in_input_order(self):
+        calls: list[list[str]] = []
+
+        def parser_run(*args, **kwargs):
+            bodies = json.loads(kwargs["input"])
+            calls.append(bodies)
+            return subprocess.CompletedProcess(args, 0, json.dumps([[] for _ in bodies]), "")
+
+        with patch.object(acceptance_criteria, "DETECTION_BATCH_SIZE", 2, create=True), patch.object(
+            acceptance_criteria.subprocess, "run", side_effect=parser_run
+        ):
+            self.assertEqual(acceptance_criteria.detect(["one", "two", "three"]), [False, False, False])
+        self.assertEqual(calls, [["one", "two"], ["three"]])
 
 
 if __name__ == "__main__":

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -397,6 +397,12 @@ class NextSelectionTests(TestCase):
             resolver.SelectionKey(priority_rank=1, path=(0, 0), repository=REPO, number=1),
         ]
         self.assertEqual(sorted(ordered), ordered)
+        # The ordering is a total order, so every comparison operator answers
+        # consistently rather than only the one `sorted` happens to call.
+        first, second = ordered[0], ordered[1]
+        self.assertTrue(first < second and first <= second and second > first and second >= first)
+        self.assertTrue(first <= first and first >= first)
+        self.assertFalse(first > second or second < first)
 
     def test_path_order_compares_vectors_lexicographically(self):
         snapshot = build_snapshot(

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -438,23 +438,19 @@ class MirrorTests(TestCase):
             resolution.findings,
         )
 
-    def test_mirror_detection_recognizes_bootstrap_lines_only(self):
-        body = "Parent: #1\n- Blocked by: #2\n**Order:** 3\nParenthetical: no\n"
-        self.assertEqual(model.mirror_relationships(body), ("blocked by", "order", "parent"))
-        self.assertEqual(model.mirror_relationships("no relationships here"), ())
-
-    def test_mirror_detection_ignores_code_examples(self):
-        body = "```markdown\nParent: #1\n```\n\n    Blocked by: #2\n"
-        self.assertEqual(model.mirror_relationships(body), ())
-
-    def test_mirror_detection_keeps_shorter_fences_inside_a_long_fence(self):
+    def test_mirror_detection_uses_top_level_markdown_structure(self):
         bodies = (
-            "````markdown\n```\nParent: #1\n````\n",
+            "Parent: #1\n**Order:** 3\n",
+            "> quoted context\nParent: #1\n",
+            "- list context\n  Parent: #1\n",
+            "```markdown\nParent: #1\n```\n\n    Blocked by: #2\n",
             "````markdown\n```not-a-close\nParent: #1\n````\n",
         )
-        for body in bodies:
-            with self.subTest(body=body):
-                self.assertEqual(model.mirror_relationships(body), ())
+        facts = acceptance_criteria.parse(bodies)
+        self.assertEqual(
+            [fact.relationship_mirrors for fact in facts],
+            [("order", "parent"), (), (), (), ()],
+        )
 
 
 class DoneTests(TestCase):
@@ -615,12 +611,14 @@ class AcceptanceCriteriaTests(TestCase):
         "trailing colon and case": "## acceptance criteria:\n\ntext\n",
         "upper case deep heading": "#### ACCEPTANCE CRITERIA\n\ntext\n",
         "emphasis inside heading": "## **Acceptance Criteria**\n\ntext\n",
+        "inline code inside heading": "## `Acceptance` Criteria\n\ntext\n",
         "fenced block as content": "## Acceptance Criteria\n\n```\ncode\n```\n",
         "heading after other sections": "# Goal\n\ntext\n\n## Acceptance Criteria\n\n- one\n",
     }
 
     REJECTED = {
         "fenced code": "```markdown\n## Acceptance Criteria\n\n- one\n```\n",
+        "image alt text": "## ![draft](x) Acceptance Criteria\n\n- one\n",
         "indented code": "    ## Acceptance Criteria\n\n    - one\n",
         "blockquote": "> ## Acceptance Criteria\n>\n> - one\n",
         "bold text": "**Acceptance Criteria**\n\n- one\n",
@@ -638,11 +636,14 @@ class AcceptanceCriteriaTests(TestCase):
         bodies = list(self.ACCEPTED.values()) + list(self.REJECTED.values())
         expected = [True] * len(self.ACCEPTED) + [False] * len(self.REJECTED)
         # One batch call also proves detection stays aligned with its input order.
-        self.assertEqual(dict(zip(labels, acceptance_criteria.detect(bodies))), dict(zip(labels, expected)))
+        self.assertEqual(
+            dict(zip(labels, [fact.has_acceptance_criteria for fact in acceptance_criteria.parse(bodies)])),
+            dict(zip(labels, expected)),
+        )
 
     def test_detection_failure_is_raised_rather_than_defaulted(self):
         with self.assertRaises(acceptance_criteria.MarkdownParserUnavailable):
-            acceptance_criteria.detect(["text"], node_executable="definitely-not-node")
+            acceptance_criteria.parse(["text"], node_executable="definitely-not-node")
 
     def test_detection_uses_bounded_parser_batches_in_input_order(self):
         calls: list[list[str]] = []
@@ -650,12 +651,20 @@ class AcceptanceCriteriaTests(TestCase):
         def parser_run(*args, **kwargs):
             bodies = json.loads(kwargs["input"])
             calls.append(bodies)
-            return subprocess.CompletedProcess(args, 0, json.dumps([[] for _ in bodies]), "")
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps([{"headings": [], "relationshipMirrors": []} for _ in bodies]),
+                "",
+            )
 
         with patch.object(acceptance_criteria, "DETECTION_BATCH_SIZE", 2, create=True), patch.object(
             acceptance_criteria.subprocess, "run", side_effect=parser_run
         ):
-            self.assertEqual(acceptance_criteria.detect(["one", "two", "three"]), [False, False, False])
+            self.assertEqual(
+                [fact.has_acceptance_criteria for fact in acceptance_criteria.parse(["one", "two", "three"])],
+                [False, False, False],
+            )
         self.assertEqual(calls, [["one", "two"], ["three"]])
 
 

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -150,6 +150,92 @@ class MalformedContainmentTests(TestCase):
             {finding.code for finding in resolution.findings},
         )
 
+    def test_an_unobservable_parent_is_not_a_standalone_root(self):
+        # Section 3.5: an inaccessible parent is not the same as no parent, and
+        # that holds wherever it sits in the chain.
+        blind = {"parent": None, "parent_observable": False}
+        cases = {
+            "the leaf itself": ([leaf(1, **blind)], key(1)),
+            "an ancestor": ([epic(1, (key(2),), **blind), leaf(2, parent=key(1))], key(2)),
+        }
+        for label, (nodes, subject) in cases.items():
+            with self.subTest(unobservable_on=label):
+                state = resolver.resolve(build_snapshot(nodes), key(1)).states[subject]
+                self.assertFalse(state.ready)
+                self.assertTrue(state.malformed)
+                self.assertIn(resolver.REASON_UNRESOLVED_ANCESTOR, state.reasons)
+
+    def test_a_containment_edge_the_child_does_not_confirm_is_not_selectable(self):
+        # One invocation reads several issues, so a parent's sub-issue list and
+        # the child's own parent can disagree. Neither is preferred.
+        for label, child_parent in (("another parent", key(8)), ("no parent", None)):
+            with self.subTest(child_says=label):
+                snapshot = build_snapshot(
+                    [epic(1, (key(2), key(3))), leaf(2, parent=child_parent), leaf(3, parent=key(1))]
+                )
+                resolution = resolver.resolve(snapshot, key(1))
+                state = resolution.states[key(2)]
+                self.assertFalse(state.ready)
+                self.assertTrue(state.malformed)
+                self.assertIn(resolver.REASON_CONTAINMENT_INCONSISTENT, state.reasons)
+                self.assertIn(
+                    model.Finding(resolver.FINDING_CONTAINMENT_INCONSISTENT, key(2), key(1)),
+                    resolution.findings,
+                )
+                self.assertNotIn(key(2), resolution.ready_leaves())
+                self.assertIsNone(resolution.select_next("alice").selected)
+
+
+class SelectionInputTests(TestCase):
+    """Sections 1.1 and 1.2: selection metadata is an input to `NEXT` only."""
+
+    def test_unobservable_priority_labels_do_not_change_ready(self):
+        snapshot = build_snapshot([leaf(1, priority_labels_observable=False)])
+        state = resolver.resolve(snapshot, key(1)).states[key(1)]
+        self.assertTrue(state.ready)
+        self.assertFalse(state.blocked)
+
+    def test_unobservable_priority_labels_are_never_silently_ranked_as_unlabeled(self):
+        snapshot = build_snapshot([leaf(1, priority_labels_observable=False)])
+        result = resolver.resolve(snapshot, key(1)).select_next("alice")
+        self.assertIsNone(result.selected)
+        self.assertIsNone(result.no_selection_reason)
+        self.assertEqual(result.incomplete_reason, resolver.INCOMPLETE_SELECTION_METADATA)
+
+
+class NextCandidateUniverseTests(TestCase):
+    """Section 4.2 and 4.3: `NEXT` needs the whole candidate set, not a subset."""
+
+    def test_an_unreadable_sibling_suspends_next_but_not_the_known_ready_leaf(self):
+        snapshot = build_snapshot([epic(1, (key(404), key(2))), leaf(2, parent=key(1))])
+        resolution = resolver.resolve(snapshot, key(1))
+        # Section 3.1: containment never blocks a sibling, so the known leaf is
+        # still truthfully READY and `ready`/`show` may report it.
+        self.assertTrue(resolution.states[key(2)].ready)
+        self.assertEqual(resolution.ready_leaves(), (key(2),))
+        self.assertFalse(resolution.complete)
+        # The unreadable sibling could outrank it, so `NEXT` is not derivable.
+        result = resolution.select_next("alice")
+        self.assertIsNone(result.selected)
+        self.assertIsNone(result.no_selection_reason)
+        self.assertEqual(result.incomplete_reason, resolver.INCOMPLETE_CANDIDATE_SCOPE)
+
+    def test_a_locally_failed_closed_leaf_still_leaves_next_derivable(self):
+        # An unresolved dependency makes that leaf canonically non-READY, which
+        # is a complete answer, so a fully known sibling stays selectable.
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(3))),
+                leaf(2, parent=key(1), blocked_by=(key(404),)),
+                leaf(3, parent=key(1)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertFalse(resolution.complete)
+        result = resolution.select_next("alice")
+        self.assertEqual(result.selected, key(3))
+        self.assertIsNone(result.incomplete_reason)
+
     def test_a_second_parent_is_reported_without_inventing_a_state_rule(self):
         snapshot = build_snapshot(
             [
@@ -428,15 +514,19 @@ class NextSelectionTests(TestCase):
         self.assertEqual(result.candidates, (key(4),))
 
     def test_no_ready_leaf_and_all_candidates_claimed_are_distinct(self):
+        # Both are ordinary answers over a complete input set, so neither is an
+        # incompleteness result.
         blocked = self.parallel_epic(leaf(5, parent=key(1), has_acceptance_criteria=False))
         empty = blocked.select_next("alice")
         self.assertIsNone(empty.selected)
         self.assertEqual(empty.no_selection_reason, resolver.NO_READY_LEAF)
+        self.assertIsNone(empty.incomplete_reason)
 
         claimed = self.parallel_epic(leaf(5, parent=key(1), claims=(Claim("bob", f"{REPO}#10"),)))
         result = claimed.select_next("alice")
         self.assertIsNone(result.selected)
         self.assertEqual(result.no_selection_reason, resolver.ALL_CANDIDATES_CLAIMED)
+        self.assertIsNone(result.incomplete_reason)
 
     def test_cross_repository_containment_keeps_native_order(self):
         snapshot = build_snapshot(

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -202,6 +202,24 @@ class MalformedContainmentTests(TestCase):
         self.assertNotIn(key(3), resolution.states)
         self.assertFalse(resolution.complete)
 
+    def test_a_late_second_parent_does_not_leave_descendants_in_scope(self):
+        # The matching parent is traversed first and expands the child's
+        # descendants before the second parent's conflicting listing is seen.
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(3))),
+                epic(2, (key(4),), parent=key(1)),
+                epic(3, (key(4),), parent=key(1)),
+                epic(4, (key(5),), parent=key(2)),
+                leaf(5, parent=key(4)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertIn(resolver.REASON_CONTAINMENT_INCONSISTENT, resolution.states[key(4)].reasons)
+        self.assertNotIn(key(5), resolution.states)
+        self.assertNotIn(key(5), resolution.ready_leaves())
+        self.assertFalse(resolution.complete)
+
 
 class SelectionInputTests(TestCase):
     """Sections 1.1 and 1.2: selection metadata is an input to `NEXT` only."""
@@ -428,6 +446,15 @@ class MirrorTests(TestCase):
     def test_mirror_detection_ignores_code_examples(self):
         body = "```markdown\nParent: #1\n```\n\n    Blocked by: #2\n"
         self.assertEqual(model.mirror_relationships(body), ())
+
+    def test_mirror_detection_keeps_shorter_fences_inside_a_long_fence(self):
+        bodies = (
+            "````markdown\n```\nParent: #1\n````\n",
+            "````markdown\n```not-a-close\nParent: #1\n````\n",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(model.mirror_relationships(body), ())
 
 
 class DoneTests(TestCase):

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -137,6 +137,35 @@ class ReadyPredicateTests(TestCase):
         )
 
 
+class MalformedContainmentTests(TestCase):
+    """Section 3.1 and 3.5 containment defects the resolver can observe."""
+
+    def test_unresolvable_sub_issue_leaves_the_executable_set_incomplete(self):
+        snapshot = build_snapshot([epic(1, (key(2), key(404))), leaf(2, parent=key(1))])
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertEqual(resolution.ready_leaves(), (key(2),))
+        self.assertFalse(resolution.complete)
+        self.assertIn(
+            resolver.FINDING_UNRESOLVED_SUB_ISSUE,
+            {finding.code for finding in resolution.findings},
+        )
+
+    def test_a_second_parent_is_reported_without_inventing_a_state_rule(self):
+        snapshot = build_snapshot(
+            [
+                epic(1, (key(2), key(3))),
+                epic(2, (key(9),), parent=key(1)),
+                epic(3, (key(9),), parent=key(1)),
+                leaf(9, parent=key(2)),
+            ]
+        )
+        resolution = resolver.resolve(snapshot, key(1))
+        self.assertIn(
+            model.Finding(resolver.FINDING_MULTIPLE_PARENTS, key(9), f"{key(2)}, {key(3)}"),
+            resolution.findings,
+        )
+
+
 class DependencyTests(TestCase):
     """Sections 3.2 and 3.5 dependency semantics."""
 
@@ -205,6 +234,21 @@ class DependencyTests(TestCase):
             resolver.FINDING_DEPENDENCY_CYCLE,
             {finding.code for finding in resolution.findings},
         )
+
+    def test_depending_on_a_cycle_fails_closed_without_participating_in_it(self):
+        # Section 4.1 makes only a participant `BLOCKED`; section 3.5 still keeps
+        # every node that depends on a cycle out of `READY`.
+        snapshot = build_snapshot(
+            [
+                leaf(1, blocked_by=(key(2),)),
+                leaf(2, blocked_by=(key(3),), **closed()),
+                leaf(3, blocked_by=(key(2),), **closed()),
+            ]
+        )
+        state = resolver.resolve(snapshot, key(1)).states[key(1)]
+        self.assertFalse(state.ready)
+        self.assertFalse(state.blocked)
+        self.assertEqual(state.reasons, (resolver.REASON_DEPENDENCY_CYCLE,))
 
     def test_dependencies_are_never_inherited_through_containment(self):
         snapshot = build_snapshot(
@@ -428,16 +472,11 @@ class AcceptanceCriteriaTests(TestCase):
     }
 
     def test_structural_detection_matches_the_canonical_procedure(self):
-        for label, body in self.ACCEPTED.items():
-            with self.subTest(accepted=label):
-                self.assertTrue(acceptance_criteria.has_acceptance_criteria(body))
-        for label, body in self.REJECTED.items():
-            with self.subTest(rejected=label):
-                self.assertFalse(acceptance_criteria.has_acceptance_criteria(body))
-
-    def test_batch_detection_preserves_input_order(self):
-        bodies = ["## Acceptance Criteria\n\ntext\n", "nothing", "## acceptance criteria:\n\ntext\n"]
-        self.assertEqual(acceptance_criteria.detect(bodies), [True, False, True])
+        labels = list(self.ACCEPTED) + list(self.REJECTED)
+        bodies = list(self.ACCEPTED.values()) + list(self.REJECTED.values())
+        expected = [True] * len(self.ACCEPTED) + [False] * len(self.REJECTED)
+        # One batch call also proves detection stays aligned with its input order.
+        self.assertEqual(dict(zip(labels, acceptance_criteria.detect(bodies))), dict(zip(labels, expected)))
 
     def test_detection_failure_is_raised_rather_than_defaulted(self):
         with self.assertRaises(acceptance_criteria.MarkdownParserUnavailable):

--- a/tests/secpal-work-graph-unit.py
+++ b/tests/secpal-work-graph-unit.py
@@ -483,12 +483,6 @@ class NextSelectionTests(TestCase):
             resolver.SelectionKey(priority_rank=1, path=(0, 0), repository=REPO, number=1),
         ]
         self.assertEqual(sorted(ordered), ordered)
-        # The ordering is a total order, so every comparison operator answers
-        # consistently rather than only the one `sorted` happens to call.
-        first, second = ordered[0], ordered[1]
-        self.assertTrue(first < second and first <= second and second > first and second >= first)
-        self.assertTrue(first <= first and first >= first)
-        self.assertFalse(first > second or second < first)
 
     def test_path_order_compares_vectors_lexicographically(self):
         snapshot = build_snapshot(


### PR DESCRIPTION
## Description

Implements read-only SecPal work-graph resolution: a small resolver that
translates GitHub's native work graph into the machine-derived state already
specified by the canonical contract.

Semantics: `docs/work-graph-contract.md`. This PR defines no work-graph
semantics of its own and does not change that document.

### Architecture

`scripts/secpal-work-graph.py` is the CLI entrypoint; the implementation lives in
`scripts/secpal_work_graph/` with one responsibility per module:

| Module                   | Responsibility                                                              |
| ------------------------ | --------------------------------------------------------------------------- |
| `github.py`              | the single GitHub read boundary, and normalization into a snapshot           |
| `model.py`               | the immutable normalized snapshot: only inputs the contract consumes         |
| `resolver.py`            | pure derivation of `BLOCKED`, `DONE`, `READY`, `ACTIVE`, executable set, `NEXT` |
| `acceptance_criteria.py` | structural Markdown facts and canonical acceptance-criteria normalization (section 4.1)                       |
| `markdown_headings.mjs`  | structural Markdown extraction through the `markdown-it` parser               |
| `cli.py`                 | argument parsing and deterministic rendering from one resolved model          |

The resolver is pure: it takes an immutable snapshot plus a scope root and runs
without GitHub, which is how every semantic case is proven. Rendering derives
both JSON and text from the same `Resolution`, so the two cannot disagree.

### GitHub surfaces used

Every read goes through `gh api graphql --input -` with named `query` documents
and no shell. The GraphQL fields consumed are exactly:

- `Issue.state`, `Issue.stateReason` — native state and closure reason
- `Issue.parent`, `Issue.subIssues` — native containment and native sibling order
- `Issue.blockedBy`, `Issue.blocking` — native dependencies, including
  cross-repository ones, plus the `blocks` count for the section 3.2 limit
- `Issue.labels` — filtered down to the recognized priority labels of section 4.3
- `Issue.body` — read only for the structural acceptance-criteria fact and for
  reporting body relationship mirrors
- `Issue.closedByPullRequestsReferences(includeClosedPrs: false)` — the
  machine-recognizable closing relationship that section 4.2 recognizes as a claim
- `viewer.login` — the invocation-context executor identity when `--executor` is
  omitted

No REST mutation endpoint, no `gh issue`/`gh pr` subcommand, and no human-readable
`gh` output is used. Every connection is paginated to exhaustion.

One issue has exactly one identity: the one GitHub returns. GitHub accepts
repository spellings it then canonicalizes, so every node is keyed by the
returned `nameWithOwner#number` and the canonical scope root is propagated to the
resolver. A returned issue number that does not match the requested lookup is a
read-boundary error rather than an alias.

Observability of a native input is all-or-nothing. A GraphQL access error
anywhere under `parent`, `subIssues` or `blockedBy` — first page or follow-up
page, whole field or a single node — is never normalized into absent data:
`parent` records that it was unobservable rather than null, and an unreadable
relationship leaves the node unresolved instead of yielding a shorter complete
list. `labels` and claims degrade on their own, because section 1.2 keeps them
out of `READY`; claim observability is all-or-nothing per invocation, so a first
page and a continuation page fail identically and a partially visible claim
subset is never treated as complete.

### Commands and machine output

```text
show <root>            normalized graph view for the scope root
validate <root>        machine-derivable structural findings only
ready <root>           every READY delivery leaf under the scope root
next <root>            the canonical NEXT result for one executor
validate-issue <issue> the resolved state of one issue
```

Machine output is deterministic JSON (`schema: secpal-work-graph/v1`) with a
stable envelope: `status`, `scope_root`, `complete`, and `findings`, plus the
command's own payload. It distinguishes successful resolution, structural
findings, node identity and predicates, the `READY` set, the selected `NEXT`
leaf, both canonical no-selection reasons, and malformed/unresolved conditions.
`--format text` renders the same document.

Exit codes: `0` success, `1` findings reported (`validate`), issue not `READY`
(`validate-issue`), or `NEXT` inputs not fully observable (`next`), `2` invalid
input, `3` GitHub or parser failure.

### Contract points worth reviewing

- `BLOCKED` is true only for an open node with an unsatisfied or unresolvable
  dependency, or one that itself participates in a dependency cycle. A node that
  merely depends on a cycle member is kept out of `READY` without being reported
  as `BLOCKED`, and malformed containment is the separate fail-closed condition,
  reported as `malformed` rather than collapsed into `BLOCKED`.
- A dependency is satisfied only by closure reason `completed`.
- Dependencies are never inherited through containment.
- Unresolved parents, containment cycles, dependency cycles, and unreadable
  dependency targets all fail closed; an inaccessible parent never becomes a root
  leaf, and an API failure never becomes absent data.
- A parent's sub-issue list and a child's own parent are read through separate
  requests, so they can disagree within one invocation. Such an edge is reported
  as a structural finding and keeps the child out of `READY` and `NEXT` in that
  scope; neither observation is preferred and nothing is retried or repaired.
- Priority labels are selection metadata only. Unreadable labels never change
  `READY`, `BLOCKED` or `DONE`, and never become a silent priority rank of zero.
- `NEXT` reports incomplete inputs rather than a canonical leaf when an
  unreadable sub-issue or an ambiguous containment edge could change the
  candidate set or its order, or when a candidate's priority metadata is
  unobservable. That is distinct from both canonical no-selection reasons, which
  are unchanged and remain ordinary answers. A leaf that fails closed on its own
  inputs is a complete answer, so a fully known sibling stays selectable and
  `ready`/`show` still report it as `READY` alongside `complete: false`.
- `DONE` is reported as native state; the resolver makes no claim about whether
  the closure was governed correctly.
- Assignment is not a claim, and a pull request that only mentions an issue is
  not a claim.
- Unknown, absent, and multiple priority labels all stay deterministic.
- Native limits (100 sub-issues, 8 nesting levels, 50 dependencies per type) are
  reported as findings; no custom hierarchy or dependency storage exists.

### Acceptance-criteria parsing

Detection uses `markdown-it`, the CommonMark/GFM parser already in this
repository's lockfile, now declared explicitly in `devDependencies` instead of
being consumed as an incidental transitive dependency. The bridge reports only
structural heading facts; the five-step normalization procedure of section 4.1 is
applied in Python. No Markdown primitive is hand-rolled and no parser is vendored.
When the parser is unavailable the tool fails closed with
`markdown_parser_unavailable`; it never falls back to scanning raw body lines.

## Related Issues

Fixes #669
Part of: #665

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [x] Manual testing performed

Focused validation:

```text
python3 -m unittest tests/secpal-work-graph-unit.py       39 tests, OK
python3 -m unittest tests/secpal-work-graph-adapter.py    32 tests, OK
python3 -m unittest tests/secpal-pr-review-actions-unit.py       189 tests, OK
python3 -m unittest tests/secpal-pr-review-unit.py               177 tests, OK
python3 -m unittest tests/secpal-resolve-fixed-threads-unit.py     64 tests, OK
bash tests/review-governance-suite.sh                             OK
bash tests/validate-ai-instructions.sh                            OK
bash tests/validate-copilot-instructions.sh                       OK
bash tests/prettier-version-alignment.sh                          OK
bash tests/license-compatibility.sh                               OK
npx prettier --check '**/*.{md,yml,yaml,json}'                    OK
npx markdownlint --config .markdownlint.json --dot '**/*.md' ...  OK
yamllint .github/workflows/quality.yml                            OK
actionlint .github/workflows/quality.yml                          OK
reuse lint                                                        compliant
git diff --check                                                  clean
```

`tests/polyscope-rollout.sh` still fails locally on the missing Git identity in
its fixture. That is the pre-existing #677 failure, unrelated to this change and
deliberately not absorbed here.

The two new suites run in CI through a dedicated `Work-Graph Resolver` job in
`.github/workflows/quality.yml`. They are hermetic: the pure resolver uses
synthetic snapshots, and the adapter tests drive a controlled fake `gh`
executable, so no live organization state is required.

### Real-system read-only smoke

Against the live foundation tree, with no mutation:

```text
$ scripts/secpal-work-graph.py --format text show SecPal/.github#665
  ancestor SecPal/.github#664 [open]
  -          SecPal/.github#665           not_a_leaf,missing_acceptance_criteria
  0          SecPal/.github#670           unsatisfied_dependency
  1          SecPal/.github#669           READY
  2          SecPal/.github#668           closed

$ scripts/secpal-work-graph.py --format text next SecPal/.github#664
  NEXT SecPal/.github#669 Implement read-only SecPal work-graph resolution

$ scripts/secpal-work-graph.py --format text validate-issue SecPal/.github#670
  SecPal/.github#670 open blocked
  not ready: unsatisfied_dependency
```

This confirms natively that #668 is closed as `completed`, that #669 has no open
blocker and is the executable foundation leaf under #664, that #670 remains
blocked by #669, and that native hierarchy and sibling order resolve.

Once this pull request existed, the same read-only smoke also proved claim
observation and both no-selection reasons against real data:

```text
$ scripts/secpal-work-graph.py validate-issue SecPal/.github#669
  ready: true, active: true,
  claims: [{executor: aroviqen, pull_request: SecPal/.github#680}]

$ scripts/secpal-work-graph.py --format text next SecPal/.github#664 --executor someone-else
  no selection: all_candidates_claimed
```

The claim comes from this pull request's native closing relationship, not from
any body text; for a different executor `NEXT` returns `all_candidates_claimed`
rather than the distinct `no_ready_leaf`, and never returns a foreign-claimed
leaf.

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-work-graph-unit.py` failed with `ImportError: cannot import name 'acceptance_criteria' from 'secpal_work_graph'` before the package existed, and `python3 -m unittest tests/secpal-work-graph-adapter.py` failed with `ImportError: cannot import name 'github' from 'secpal_work_graph'` before the read adapter existed.
- Passing proof after implementation: `python3 -m unittest tests/secpal-work-graph-unit.py tests/secpal-work-graph-adapter.py` reports `Ran 71 tests ... OK`. Each self-review fix below was also pinned by a test that failed first: `AssertionError: True is not false` for the `BLOCKED` cycle distinction, `KeyError: 'SecPal/.github#404'` for the unreadable sub-issue, and an uncaught `ValueError` from the read boundary for the unvalidated reference.
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Corrections after the first push

A self-review pass found and fixed three real defects, each pinned by a failing
test first:

- `BLOCKED` was true for a node that merely depended on a dependency-cycle
  member. Section 4.1 makes only a participant `BLOCKED`; section 3.5 keeps the
  dependent out of `READY` without that. Cycle membership and cycle taint are now
  tracked separately.
- `ready` and `next` raised `KeyError` whenever a subtree contained an unreadable
  sub-issue, because the rendering guarded against unresolved nodes and the
  resolver did not. `Resolution.resolved_states()` is now the single guard.
- A reference such as `foo#1` passed reference resolution and produced a
  traceback deep in the read boundary instead of exit code 2. Every accepted form
  is now validated where it is parsed.

A code-scanning review finding on `scripts/secpal_work_graph/resolver.py`
reported that `SelectionKey` implemented `__lt__` without `__le__` or `__ge__`.
Confirmed: `<` and `>` worked, `<=` and `>=` raised `TypeError`. Sorting was
unaffected because `sorted()` calls `__lt__`, but the type exposed a partial
comparison protocol. Because priority ranks descend while the other keys ascend,
the ordering cannot come from the dataclass field order, so the missing
operators are now derived from `__lt__` and the dataclass equality with
`functools.total_ordering`. The existing ordering test was strengthened rather
than duplicated.

Two smaller corrections: the `blocking` count no longer gates node resolution,
since it feeds only the advisory section 3.2 limit finding and must not make
`READY` depend on an input section 1.2 never declares; and the unconsumed
`isDraft` selection plus a test-only acceptance-criteria wrapper were removed.

## Final corrections

An independent implementation-versus-contract review found two remaining
defects, each reproduced before being fixed:

- **Canonical identity.** `ready secpal/.github#669` crashed with a raw
  `KeyError`, because GitHub canonicalizes the repository spelling while the
  loader kept the requested one. On an epic scope root the same split fabricated
  `containment_inconsistent` findings and refused `NEXT` on a valid graph. The
  snapshot is now keyed by the identity GitHub returns and the canonical scope
  root reaches the resolver; canonical and case-variant references produce
  byte-identical output.
- **Claim continuation pages.** An unreadable first claim page already degraded
  to `claims_observable=false`, but an unreadable continuation page raised out of
  the claim path. Both now degrade identically, leaving `READY` unchanged and
  `claims_unobservable` as the diagnostic.

Neither defect could grant `READY`, `ACTIVE`, `DONE` or a `NEXT` selection from
partial data. `resolver.py`, `model.py` and `acceptance_criteria.py` are
unchanged by these corrections.

## Deliberately not implemented here

Owned downstream and out of scope for #669: advisory organization-wide validation
(#670), execution-claim persistence and Polyscope execution coordination (#672),
graph mutation and replanning (#673), pull-request enforcement gates (#674),
repository rollout (#666), and the unrelated #677 and #678. No judgment rule about
contract quality, materiality, architecture, evidence sufficiency, or review
classification is automated here.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] If CHANGELOG.md changed, every entry was checked against the implementation, tests, schema, or config changed in this PR and avoids claims that the code does not actually enforce yet
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Related issues linked above

## No mutation, no persistent state

The tool performs no issue, pull-request, project, branch, label, dependency,
hierarchy, or comment mutation, introduces no persistent graph store, cache, or
database, and creates no claim-persistence mechanism. The only state it keeps is
one invocation's in-memory snapshot.

