### PR TITLE
Add advisory organization-wide work-graph validation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Run fake-GitHub adapter and command tests
         run: python3 -m unittest tests/secpal-work-graph-adapter.py
 
+      - name: Run advisory audit tests
+        run: python3 -m unittest tests/secpal-work-graph-audit.py
+
   prettier:
     name: Check Code Formatting
     runs-on: ubuntu-latest

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -40,6 +40,10 @@ def main(argv=None):
     if not page.get("hasNextPage"): break
     cursor=page.get("endCursor")
     if not cursor: raise github.GitHubError("issues pagination has no cursor")
+   canonical_repositories={((row.get("repository") or {}).get("nameWithOwner")) for row in rows}
+   if rows and (None in canonical_repositories or len(canonical_repositories)!=1):
+    raise github.GitHubError("audit discovery repository identity is unreadable")
+   canonical_repository=str(next(iter(canonical_repositories))) if rows else repository
    facts=parse([row.get("body") for row in rows])
    closing_by_issue={}
    for row in rows:
@@ -47,7 +51,7 @@ def main(argv=None):
     for pull in ((row.get("closedByPullRequestsReferences") or {}).get("nodes") or []):
      pull_repo=((pull.get("repository") or {}).get("nameWithOwner")); pull_number=pull.get("number")
      if pull_repo and pull_number is not None: refs.append(f"{pull_repo}#{int(pull_number)}")
-    closing_by_issue[f"{repository}#{int(row['number'])}"]=tuple(sorted(refs))
+    closing_by_issue[f"{canonical_repository}#{int(row['number'])}"]=tuple(sorted(refs))
    candidates=[]
    for row,fact in zip(rows,facts):
     labels={str(x.get("name", "")).casefold() for x in ((row.get("labels") or {}).get("nodes") or [])}
@@ -55,19 +59,22 @@ def main(argv=None):
     multiple_closing=((row.get("closedByPullRequestsReferences") or {}).get("totalCount") or 0)>1
     legacy_epic="epic" in labels or "[epic]" in str(row.get("title","")).casefold()
     legacy=legacy_epic or bool(fact.relationship_mirrors) or fact.has_status_checklist
-    # A native subtree is resolved once from its highest local container.  Its
-    # descendants are classified from that canonical resolver result, avoiding
-    # repeated overlapping graph reads.  Cross-repository children remain roots
-    # in this repository result because their parent is outside this listing.
+    # Native subtrees start at their highest local container.  A descendant can
+    # still be a candidate for its own legacy evidence, so identical findings
+    # from overlapping snapshots are deduplicated below.  Cross-repository
+    # children remain roots here because their parent is outside this listing.
     parent_repo = ((row.get("parent") or {}).get("repository") or {}).get("nameWithOwner")
-    native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, repository))
+    native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, canonical_repository))
     if native_root or legacy or multiple_closing:
-     key=f"{repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist,legacy_epic))
-   findings=[]
+     key=f"{canonical_repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist,legacy_epic))
+   findings=[]; seen_findings=set()
    for candidate in sorted(candidates,key=lambda x:x.key):
     snapshot,root=github.load_snapshot(adapter,candidate.key)
-    findings.extend(audit.classify(snapshot,root,candidate,repository=repository,closing_pull_requests_by_issue=closing_by_issue))
-   results.append({"repository":repository,"status":"findings" if findings else "clean","findings":findings})
+    for finding in audit.classify(snapshot,root,candidate,repository=canonical_repository,closing_pull_requests_by_issue=closing_by_issue):
+     identity=json.dumps(finding,sort_keys=True,separators=(",",":"))
+     if identity not in seen_findings:
+      seen_findings.add(identity); findings.append(finding)
+   results.append({"repository":canonical_repository,"status":"findings" if findings else "clean","findings":findings})
   except (github.GitHubError, MarkdownParserUnavailable) as error:
    failed=True; results.append({"repository":repository,"status":"unavailable","findings":[],"error":str(error)})
  print(json.dumps(audit.document(results),sort_keys=True,indent=2))

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -9,74 +9,197 @@ epic, relationship-mirror, or task-list signals.  Legacy signals select audit
 candidates only; they are never turned into native graph edges.
 """
 from __future__ import annotations
-import argparse, json, sys
+
+import argparse
+import json
+import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from secpal_work_graph import audit, github
 from secpal_work_graph.acceptance_criteria import MarkdownParserUnavailable, parse
 
-QUERY = '''query WorkGraphAuditIssues($owner: String!, $name: String!, $cursor: String) {
- repository(owner: $owner, name: $name) { issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
- pageInfo { hasNextPage endCursor } nodes { number title body state stateReason repository { nameWithOwner } parent { number repository { nameWithOwner } } subIssues(first: 1) { totalCount } labels(first: 100) { nodes { name } } closedByPullRequestsReferences(first: 100, includeClosedPrs: true) { totalCount nodes { number repository { nameWithOwner } } } } } } }'''
+QUERY = """query WorkGraphAuditIssues($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        body
+        repository { nameWithOwner }
+        parent { number repository { nameWithOwner } }
+        subIssues(first: 1) { totalCount }
+        labels(first: 100) { nodes { name } }
+        blockedBy(first: 1) { totalCount }
+        blocking(first: 1) { totalCount }
+        closedByPullRequestsReferences(first: 100, includeClosedPrs: true) {
+          totalCount
+          nodes { number repository { nameWithOwner } }
+        }
+      }
+    }
+  }
+}"""
+
+
+def _discover(adapter, repository: str):
+    owner, name = repository.split("/", 1)
+    cursor = None
+    rows = []
+    while True:
+        response = adapter.query(
+            QUERY, {"owner": owner, "name": name, "cursor": cursor}
+        )
+        if response.errors:
+            raise github.GitHubError("audit discovery data is unreadable")
+        repository_payload = (response.data or {}).get("repository")
+        connection = (repository_payload or {}).get("issues")
+        if not repository_payload or not connection:
+            raise github.GitHubError(
+                "audit discovery repository or issues connection is unreadable"
+            )
+        rows.extend(connection.get("nodes") or [])
+        page = connection.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            return rows
+        cursor = page.get("endCursor")
+        if not cursor:
+            raise github.GitHubError("issues pagination has no cursor")
+
+
+def _canonical_repository(rows, requested_repository: str) -> str:
+    identities = {
+        ((row.get("repository") or {}).get("nameWithOwner")) for row in rows
+    }
+    if rows and (None in identities or len(identities) != 1):
+        raise github.GitHubError("audit discovery repository identity is unreadable")
+    return str(next(iter(identities))) if rows else requested_repository
+
+
+def _closing_pull_requests(row) -> tuple[str, ...]:
+    references = []
+    for pull in (
+        (row.get("closedByPullRequestsReferences") or {}).get("nodes") or []
+    ):
+        repository = (pull.get("repository") or {}).get("nameWithOwner")
+        number = pull.get("number")
+        if repository and number is not None:
+            references.append(f"{repository}#{int(number)}")
+    return tuple(sorted(references))
+
+
+def _advisory_facts(row, structural, repository: str) -> audit.AdvisoryIssueFacts:
+    labels = {
+        str(item.get("name", "")).casefold()
+        for item in ((row.get("labels") or {}).get("nodes") or [])
+    }
+    parent = row.get("parent")
+    children = int((row.get("subIssues") or {}).get("totalCount") or 0)
+    closing_pull_requests = _closing_pull_requests(row)
+    native = bool(parent) or bool(children)
+    return audit.AdvisoryIssueFacts(
+        key=f"{repository}#{int(row['number'])}",
+        repository=repository,
+        discovery_source=(
+            "native" if native or closing_pull_requests else "legacy_candidate"
+        ),
+        relationship_mirrors=structural.relationship_mirrors,
+        has_status_checklist=structural.has_status_checklist,
+        legacy_epic_candidate=(
+            "epic" in labels
+            or str(row.get("title", "")).casefold().startswith("[epic]")
+        ),
+        native_children_count=children,
+        closing_pull_requests=closing_pull_requests,
+        blocked_by_count=int((row.get("blockedBy") or {}).get("totalCount") or 0),
+        blocking_count=int((row.get("blocking") or {}).get("totalCount") or 0),
+    )
+
+
+def _native_root(row, repository: str) -> str | None:
+    parent = row.get("parent")
+    children = int((row.get("subIssues") or {}).get("totalCount") or 0)
+    parent_repository = ((parent or {}).get("repository") or {}).get(
+        "nameWithOwner"
+    )
+    if (children and not parent) or parent_repository not in (None, repository):
+        return f"{repository}#{int(row['number'])}"
+    return None
+
+
+def _audit_repository(adapter, requested_repository: str) -> dict:
+    rows = _discover(adapter, requested_repository)
+    repository = _canonical_repository(rows, requested_repository)
+    structural = parse([row.get("body") for row in rows])
+    advisory_facts = [
+        _advisory_facts(row, fact, repository)
+        for row, fact in zip(rows, structural)
+    ]
+    findings = [
+        finding
+        for facts in advisory_facts
+        for finding in audit.classify_advisory(facts)
+    ]
+    native_roots = sorted(
+        {
+            root
+            for row in rows
+            if (root := _native_root(row, repository)) is not None
+        }
+    )
+    for native_root in native_roots:
+        snapshot, canonical_root = github.load_snapshot(adapter, native_root)
+        findings.extend(
+            audit.classify_native(
+                snapshot,
+                canonical_root,
+                repository=repository,
+            )
+        )
+    findings = audit.deduplicate_findings(findings)
+    return {
+        "repository": repository,
+        "status": "findings" if findings else "clean",
+        "findings": findings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="secpal-work-graph-audit")
+    parser.add_argument("--repo", action="append", dest="repos")
+    parser.add_argument("--gh", default="gh")
+    parser.add_argument("--timeout", type=float, default=30)
+    return parser
+
+
 def main(argv=None):
- p=argparse.ArgumentParser(prog="secpal-work-graph-audit")
- p.add_argument("--repo", action="append", dest="repos")
- p.add_argument("--gh", default="gh"); p.add_argument("--timeout", type=float, default=30)
- args=p.parse_args(argv); repos=tuple(args.repos or audit.DEFAULT_REPOSITORIES)
- if any("/" not in repo for repo in repos): return 2
- adapter=github.GitHubReadAdapter(gh_executable=args.gh, timeout=args.timeout)
- results=[]; failed=False
- for repository in repos:
-  try:
-   owner,name=repository.split("/",1); cursor=None; rows=[]
-   while True:
-    response=adapter.query(QUERY,{"owner":owner,"name":name,"cursor":cursor})
-    if response.errors:
-     raise github.GitHubError("audit discovery data is unreadable")
-    connection=(((response.data or {}).get("repository") or {}).get("issues") or {})
-    if not ((response.data or {}).get("repository")) or not connection:
-     raise github.GitHubError("audit discovery repository or issues connection is unreadable")
-    rows.extend(connection.get("nodes") or []); page=connection.get("pageInfo") or {}
-    if not page.get("hasNextPage"): break
-    cursor=page.get("endCursor")
-    if not cursor: raise github.GitHubError("issues pagination has no cursor")
-   canonical_repositories={((row.get("repository") or {}).get("nameWithOwner")) for row in rows}
-   if rows and (None in canonical_repositories or len(canonical_repositories)!=1):
-    raise github.GitHubError("audit discovery repository identity is unreadable")
-   canonical_repository=str(next(iter(canonical_repositories))) if rows else repository
-   facts=parse([row.get("body") for row in rows])
-   closing_by_issue={}
-   for row in rows:
-    refs=[]
-    for pull in ((row.get("closedByPullRequestsReferences") or {}).get("nodes") or []):
-     pull_repo=((pull.get("repository") or {}).get("nameWithOwner")); pull_number=pull.get("number")
-     if pull_repo and pull_number is not None: refs.append(f"{pull_repo}#{int(pull_number)}")
-    closing_by_issue[f"{canonical_repository}#{int(row['number'])}"]=tuple(sorted(refs))
-   candidates=[]
-   for row,fact in zip(rows,facts):
-    labels={str(x.get("name", "")).casefold() for x in ((row.get("labels") or {}).get("nodes") or [])}
-    native=bool(row.get("parent")) or bool(((row.get("subIssues") or {}).get("totalCount") or 0))
-    multiple_closing=((row.get("closedByPullRequestsReferences") or {}).get("totalCount") or 0)>1
-    legacy_epic="epic" in labels or "[epic]" in str(row.get("title","")).casefold()
-    legacy=legacy_epic or bool(fact.relationship_mirrors) or fact.has_status_checklist
-    # Native subtrees start at their highest local container.  A descendant can
-    # still be a candidate for its own legacy evidence, so identical findings
-    # from overlapping snapshots are deduplicated below.  Cross-repository
-    # children remain roots here because their parent is outside this listing.
-    parent_repo = ((row.get("parent") or {}).get("repository") or {}).get("nameWithOwner")
-    native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, canonical_repository))
-    if native_root or legacy or multiple_closing:
-     key=f"{canonical_repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist,legacy_epic))
-   findings=[]; seen_findings=set()
-   for candidate in sorted(candidates,key=lambda x:x.key):
-    snapshot,root=github.load_snapshot(adapter,candidate.key)
-    for finding in audit.classify(snapshot,root,candidate,repository=canonical_repository,closing_pull_requests_by_issue=closing_by_issue):
-     identity=json.dumps(finding,sort_keys=True,separators=(",",":"))
-     if identity not in seen_findings:
-      seen_findings.add(identity); findings.append(finding)
-   results.append({"repository":canonical_repository,"status":"findings" if findings else "clean","findings":findings})
-  except (github.GitHubError, MarkdownParserUnavailable) as error:
-   failed=True; results.append({"repository":repository,"status":"unavailable","findings":[],"error":str(error)})
- print(json.dumps(audit.document(results),sort_keys=True,indent=2))
- return 3 if failed else 0
-if __name__ == "__main__": raise SystemExit(main())
+    arguments = build_parser().parse_args(argv)
+    repositories = tuple(arguments.repos or audit.DEFAULT_REPOSITORIES)
+    if any("/" not in repository for repository in repositories):
+        return 2
+    adapter = github.GitHubReadAdapter(
+        gh_executable=arguments.gh, timeout=arguments.timeout
+    )
+    results = []
+    failed = False
+    for repository in repositories:
+        try:
+            results.append(_audit_repository(adapter, repository))
+        except (github.GitHubError, MarkdownParserUnavailable) as error:
+            failed = True
+            results.append(
+                {
+                    "repository": repository,
+                    "status": "unavailable",
+                    "findings": [],
+                    "error": str(error),
+                }
+            )
+    print(json.dumps(audit.document(results), sort_keys=True, indent=2))
+    return 3 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Read-only advisory audit entrypoint; it never mutates GitHub.
+
+Discovery is deliberately narrow: native containment participants and legacy
+epic, relationship-mirror, or task-list signals.  Legacy signals select audit
+candidates only; they are never turned into native graph edges.
+"""
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from secpal_work_graph import audit, github
+from secpal_work_graph.acceptance_criteria import MarkdownParserUnavailable, parse
+
+QUERY = '''query WorkGraphAuditIssues($owner: String!, $name: String!, $cursor: String) {
+ repository(owner: $owner, name: $name) { issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
+ pageInfo { hasNextPage endCursor } nodes { number title body state stateReason repository { nameWithOwner } parent { number repository { nameWithOwner } } subIssues(first: 1) { totalCount } labels(first: 100) { nodes { name } } } } } }'''
+def main(argv=None):
+ p=argparse.ArgumentParser(prog="secpal-work-graph-audit")
+ p.add_argument("--repo", action="append", dest="repos")
+ p.add_argument("--gh", default="gh"); p.add_argument("--timeout", type=float, default=30)
+ args=p.parse_args(argv); repos=tuple(args.repos or audit.DEFAULT_REPOSITORIES)
+ if any("/" not in repo for repo in repos): return 2
+ adapter=github.GitHubReadAdapter(gh_executable=args.gh, timeout=args.timeout)
+ results=[]; failed=False
+ for repository in repos:
+  try:
+   owner,name=repository.split("/",1); cursor=None; rows=[]
+   while True:
+    response=adapter.query(QUERY,{"owner":owner,"name":name,"cursor":cursor})
+    connection=(((response.data or {}).get("repository") or {}).get("issues") or {})
+    rows.extend(connection.get("nodes") or []); page=connection.get("pageInfo") or {}
+    if not page.get("hasNextPage"): break
+    cursor=page.get("endCursor")
+    if not cursor: raise github.GitHubError("issues pagination has no cursor")
+   facts=parse([row.get("body") for row in rows])
+   candidates=[]
+   for row,fact in zip(rows,facts):
+    labels={str(x.get("name", "")).casefold() for x in ((row.get("labels") or {}).get("nodes") or [])}
+    native=bool(row.get("parent")) or bool(((row.get("subIssues") or {}).get("totalCount") or 0))
+    legacy="epic" in labels or "[epic]" in str(row.get("title","")).casefold() or bool(fact.relationship_mirrors) or fact.has_status_checklist
+    # A native subtree is resolved once from its highest local container.  Its
+    # descendants are classified from that canonical resolver result, avoiding
+    # repeated overlapping graph reads.  Cross-repository children remain roots
+    # in this repository result because their parent is outside this listing.
+    parent_repo = ((row.get("parent") or {}).get("repository") or {}).get("nameWithOwner")
+    native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, repository))
+    if native_root or legacy:
+     key=f"{repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist))
+   findings=[]
+   for candidate in sorted(candidates,key=lambda x:x.key):
+    snapshot,root=github.load_snapshot(adapter,candidate.key)
+    findings.extend(audit.classify(snapshot,root,candidate))
+   results.append({"repository":repository,"status":"findings" if findings else "clean","findings":findings})
+  except (github.GitHubError, MarkdownParserUnavailable) as error:
+   failed=True; results.append({"repository":repository,"status":"unavailable","findings":[],"error":str(error)})
+ print(json.dumps(audit.document(results),sort_keys=True,indent=2))
+ return 3 if failed else 0
+if __name__ == "__main__": raise SystemExit(main())

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -17,7 +17,7 @@ from secpal_work_graph.acceptance_criteria import MarkdownParserUnavailable, par
 
 QUERY = '''query WorkGraphAuditIssues($owner: String!, $name: String!, $cursor: String) {
  repository(owner: $owner, name: $name) { issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
- pageInfo { hasNextPage endCursor } nodes { number title body state stateReason repository { nameWithOwner } parent { number repository { nameWithOwner } } subIssues(first: 1) { totalCount } labels(first: 100) { nodes { name } } } } } }'''
+ pageInfo { hasNextPage endCursor } nodes { number title body state stateReason repository { nameWithOwner } parent { number repository { nameWithOwner } } subIssues(first: 1) { totalCount } labels(first: 100) { nodes { name } } closedByPullRequestsReferences(first: 100, includeClosedPrs: true) { totalCount nodes { number repository { nameWithOwner } } } } } } }'''
 def main(argv=None):
  p=argparse.ArgumentParser(prog="secpal-work-graph-audit")
  p.add_argument("--repo", action="append", dest="repos")
@@ -31,16 +31,28 @@ def main(argv=None):
    owner,name=repository.split("/",1); cursor=None; rows=[]
    while True:
     response=adapter.query(QUERY,{"owner":owner,"name":name,"cursor":cursor})
+    if response.errors:
+     raise github.GitHubError("audit discovery data is unreadable")
     connection=(((response.data or {}).get("repository") or {}).get("issues") or {})
+    if not ((response.data or {}).get("repository")) or not connection:
+     raise github.GitHubError("audit discovery repository or issues connection is unreadable")
     rows.extend(connection.get("nodes") or []); page=connection.get("pageInfo") or {}
     if not page.get("hasNextPage"): break
     cursor=page.get("endCursor")
     if not cursor: raise github.GitHubError("issues pagination has no cursor")
    facts=parse([row.get("body") for row in rows])
+   closing_by_issue={}
+   for row in rows:
+    refs=[]
+    for pull in ((row.get("closedByPullRequestsReferences") or {}).get("nodes") or []):
+     pull_repo=((pull.get("repository") or {}).get("nameWithOwner")); pull_number=pull.get("number")
+     if pull_repo and pull_number is not None: refs.append(f"{pull_repo}#{int(pull_number)}")
+    closing_by_issue[f"{repository}#{int(row['number'])}"]=tuple(sorted(refs))
    candidates=[]
    for row,fact in zip(rows,facts):
     labels={str(x.get("name", "")).casefold() for x in ((row.get("labels") or {}).get("nodes") or [])}
     native=bool(row.get("parent")) or bool(((row.get("subIssues") or {}).get("totalCount") or 0))
+    multiple_closing=((row.get("closedByPullRequestsReferences") or {}).get("totalCount") or 0)>1
     legacy_epic="epic" in labels or "[epic]" in str(row.get("title","")).casefold()
     legacy=legacy_epic or bool(fact.relationship_mirrors) or fact.has_status_checklist
     # A native subtree is resolved once from its highest local container.  Its
@@ -49,12 +61,12 @@ def main(argv=None):
     # in this repository result because their parent is outside this listing.
     parent_repo = ((row.get("parent") or {}).get("repository") or {}).get("nameWithOwner")
     native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, repository))
-    if native_root or legacy:
+    if native_root or legacy or multiple_closing:
      key=f"{repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist,legacy_epic))
    findings=[]
    for candidate in sorted(candidates,key=lambda x:x.key):
     snapshot,root=github.load_snapshot(adapter,candidate.key)
-    findings.extend(audit.classify(snapshot,root,candidate,repository=repository))
+    findings.extend(audit.classify(snapshot,root,candidate,repository=repository,closing_pull_requests_by_issue=closing_by_issue))
    results.append({"repository":repository,"status":"findings" if findings else "clean","findings":findings})
   except (github.GitHubError, MarkdownParserUnavailable) as error:
    failed=True; results.append({"repository":repository,"status":"unavailable","findings":[],"error":str(error)})

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -41,7 +41,8 @@ def main(argv=None):
    for row,fact in zip(rows,facts):
     labels={str(x.get("name", "")).casefold() for x in ((row.get("labels") or {}).get("nodes") or [])}
     native=bool(row.get("parent")) or bool(((row.get("subIssues") or {}).get("totalCount") or 0))
-    legacy="epic" in labels or "[epic]" in str(row.get("title","")).casefold() or bool(fact.relationship_mirrors) or fact.has_status_checklist
+    legacy_epic="epic" in labels or "[epic]" in str(row.get("title","")).casefold()
+    legacy=legacy_epic or bool(fact.relationship_mirrors) or fact.has_status_checklist
     # A native subtree is resolved once from its highest local container.  Its
     # descendants are classified from that canonical resolver result, avoiding
     # repeated overlapping graph reads.  Cross-repository children remain roots
@@ -49,11 +50,11 @@ def main(argv=None):
     parent_repo = ((row.get("parent") or {}).get("repository") or {}).get("nameWithOwner")
     native_root = native and (bool(((row.get("subIssues") or {}).get("totalCount") or 0)) and not row.get("parent") or parent_repo not in (None, repository))
     if native_root or legacy:
-     key=f"{repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist))
+     key=f"{repository}#{int(row['number'])}"; candidates.append(audit.Candidate(key,"native" if native else "legacy_candidate",fact.has_status_checklist,legacy_epic))
    findings=[]
    for candidate in sorted(candidates,key=lambda x:x.key):
     snapshot,root=github.load_snapshot(adapter,candidate.key)
-    findings.extend(audit.classify(snapshot,root,candidate))
+    findings.extend(audit.classify(snapshot,root,candidate,repository=repository))
    results.append({"repository":repository,"status":"findings" if findings else "clean","findings":findings})
   except (github.GitHubError, MarkdownParserUnavailable) as error:
    failed=True; results.append({"repository":repository,"status":"unavailable","findings":[],"error":str(error)})

--- a/scripts/secpal-work-graph-audit.py
+++ b/scripts/secpal-work-graph-audit.py
@@ -121,10 +121,14 @@ def _advisory_facts(row, structural, repository: str) -> audit.AdvisoryIssueFact
 def _native_root(row, repository: str) -> str | None:
     parent = row.get("parent")
     children = int((row.get("subIssues") or {}).get("totalCount") or 0)
+    blocked_by = int((row.get("blockedBy") or {}).get("totalCount") or 0)
     parent_repository = ((parent or {}).get("repository") or {}).get(
         "nameWithOwner"
     )
-    if (children and not parent) or parent_repository not in (None, repository):
+    if (
+        (not parent and (children or blocked_by))
+        or parent_repository not in (None, repository)
+    ):
         return f"{repository}#{int(row['number'])}"
     return None
 

--- a/scripts/secpal_work_graph/acceptance_criteria.py
+++ b/scripts/secpal_work_graph/acceptance_criteria.py
@@ -41,6 +41,7 @@ class StructuralBody:
 
     has_acceptance_criteria: bool
     relationship_mirrors: tuple[str, ...]
+    has_status_checklist: bool = False
 
 
 def qualifies(heading_text: str) -> bool:
@@ -89,6 +90,7 @@ def parse(
         for item in parsed:
             headings = item.get("headings") if isinstance(item, dict) else None
             mirrors = item.get("relationshipMirrors") if isinstance(item, dict) else None
+            checklist = item.get("hasStatusChecklist", False) if isinstance(item, dict) else None
             if (
                 not isinstance(headings, list)
                 or any(
@@ -99,6 +101,7 @@ def parse(
                 )
                 or not isinstance(mirrors, list)
                 or any(not isinstance(mirror, str) for mirror in mirrors)
+                or not isinstance(checklist, bool)
             ):
                 raise MarkdownParserUnavailable("Markdown parser returned an unexpected result")
             detected.append(
@@ -107,6 +110,7 @@ def parse(
                         qualifies(heading["text"]) and heading["hasContent"] for heading in headings
                     ),
                     relationship_mirrors=tuple(sorted(set(mirrors))),
+                    has_status_checklist=checklist,
                 )
             )
     return detected

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -144,6 +144,42 @@ def classify_advisory(facts: AdvisoryIssueFacts) -> list[dict]:
     return findings
 
 
+def _attribution_node(snapshot, resolution, finding, repository: str) -> Node | None:
+    """Return the audited-repository node materially affected by a finding."""
+    representative = snapshot.require(finding.node or resolution.scope_root)
+    if representative.repository == repository:
+        return representative
+
+    if finding.code == resolver.FINDING_DEPENDENCY_CYCLE:
+        # Finding.detail is the resolver's stable, sorted cycle-member shape.
+        # Finding has no structured member collection, so keep this audit-side
+        # interpretation limited to that exact canonical finding form.
+        members = tuple(finding.detail.split(", ")) if finding.detail else ()
+        if finding.node not in members:
+            return None
+        candidate_keys = members
+    elif finding.code in {
+        resolver.FINDING_UNRESOLVED_SUB_ISSUE,
+        resolver.FINDING_CONTAINMENT_INCONSISTENT,
+    }:
+        candidate_keys = tuple(
+            key
+            for key in resolution.order
+            if (candidate := snapshot.get(key)) is not None
+            and finding.node in candidate.children
+        )
+    else:
+        return None
+
+    local_nodes = [
+        node
+        for key in candidate_keys
+        if (node := snapshot.get(key)) is not None
+        and node.repository == repository
+    ]
+    return min(local_nodes, key=lambda node: node.key) if local_nodes else None
+
+
 def classify_native(snapshot: Snapshot, root: str, *, repository: str) -> list[dict]:
     """Classify facts; all graph predicates are delegated to ``resolver``."""
     resolution = resolver.resolve(snapshot, root)
@@ -185,8 +221,8 @@ def classify_native(snapshot: Snapshot, root: str, *, repository: str) -> list[d
         if finding.code in resolver.INCOMPLETE_FINDINGS or finding.code in {
             resolver.FINDING_CONTAINMENT_CYCLE, resolver.FINDING_DEPENDENCY_CYCLE,
         }:
-            node = snapshot.require(finding.node or root)
-            if node.repository == repository:
+            node = _attribution_node(snapshot, resolution, finding, repository)
+            if node is not None:
                 findings.append(
                     _finding(
                         node,

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Advisory migration classification layered on canonical resolver results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from . import resolver
+from .model import CLOSED, Node, Snapshot
+
+SCHEMA = "secpal-work-graph-audit/v1"
+DEFAULT_REPOSITORIES = (
+    "SecPal/.github", "SecPal/android", "SecPal/frontend", "SecPal/deployment",
+    "SecPal/api", "SecPal/contracts", "SecPal/secpal.app", "SecPal/GuardGuide",
+    "SecPal/guardguide.de",
+)
+_PRIORITY = {"before_rollout": 0, "normal": 1, "cleanup": 2}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    key: str
+    discovery_source: str
+    status_checklist: bool = False
+
+
+def is_epic(node: Node) -> bool:
+    return bool(node.children) or "epic" in node.title.casefold() or "epic" in node.priority_labels
+
+
+def _finding(node: Node, kind: str, classification: str, source: str, evidence: str, **extra):
+    result = {"kind": kind, "classification": classification,
+              "migration_priority": "before_rollout" if classification == "execution_blocker" else "normal",
+              "repository": node.repository, "issue": node.key,
+              "discovery_source": source, "requires_judgment": False, "evidence": evidence}
+    result.update(extra)
+    return result
+
+
+def classify(snapshot: Snapshot, root: str, candidate: Candidate) -> list[dict]:
+    """Classify facts; all graph predicates are delegated to ``resolver``."""
+    resolution = resolver.resolve(snapshot, root)
+    findings: list[dict] = []
+    for state in resolution.resolved_states():
+        node = snapshot.nodes[state.key]
+        source = candidate.discovery_source if state.key == candidate.key else "native"
+        if node.mirror_relationships:
+            findings.append(_finding(node, "body_relationship_mirror", "migration_debt", source,
+                "Markdown mirrors: " + ", ".join(node.mirror_relationships)))
+            if any(name in {"blocked by", "blocks", "depends on"} for name in node.mirror_relationships) and not node.blocked_by:
+                findings.append(_finding(node, "prose_only_blocker", "migration_debt", source,
+                    "Dependency mirror has no native dependency"))
+        if state.leaf and node.is_open and resolver.REASON_MISSING_ACCEPTANCE_CRITERIA in state.reasons:
+            findings.append(_finding(node, "structurally_incomplete_delivery_leaf", "execution_blocker", source,
+                "Canonical resolver reports missing_acceptance_criteria"))
+        if state.leaf and node.blocking_count > 1:
+            findings.append(_finding(node, "multi_contract_leaf_candidate", "migration_debt", source,
+                "Multiple issues are natively blocked by this leaf; review its delivery contract",
+                requires_judgment=True))
+        if node.state == CLOSED and node.children:
+            for child_key in node.children:
+                child = snapshot.get(child_key)
+                if child and child.is_open:
+                    findings.append(_finding(node, "closed_parent_open_child", "execution_blocker", source,
+                        "Native child remains open", related_issue=child_key))
+        if is_epic(node) and node.closing_pull_requests:
+            for pull_request in node.closing_pull_requests:
+                findings.append(_finding(node, "direct_epic_delivery_pull_request", "migration_debt", source,
+                    "Epic has a native closing pull-request relationship", pull_request=pull_request))
+    if candidate.status_checklist:
+        node = snapshot.require(candidate.key)
+        findings.append(_finding(node, "duplicated_markdown_status", "migration_debt", candidate.discovery_source,
+            "Parser-derived Markdown task-list status mirror"))
+    for finding in resolution.findings:
+        if finding.code in resolver.INCOMPLETE_FINDINGS or finding.code in {
+            resolver.FINDING_CONTAINMENT_CYCLE, resolver.FINDING_DEPENDENCY_CYCLE,
+        }:
+            node = snapshot.require(finding.node or root)
+            findings.append(_finding(node, finding.code, "execution_blocker", "native", finding.detail or finding.code))
+    return findings
+
+
+def document(results: Iterable[dict]) -> dict:
+    repositories = sorted(results, key=lambda item: item["repository"])
+    for result in repositories:
+        result["findings"].sort(key=lambda f: (0 if f["classification"] == "execution_blocker" else 1,
+            _PRIORITY[f["migration_priority"]], f["repository"], int(f["issue"].rsplit("#", 1)[1]),
+            f["kind"], f.get("related_issue", f.get("pull_request", ""))))
+    findings = [finding for result in repositories for finding in result["findings"]]
+    return {"schema": SCHEMA, "repositories": repositories,
+            "summary": {"repositories": len(repositories), "execution_blockers": sum(f["classification"] == "execution_blocker" for f in findings),
+                        "migration_debt": sum(f["classification"] == "migration_debt" for f in findings),
+                        "requires_judgment": sum(f["requires_judgment"] for f in findings)}}

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -114,7 +114,7 @@ def classify_advisory(facts: AdvisoryIssueFacts) -> list[dict]:
                 "Parser-derived Markdown task-list status mirror",
             )
         )
-    if len(facts.closing_pull_requests) > 1:
+    if facts.native_children_count == 0 and len(facts.closing_pull_requests) > 1:
         findings.append(
             _issue_finding(
                 facts.repository,

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -21,80 +21,193 @@ _PRIORITY = {"before_rollout": 0, "normal": 1, "cleanup": 2}
 
 
 @dataclass(frozen=True)
-class Candidate:
+class AdvisoryIssueFacts:
+    """Audit-local discovery evidence that never becomes resolver input."""
+
     key: str
+    repository: str
     discovery_source: str
-    status_checklist: bool = False
-    epic_candidate: bool = False
+    relationship_mirrors: tuple[str, ...] = ()
+    has_status_checklist: bool = False
+    legacy_epic_candidate: bool = False
+    native_children_count: int = 0
+    closing_pull_requests: tuple[str, ...] = ()
+    blocked_by_count: int = 0
+    blocking_count: int = 0
 
 
-def is_epic(node: Node) -> bool:
-    """A native epic is only a node with native children."""
-    return bool(node.children)
+def _finding(
+    node: Node,
+    kind: str,
+    classification: str,
+    source: str,
+    evidence: str,
+    **extra,
+):
+    return _issue_finding(
+        node.repository, node.key, kind, classification, source, evidence, **extra
+    )
 
 
-def _finding(node: Node, kind: str, classification: str, source: str, evidence: str, **extra):
-    result = {"kind": kind, "classification": classification,
-              "migration_priority": "before_rollout" if classification == "execution_blocker" else "normal",
-              "repository": node.repository, "issue": node.key,
-              "discovery_source": source, "requires_judgment": False, "evidence": evidence}
+def _issue_finding(
+    repository: str,
+    issue: str,
+    kind: str,
+    classification: str,
+    source: str,
+    evidence: str,
+    **extra,
+):
+    result = {
+        "kind": kind,
+        "classification": classification,
+        "migration_priority": (
+            "before_rollout" if classification == "execution_blocker" else "normal"
+        ),
+        "repository": repository,
+        "issue": issue,
+        "discovery_source": source,
+        "requires_judgment": False,
+        "evidence": evidence,
+    }
     result.update(extra)
     return result
 
 
-def classify(
-    snapshot: Snapshot,
-    root: str,
-    candidate: Candidate,
-    *,
-    repository: str,
-    closing_pull_requests_by_issue: dict[str, tuple[str, ...]] | None = None,
-) -> list[dict]:
+def classify_advisory(facts: AdvisoryIssueFacts) -> list[dict]:
+    """Classify migration evidence without constructing canonical graph state."""
+    findings: list[dict] = []
+    if facts.relationship_mirrors:
+        findings.append(
+            _issue_finding(
+                facts.repository,
+                facts.key,
+                "body_relationship_mirror",
+                "migration_debt",
+                facts.discovery_source,
+                "Markdown mirrors: " + ", ".join(facts.relationship_mirrors),
+            )
+        )
+        missing_dependency = (
+            any(name in {"blocked by", "depends on"} for name in facts.relationship_mirrors)
+            and facts.blocked_by_count == 0
+        ) or ("blocks" in facts.relationship_mirrors and facts.blocking_count == 0)
+        if missing_dependency:
+            findings.append(
+                _issue_finding(
+                    facts.repository,
+                    facts.key,
+                    "prose_only_blocker",
+                    "migration_debt",
+                    facts.discovery_source,
+                    "Dependency mirror has no corresponding native relationship",
+                )
+            )
+    if facts.has_status_checklist:
+        findings.append(
+            _issue_finding(
+                facts.repository,
+                facts.key,
+                "duplicated_markdown_status",
+                "migration_debt",
+                facts.discovery_source,
+                "Parser-derived Markdown task-list status mirror",
+            )
+        )
+    if len(facts.closing_pull_requests) > 1:
+        findings.append(
+            _issue_finding(
+                facts.repository,
+                facts.key,
+                "multi_contract_leaf_candidate",
+                "migration_debt",
+                facts.discovery_source,
+                "Multiple native closing pull-request relationships; review its delivery contract",
+                requires_judgment=True,
+            )
+        )
+    if (
+        facts.native_children_count > 0 or facts.legacy_epic_candidate
+    ) and facts.closing_pull_requests:
+        for pull_request in facts.closing_pull_requests:
+            findings.append(
+                _issue_finding(
+                    facts.repository,
+                    facts.key,
+                    "direct_epic_delivery_pull_request",
+                    "migration_debt",
+                    facts.discovery_source,
+                    "Epic has a native closing pull-request relationship",
+                    pull_request=pull_request,
+                )
+            )
+    return findings
+
+
+def classify_native(snapshot: Snapshot, root: str, *, repository: str) -> list[dict]:
     """Classify facts; all graph predicates are delegated to ``resolver``."""
     resolution = resolver.resolve(snapshot, root)
-    closing_pull_requests_by_issue = closing_pull_requests_by_issue or {}
     findings: list[dict] = []
     for state in resolution.resolved_states():
         node = snapshot.nodes[state.key]
         if node.repository != repository:
             continue
-        source = candidate.discovery_source if state.key == candidate.key else "native"
-        if node.mirror_relationships:
-            findings.append(_finding(node, "body_relationship_mirror", "migration_debt", source,
-                "Markdown mirrors: " + ", ".join(node.mirror_relationships)))
-            if any(name in {"blocked by", "blocks", "depends on"} for name in node.mirror_relationships) and not node.blocked_by:
-                findings.append(_finding(node, "prose_only_blocker", "migration_debt", source,
-                    "Dependency mirror has no native dependency"))
-        if state.leaf and node.is_open and resolver.REASON_MISSING_ACCEPTANCE_CRITERIA in state.reasons:
-            findings.append(_finding(node, "structurally_incomplete_delivery_leaf", "execution_blocker", source,
-                "Canonical resolver reports missing_acceptance_criteria"))
-        closing_pull_requests = closing_pull_requests_by_issue.get(node.key, ())
-        if state.leaf and len(closing_pull_requests) > 1:
-            findings.append(_finding(node, "multi_contract_leaf_candidate", "migration_debt", source,
-                "Multiple native closing pull-request relationships; review its delivery contract",
-                requires_judgment=True))
+        source = "native"
+        if (
+            state.leaf
+            and node.is_open
+            and resolver.REASON_MISSING_ACCEPTANCE_CRITERIA in state.reasons
+        ):
+            findings.append(
+                _finding(
+                    node,
+                    "structurally_incomplete_delivery_leaf",
+                    "execution_blocker",
+                    source,
+                    "Canonical resolver reports missing_acceptance_criteria",
+                )
+            )
         if node.state == CLOSED and node.children:
             for child_key in node.children:
                 child = snapshot.get(child_key)
                 if child and child.is_open:
-                    findings.append(_finding(node, "closed_parent_open_child", "execution_blocker", source,
-                        "Native child remains open", related_issue=child_key))
-        if (is_epic(node) or (node.key == candidate.key and candidate.epic_candidate)) and closing_pull_requests:
-            for pull_request in closing_pull_requests:
-                findings.append(_finding(node, "direct_epic_delivery_pull_request", "migration_debt", source,
-                    "Epic has a native closing pull-request relationship", pull_request=pull_request))
-    if candidate.status_checklist:
-        node = snapshot.require(candidate.key)
-        findings.append(_finding(node, "duplicated_markdown_status", "migration_debt", candidate.discovery_source,
-            "Parser-derived Markdown task-list status mirror"))
+                    findings.append(
+                        _finding(
+                            node,
+                            "closed_parent_open_child",
+                            "execution_blocker",
+                            source,
+                            "Native child remains open",
+                            related_issue=child_key,
+                        )
+                    )
     for finding in resolution.findings:
         if finding.code in resolver.INCOMPLETE_FINDINGS or finding.code in {
             resolver.FINDING_CONTAINMENT_CYCLE, resolver.FINDING_DEPENDENCY_CYCLE,
         }:
             node = snapshot.require(finding.node or root)
             if node.repository == repository:
-                findings.append(_finding(node, finding.code, "execution_blocker", "native", finding.detail or finding.code))
+                findings.append(
+                    _finding(
+                        node,
+                        finding.code,
+                        "execution_blocker",
+                        "native",
+                        finding.detail or finding.code,
+                    )
+                )
     return findings
+
+
+def deduplicate_findings(findings: Iterable[dict]) -> list[dict]:
+    """Deduplicate complete semantic finding documents deterministically."""
+    import json
+
+    unique = {
+        json.dumps(finding, sort_keys=True, separators=(",", ":")): finding
+        for finding in findings
+    }
+    return [unique[key] for key in sorted(unique)]
 
 
 def document(results: Iterable[dict]) -> dict:

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -25,6 +25,7 @@ class Candidate:
     key: str
     discovery_source: str
     status_checklist: bool = False
+    epic_candidate: bool = False
 
 
 def is_epic(node: Node) -> bool:
@@ -40,12 +41,16 @@ def _finding(node: Node, kind: str, classification: str, source: str, evidence: 
     return result
 
 
-def classify(snapshot: Snapshot, root: str, candidate: Candidate) -> list[dict]:
+def classify(
+    snapshot: Snapshot, root: str, candidate: Candidate, *, repository: str
+) -> list[dict]:
     """Classify facts; all graph predicates are delegated to ``resolver``."""
     resolution = resolver.resolve(snapshot, root)
     findings: list[dict] = []
     for state in resolution.resolved_states():
         node = snapshot.nodes[state.key]
+        if node.repository != repository:
+            continue
         source = candidate.discovery_source if state.key == candidate.key else "native"
         if node.mirror_relationships:
             findings.append(_finding(node, "body_relationship_mirror", "migration_debt", source,
@@ -56,9 +61,9 @@ def classify(snapshot: Snapshot, root: str, candidate: Candidate) -> list[dict]:
         if state.leaf and node.is_open and resolver.REASON_MISSING_ACCEPTANCE_CRITERIA in state.reasons:
             findings.append(_finding(node, "structurally_incomplete_delivery_leaf", "execution_blocker", source,
                 "Canonical resolver reports missing_acceptance_criteria"))
-        if state.leaf and node.blocking_count > 1:
+        if state.leaf and len(node.closing_pull_requests) > 1:
             findings.append(_finding(node, "multi_contract_leaf_candidate", "migration_debt", source,
-                "Multiple issues are natively blocked by this leaf; review its delivery contract",
+                "Multiple native closing pull-request relationships; review its delivery contract",
                 requires_judgment=True))
         if node.state == CLOSED and node.children:
             for child_key in node.children:
@@ -66,7 +71,7 @@ def classify(snapshot: Snapshot, root: str, candidate: Candidate) -> list[dict]:
                 if child and child.is_open:
                     findings.append(_finding(node, "closed_parent_open_child", "execution_blocker", source,
                         "Native child remains open", related_issue=child_key))
-        if is_epic(node) and node.closing_pull_requests:
+        if (is_epic(node) or (node.key == candidate.key and candidate.epic_candidate)) and node.closing_pull_requests:
             for pull_request in node.closing_pull_requests:
                 findings.append(_finding(node, "direct_epic_delivery_pull_request", "migration_debt", source,
                     "Epic has a native closing pull-request relationship", pull_request=pull_request))
@@ -79,7 +84,8 @@ def classify(snapshot: Snapshot, root: str, candidate: Candidate) -> list[dict]:
             resolver.FINDING_CONTAINMENT_CYCLE, resolver.FINDING_DEPENDENCY_CYCLE,
         }:
             node = snapshot.require(finding.node or root)
-            findings.append(_finding(node, finding.code, "execution_blocker", "native", finding.detail or finding.code))
+            if node.repository == repository:
+                findings.append(_finding(node, finding.code, "execution_blocker", "native", finding.detail or finding.code))
     return findings
 
 

--- a/scripts/secpal_work_graph/audit.py
+++ b/scripts/secpal_work_graph/audit.py
@@ -29,7 +29,8 @@ class Candidate:
 
 
 def is_epic(node: Node) -> bool:
-    return bool(node.children) or "epic" in node.title.casefold() or "epic" in node.priority_labels
+    """A native epic is only a node with native children."""
+    return bool(node.children)
 
 
 def _finding(node: Node, kind: str, classification: str, source: str, evidence: str, **extra):
@@ -42,10 +43,16 @@ def _finding(node: Node, kind: str, classification: str, source: str, evidence: 
 
 
 def classify(
-    snapshot: Snapshot, root: str, candidate: Candidate, *, repository: str
+    snapshot: Snapshot,
+    root: str,
+    candidate: Candidate,
+    *,
+    repository: str,
+    closing_pull_requests_by_issue: dict[str, tuple[str, ...]] | None = None,
 ) -> list[dict]:
     """Classify facts; all graph predicates are delegated to ``resolver``."""
     resolution = resolver.resolve(snapshot, root)
+    closing_pull_requests_by_issue = closing_pull_requests_by_issue or {}
     findings: list[dict] = []
     for state in resolution.resolved_states():
         node = snapshot.nodes[state.key]
@@ -61,7 +68,8 @@ def classify(
         if state.leaf and node.is_open and resolver.REASON_MISSING_ACCEPTANCE_CRITERIA in state.reasons:
             findings.append(_finding(node, "structurally_incomplete_delivery_leaf", "execution_blocker", source,
                 "Canonical resolver reports missing_acceptance_criteria"))
-        if state.leaf and len(node.closing_pull_requests) > 1:
+        closing_pull_requests = closing_pull_requests_by_issue.get(node.key, ())
+        if state.leaf and len(closing_pull_requests) > 1:
             findings.append(_finding(node, "multi_contract_leaf_candidate", "migration_debt", source,
                 "Multiple native closing pull-request relationships; review its delivery contract",
                 requires_judgment=True))
@@ -71,8 +79,8 @@ def classify(
                 if child and child.is_open:
                     findings.append(_finding(node, "closed_parent_open_child", "execution_blocker", source,
                         "Native child remains open", related_issue=child_key))
-        if (is_epic(node) or (node.key == candidate.key and candidate.epic_candidate)) and node.closing_pull_requests:
-            for pull_request in node.closing_pull_requests:
+        if (is_epic(node) or (node.key == candidate.key and candidate.epic_candidate)) and closing_pull_requests:
+            for pull_request in closing_pull_requests:
                 findings.append(_finding(node, "direct_epic_delivery_pull_request", "migration_debt", source,
                     "Epic has a native closing pull-request relationship", pull_request=pull_request))
     if candidate.status_checklist:

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -68,7 +68,7 @@ ISSUE_QUERY = f"""query WorkGraphIssue($owner: String!, $name: String!, $number:
         nodes {{ {_REFERENCE_FIELDS} }}
       }}
       blocking(first: 1) {{ totalCount }}
-      closedByPullRequestsReferences(first: {CLAIM_PAGE_SIZE}, includeClosedPrs: false) {{
+      closedByPullRequestsReferences(first: {CLAIM_PAGE_SIZE}, includeClosedPrs: true) {{
         pageInfo {{ hasNextPage endCursor }}
         nodes {{
           number
@@ -110,7 +110,7 @@ PAGE_QUERIES: Mapping[str, str] = {
         "closedByPullRequestsReferences",
         CLAIM_PAGE_SIZE,
         _CLAIM_SELECTION,
-        ", includeClosedPrs: false",
+        ", includeClosedPrs: true",
     ),
 }
 
@@ -286,6 +286,11 @@ def _claims(entries: Iterable[Mapping[str, Any]]) -> tuple[Claim, ...]:
     return tuple(sorted(claims))
 
 
+def _closing_pull_requests(entries: Iterable[Mapping[str, Any]]) -> tuple[str, ...]:
+    """Return all native closing PR identities for advisory governance checks."""
+    return tuple(sorted(reference for reference in (_reference(entry) for entry in entries) if reference))
+
+
 def _unresolved_reason(errors: Iterable[Mapping[str, Any]]) -> str:
     return next((str(error.get("type")) for error in errors if error.get("type")), "unresolved")
 
@@ -338,18 +343,18 @@ def _fetch(
         labels, priority_labels_observable = set(), False
 
     try:
-        claims = _claims(
-            _paginate(
-                adapter,
-                "closedByPullRequestsReferences",
-                issue,
-                variables,
-                response.errors_touching("closedByPullRequestsReferences"),
-            )
+        claim_entries = _paginate(
+            adapter,
+            "closedByPullRequestsReferences",
+            issue,
+            variables,
+            response.errors_touching("closedByPullRequestsReferences"),
         )
+        claims = _claims(claim_entries)
+        closing_pull_requests = _closing_pull_requests(claim_entries)
         claims_observable = True
     except ConnectionUnreadable:
-        claims, claims_observable = (), False
+        claims, closing_pull_requests, claims_observable = (), (), False
 
     state_reason = issue.get("stateReason")
     node = Node(
@@ -370,6 +375,7 @@ def _fetch(
         priority_labels_observable=priority_labels_observable,
         claims=claims,
         claims_observable=claims_observable,
+        closing_pull_requests=closing_pull_requests,
     )
     return Fetched(node.key, node, issue.get("body") or "")
 

--- a/scripts/secpal_work_graph/github.py
+++ b/scripts/secpal_work_graph/github.py
@@ -68,7 +68,7 @@ ISSUE_QUERY = f"""query WorkGraphIssue($owner: String!, $name: String!, $number:
         nodes {{ {_REFERENCE_FIELDS} }}
       }}
       blocking(first: 1) {{ totalCount }}
-      closedByPullRequestsReferences(first: {CLAIM_PAGE_SIZE}, includeClosedPrs: true) {{
+      closedByPullRequestsReferences(first: {CLAIM_PAGE_SIZE}, includeClosedPrs: false) {{
         pageInfo {{ hasNextPage endCursor }}
         nodes {{
           number
@@ -110,7 +110,7 @@ PAGE_QUERIES: Mapping[str, str] = {
         "closedByPullRequestsReferences",
         CLAIM_PAGE_SIZE,
         _CLAIM_SELECTION,
-        ", includeClosedPrs: true",
+        ", includeClosedPrs: false",
     ),
 }
 
@@ -286,11 +286,6 @@ def _claims(entries: Iterable[Mapping[str, Any]]) -> tuple[Claim, ...]:
     return tuple(sorted(claims))
 
 
-def _closing_pull_requests(entries: Iterable[Mapping[str, Any]]) -> tuple[str, ...]:
-    """Return all native closing PR identities for advisory governance checks."""
-    return tuple(sorted(reference for reference in (_reference(entry) for entry in entries) if reference))
-
-
 def _unresolved_reason(errors: Iterable[Mapping[str, Any]]) -> str:
     return next((str(error.get("type")) for error in errors if error.get("type")), "unresolved")
 
@@ -351,10 +346,9 @@ def _fetch(
             response.errors_touching("closedByPullRequestsReferences"),
         )
         claims = _claims(claim_entries)
-        closing_pull_requests = _closing_pull_requests(claim_entries)
         claims_observable = True
     except ConnectionUnreadable:
-        claims, closing_pull_requests, claims_observable = (), (), False
+        claims, claims_observable = (), False
 
     state_reason = issue.get("stateReason")
     node = Node(
@@ -375,7 +369,6 @@ def _fetch(
         priority_labels_observable=priority_labels_observable,
         claims=claims,
         claims_observable=claims_observable,
-        closing_pull_requests=closing_pull_requests,
     )
     return Fetched(node.key, node, issue.get("body") or "")
 

--- a/scripts/secpal_work_graph/markdown_headings.mjs
+++ b/scripts/secpal_work_graph/markdown_headings.mjs
@@ -96,7 +96,11 @@ function hasStatusChecklist(tokens) {
       listDepth += 1;
     } else if (token.type === "list_item_close") {
       listDepth -= 1;
-    } else if (listDepth > 0 && token.type === "inline" && /\[[ xX]\]/.test(token.content)) {
+    } else if (
+      listDepth > 0 &&
+      token.type === "inline" &&
+      /^\[[ xX]\](?:[ \t]+|$)/.test(token.content)
+    ) {
       return true;
     }
   }

--- a/scripts/secpal_work_graph/markdown_headings.mjs
+++ b/scripts/secpal_work_graph/markdown_headings.mjs
@@ -89,6 +89,20 @@ function relationshipMirrors(tokens) {
   return [...mirrors].sort();
 }
 
+function hasStatusChecklist(tokens) {
+  let listDepth = 0;
+  for (const token of tokens) {
+    if (token.type === "list_item_open") {
+      listDepth += 1;
+    } else if (token.type === "list_item_close") {
+      listDepth -= 1;
+    } else if (listDepth > 0 && token.type === "inline" && /\[[ xX]\]/.test(token.content)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function bodyFacts(body) {
   const tokens = parser.parse(body ?? "", {});
   return {
@@ -96,7 +110,7 @@ function bodyFacts(body) {
     relationshipMirrors: relationshipMirrors(tokens),
     // A task list is migration evidence only.  The audit never derives issue
     // state or relationships from it.
-    hasStatusChecklist: tokens.some(token => token.type === "inline" && token.level === 1 && /\[[ xX]\]/.test(token.content)),
+    hasStatusChecklist: hasStatusChecklist(tokens),
   };
 }
 

--- a/scripts/secpal_work_graph/markdown_headings.mjs
+++ b/scripts/secpal_work_graph/markdown_headings.mjs
@@ -91,7 +91,13 @@ function relationshipMirrors(tokens) {
 
 function bodyFacts(body) {
   const tokens = parser.parse(body ?? "", {});
-  return { headings: headings(tokens), relationshipMirrors: relationshipMirrors(tokens) };
+  return {
+    headings: headings(tokens),
+    relationshipMirrors: relationshipMirrors(tokens),
+    // A task list is migration evidence only.  The audit never derives issue
+    // state or relationships from it.
+    hasStatusChecklist: tokens.some(token => token.type === "inline" && token.level === 1 && /\[[ xX]\]/.test(token.content)),
+  };
 }
 
 const chunks = [];

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -95,9 +95,6 @@ class Node:
     has_acceptance_criteria: bool = False
     claims: tuple[Claim, ...] = ()
     claims_observable: bool = True
-    # Closing references are advisory evidence.  Unlike ``claims`` they include
-    # merged PRs and are never consumed by canonical resolution.
-    closing_pull_requests: tuple[str, ...] = ()
     resolved: bool = True
     unresolved_reason: str | None = None
     mirror_relationships: tuple[str, ...] = ()

--- a/scripts/secpal_work_graph/model.py
+++ b/scripts/secpal_work_graph/model.py
@@ -95,6 +95,9 @@ class Node:
     has_acceptance_criteria: bool = False
     claims: tuple[Claim, ...] = ()
     claims_observable: bool = True
+    # Closing references are advisory evidence.  Unlike ``claims`` they include
+    # merged PRs and are never consumed by canonical resolution.
+    closing_pull_requests: tuple[str, ...] = ()
     resolved: bool = True
     unresolved_reason: str | None = None
     mirror_relationships: tuple[str, ...] = ()

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from secpal_work_graph import audit  # noqa: E402
+from secpal_work_graph import acceptance_criteria  # noqa: E402
 from secpal_work_graph.model import CLOSED, COMPLETED, Node, build_snapshot  # noqa: E402
 
 SPEC = importlib.util.spec_from_file_location("work_graph_audit_cli", ROOT / "scripts" / "secpal-work-graph-audit.py")
@@ -28,10 +29,10 @@ def leaf(number, **kwargs): return Node(REPO, number, has_acceptance_criteria=Tr
 
 
 class AuditClassificationTests(TestCase):
-    def findings(self, nodes, candidate=None, repository=REPO):
+    def findings(self, nodes, candidate=None, repository=REPO, closing_pull_requests_by_issue=None):
         snapshot = build_snapshot(nodes)
         candidate = candidate or audit.Candidate(nodes[0].key, "native")
-        return audit.classify(snapshot, nodes[0].key, candidate, repository=repository)
+        return audit.classify(snapshot, nodes[0].key, candidate, repository=repository, closing_pull_requests_by_issue=closing_pull_requests_by_issue)
 
     def test_clean_native_graph_is_clean(self):
         self.assertEqual(self.findings([leaf(1)]), [])
@@ -49,18 +50,23 @@ class AuditClassificationTests(TestCase):
         self.assertTrue(all(item["classification"] == "execution_blocker" for item in findings))
 
     def test_direct_epic_pr_and_multiple_delivery_prs_are_advisory(self):
-        epic = Node(REPO, 1, title="[EPIC] rollout", children=(key(2),), closing_pull_requests=(f"{REPO}#9",))
-        child = leaf(2, parent=key(1), closing_pull_requests=(f"{REPO}#10", f"{REPO}#11"))
-        findings = self.findings([epic, child])
+        epic = Node(REPO, 1, title="[EPIC] rollout", children=(key(2),))
+        child = leaf(2, parent=key(1))
+        findings = self.findings([epic, child], closing_pull_requests_by_issue={key(1): (f"{REPO}#9",), key(2): (f"{REPO}#10", f"{REPO}#11")})
         direct = next(item for item in findings if item["kind"] == "direct_epic_delivery_pull_request")
         multi = next(item for item in findings if item["kind"] == "multi_contract_leaf_candidate")
         self.assertEqual(direct["classification"], "migration_debt")
         self.assertTrue(multi["requires_judgment"])
 
     def test_legacy_epic_label_remains_epic_evidence_for_closing_prs(self):
-        node = leaf(1, closing_pull_requests=(f"{REPO}#9",))
-        findings = self.findings([node], audit.Candidate(node.key, "legacy_candidate", epic_candidate=True))
+        node = leaf(1)
+        findings = self.findings([node], audit.Candidate(node.key, "legacy_candidate", epic_candidate=True), closing_pull_requests_by_issue={key(1): (f"{REPO}#9",)})
         self.assertIn("direct_epic_delivery_pull_request", {item["kind"] for item in findings})
+
+    def test_leaf_title_does_not_make_an_epic(self):
+        node = leaf(1, title="Fix epic synchronization failure")
+        findings = self.findings([node], closing_pull_requests_by_issue={key(1): (f"{REPO}#9",)})
+        self.assertNotIn("direct_epic_delivery_pull_request", {item["kind"] for item in findings})
 
     def test_cross_repository_nodes_are_reported_only_by_their_repository(self):
         other = "SecPal/api"
@@ -103,6 +109,42 @@ class AuditClassificationTests(TestCase):
         with patch.object(audit_cli.github, "GitHubReadAdapter", FailingAdapter), patch("sys.stdout", output):
             self.assertEqual(audit_cli.main(["--repo", REPO]), 3)
         self.assertEqual(__import__("json").loads(output.getvalue())["repositories"][0]["status"], "unavailable")
+
+    def test_cli_marks_graphql_access_error_unavailable(self):
+        class ForbiddenAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                return audit_cli.github.GraphQLResponse(None, ({"type": "FORBIDDEN"},))
+
+        output = io.StringIO()
+        with patch.object(audit_cli.github, "GitHubReadAdapter", ForbiddenAdapter), patch("sys.stdout", output):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 3)
+        self.assertEqual(__import__("json").loads(output.getvalue())["repositories"][0]["status"], "unavailable")
+
+    def test_cli_rejects_partially_readable_discovery_pagination(self):
+        class PartialAdapter:
+            def __init__(self, **_kwargs):
+                self.calls = 0
+
+            def query(self, _document, _variables):
+                self.calls += 1
+                if self.calls == 1:
+                    return audit_cli.github.GraphQLResponse(
+                        {"repository": {"issues": {"nodes": [], "pageInfo": {"hasNextPage": True, "endCursor": "next"}}}}, ()
+                    )
+                return audit_cli.github.GraphQLResponse(None, ({"type": "NOT_FOUND"},))
+
+        output = io.StringIO()
+        with patch.object(audit_cli.github, "GitHubReadAdapter", PartialAdapter), patch("sys.stdout", output):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 3)
+        self.assertEqual(__import__("json").loads(output.getvalue())["repositories"][0]["status"], "unavailable")
+
+    def test_markdown_task_lists_are_structural_migration_evidence(self):
+        checklist, code_example = acceptance_criteria.parse(["- [ ] first item\n- [x] second item", "```md\n- [ ] example\n```"])
+        self.assertTrue(checklist.has_status_checklist)
+        self.assertFalse(code_example.has_status_checklist)
 
 
 if __name__ == "__main__":

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -141,10 +141,120 @@ class AuditClassificationTests(TestCase):
             self.assertEqual(audit_cli.main(["--repo", REPO]), 3)
         self.assertEqual(__import__("json").loads(output.getvalue())["repositories"][0]["status"], "unavailable")
 
+    def test_cli_deduplicates_findings_from_overlapping_candidates(self):
+        rows = [
+            {
+                "number": 1,
+                "title": "Root",
+                "body": "",
+                "repository": {"nameWithOwner": REPO},
+                "parent": None,
+                "subIssues": {"totalCount": 1},
+                "labels": {"nodes": []},
+                "closedByPullRequestsReferences": {"totalCount": 0, "nodes": []},
+            },
+            {
+                "number": 2,
+                "title": "Child",
+                "body": "Blocked by: #9",
+                "repository": {"nameWithOwner": REPO},
+                "parent": {"number": 1, "repository": {"nameWithOwner": REPO}},
+                "subIssues": {"totalCount": 0},
+                "labels": {"nodes": []},
+                "closedByPullRequestsReferences": {"totalCount": 0, "nodes": []},
+            },
+        ]
+
+        class DiscoveryAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                return audit_cli.github.GraphQLResponse(
+                    {"repository": {"issues": {"nodes": rows, "pageInfo": {"hasNextPage": False}}}}, ()
+                )
+
+        snapshot = build_snapshot(
+            [
+                Node(REPO, 1, children=(key(2),)),
+                leaf(2, parent=key(1), mirror_relationships=("blocked by",)),
+            ]
+        )
+        facts = [
+            acceptance_criteria.StructuralBody(False, ()),
+            acceptance_criteria.StructuralBody(False, ("blocked by",)),
+        ]
+        output = io.StringIO()
+        with (
+            patch.object(audit_cli.github, "GitHubReadAdapter", DiscoveryAdapter),
+            patch.object(audit_cli.github, "load_snapshot", side_effect=lambda _adapter, root: (snapshot, root)),
+            patch.object(audit_cli, "parse", return_value=facts),
+            patch("sys.stdout", output),
+        ):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
+        document = __import__("json").loads(output.getvalue())
+        kinds = [item["kind"] for item in document["repositories"][0]["findings"]]
+        self.assertEqual(kinds.count("body_relationship_mirror"), 1)
+        self.assertEqual(kinds.count("prose_only_blocker"), 1)
+        self.assertEqual(document["summary"]["migration_debt"], 2)
+
+    def test_cli_uses_canonical_repository_identity_from_discovery(self):
+        requested_repository = "secpal/.github"
+        rows = [
+            {
+                "number": 1,
+                "title": "Root",
+                "body": "",
+                "repository": {"nameWithOwner": REPO},
+                "parent": None,
+                "subIssues": {"totalCount": 1},
+                "labels": {"nodes": []},
+                "closedByPullRequestsReferences": {"totalCount": 0, "nodes": []},
+            }
+        ]
+
+        class DiscoveryAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                return audit_cli.github.GraphQLResponse(
+                    {"repository": {"issues": {"nodes": rows, "pageInfo": {"hasNextPage": False}}}}, ()
+                )
+
+        snapshot = build_snapshot(
+            [
+                Node(REPO, 1, children=(key(2),)),
+                Node(REPO, 2, parent=key(1), has_acceptance_criteria=False),
+            ]
+        )
+        output = io.StringIO()
+        with (
+            patch.object(audit_cli.github, "GitHubReadAdapter", DiscoveryAdapter),
+            patch.object(audit_cli.github, "load_snapshot", return_value=(snapshot, key(1))),
+            patch("sys.stdout", output),
+        ):
+            self.assertEqual(audit_cli.main(["--repo", requested_repository]), 0)
+        result = __import__("json").loads(output.getvalue())["repositories"][0]
+        self.assertEqual(result["repository"], REPO)
+        self.assertIn("structurally_incomplete_delivery_leaf", {item["kind"] for item in result["findings"]})
+
     def test_markdown_task_lists_are_structural_migration_evidence(self):
         checklist, code_example = acceptance_criteria.parse(["- [ ] first item\n- [x] second item", "```md\n- [ ] example\n```"])
         self.assertTrue(checklist.has_status_checklist)
         self.assertFalse(code_example.has_status_checklist)
+
+    def test_checkbox_like_list_prose_is_not_a_task_list(self):
+        link, inline_code, prose = acceptance_criteria.parse(
+            [
+                "- See [x](https://example.com)",
+                "- The literal marker is `[x]`",
+                "- A later marker [ ] is explanatory prose",
+            ]
+        )
+        self.assertFalse(link.has_status_checklist)
+        self.assertFalse(inline_code.has_status_checklist)
+        self.assertFalse(prose.has_status_checklist)
 
 
 if __name__ == "__main__":

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from secpal_work_graph import audit  # noqa: E402
 from secpal_work_graph import acceptance_criteria  # noqa: E402
+from secpal_work_graph import resolver  # noqa: E402
 from secpal_work_graph.model import CLOSED, COMPLETED, Node, build_snapshot  # noqa: E402
 
 SPEC = importlib.util.spec_from_file_location("work_graph_audit_cli", ROOT / "scripts" / "secpal-work-graph-audit.py")
@@ -145,6 +146,84 @@ class AuditClassificationTests(TestCase):
         child = Node(other, 2, parent=key(1), has_acceptance_criteria=False)
         findings = self.findings([parent, child])
         self.assertTrue(all(item["repository"] == REPO for item in findings))
+
+    def test_cross_repository_dependency_cycle_is_attributed_to_local_member(self):
+        frontend = "SecPal/frontend"
+        api = "SecPal/api"
+        root = f"{frontend}#1"
+        frontend_leaf = f"{frontend}#10"
+        api_dependency = f"{api}#2"
+        snapshot = build_snapshot(
+            [
+                Node(frontend, 1, children=(frontend_leaf,)),
+                Node(
+                    frontend,
+                    10,
+                    parent=root,
+                    blocked_by=(api_dependency,),
+                    has_acceptance_criteria=True,
+                ),
+                Node(
+                    api,
+                    2,
+                    blocked_by=(frontend_leaf,),
+                    has_acceptance_criteria=True,
+                ),
+            ]
+        )
+
+        resolution = resolver.resolve(snapshot, root)
+        canonical = next(
+            finding
+            for finding in resolution.findings
+            if finding.code == resolver.FINDING_DEPENDENCY_CYCLE
+        )
+        self.assertEqual(canonical.node, api_dependency)
+
+        findings = audit.classify_native(snapshot, root, repository=frontend)
+        cycle = next(item for item in findings if item["kind"] == "dependency_cycle")
+        self.assertEqual(cycle["classification"], "execution_blocker")
+        self.assertEqual(cycle["issue"], frontend_leaf)
+        self.assertFalse(
+            any(
+                item["kind"] == "dependency_cycle"
+                for item in audit.classify_native(
+                    snapshot, root, repository="SecPal/contracts"
+                )
+            )
+        )
+
+    def test_cross_repository_unresolved_child_is_attributed_to_local_parent(self):
+        frontend = "SecPal/frontend"
+        root = f"{frontend}#1"
+        missing_child = "SecPal/api#2"
+        snapshot = build_snapshot([Node(frontend, 1, children=(missing_child,))])
+
+        findings = audit.classify_native(snapshot, root, repository=frontend)
+        unresolved = next(
+            item for item in findings if item["kind"] == "unresolved_sub_issue"
+        )
+        self.assertEqual(unresolved["issue"], root)
+        self.assertEqual(unresolved["classification"], "execution_blocker")
+
+    def test_cross_repository_inconsistent_child_is_attributed_to_local_parent(self):
+        frontend = "SecPal/frontend"
+        root = f"{frontend}#1"
+        inconsistent_child = "SecPal/api#2"
+        snapshot = build_snapshot(
+            [
+                Node(frontend, 1, children=(inconsistent_child,)),
+                Node("SecPal/api", 2, has_acceptance_criteria=True),
+            ]
+        )
+
+        findings = audit.classify_native(snapshot, root, repository=frontend)
+        inconsistent = next(
+            item for item in findings
+            if item["kind"] == "containment_inconsistent"
+        )
+        self.assertEqual(inconsistent["issue"], root)
+        self.assertEqual(inconsistent["classification"], "execution_blocker")
 
     def test_document_is_deterministic_and_explicitly_clean(self):
         first = {"repository": "SecPal/z", "status": "clean", "findings": []}

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -52,7 +52,16 @@ class AuditClassificationTests(TestCase):
         return DiscoveryAdapter
 
     @staticmethod
-    def discovery_row(number, *, body="", parent=None, children=0, closing=()):
+    def discovery_row(
+        number,
+        *,
+        body="",
+        parent=None,
+        children=0,
+        blocked_by=0,
+        blocking=0,
+        closing=(),
+    ):
         return {
             "number": number,
             "title": f"Issue {number}",
@@ -60,8 +69,8 @@ class AuditClassificationTests(TestCase):
             "repository": {"nameWithOwner": REPO},
             "parent": parent,
             "subIssues": {"totalCount": children},
-            "blockedBy": {"totalCount": 0},
-            "blocking": {"totalCount": 0},
+            "blockedBy": {"totalCount": blocked_by},
+            "blocking": {"totalCount": blocking},
             "labels": {"nodes": []},
             "closedByPullRequestsReferences": {
                 "totalCount": len(closing),
@@ -116,6 +125,40 @@ class AuditClassificationTests(TestCase):
         multi = next(item for item in findings if item["kind"] == "multi_contract_leaf_candidate")
         self.assertEqual(direct["classification"], "migration_debt")
         self.assertTrue(multi["requires_judgment"])
+
+    def test_native_epic_is_not_a_multi_contract_leaf_candidate(self):
+        epic_findings = audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(1),
+                REPO,
+                "native",
+                native_children_count=1,
+                closing_pull_requests=(f"{REPO}#10", f"{REPO}#11"),
+            )
+        )
+        self.assertEqual(
+            [item["kind"] for item in epic_findings],
+            [
+                "direct_epic_delivery_pull_request",
+                "direct_epic_delivery_pull_request",
+            ],
+        )
+
+        leaf_findings = audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(2),
+                REPO,
+                "native",
+                closing_pull_requests=(f"{REPO}#12", f"{REPO}#13"),
+            )
+        )
+        candidate = next(
+            item
+            for item in leaf_findings
+            if item["kind"] == "multi_contract_leaf_candidate"
+        )
+        self.assertEqual(candidate["classification"], "migration_debt")
+        self.assertTrue(candidate["requires_judgment"])
 
     def test_legacy_epic_label_remains_epic_evidence_for_closing_prs(self):
         findings = audit.classify_advisory(
@@ -274,6 +317,82 @@ class AuditClassificationTests(TestCase):
         self.assertEqual(len(findings), 125)
         self.assertEqual({item["kind"] for item in findings}, {"duplicated_markdown_status"})
         load_snapshot.assert_not_called()
+
+    def test_standalone_dependency_root_reports_unresolved_dependency(self):
+        rows = [self.discovery_row(1, blocked_by=1)]
+        adapter = self.discovery_adapter(rows)()
+        snapshot = build_snapshot([leaf(1, blocked_by=(key(404),))])
+        with patch.object(
+            audit_cli.github,
+            "load_snapshot",
+            return_value=(snapshot, key(1)),
+        ) as load_snapshot:
+            result = audit_cli._audit_repository(adapter, REPO)
+
+        self.assertEqual(result["status"], "findings")
+        unresolved = next(
+            item
+            for item in result["findings"]
+            if item["kind"] == "unresolved_dependency"
+        )
+        self.assertEqual(unresolved["classification"], "execution_blocker")
+        load_snapshot.assert_called_once_with(adapter, key(1))
+
+    def test_standalone_dependency_root_reports_dependency_cycle(self):
+        rows = [self.discovery_row(1, blocked_by=1)]
+        adapter = self.discovery_adapter(rows)()
+        peer = "SecPal/api#2"
+        snapshot = build_snapshot(
+            [
+                leaf(1, blocked_by=(peer,)),
+                Node(
+                    "SecPal/api",
+                    2,
+                    blocked_by=(key(1),),
+                    has_acceptance_criteria=True,
+                ),
+            ]
+        )
+        with patch.object(
+            audit_cli.github,
+            "load_snapshot",
+            return_value=(snapshot, key(1)),
+        ) as load_snapshot:
+            result = audit_cli._audit_repository(adapter, REPO)
+
+        cycle = next(
+            item
+            for item in result["findings"]
+            if item["kind"] == "dependency_cycle"
+        )
+        self.assertEqual(cycle["classification"], "execution_blocker")
+        load_snapshot.assert_called_once_with(adapter, key(1))
+
+    def test_contained_dependency_leaf_does_not_add_native_root(self):
+        parent = {"number": 1, "repository": {"nameWithOwner": REPO}}
+        rows = [
+            self.discovery_row(1, children=1),
+            self.discovery_row(2, parent=parent, blocked_by=1),
+        ]
+        adapter = self.discovery_adapter(rows)()
+        snapshot = build_snapshot(
+            [
+                Node(REPO, 1, children=(key(2),)),
+                leaf(2, parent=key(1), blocked_by=(key(404),)),
+            ]
+        )
+        with patch.object(
+            audit_cli.github,
+            "load_snapshot",
+            return_value=(snapshot, key(1)),
+        ) as load_snapshot:
+            result = audit_cli._audit_repository(adapter, REPO)
+
+        self.assertIn(
+            "unresolved_dependency",
+            {item["kind"] for item in result["findings"]},
+        )
+        load_snapshot.assert_called_once_with(adapter, key(1))
 
     def test_one_native_root_serves_advisory_descendants_without_reresolution(self):
         parent = {"number": 1, "repository": {"nameWithOwner": REPO}}

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+"""Focused pure evidence for the report-only work-graph migration audit."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase, main
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+from secpal_work_graph import audit  # noqa: E402
+from secpal_work_graph.model import CLOSED, COMPLETED, Node, build_snapshot  # noqa: E402
+
+REPO = "SecPal/.github"
+def key(number): return f"{REPO}#{number}"
+def leaf(number, **kwargs): return Node(REPO, number, has_acceptance_criteria=True, **kwargs)
+
+
+class AuditClassificationTests(TestCase):
+    def findings(self, nodes, candidate=None):
+        snapshot = build_snapshot(nodes)
+        candidate = candidate or audit.Candidate(nodes[0].key, "native")
+        return audit.classify(snapshot, nodes[0].key, candidate)
+
+    def test_clean_native_graph_is_clean(self):
+        self.assertEqual(self.findings([leaf(1)]), [])
+
+    def test_mirrors_are_migration_debt_not_graph_authority(self):
+        findings = self.findings([leaf(1, mirror_relationships=("blocked by",))])
+        self.assertEqual({item["kind"] for item in findings}, {"body_relationship_mirror", "prose_only_blocker"})
+        self.assertTrue(all(item["classification"] == "migration_debt" for item in findings))
+
+    def test_closed_parent_open_child_and_incomplete_leaf_are_blockers(self):
+        parent = Node(REPO, 1, state=CLOSED, state_reason=COMPLETED, children=(key(2),))
+        child = Node(REPO, 2, parent=key(1), has_acceptance_criteria=False)
+        findings = self.findings([parent, child])
+        self.assertEqual({item["kind"] for item in findings}, {"closed_parent_open_child", "structurally_incomplete_delivery_leaf"})
+        self.assertTrue(all(item["classification"] == "execution_blocker" for item in findings))
+
+    def test_direct_epic_pr_and_multi_contract_candidate_are_advisory(self):
+        epic = Node(REPO, 1, title="[EPIC] rollout", children=(key(2),), closing_pull_requests=(f"{REPO}#9",))
+        child = leaf(2, parent=key(1), blocking_count=2)
+        findings = self.findings([epic, child])
+        direct = next(item for item in findings if item["kind"] == "direct_epic_delivery_pull_request")
+        multi = next(item for item in findings if item["kind"] == "multi_contract_leaf_candidate")
+        self.assertEqual(direct["classification"], "migration_debt")
+        self.assertTrue(multi["requires_judgment"])
+
+    def test_document_is_deterministic_and_explicitly_clean(self):
+        first = {"repository": "SecPal/z", "status": "clean", "findings": []}
+        second = {"repository": "SecPal/a", "status": "clean", "findings": []}
+        self.assertEqual(audit.document([first, second]), audit.document([second, first]))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -29,16 +29,61 @@ def leaf(number, **kwargs): return Node(REPO, number, has_acceptance_criteria=Tr
 
 
 class AuditClassificationTests(TestCase):
-    def findings(self, nodes, candidate=None, repository=REPO, closing_pull_requests_by_issue=None):
+    @staticmethod
+    def discovery_adapter(rows):
+        class DiscoveryAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                return audit_cli.github.GraphQLResponse(
+                    {
+                        "repository": {
+                            "issues": {
+                                "nodes": rows,
+                                "pageInfo": {"hasNextPage": False},
+                            }
+                        }
+                    },
+                    (),
+                )
+
+        return DiscoveryAdapter
+
+    @staticmethod
+    def discovery_row(number, *, body="", parent=None, children=0, closing=()):
+        return {
+            "number": number,
+            "title": f"Issue {number}",
+            "body": body,
+            "repository": {"nameWithOwner": REPO},
+            "parent": parent,
+            "subIssues": {"totalCount": children},
+            "blockedBy": {"totalCount": 0},
+            "blocking": {"totalCount": 0},
+            "labels": {"nodes": []},
+            "closedByPullRequestsReferences": {
+                "totalCount": len(closing),
+                "nodes": [
+                    {"number": number, "repository": {"nameWithOwner": REPO}}
+                    for number in closing
+                ],
+            },
+        }
+
+    def findings(self, nodes, repository=REPO):
         snapshot = build_snapshot(nodes)
-        candidate = candidate or audit.Candidate(nodes[0].key, "native")
-        return audit.classify(snapshot, nodes[0].key, candidate, repository=repository, closing_pull_requests_by_issue=closing_pull_requests_by_issue)
+        return audit.classify_native(snapshot, nodes[0].key, repository=repository)
 
     def test_clean_native_graph_is_clean(self):
         self.assertEqual(self.findings([leaf(1)]), [])
 
     def test_mirrors_are_migration_debt_not_graph_authority(self):
-        findings = self.findings([leaf(1, mirror_relationships=("blocked by",))])
+        findings = audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(1), REPO, "legacy_candidate", relationship_mirrors=("blocked by",)
+            )
+        )
         self.assertEqual({item["kind"] for item in findings}, {"body_relationship_mirror", "prose_only_blocker"})
         self.assertTrue(all(item["classification"] == "migration_debt" for item in findings))
 
@@ -50,22 +95,48 @@ class AuditClassificationTests(TestCase):
         self.assertTrue(all(item["classification"] == "execution_blocker" for item in findings))
 
     def test_direct_epic_pr_and_multiple_delivery_prs_are_advisory(self):
-        epic = Node(REPO, 1, title="[EPIC] rollout", children=(key(2),))
-        child = leaf(2, parent=key(1))
-        findings = self.findings([epic, child], closing_pull_requests_by_issue={key(1): (f"{REPO}#9",), key(2): (f"{REPO}#10", f"{REPO}#11")})
+        findings = audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(1),
+                REPO,
+                "native",
+                native_children_count=1,
+                closing_pull_requests=(f"{REPO}#9",),
+            )
+        ) + audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(2),
+                REPO,
+                "native",
+                closing_pull_requests=(f"{REPO}#10", f"{REPO}#11"),
+            )
+        )
         direct = next(item for item in findings if item["kind"] == "direct_epic_delivery_pull_request")
         multi = next(item for item in findings if item["kind"] == "multi_contract_leaf_candidate")
         self.assertEqual(direct["classification"], "migration_debt")
         self.assertTrue(multi["requires_judgment"])
 
     def test_legacy_epic_label_remains_epic_evidence_for_closing_prs(self):
-        node = leaf(1)
-        findings = self.findings([node], audit.Candidate(node.key, "legacy_candidate", epic_candidate=True), closing_pull_requests_by_issue={key(1): (f"{REPO}#9",)})
+        findings = audit.classify_advisory(
+            audit.AdvisoryIssueFacts(
+                key(1),
+                REPO,
+                "legacy_candidate",
+                legacy_epic_candidate=True,
+                closing_pull_requests=(f"{REPO}#9",),
+            )
+        )
         self.assertIn("direct_epic_delivery_pull_request", {item["kind"] for item in findings})
 
     def test_leaf_title_does_not_make_an_epic(self):
-        node = leaf(1, title="Fix epic synchronization failure")
-        findings = self.findings([node], closing_pull_requests_by_issue={key(1): (f"{REPO}#9",)})
+        row = self.discovery_row(1, closing=(9,))
+        row["title"] = "Fix epic synchronization failure"
+        facts = audit_cli._advisory_facts(
+            row,
+            acceptance_criteria.StructuralBody(False, ()),
+            REPO,
+        )
+        findings = audit.classify_advisory(facts)
         self.assertNotIn("direct_epic_delivery_pull_request", {item["kind"] for item in findings})
 
     def test_cross_repository_nodes_are_reported_only_by_their_repository(self):
@@ -96,6 +167,71 @@ class AuditClassificationTests(TestCase):
             self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
         document = __import__("json").loads(output.getvalue())
         self.assertEqual(document["repositories"], [{"repository": REPO, "status": "clean", "findings": []}])
+
+    def test_checklist_only_issue_is_advisory_without_snapshot_resolution(self):
+        rows = [self.discovery_row(1, body="- [ ] one\n- [x] two")]
+        output = io.StringIO()
+        with (
+            patch.object(audit_cli.github, "GitHubReadAdapter", self.discovery_adapter(rows)),
+            patch.object(audit_cli.github, "load_snapshot") as load_snapshot,
+            patch("sys.stdout", output),
+        ):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
+        findings = __import__("json").loads(output.getvalue())["repositories"][0]["findings"]
+        self.assertEqual({item["kind"] for item in findings}, {"duplicated_markdown_status"})
+        self.assertEqual(findings[0]["classification"], "migration_debt")
+        load_snapshot.assert_not_called()
+
+    def test_many_checklist_only_issues_do_not_fan_out_snapshot_resolution(self):
+        rows = [self.discovery_row(number, body="- [ ] migrate") for number in range(1, 126)]
+        output = io.StringIO()
+        with (
+            patch.object(audit_cli.github, "GitHubReadAdapter", self.discovery_adapter(rows)),
+            patch.object(audit_cli.github, "load_snapshot") as load_snapshot,
+            patch("sys.stdout", output),
+        ):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
+        findings = __import__("json").loads(output.getvalue())["repositories"][0]["findings"]
+        self.assertEqual(len(findings), 125)
+        self.assertEqual({item["kind"] for item in findings}, {"duplicated_markdown_status"})
+        load_snapshot.assert_not_called()
+
+    def test_one_native_root_serves_advisory_descendants_without_reresolution(self):
+        parent = {"number": 1, "repository": {"nameWithOwner": REPO}}
+        rows = [
+            self.discovery_row(1, children=3),
+            self.discovery_row(2, parent=parent, body="- [ ] migrate"),
+            self.discovery_row(3, parent=parent, body="Blocked by: #9"),
+            self.discovery_row(4, parent=parent, closing=(10, 11)),
+        ]
+        snapshot = build_snapshot(
+            [
+                Node(REPO, 1, children=(key(2), key(3), key(4))),
+                Node(REPO, 2, parent=key(1), has_acceptance_criteria=False),
+                leaf(3, parent=key(1)),
+                leaf(4, parent=key(1)),
+            ]
+        )
+        output = io.StringIO()
+        with (
+            patch.object(audit_cli.github, "GitHubReadAdapter", self.discovery_adapter(rows)),
+            patch.object(
+                audit_cli.github,
+                "load_snapshot",
+                return_value=(snapshot, key(1)),
+            ) as load_snapshot,
+            patch("sys.stdout", output),
+        ):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
+        kinds = {
+            item["kind"]
+            for item in __import__("json").loads(output.getvalue())["repositories"][0]["findings"]
+        }
+        self.assertIn("structurally_incomplete_delivery_leaf", kinds)
+        self.assertIn("duplicated_markdown_status", kinds)
+        self.assertIn("body_relationship_mirror", kinds)
+        self.assertIn("multi_contract_leaf_candidate", kinds)
+        load_snapshot.assert_called_once()
 
     def test_cli_marks_operational_failure_and_returns_three(self):
         class FailingAdapter:

--- a/tests/secpal-work-graph-audit.py
+++ b/tests/secpal-work-graph-audit.py
@@ -6,13 +6,21 @@
 from __future__ import annotations
 
 import sys
+import importlib.util
+import io
 from pathlib import Path
 from unittest import TestCase, main
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from secpal_work_graph import audit  # noqa: E402
 from secpal_work_graph.model import CLOSED, COMPLETED, Node, build_snapshot  # noqa: E402
+
+SPEC = importlib.util.spec_from_file_location("work_graph_audit_cli", ROOT / "scripts" / "secpal-work-graph-audit.py")
+audit_cli = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(audit_cli)
 
 REPO = "SecPal/.github"
 def key(number): return f"{REPO}#{number}"
@@ -20,10 +28,10 @@ def leaf(number, **kwargs): return Node(REPO, number, has_acceptance_criteria=Tr
 
 
 class AuditClassificationTests(TestCase):
-    def findings(self, nodes, candidate=None):
+    def findings(self, nodes, candidate=None, repository=REPO):
         snapshot = build_snapshot(nodes)
         candidate = candidate or audit.Candidate(nodes[0].key, "native")
-        return audit.classify(snapshot, nodes[0].key, candidate)
+        return audit.classify(snapshot, nodes[0].key, candidate, repository=repository)
 
     def test_clean_native_graph_is_clean(self):
         self.assertEqual(self.findings([leaf(1)]), [])
@@ -40,19 +48,61 @@ class AuditClassificationTests(TestCase):
         self.assertEqual({item["kind"] for item in findings}, {"closed_parent_open_child", "structurally_incomplete_delivery_leaf"})
         self.assertTrue(all(item["classification"] == "execution_blocker" for item in findings))
 
-    def test_direct_epic_pr_and_multi_contract_candidate_are_advisory(self):
+    def test_direct_epic_pr_and_multiple_delivery_prs_are_advisory(self):
         epic = Node(REPO, 1, title="[EPIC] rollout", children=(key(2),), closing_pull_requests=(f"{REPO}#9",))
-        child = leaf(2, parent=key(1), blocking_count=2)
+        child = leaf(2, parent=key(1), closing_pull_requests=(f"{REPO}#10", f"{REPO}#11"))
         findings = self.findings([epic, child])
         direct = next(item for item in findings if item["kind"] == "direct_epic_delivery_pull_request")
         multi = next(item for item in findings if item["kind"] == "multi_contract_leaf_candidate")
         self.assertEqual(direct["classification"], "migration_debt")
         self.assertTrue(multi["requires_judgment"])
 
+    def test_legacy_epic_label_remains_epic_evidence_for_closing_prs(self):
+        node = leaf(1, closing_pull_requests=(f"{REPO}#9",))
+        findings = self.findings([node], audit.Candidate(node.key, "legacy_candidate", epic_candidate=True))
+        self.assertIn("direct_epic_delivery_pull_request", {item["kind"] for item in findings})
+
+    def test_cross_repository_nodes_are_reported_only_by_their_repository(self):
+        other = "SecPal/api"
+        parent = Node(REPO, 1, children=(f"{other}#2",))
+        child = Node(other, 2, parent=key(1), has_acceptance_criteria=False)
+        findings = self.findings([parent, child])
+        self.assertTrue(all(item["repository"] == REPO for item in findings))
+
     def test_document_is_deterministic_and_explicitly_clean(self):
         first = {"repository": "SecPal/z", "status": "clean", "findings": []}
         second = {"repository": "SecPal/a", "status": "clean", "findings": []}
         self.assertEqual(audit.document([first, second]), audit.document([second, first]))
+        self.assertEqual(len(audit.DEFAULT_REPOSITORIES), 9)
+
+    def test_cli_returns_zero_for_a_clean_repository(self):
+        class EmptyAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                return audit_cli.github.GraphQLResponse(
+                    {"repository": {"issues": {"nodes": [], "pageInfo": {"hasNextPage": False}}}}, ()
+                )
+
+        output = io.StringIO()
+        with patch.object(audit_cli.github, "GitHubReadAdapter", EmptyAdapter), patch("sys.stdout", output):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 0)
+        document = __import__("json").loads(output.getvalue())
+        self.assertEqual(document["repositories"], [{"repository": REPO, "status": "clean", "findings": []}])
+
+    def test_cli_marks_operational_failure_and_returns_three(self):
+        class FailingAdapter:
+            def __init__(self, **_kwargs):
+                pass
+
+            def query(self, _document, _variables):
+                raise audit_cli.github.GitHubError("unavailable")
+
+        output = io.StringIO()
+        with patch.object(audit_cli.github, "GitHubReadAdapter", FailingAdapter), patch("sys.stdout", output):
+            self.assertEqual(audit_cli.main(["--repo", REPO]), 3)
+        self.assertEqual(__import__("json").loads(output.getvalue())["repositories"][0]["status"], "unavailable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #670

Part of: #665

## Architecture

The audit preserves the required boundary:

GitHub-native discovery → advisory migration classification → minimal native roots → canonical resolver → deterministic `secpal-work-graph-audit/v1` report.

Parser-derived checklists and relationship mirrors, legacy epic evidence, and audit-specific closing-PR evidence produce migration findings directly. They do not create canonical graph membership. Each minimal native root is resolved once, and canonical execution blockers remain derived by the existing resolver.

## Finding taxonomy

- Canonical malformed or incomplete graph state and structurally incomplete native delivery leaves are `execution_blocker` findings.
- Legacy mirrors, duplicated Markdown status, and delivery-shape findings are `migration_debt`.
- Multiple-closing-PR candidates remain advisory with `requires_judgment: true`.
- Findings are partitioned by the repository owning the issue and sorted deterministically.

## TDD / Validate-First Evidence

- Failing proof before implementation: `python3 -m unittest tests/secpal-work-graph-audit.py` failed because checklist-only issues still called `github.load_snapshot`, and advisory descendants were re-resolved instead of being classified from discovery evidence.
- Passing proof after implementation: `python3 -m unittest tests/secpal-work-graph-unit.py tests/secpal-work-graph-adapter.py tests/secpal-work-graph-audit.py` — 107 tests passed.
- Validate-first exception reference: N/A.
- No executable change reason: N/A.

## Validation

- `python3 -m unittest tests/secpal-work-graph-unit.py tests/secpal-work-graph-adapter.py tests/secpal-work-graph-audit.py` — 107 tests passed.
- `bash tests/pull-request-evidence.sh` — passed.
- `bash tests/license-compatibility.sh` — passed, 12 allowlist entries checked.
- `reuse lint` — passed with 271/271 files compliant.
- `git diff --check` — passed.
- `scripts/secpal-work-graph-audit.py --repo SecPal/api` — exit 0 in 68 seconds.

## Live migration baseline

Exact default command: `scripts/secpal-work-graph-audit.py`

Default exit code: `0`. The audit was read-only and did not mutate GitHub. No reported migration finding was remediated in this pull request; this report is the migration baseline for #666.

| Repository | Execution blockers | Migration debt | Judgment candidates | Status |
| --- | ---: | ---: | ---: | --- |
| SecPal/.github | 2 | 84 | 1 | findings |
| SecPal/android | 0 | 42 | 8 | findings |
| SecPal/frontend | 1 | 109 | 6 | findings |
| SecPal/deployment | 0 | 33 | 1 | findings |
| SecPal/api | 1 | 309 | 12 | findings |
| SecPal/contracts | 0 | 22 | 1 | findings |
| SecPal/secpal.app | 0 | 2 | 0 | findings |
| SecPal/GuardGuide | 0 | 1 | 0 | findings |
| SecPal/guardguide.de | 0 | 0 | 0 | clean |

## Boundaries

This pull request does not migrate repositories (#666), coordinate execution (#672), mutate or replan graphs (#673), or enforce findings (#674). It does not add a live organization-wide required check. `audit-closed-epics.sh` remains legacy comparison only.


